### PR TITLE
Allow users to pass in their own version of IfNonMatch header

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -3,6 +3,7 @@ namespace Azure.DigitalTwins.Core
     public partial class CreateDigitalTwinOptions
     {
         public CreateDigitalTwinOptions() { }
+        public string IfNoneMatch { get { throw null; } set { } }
         public string TraceParent { get { throw null; } set { } }
         public string TraceState { get { throw null; } set { } }
     }
@@ -21,6 +22,7 @@ namespace Azure.DigitalTwins.Core
     public partial class CreateRelationshipOptions
     {
         public CreateRelationshipOptions() { }
+        public string IfNoneMatch { get { throw null; } set { } }
         public string TraceParent { get { throw null; } set { } }
         public string TraceState { get { throw null; } set { } }
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/DigitalTwinsRestClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/DigitalTwinsRestClient.cs
@@ -36,7 +36,10 @@ namespace Azure.DigitalTwins.Core
             {
                 request.Headers.Add("TraceState", digitalTwinsAddOptions.TraceState);
             }
-            request.Headers.Add("If-None-Match", "*");
+            if (digitalTwinsAddOptions?.IfNoneMatch != null)
+            {
+                request.Headers.Add("If-None-Match", digitalTwinsAddOptions.IfNoneMatch);
+            }
             request.Headers.Add("Content-Type", "application/json");
             request.Headers.Add("Accept", "application/json");
             var content = RequestContent.Create(twin);
@@ -639,7 +642,10 @@ namespace Azure.DigitalTwins.Core
             {
                 request.Headers.Add("TraceState", digitalTwinsAddRelationshipOptions.TraceState);
             }
-            request.Headers.Add("If-None-Match", "*");
+            if (digitalTwinsAddRelationshipOptions?.IfNoneMatch != null)
+            {
+                request.Headers.Add("If-None-Match", digitalTwinsAddRelationshipOptions.IfNoneMatch);
+            }
             request.Headers.Add("Content-Type", "application/json");
             request.Headers.Add("Accept", "application/json");
             request.Content = RequestContent.Create(relationship);

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateDigitalTwinOptions.cs
@@ -18,5 +18,15 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         public string TraceState { get; set; }
+
+        /// <summary>
+        /// If-Non-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
+        /// For more information about this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC</see>.
+        /// Acceptable values are null or "*".
+        /// If IfNonMatch option is null the service will replace the existing entity with the new entity.
+        /// If IfNonMatch option is "*" the service will reject the request if the entity already exists.
+        /// </summary>
+        [CodeGenMember("IfNoneMatch")]
+        public string IfNoneMatch { get; set; }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateRelationshipOptions.cs
@@ -18,5 +18,15 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         public string TraceState { get; set; }
+
+        /// <summary>
+        /// If-Non-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
+        /// For more information about this property, see <see href="https://tools.ietf.org/html/rfc7232#section-3.2">RFC</see>.
+        /// Acceptable values are null or "*".
+        /// If IfNonMatch option is null the service will replace the existing entity with the new entity.
+        /// If IfNonMatch option is "*" the service will reject the request if the entity already exists.
+        /// </summary>
+        [CodeGenMember("IfNoneMatch")]
+        public string IfNoneMatch { get; set; }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/DigitalTwinsRestClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/DigitalTwinsRestClient.cs
@@ -392,7 +392,10 @@ namespace Azure.DigitalTwins.Core
             {
                 request.Headers.Add("tracestate", digitalTwinsAddRelationshipOptions.TraceState);
             }
-            request.Headers.Add("If-None-Match", "*");
+            if (digitalTwinsAddRelationshipOptions?.IfNoneMatch != null)
+            {
+                request.Headers.Add("If-None-Match", digitalTwinsAddRelationshipOptions.IfNoneMatch);
+            }
             request.Headers.Add("Content-Type", "application/json");
             request.Headers.Add("Accept", "application/json");
             var content = new Utf8JsonRequestContent();

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/autorest.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/autorest.md
@@ -36,3 +36,10 @@ directive:
 #payload-flattening-threshold: 1
 #namespace: Azure.DigitalTwins.Core
 ```
+
+``` yaml
+directive:
+- from: swagger-document
+  where: $..[?(@.name=='If-None-Match')]
+  transform: delete $.enum;
+```

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/autorest.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/autorest.md
@@ -37,6 +37,8 @@ directive:
 #namespace: Azure.DigitalTwins.Core
 ```
 
+## This directive removes the specified enum values from the swagger so the code generator will expose IfNonMatch header as an option instead of always attaching it to requests with its only default value.
+
 ``` yaml
 directive:
 - from: swagger-document

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_Lifecycle.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -104,10 +104,10 @@
       "ResponseHeaders": {
         "Content-Length": "317",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11118\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.9479145\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120276595\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.9480495\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11118\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6306843\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120276595\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6310586\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin975739354?api-version=2020-10-31",
@@ -117,7 +117,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "229",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -145,13 +144,13 @@
       "ResponseHeaders": {
         "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "ETag": "W/\u00228cdf3061-1533-42e9-9199-ec8b3f0cbc34\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022f099526a-3c33-4fcd-8272-74228b94b0ba\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin975739354",
-        "$etag": "W/\u00228cdf3061-1533-42e9-9199-ec8b3f0cbc34\u0022",
+        "$etag": "W/\u0022f099526a-3c33-4fcd-8272-74228b94b0ba\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -161,26 +160,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+              "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+              "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;11118",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
           }
         }
       }
@@ -203,8 +202,8 @@
       "ResponseHeaders": {
         "Content-Length": "178",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "ETag": "W/\u00228cdf3061-1533-42e9-9199-ec8b3f0cbc34\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022f099526a-3c33-4fcd-8272-74228b94b0ba\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -212,10 +211,10 @@
         "Network": "Room1",
         "$metadata": {
           "RouterName": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
           },
           "Network": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.6888039Z"
           }
         }
       }
@@ -239,8 +238,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "ETag": "W/\u002275e3c602-e0f9-48b9-805c-45ac192843e6\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00222cb34a58-a595-43ff-8fa6-37c2087c2cd0\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -262,7 +261,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -284,7 +283,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -306,7 +305,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_Lifecycle.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "07851d7da6749ffa0f4483e261689466",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "805cd1a5276719e27ca9d862f63cf8e1",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d5745734aba48b92afe010ed3d76cba4",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -93,8 +93,8 @@
         "Content-Length": "1139",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ddc17cdf158ea3f5eef7fc223c19078b",
         "x-ms-return-client-request-id": "true"
@@ -104,10 +104,10 @@
       "ResponseHeaders": {
         "Content-Length": "317",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11118\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.8993363\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120276595\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.8994791\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11118\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.9479145\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120276595\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.9480495\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin975739354?api-version=2020-10-31",
@@ -119,8 +119,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "3d338701aff12600caf4b747d12b3f32",
         "x-ms-return-client-request-id": "true"
@@ -145,13 +145,13 @@
       "ResponseHeaders": {
         "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002246ddb1eb-c4b5-41bd-9345-dd8e6f4045ac\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "ETag": "W/\u00228cdf3061-1533-42e9-9199-ec8b3f0cbc34\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin975739354",
-        "$etag": "W/\u002246ddb1eb-c4b5-41bd-9345-dd8e6f4045ac\u0022",
+        "$etag": "W/\u00228cdf3061-1533-42e9-9199-ec8b3f0cbc34\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -161,26 +161,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;11118",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
           }
         }
       }
@@ -192,8 +192,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c016bd0c04361e4b61d1e7acae704e96",
         "x-ms-return-client-request-id": "true"
@@ -203,8 +203,8 @@
       "ResponseHeaders": {
         "Content-Length": "178",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u002246ddb1eb-c4b5-41bd-9345-dd8e6f4045ac\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "ETag": "W/\u00228cdf3061-1533-42e9-9199-ec8b3f0cbc34\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -212,10 +212,10 @@
         "Network": "Room1",
         "$metadata": {
           "RouterName": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
           },
           "Network": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0418223Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0879658Z"
           }
         }
       }
@@ -229,8 +229,8 @@
         "Content-Length": "58",
         "Content-Type": "application/json-patch\u002Bjson",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b6ec85d88e4230b37c9b12995eaed1c3",
         "x-ms-return-client-request-id": "true"
@@ -239,8 +239,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u002213ce668d-ca0b-45a6-a9e7-2d5f4264c141\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "ETag": "W/\u002275e3c602-e0f9-48b9-805c-45ac192843e6\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -252,8 +252,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7e15c9b84703fc553b15db1fc8537759",
         "x-ms-return-client-request-id": "true"
@@ -262,7 +262,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -274,8 +274,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4c6e21a5883e7eef0ae6449bf1b2bfb3",
         "x-ms-return-client-request-id": "true"
@@ -284,7 +284,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -296,8 +296,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e4f424ffcf5b91932fef7a2db3936728",
         "x-ms-return-client-request-id": "true"
@@ -306,7 +306,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_LifecycleAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8d9acb85630bfd04a1c4f625dbc6325f",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7a6c662133112af6044d2ad8393dc8e3",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f62fa93e17a62e6b96ae44975353a10f",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -93,8 +93,8 @@
         "Content-Length": "1139",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b37a84017330a498620716da2568872e",
         "x-ms-return-client-request-id": "true"
@@ -102,12 +102,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:wifiroom;12093\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022RoomWithWifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Component\u0022,            \u0022name\u0022: \u0022wifiAccessPoint\u0022,            \u0022schema\u0022: \u0022dtmi:example:wifi;196111479\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:wifi;196111479\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Wifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022RouterName\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Network\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ]}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "317",
+        "Content-Length": "316",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;12093\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.9460153\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;196111479\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.9462247\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;12093\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0724631\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;196111479\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.072647\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin929862073?api-version=2020-10-31",
@@ -119,8 +119,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "88872242ad2f4f7a004b7a85b193b1fa",
         "x-ms-return-client-request-id": "true"
@@ -145,13 +145,13 @@
       "ResponseHeaders": {
         "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002267bad551-706f-48b3-b419-76a8dbcd72dc\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002265243c01-ec62-4ea2-96dd-7d35af8507cd\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin929862073",
-        "$etag": "W/\u002267bad551-706f-48b3-b419-76a8dbcd72dc\u0022",
+        "$etag": "W/\u002265243c01-ec62-4ea2-96dd-7d35af8507cd\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -161,26 +161,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;12093",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
           }
         }
       }
@@ -192,8 +192,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b837c8892f4ecb88118b939f0191092e",
         "x-ms-return-client-request-id": "true"
@@ -203,8 +203,8 @@
       "ResponseHeaders": {
         "Content-Length": "178",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u002267bad551-706f-48b3-b419-76a8dbcd72dc\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002265243c01-ec62-4ea2-96dd-7d35af8507cd\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -212,10 +212,10 @@
         "Network": "Room1",
         "$metadata": {
           "RouterName": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
           },
           "Network": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0898112Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
           }
         }
       }
@@ -229,8 +229,8 @@
         "Content-Length": "58",
         "Content-Type": "application/json-patch\u002Bjson",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "3155162618cb54df0a2ab2e4f912f3cf",
         "x-ms-return-client-request-id": "true"
@@ -239,8 +239,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022f5d7492c-3895-4146-a12e-c14f8f52ab09\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002283d54d68-1472-44d7-8397-da6df59afb00\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -252,8 +252,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5c511b56cf3012e099bc77a419db4e6f",
         "x-ms-return-client-request-id": "true"
@@ -262,7 +262,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -274,8 +274,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9b5e4c427f3d712fe9e3ae237da3d1fe",
         "x-ms-return-client-request-id": "true"
@@ -284,7 +284,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -296,8 +296,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e549c497ac3f57fd3543970ea03a3a2e",
         "x-ms-return-client-request-id": "true"
@@ -306,7 +306,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ComponentTests/Component_LifecycleAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -102,12 +102,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:wifiroom;12093\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022RoomWithWifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Component\u0022,            \u0022name\u0022: \u0022wifiAccessPoint\u0022,            \u0022schema\u0022: \u0022dtmi:example:wifi;196111479\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:wifi;196111479\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Wifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022RouterName\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Network\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ]}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "316",
+        "Content-Length": "317",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;12093\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0724631\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;196111479\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.072647\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;12093\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.5213982\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;196111479\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.5215318\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin929862073?api-version=2020-10-31",
@@ -117,7 +117,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "229",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -145,13 +144,13 @@
       "ResponseHeaders": {
         "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002265243c01-ec62-4ea2-96dd-7d35af8507cd\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
+        "ETag": "W/\u00227f2075f4-4f72-485c-af65-e97723f22249\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin929862073",
-        "$etag": "W/\u002265243c01-ec62-4ea2-96dd-7d35af8507cd\u0022",
+        "$etag": "W/\u00227f2075f4-4f72-485c-af65-e97723f22249\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -161,26 +160,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+              "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+              "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;12093",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
           }
         }
       }
@@ -203,8 +202,8 @@
       "ResponseHeaders": {
         "Content-Length": "178",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002265243c01-ec62-4ea2-96dd-7d35af8507cd\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
+        "ETag": "W/\u00227f2075f4-4f72-485c-af65-e97723f22249\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -212,10 +211,10 @@
         "Network": "Room1",
         "$metadata": {
           "RouterName": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
           },
           "Network": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1181164Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5943071Z"
           }
         }
       }
@@ -239,8 +238,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002283d54d68-1472-44d7-8397-da6df59afb00\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
+        "ETag": "W/\u0022a403f1ba-65dc-4097-b4f2-1418b44881d3\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -262,7 +261,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -284,7 +283,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -306,7 +305,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_Lifecycle.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6419e62d960b95e549641649ee09c075",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b71bc91730aff0007fa6612cb25b930a",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c9f904ea88a8c46c6896ab430541cdc0",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -91,8 +91,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2b11f79cb57e74188cf083689708833e",
         "x-ms-return-client-request-id": "true"
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "272",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -119,8 +119,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "287bbb1e406ff3af479a55ad7964936b",
         "x-ms-return-client-request-id": "true"
@@ -130,7 +130,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -147,8 +147,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "21f89bbf4e6c55e11c98e85bd18e2804",
         "x-ms-return-client-request-id": "true"
@@ -158,7 +158,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -177,8 +177,8 @@
         "Content-Length": "2310",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "451222642c7c62b638371bc2c6128bef",
         "x-ms-return-client-request-id": "true"
@@ -186,12 +186,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:floor;12904852\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Floor\u0022,    \u0022description\u0022: \u0022A building story.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022contains\u0022,            \u0022target\u0022: \u0022dtmi:example:room;114513986\u0022,            \u0022properties\u0022: [                {                    \u0022@type\u0022: \u0022Property\u0022,                    \u0022name\u0022: \u0022isAccessRestricted\u0022,                    \u0022schema\u0022: \u0022boolean\u0022                }            ]        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022cooledBy\u0022,            \u0022target\u0022: \u0022dtmi:example:hvac;113394842\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022AverageTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        }    ]},{    \u0022@id\u0022: \u0022dtmi:example:room;114513986\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;12904852\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:hvac;113394842\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022HVAC\u0022,    \u0022description\u0022: \u0022A heating, ventilation, and air conditioning unit.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Efficiency\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetHumidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022cools\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;12904852\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "582",
+        "Content-Length": "583",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;12904852\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.0892434\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;114513986\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.0894116\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;113394842\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.089552\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;12904852\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0716608\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;114513986\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0718279\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;113394842\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0720338\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/floorTwin1355639973?api-version=2020-10-31",
@@ -203,8 +203,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e7488afd7e466db29ad253a8c797750c",
         "x-ms-return-client-request-id": "true"
@@ -221,18 +221,18 @@
       "ResponseHeaders": {
         "Content-Length": "232",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002253737dee-39a6-4a85-b388-9a023d64fc1d\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00223d0c9598-8ddc-47fb-83c3-e4c184d93fcb\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "floorTwin1355639973",
-        "$etag": "W/\u002253737dee-39a6-4a85-b388-9a023d64fc1d\u0022",
+        "$etag": "W/\u00223d0c9598-8ddc-47fb-83c3-e4c184d93fcb\u0022",
         "AverageTemperature": 75,
         "$metadata": {
           "$model": "dtmi:example:floor;12904852",
           "AverageTemperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1595078Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1259420Z"
           }
         }
       }
@@ -247,8 +247,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4114a82d2681928fe596e935331e8f09",
         "x-ms-return-client-request-id": "true"
@@ -268,13 +268,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022b2daf7f7-9a4c-4d97-9ee6-2f32239fc8ab\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022a5055edf-fea6-4cc9-9d91-ca80c321f0c3\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin2002815648",
-        "$etag": "W/\u0022b2daf7f7-9a4c-4d97-9ee6-2f32239fc8ab\u0022",
+        "$etag": "W/\u0022a5055edf-fea6-4cc9-9d91-ca80c321f0c3\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -282,16 +282,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;114513986",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.3890155Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.3890155Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.3890155Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.3890155Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
           }
         }
       }
@@ -306,8 +306,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "465ef80c4045e5bd70a5aaaad90d9aa0",
         "x-ms-return-client-request-id": "true"
@@ -325,22 +325,22 @@
       "ResponseHeaders": {
         "Content-Length": "316",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00222fafc2fe-638c-4049-9b36-bf80b202d3c5\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00227a54d664-bba1-458b-9572-bd5ca1f00905\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "hvacTwin1811962380",
-        "$etag": "W/\u00222fafc2fe-638c-4049-9b36-bf80b202d3c5\u0022",
+        "$etag": "W/\u00227a54d664-bba1-458b-9572-bd5ca1f00905\u0022",
         "TargetTemperature": 80,
         "TargetHumidity": 25,
         "$metadata": {
           "$model": "dtmi:example:hvac;113394842",
           "TargetTemperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4601487Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2117102Z"
           },
           "TargetHumidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4601487Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2117102Z"
           }
         }
       }
@@ -355,8 +355,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1d950ec149fed66efab601b0957c397c",
         "x-ms-return-client-request-id": "true"
@@ -372,13 +372,13 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002201533d3e-01dc-497d-9f58-98fafb010749\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002277b9ef57-1ef7-4668-aa4f-f3c79ab93235\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u002201533d3e-01dc-497d-9f58-98fafb010749\u0022",
+        "$etag": "W/\u002277b9ef57-1ef7-4668-aa4f-f3c79ab93235\u0022",
         "$sourceId": "floorTwin1355639973",
         "$relationshipName": "contains",
         "$targetId": "roomTwin2002815648",
@@ -395,8 +395,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "cf9c4a432e39ecc7eb2ed1dc7be5b9d7",
         "x-ms-return-client-request-id": "true"
@@ -411,13 +411,13 @@
       "ResponseHeaders": {
         "Content-Length": "196",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002292b40bd5-9dce-4117-8854-32c5bb78b7d9\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c2f09e4b-cf67-4cd5-a06b-cbb94070b3a7\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToHvacRelationship",
-        "$etag": "W/\u002292b40bd5-9dce-4117-8854-32c5bb78b7d9\u0022",
+        "$etag": "W/\u0022c2f09e4b-cf67-4cd5-a06b-cbb94070b3a7\u0022",
         "$sourceId": "floorTwin1355639973",
         "$relationshipName": "cooledBy",
         "$targetId": "hvacTwin1811962380"
@@ -433,8 +433,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "247448fb7189c30b8a874c8e3f0d50f4",
         "x-ms-return-client-request-id": "true"
@@ -449,13 +449,13 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022a2b67805-d0d4-4118-bcd3-025f8809434d\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002244db6c0e-73e6-44ef-ac28-343c1dfa626e\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "HvacToFloorRelationship",
-        "$etag": "W/\u0022a2b67805-d0d4-4118-bcd3-025f8809434d\u0022",
+        "$etag": "W/\u002244db6c0e-73e6-44ef-ac28-343c1dfa626e\u0022",
         "$sourceId": "hvacTwin1811962380",
         "$relationshipName": "cools",
         "$targetId": "floorTwin1355639973"
@@ -471,8 +471,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8f662e6bcb71926747a832cf78915a14",
         "x-ms-return-client-request-id": "true"
@@ -487,13 +487,13 @@
       "ResponseHeaders": {
         "Content-Length": "199",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00221d3d1568-23bb-43db-8157-63723d2bc86b\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c21c9194-e8c3-4cb7-bd0e-25ccf1bab63f\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "RoomToFloorRelationship",
-        "$etag": "W/\u00221d3d1568-23bb-43db-8157-63723d2bc86b\u0022",
+        "$etag": "W/\u0022c21c9194-e8c3-4cb7-bd0e-25ccf1bab63f\u0022",
         "$sourceId": "roomTwin2002815648",
         "$relationshipName": "containedIn",
         "$targetId": "floorTwin1355639973"
@@ -508,8 +508,8 @@
         "Content-Length": "61",
         "Content-Type": "application/json-patch\u002Bjson",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4cb529fd1408d2f33ed845b1e238addd",
         "x-ms-return-client-request-id": "true"
@@ -518,8 +518,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00222bba24f4-a29b-437b-ba3d-4c0a925b00c4\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -531,8 +531,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4d70dcde297f2f66e0e1dde03e3b4af8",
         "x-ms-return-client-request-id": "true"
@@ -542,13 +542,13 @@
       "ResponseHeaders": {
         "Content-Length": "223",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00222bba24f4-a29b-437b-ba3d-4c0a925b00c4\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u00222bba24f4-a29b-437b-ba3d-4c0a925b00c4\u0022",
+        "$etag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
         "$sourceId": "floorTwin1355639973",
         "$relationshipName": "contains",
         "$targetId": "roomTwin2002815648",
@@ -562,8 +562,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1591372d035857ec3b93509886b6b00e",
         "x-ms-return-client-request-id": "true"
@@ -571,9 +571,9 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "605",
+        "Content-Length": "583",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -583,13 +583,13 @@
             "$relationshipId": "HvacToFloorRelationship",
             "$sourceId": "hvacTwin1811962380",
             "$relationshipName": "cools",
-            "$relationshipLink": "https://barustum-adt-10212020-2.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin1811962380/relationships/HvacToFloorRelationship?api-version=2020-10-31"
+            "$relationshipLink": "https://aziadtwhatup.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin1811962380/relationships/HvacToFloorRelationship?api-version=2020-10-31"
           },
           {
             "$relationshipId": "RoomToFloorRelationship",
             "$sourceId": "roomTwin2002815648",
             "$relationshipName": "containedIn",
-            "$relationshipLink": "https://barustum-adt-10212020-2.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2002815648/relationships/RoomToFloorRelationship?api-version=2020-10-31"
+            "$relationshipLink": "https://aziadtwhatup.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2002815648/relationships/RoomToFloorRelationship?api-version=2020-10-31"
           }
         ]
       }
@@ -601,8 +601,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9bf155fb0d20d394c3856b2636129403",
         "x-ms-return-client-request-id": "true"
@@ -612,7 +612,7 @@
       "ResponseHeaders": {
         "Content-Length": "448",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -620,14 +620,14 @@
         "value": [
           {
             "$relationshipId": "FloorToHvacRelationship",
-            "$etag": "W/\u002292b40bd5-9dce-4117-8854-32c5bb78b7d9\u0022",
+            "$etag": "W/\u0022c2f09e4b-cf67-4cd5-a06b-cbb94070b3a7\u0022",
             "$sourceId": "floorTwin1355639973",
             "$relationshipName": "cooledBy",
             "$targetId": "hvacTwin1811962380"
           },
           {
             "$relationshipId": "FloorToRoomRelationship",
-            "$etag": "W/\u00222bba24f4-a29b-437b-ba3d-4c0a925b00c4\u0022",
+            "$etag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
             "$sourceId": "floorTwin1355639973",
             "$relationshipName": "contains",
             "$targetId": "roomTwin2002815648",
@@ -643,8 +643,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "aa834c8e97a7da85f01912ecd9cda82a",
         "x-ms-return-client-request-id": "true"
@@ -654,7 +654,7 @@
       "ResponseHeaders": {
         "Content-Length": "227",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -662,7 +662,7 @@
         "value": [
           {
             "$relationshipId": "RoomToFloorRelationship",
-            "$etag": "W/\u00221d3d1568-23bb-43db-8157-63723d2bc86b\u0022",
+            "$etag": "W/\u0022c21c9194-e8c3-4cb7-bd0e-25ccf1bab63f\u0022",
             "$sourceId": "roomTwin2002815648",
             "$relationshipName": "containedIn",
             "$targetId": "floorTwin1355639973"
@@ -677,8 +677,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e8e5ce31af4a20d7a3bd52d297c52028",
         "x-ms-return-client-request-id": "true"
@@ -687,7 +687,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -699,8 +699,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "390a4dfe05326467cf16ab07faa8faf5",
         "x-ms-return-client-request-id": "true"
@@ -709,7 +709,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -721,8 +721,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "68f441dcab2ddeb8756307ea44b2422a",
         "x-ms-return-client-request-id": "true"
@@ -731,7 +731,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -743,8 +743,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8bede9f86fc22cf76781193304cf25fa",
         "x-ms-return-client-request-id": "true"
@@ -753,7 +753,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -765,8 +765,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "56f65dc2b8d153fb942bc4cefe7d1f1d",
         "x-ms-return-client-request-id": "true"
@@ -776,7 +776,7 @@
       "ResponseHeaders": {
         "Content-Length": "310",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -793,8 +793,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "110e80d46eba6d3249c800ac9285daa5",
         "x-ms-return-client-request-id": "true"
@@ -804,7 +804,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -821,8 +821,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e7270c3eecbc4059ee9af797aa292dea",
         "x-ms-return-client-request-id": "true"
@@ -832,7 +832,7 @@
       "ResponseHeaders": {
         "Content-Length": "310",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -849,8 +849,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "835ffc6114c0543f2a880c09b74fc00f",
         "x-ms-return-client-request-id": "true"
@@ -860,7 +860,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -877,8 +877,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f2901e513855e76027ce2320779bc320",
         "x-ms-return-client-request-id": "true"
@@ -887,7 +887,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -899,8 +899,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "964b159a57252ae4ccd3bc33df4f889e",
         "x-ms-return-client-request-id": "true"
@@ -909,7 +909,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -921,8 +921,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8b46e7d93b9828949b775cf2f11fdc8f",
         "x-ms-return-client-request-id": "true"
@@ -931,7 +931,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -943,8 +943,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a16eecc52a04f9e93a6625827c2d08d7",
         "x-ms-return-client-request-id": "true"
@@ -953,7 +953,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -965,8 +965,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8f46844637555e878122fbaefaf239ac",
         "x-ms-return-client-request-id": "true"
@@ -975,7 +975,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -987,8 +987,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f26d2cf6e6e1af9afe4c51321512ab6e",
         "x-ms-return-client-request-id": "true"
@@ -997,7 +997,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_Lifecycle.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "272",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -130,7 +130,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -158,7 +158,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -188,10 +188,10 @@
       "ResponseHeaders": {
         "Content-Length": "583",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;12904852\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0716608\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;114513986\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0718279\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;113394842\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0720338\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;12904852\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6708214\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;114513986\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6709975\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;113394842\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6711672\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/floorTwin1355639973?api-version=2020-10-31",
@@ -201,7 +201,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "104",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -221,18 +220,18 @@
       "ResponseHeaders": {
         "Content-Length": "232",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00223d0c9598-8ddc-47fb-83c3-e4c184d93fcb\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022157f0410-5555-4d56-ae70-d6585531ac90\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "floorTwin1355639973",
-        "$etag": "W/\u00223d0c9598-8ddc-47fb-83c3-e4c184d93fcb\u0022",
+        "$etag": "W/\u0022157f0410-5555-4d56-ae70-d6585531ac90\u0022",
         "AverageTemperature": 75,
         "$metadata": {
           "$model": "dtmi:example:floor;12904852",
           "AverageTemperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1259420Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7160421Z"
           }
         }
       }
@@ -245,7 +244,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -268,13 +266,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022a5055edf-fea6-4cc9-9d91-ca80c321f0c3\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00223951a440-d2e5-4e9e-ab2f-3b5b20972a9c\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin2002815648",
-        "$etag": "W/\u0022a5055edf-fea6-4cc9-9d91-ca80c321f0c3\u0022",
+        "$etag": "W/\u00223951a440-d2e5-4e9e-ab2f-3b5b20972a9c\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -282,16 +280,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;114513986",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7677981Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7677981Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7677981Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1730290Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7677981Z"
           }
         }
       }
@@ -304,7 +302,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "123",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -325,22 +322,22 @@
       "ResponseHeaders": {
         "Content-Length": "316",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00227a54d664-bba1-458b-9572-bd5ca1f00905\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00229a01c56e-7c16-4a62-ba3d-a5c8e3edc773\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "hvacTwin1811962380",
-        "$etag": "W/\u00227a54d664-bba1-458b-9572-bd5ca1f00905\u0022",
+        "$etag": "W/\u00229a01c56e-7c16-4a62-ba3d-a5c8e3edc773\u0022",
         "TargetTemperature": 80,
         "TargetHumidity": 25,
         "$metadata": {
           "$model": "dtmi:example:hvac;113394842",
           "TargetTemperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.2117102Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.8224309Z"
           },
           "TargetHumidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.2117102Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.8224309Z"
           }
         }
       }
@@ -353,7 +350,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "131",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -372,13 +368,13 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002277b9ef57-1ef7-4668-aa4f-f3c79ab93235\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00220e0c1f86-7d2e-47e0-93fc-75fe4cdbefeb\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u002277b9ef57-1ef7-4668-aa4f-f3c79ab93235\u0022",
+        "$etag": "W/\u00220e0c1f86-7d2e-47e0-93fc-75fe4cdbefeb\u0022",
         "$sourceId": "floorTwin1355639973",
         "$relationshipName": "contains",
         "$targetId": "roomTwin2002815648",
@@ -393,7 +389,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "105",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -411,13 +406,13 @@
       "ResponseHeaders": {
         "Content-Length": "196",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022c2f09e4b-cf67-4cd5-a06b-cbb94070b3a7\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022309b68dc-bfcb-46b9-84c1-1c4108cd3d33\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToHvacRelationship",
-        "$etag": "W/\u0022c2f09e4b-cf67-4cd5-a06b-cbb94070b3a7\u0022",
+        "$etag": "W/\u0022309b68dc-bfcb-46b9-84c1-1c4108cd3d33\u0022",
         "$sourceId": "floorTwin1355639973",
         "$relationshipName": "cooledBy",
         "$targetId": "hvacTwin1811962380"
@@ -431,7 +426,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "103",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -449,13 +443,13 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002244db6c0e-73e6-44ef-ac28-343c1dfa626e\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022c61504fd-3048-4c30-a178-987efd49ecdf\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "HvacToFloorRelationship",
-        "$etag": "W/\u002244db6c0e-73e6-44ef-ac28-343c1dfa626e\u0022",
+        "$etag": "W/\u0022c61504fd-3048-4c30-a178-987efd49ecdf\u0022",
         "$sourceId": "hvacTwin1811962380",
         "$relationshipName": "cools",
         "$targetId": "floorTwin1355639973"
@@ -469,7 +463,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "109",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -487,13 +480,13 @@
       "ResponseHeaders": {
         "Content-Length": "199",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022c21c9194-e8c3-4cb7-bd0e-25ccf1bab63f\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00228a079a3c-f49a-4b10-b42d-f790c60efca7\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "RoomToFloorRelationship",
-        "$etag": "W/\u0022c21c9194-e8c3-4cb7-bd0e-25ccf1bab63f\u0022",
+        "$etag": "W/\u00228a079a3c-f49a-4b10-b42d-f790c60efca7\u0022",
         "$sourceId": "roomTwin2002815648",
         "$relationshipName": "containedIn",
         "$targetId": "floorTwin1355639973"
@@ -518,8 +511,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022e2098774-b547-44cc-98a0-7b80ed14c636\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -542,13 +535,13 @@
       "ResponseHeaders": {
         "Content-Length": "223",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022e2098774-b547-44cc-98a0-7b80ed14c636\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
+        "$etag": "W/\u0022e2098774-b547-44cc-98a0-7b80ed14c636\u0022",
         "$sourceId": "floorTwin1355639973",
         "$relationshipName": "contains",
         "$targetId": "roomTwin2002815648",
@@ -573,7 +566,7 @@
       "ResponseHeaders": {
         "Content-Length": "583",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -612,7 +605,7 @@
       "ResponseHeaders": {
         "Content-Length": "448",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -620,14 +613,14 @@
         "value": [
           {
             "$relationshipId": "FloorToHvacRelationship",
-            "$etag": "W/\u0022c2f09e4b-cf67-4cd5-a06b-cbb94070b3a7\u0022",
+            "$etag": "W/\u0022309b68dc-bfcb-46b9-84c1-1c4108cd3d33\u0022",
             "$sourceId": "floorTwin1355639973",
             "$relationshipName": "cooledBy",
             "$targetId": "hvacTwin1811962380"
           },
           {
             "$relationshipId": "FloorToRoomRelationship",
-            "$etag": "W/\u00227ced189d-b2ab-4fb7-8db6-645cb5b26140\u0022",
+            "$etag": "W/\u0022e2098774-b547-44cc-98a0-7b80ed14c636\u0022",
             "$sourceId": "floorTwin1355639973",
             "$relationshipName": "contains",
             "$targetId": "roomTwin2002815648",
@@ -654,7 +647,7 @@
       "ResponseHeaders": {
         "Content-Length": "227",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -662,7 +655,7 @@
         "value": [
           {
             "$relationshipId": "RoomToFloorRelationship",
-            "$etag": "W/\u0022c21c9194-e8c3-4cb7-bd0e-25ccf1bab63f\u0022",
+            "$etag": "W/\u00228a079a3c-f49a-4b10-b42d-f790c60efca7\u0022",
             "$sourceId": "roomTwin2002815648",
             "$relationshipName": "containedIn",
             "$targetId": "floorTwin1355639973"
@@ -687,7 +680,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -709,7 +702,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -731,7 +724,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -753,7 +746,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -776,7 +769,7 @@
       "ResponseHeaders": {
         "Content-Length": "310",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -804,7 +797,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -832,7 +825,7 @@
       "ResponseHeaders": {
         "Content-Length": "310",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -860,7 +853,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -887,7 +880,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -909,7 +902,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -931,7 +924,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -953,7 +946,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -975,7 +968,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -997,7 +990,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_LifecycleAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "42bc275f08ef9e73a5948af53be38f49",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1fc62c683bcba1b74a4eda08f0fc2ca9",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bb207e50063d0cd181317a64ad7cbcf2",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -91,8 +91,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "17d412ebeb94a104a5b99895b5985e4c",
         "x-ms-return-client-request-id": "true"
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -119,8 +119,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b0291093252a13f4490a3d3d9cd11d16",
         "x-ms-return-client-request-id": "true"
@@ -130,7 +130,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -147,8 +147,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "52d5191193bc1a1b984c3876cc991c17",
         "x-ms-return-client-request-id": "true"
@@ -158,7 +158,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -177,8 +177,8 @@
         "Content-Length": "2310",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c8abe9dbc0b4e0ec044ae1c76408e87b",
         "x-ms-return-client-request-id": "true"
@@ -186,12 +186,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:floor;19932306\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Floor\u0022,    \u0022description\u0022: \u0022A building story.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022contains\u0022,            \u0022target\u0022: \u0022dtmi:example:room;137155543\u0022,            \u0022properties\u0022: [                {                    \u0022@type\u0022: \u0022Property\u0022,                    \u0022name\u0022: \u0022isAccessRestricted\u0022,                    \u0022schema\u0022: \u0022boolean\u0022                }            ]        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022cooledBy\u0022,            \u0022target\u0022: \u0022dtmi:example:hvac;111092475\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022AverageTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        }    ]},{    \u0022@id\u0022: \u0022dtmi:example:room;137155543\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;19932306\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:hvac;111092475\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022HVAC\u0022,    \u0022description\u0022: \u0022A heating, ventilation, and air conditioning unit.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Efficiency\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetHumidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022cools\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;19932306\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "583",
+        "Content-Length": "581",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;19932306\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.9934006\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;137155543\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.9935661\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;111092475\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.9937162\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;19932306\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.8034132\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;137155543\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.803554\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;111092475\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.803719\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/floorTwin292023397?api-version=2020-10-31",
@@ -203,8 +203,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "44872a7f80767dd70d9591d8bb9c7c70",
         "x-ms-return-client-request-id": "true"
@@ -221,18 +221,18 @@
       "ResponseHeaders": {
         "Content-Length": "231",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u0022f1b9b8dd-6444-4254-a5e0-2dff42379dc5\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00225825a683-c7a4-49f7-9d52-a12d02467114\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "floorTwin292023397",
-        "$etag": "W/\u0022f1b9b8dd-6444-4254-a5e0-2dff42379dc5\u0022",
+        "$etag": "W/\u00225825a683-c7a4-49f7-9d52-a12d02467114\u0022",
         "AverageTemperature": 75,
         "$metadata": {
           "$model": "dtmi:example:floor;19932306",
           "AverageTemperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0603765Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.8555447Z"
           }
         }
       }
@@ -247,8 +247,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e8c125214d7250d62cf44d71b254b690",
         "x-ms-return-client-request-id": "true"
@@ -268,13 +268,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022ebde3fb4-a778-455f-8f57-03d03b65a3fd\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c49160fa-5304-4a42-8bdb-3223531fddba\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin501107922",
-        "$etag": "W/\u0022ebde3fb4-a778-455f-8f57-03d03b65a3fd\u0022",
+        "$etag": "W/\u0022c49160fa-5304-4a42-8bdb-3223531fddba\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -282,16 +282,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;137155543",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4042640Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4042640Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4042640Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4042640Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
           }
         }
       }
@@ -306,8 +306,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a2f7bd64d7125ba1122dba1f2e142467",
         "x-ms-return-client-request-id": "true"
@@ -325,22 +325,22 @@
       "ResponseHeaders": {
         "Content-Length": "316",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022d3c46d41-237b-49e1-8bfa-2ac8e4a67aef\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u00220cc6ae92-b6d4-419c-87ea-2224772d19e0\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "hvacTwin2100586634",
-        "$etag": "W/\u0022d3c46d41-237b-49e1-8bfa-2ac8e4a67aef\u0022",
+        "$etag": "W/\u00220cc6ae92-b6d4-419c-87ea-2224772d19e0\u0022",
         "TargetTemperature": 80,
         "TargetHumidity": 25,
         "$metadata": {
           "$model": "dtmi:example:hvac;111092475",
           "TargetTemperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4767088Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9647205Z"
           },
           "TargetHumidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.4767088Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9647205Z"
           }
         }
       }
@@ -355,8 +355,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "3fa670cd00473108543617813265cbb9",
         "x-ms-return-client-request-id": "true"
@@ -372,13 +372,13 @@
       "ResponseHeaders": {
         "Content-Length": "220",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022c50d2d06-18b1-4d69-a82d-08010e766e84\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022267931d4-f6bb-471b-889f-3598fa451d84\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u0022c50d2d06-18b1-4d69-a82d-08010e766e84\u0022",
+        "$etag": "W/\u0022267931d4-f6bb-471b-889f-3598fa451d84\u0022",
         "$sourceId": "floorTwin292023397",
         "$relationshipName": "contains",
         "$targetId": "roomTwin501107922",
@@ -395,8 +395,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fd7401dfdaa5495e8365d54492b62118",
         "x-ms-return-client-request-id": "true"
@@ -411,13 +411,13 @@
       "ResponseHeaders": {
         "Content-Length": "195",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022b5777ba6-34fc-418c-bab0-28eebf2cfd83\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022f1595e15-de8b-43a7-902c-dffd04f93e67\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToHvacRelationship",
-        "$etag": "W/\u0022b5777ba6-34fc-418c-bab0-28eebf2cfd83\u0022",
+        "$etag": "W/\u0022f1595e15-de8b-43a7-902c-dffd04f93e67\u0022",
         "$sourceId": "floorTwin292023397",
         "$relationshipName": "cooledBy",
         "$targetId": "hvacTwin2100586634"
@@ -433,8 +433,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "41a3e5cf76ad6449b5c64edbbf1f29ac",
         "x-ms-return-client-request-id": "true"
@@ -449,13 +449,13 @@
       "ResponseHeaders": {
         "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022a098baac-8c8d-4b8a-8b58-f9401362d1f4\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022edada992-ba26-4daf-be79-fa1d1768d196\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "HvacToFloorRelationship",
-        "$etag": "W/\u0022a098baac-8c8d-4b8a-8b58-f9401362d1f4\u0022",
+        "$etag": "W/\u0022edada992-ba26-4daf-be79-fa1d1768d196\u0022",
         "$sourceId": "hvacTwin2100586634",
         "$relationshipName": "cools",
         "$targetId": "floorTwin292023397"
@@ -471,8 +471,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2d3f016227a0f3c2125cbbe12ac39e9d",
         "x-ms-return-client-request-id": "true"
@@ -487,13 +487,13 @@
       "ResponseHeaders": {
         "Content-Length": "197",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022d3c396ea-4890-455b-ade0-4d23f845b5c3\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u002239cc6389-b2f2-4d4c-b24a-47394e81ac8d\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "RoomToFloorRelationship",
-        "$etag": "W/\u0022d3c396ea-4890-455b-ade0-4d23f845b5c3\u0022",
+        "$etag": "W/\u002239cc6389-b2f2-4d4c-b24a-47394e81ac8d\u0022",
         "$sourceId": "roomTwin501107922",
         "$relationshipName": "containedIn",
         "$targetId": "floorTwin292023397"
@@ -508,8 +508,8 @@
         "Content-Length": "61",
         "Content-Type": "application/json-patch\u002Bjson",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4cb1ff158ac1680cb80f47de8b828964",
         "x-ms-return-client-request-id": "true"
@@ -518,8 +518,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022f75dbc52-f8ca-4592-b0a7-bb721ae7e732\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -531,8 +531,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "91e2293cf377a87723b02e50bb6739f1",
         "x-ms-return-client-request-id": "true"
@@ -542,13 +542,13 @@
       "ResponseHeaders": {
         "Content-Length": "221",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022f75dbc52-f8ca-4592-b0a7-bb721ae7e732\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u0022f75dbc52-f8ca-4592-b0a7-bb721ae7e732\u0022",
+        "$etag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
         "$sourceId": "floorTwin292023397",
         "$relationshipName": "contains",
         "$targetId": "roomTwin501107922",
@@ -562,8 +562,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c0c6b127dc6dd8eaf5d67590dfe36790",
         "x-ms-return-client-request-id": "true"
@@ -571,9 +571,9 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "603",
+        "Content-Length": "581",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -583,13 +583,13 @@
             "$relationshipId": "HvacToFloorRelationship",
             "$sourceId": "hvacTwin2100586634",
             "$relationshipName": "cools",
-            "$relationshipLink": "https://barustum-adt-10212020-2.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin2100586634/relationships/HvacToFloorRelationship?api-version=2020-10-31"
+            "$relationshipLink": "https://aziadtwhatup.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin2100586634/relationships/HvacToFloorRelationship?api-version=2020-10-31"
           },
           {
             "$relationshipId": "RoomToFloorRelationship",
             "$sourceId": "roomTwin501107922",
             "$relationshipName": "containedIn",
-            "$relationshipLink": "https://barustum-adt-10212020-2.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin501107922/relationships/RoomToFloorRelationship?api-version=2020-10-31"
+            "$relationshipLink": "https://aziadtwhatup.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin501107922/relationships/RoomToFloorRelationship?api-version=2020-10-31"
           }
         ]
       }
@@ -601,8 +601,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "01a456d20de12125870929115bbbad50",
         "x-ms-return-client-request-id": "true"
@@ -612,7 +612,7 @@
       "ResponseHeaders": {
         "Content-Length": "445",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -620,14 +620,14 @@
         "value": [
           {
             "$relationshipId": "FloorToHvacRelationship",
-            "$etag": "W/\u0022b5777ba6-34fc-418c-bab0-28eebf2cfd83\u0022",
+            "$etag": "W/\u0022f1595e15-de8b-43a7-902c-dffd04f93e67\u0022",
             "$sourceId": "floorTwin292023397",
             "$relationshipName": "cooledBy",
             "$targetId": "hvacTwin2100586634"
           },
           {
             "$relationshipId": "FloorToRoomRelationship",
-            "$etag": "W/\u0022f75dbc52-f8ca-4592-b0a7-bb721ae7e732\u0022",
+            "$etag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
             "$sourceId": "floorTwin292023397",
             "$relationshipName": "contains",
             "$targetId": "roomTwin501107922",
@@ -643,8 +643,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "dab756d6c9bb5ff73e099ca07ee7c83f",
         "x-ms-return-client-request-id": "true"
@@ -654,7 +654,7 @@
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -662,7 +662,7 @@
         "value": [
           {
             "$relationshipId": "RoomToFloorRelationship",
-            "$etag": "W/\u0022d3c396ea-4890-455b-ade0-4d23f845b5c3\u0022",
+            "$etag": "W/\u002239cc6389-b2f2-4d4c-b24a-47394e81ac8d\u0022",
             "$sourceId": "roomTwin501107922",
             "$relationshipName": "containedIn",
             "$targetId": "floorTwin292023397"
@@ -677,8 +677,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "657e9e4838c319108ba53863b3d87c39",
         "x-ms-return-client-request-id": "true"
@@ -687,7 +687,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -699,8 +699,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "89ba25298c2c09d45e45c2d77085a29f",
         "x-ms-return-client-request-id": "true"
@@ -709,7 +709,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -721,8 +721,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bdc9e940473d9d8d469d4f169093ab65",
         "x-ms-return-client-request-id": "true"
@@ -731,7 +731,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -743,8 +743,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5976628c3f2dbb13ca75067d7638a805",
         "x-ms-return-client-request-id": "true"
@@ -753,7 +753,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -765,8 +765,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c9239802bf0fe2fc981c438e3dbd78cb",
         "x-ms-return-client-request-id": "true"
@@ -776,7 +776,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -793,8 +793,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0e4a5c99490e0072d60df3c7410f270d",
         "x-ms-return-client-request-id": "true"
@@ -804,7 +804,7 @@
       "ResponseHeaders": {
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -821,8 +821,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f81449f4e170cd566594c010fc847e0c",
         "x-ms-return-client-request-id": "true"
@@ -832,7 +832,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -849,8 +849,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1ae43bfd9aedb8f62522f302cc34a088",
         "x-ms-return-client-request-id": "true"
@@ -860,7 +860,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -871,23 +871,23 @@
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B137155543?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/floorTwin292023397?api-version=2020-10-31",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "4d300e2c1bdf59c6da32b2acea16cfd4",
+        "x-ms-client-request-id": "f39935f57fa9b75a067da87a88620451",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -899,8 +899,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "06cae68e0d2b5a20535cd24eee530130",
         "x-ms-return-client-request-id": "true"
@@ -909,7 +909,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -921,8 +921,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e573a11d9a6ae85d143fa04cad0cc9b2",
         "x-ms-return-client-request-id": "true"
@@ -931,51 +931,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin2100586634?api-version=2020-10-31",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "c71a38f38beb7d63e02c136ff27c2fc3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 204,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/floorTwin292023397?api-version=2020-10-31",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f39935f57fa9b75a067da87a88620451",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 204,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -987,8 +943,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5086777c3d470366834d25fff9b068d6",
         "x-ms-return-client-request-id": "true"
@@ -997,7 +953,51 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin2100586634?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c71a38f38beb7d63e02c136ff27c2fc3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B137155543?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "4d300e2c1bdf59c6da32b2acea16cfd4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinRelationshipTests/Relationships_LifecycleAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "280",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -130,7 +130,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -158,7 +158,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -186,12 +186,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:floor;19932306\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Floor\u0022,    \u0022description\u0022: \u0022A building story.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022contains\u0022,            \u0022target\u0022: \u0022dtmi:example:room;137155543\u0022,            \u0022properties\u0022: [                {                    \u0022@type\u0022: \u0022Property\u0022,                    \u0022name\u0022: \u0022isAccessRestricted\u0022,                    \u0022schema\u0022: \u0022boolean\u0022                }            ]        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022cooledBy\u0022,            \u0022target\u0022: \u0022dtmi:example:hvac;111092475\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022AverageTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        }    ]},{    \u0022@id\u0022: \u0022dtmi:example:room;137155543\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;19932306\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:hvac;111092475\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022HVAC\u0022,    \u0022description\u0022: \u0022A heating, ventilation, and air conditioning unit.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Efficiency\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetHumidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022cools\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;19932306\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "581",
+        "Content-Length": "583",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;19932306\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.8034132\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;137155543\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.803554\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;111092475\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.803719\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:floor;19932306\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A building story.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Floor\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6764853\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:room;137155543\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6766414\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:hvac;111092475\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6768058\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/floorTwin292023397?api-version=2020-10-31",
@@ -201,7 +201,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "104",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -221,18 +220,18 @@
       "ResponseHeaders": {
         "Content-Length": "231",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00225825a683-c7a4-49f7-9d52-a12d02467114\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022c48ddf23-bbc3-4c60-9408-33db3e77f649\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "floorTwin292023397",
-        "$etag": "W/\u00225825a683-c7a4-49f7-9d52-a12d02467114\u0022",
+        "$etag": "W/\u0022c48ddf23-bbc3-4c60-9408-33db3e77f649\u0022",
         "AverageTemperature": 75,
         "$metadata": {
           "$model": "dtmi:example:floor;19932306",
           "AverageTemperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8555447Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7240212Z"
           }
         }
       }
@@ -245,7 +244,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -268,13 +266,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022c49160fa-5304-4a42-8bdb-3223531fddba\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u002216d0cf55-f522-4809-95b2-70821b576c64\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin501107922",
-        "$etag": "W/\u0022c49160fa-5304-4a42-8bdb-3223531fddba\u0022",
+        "$etag": "W/\u002216d0cf55-f522-4809-95b2-70821b576c64\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -282,16 +280,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;137155543",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7733600Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7733600Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7733600Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9130363Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7733600Z"
           }
         }
       }
@@ -304,7 +302,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "123",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -325,22 +322,22 @@
       "ResponseHeaders": {
         "Content-Length": "316",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u00220cc6ae92-b6d4-419c-87ea-2224772d19e0\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u002280036407-54e0-4afc-892e-a40ccca08cbc\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "hvacTwin2100586634",
-        "$etag": "W/\u00220cc6ae92-b6d4-419c-87ea-2224772d19e0\u0022",
+        "$etag": "W/\u002280036407-54e0-4afc-892e-a40ccca08cbc\u0022",
         "TargetTemperature": 80,
         "TargetHumidity": 25,
         "$metadata": {
           "$model": "dtmi:example:hvac;111092475",
           "TargetTemperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9647205Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.8312941Z"
           },
           "TargetHumidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9647205Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.8312941Z"
           }
         }
       }
@@ -353,7 +350,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "130",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -372,13 +368,13 @@
       "ResponseHeaders": {
         "Content-Length": "220",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u0022267931d4-f6bb-471b-889f-3598fa451d84\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022ced67294-0091-415e-9301-36e20a7162c1\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u0022267931d4-f6bb-471b-889f-3598fa451d84\u0022",
+        "$etag": "W/\u0022ced67294-0091-415e-9301-36e20a7162c1\u0022",
         "$sourceId": "floorTwin292023397",
         "$relationshipName": "contains",
         "$targetId": "roomTwin501107922",
@@ -393,7 +389,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "105",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -411,13 +406,13 @@
       "ResponseHeaders": {
         "Content-Length": "195",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u0022f1595e15-de8b-43a7-902c-dffd04f93e67\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022033e70f7-feda-4d28-a9c5-86f64721d6e9\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToHvacRelationship",
-        "$etag": "W/\u0022f1595e15-de8b-43a7-902c-dffd04f93e67\u0022",
+        "$etag": "W/\u0022033e70f7-feda-4d28-a9c5-86f64721d6e9\u0022",
         "$sourceId": "floorTwin292023397",
         "$relationshipName": "cooledBy",
         "$targetId": "hvacTwin2100586634"
@@ -431,7 +426,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "102",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -449,13 +443,13 @@
       "ResponseHeaders": {
         "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u0022edada992-ba26-4daf-be79-fa1d1768d196\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00225e5f053f-f3ac-4ba8-9e96-cbd1a993d32e\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "HvacToFloorRelationship",
-        "$etag": "W/\u0022edada992-ba26-4daf-be79-fa1d1768d196\u0022",
+        "$etag": "W/\u00225e5f053f-f3ac-4ba8-9e96-cbd1a993d32e\u0022",
         "$sourceId": "hvacTwin2100586634",
         "$relationshipName": "cools",
         "$targetId": "floorTwin292023397"
@@ -469,7 +463,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "108",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -487,13 +480,13 @@
       "ResponseHeaders": {
         "Content-Length": "197",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u002239cc6389-b2f2-4d4c-b24a-47394e81ac8d\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022cd4a1827-411b-4157-bea5-df275d72d998\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "RoomToFloorRelationship",
-        "$etag": "W/\u002239cc6389-b2f2-4d4c-b24a-47394e81ac8d\u0022",
+        "$etag": "W/\u0022cd4a1827-411b-4157-bea5-df275d72d998\u0022",
         "$sourceId": "roomTwin501107922",
         "$relationshipName": "containedIn",
         "$targetId": "floorTwin292023397"
@@ -518,8 +511,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "ETag": "W/\u0022c0affa53-1e99-4040-9bd3-5cc357eedb66\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -542,13 +535,13 @@
       "ResponseHeaders": {
         "Content-Length": "221",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "ETag": "W/\u0022c0affa53-1e99-4040-9bd3-5cc357eedb66\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$relationshipId": "FloorToRoomRelationship",
-        "$etag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
+        "$etag": "W/\u0022c0affa53-1e99-4040-9bd3-5cc357eedb66\u0022",
         "$sourceId": "floorTwin292023397",
         "$relationshipName": "contains",
         "$targetId": "roomTwin501107922",
@@ -573,7 +566,7 @@
       "ResponseHeaders": {
         "Content-Length": "581",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -612,7 +605,7 @@
       "ResponseHeaders": {
         "Content-Length": "445",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -620,14 +613,14 @@
         "value": [
           {
             "$relationshipId": "FloorToHvacRelationship",
-            "$etag": "W/\u0022f1595e15-de8b-43a7-902c-dffd04f93e67\u0022",
+            "$etag": "W/\u0022033e70f7-feda-4d28-a9c5-86f64721d6e9\u0022",
             "$sourceId": "floorTwin292023397",
             "$relationshipName": "cooledBy",
             "$targetId": "hvacTwin2100586634"
           },
           {
             "$relationshipId": "FloorToRoomRelationship",
-            "$etag": "W/\u0022ac3c823a-e2f2-4a94-b3ca-11611ef25b65\u0022",
+            "$etag": "W/\u0022c0affa53-1e99-4040-9bd3-5cc357eedb66\u0022",
             "$sourceId": "floorTwin292023397",
             "$relationshipName": "contains",
             "$targetId": "roomTwin501107922",
@@ -654,7 +647,7 @@
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -662,7 +655,7 @@
         "value": [
           {
             "$relationshipId": "RoomToFloorRelationship",
-            "$etag": "W/\u002239cc6389-b2f2-4d4c-b24a-47394e81ac8d\u0022",
+            "$etag": "W/\u0022cd4a1827-411b-4157-bea5-df275d72d998\u0022",
             "$sourceId": "roomTwin501107922",
             "$relationshipName": "containedIn",
             "$targetId": "floorTwin292023397"
@@ -687,7 +680,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -709,7 +702,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -731,7 +724,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -753,7 +746,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -776,7 +769,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -804,7 +797,7 @@
       "ResponseHeaders": {
         "Content-Length": "308",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -832,7 +825,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -860,7 +853,7 @@
       "ResponseHeaders": {
         "Content-Length": "309",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -884,13 +877,14 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 204,
+      "StatusCode": 429,
       "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
+        "Content-Length": "167",
+        "Content-Type": "application/json",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Retry-After": "5"
       },
-      "ResponseBody": []
+      "ResponseBody": "{ \u0022error\u0022: { \u0022statusCode\u0022: 429, \u0022message\u0022: \u0022Maximum request rate limit reached. For Azure Digital Twins rate limiting details please see http://aka.ms/dtv2limits.\u0022 } }"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin501107922?api-version=2020-10-31",
@@ -906,13 +900,14 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 204,
+      "StatusCode": 429,
       "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
+        "Content-Length": "167",
+        "Content-Type": "application/json",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Retry-After": "5"
       },
-      "ResponseBody": []
+      "ResponseBody": "{ \u0022error\u0022: { \u0022statusCode\u0022: 429, \u0022message\u0022: \u0022Maximum request rate limit reached. For Azure Digital Twins rate limiting details please see http://aka.ms/dtv2limits.\u0022 } }"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Ahvac%3B111092475?api-version=2020-10-31",
@@ -931,51 +926,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Afloor%3B19932306?api-version=2020-10-31",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "5086777c3d470366834d25fff9b068d6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 204,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": []
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin2100586634?api-version=2020-10-31",
-      "RequestMethod": "DELETE",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "c71a38f38beb7d63e02c136ff27c2fc3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 204,
-      "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -997,7 +948,95 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Afloor%3B19932306?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5086777c3d470366834d25fff9b068d6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/hvacTwin2100586634?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c71a38f38beb7d63e02c136ff27c2fc3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/floorTwin292023397?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f39935f57fa9b75a067da87a88620451",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 26 Oct 2020 17:04:56 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin501107922?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "06cae68e0d2b5a20535cd24eee530130",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Mon, 26 Oct 2020 17:04:56 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_Lifecycle.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f89a1358885c5a4d7e27bd45b3ae8b8a",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7091dd268409dfe995f799a112d9b79d",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4d548383587aa8ee0c7129c7e9837488",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -93,8 +93,8 @@
         "Content-Length": "804",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "65dcb4b44ff6b08f19c690b4b96b4e05",
         "x-ms-return-client-request-id": "true"
@@ -104,10 +104,10 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;135050739\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.9717745\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;135050739\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0775338\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin980686438?api-version=2020-10-31",
@@ -119,8 +119,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "082b2ea7f63584aba3c8fc13bf17ab74",
         "x-ms-return-client-request-id": "true"
@@ -140,13 +140,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00227ea4b339-f75f-4149-8ebe-658f37e564f4\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin980686438",
-        "$etag": "W/\u00227ea4b339-f75f-4149-8ebe-658f37e564f4\u0022",
+        "$etag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,16 +154,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;135050739",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           }
         }
       }
@@ -175,8 +175,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "255e192538db348ff4a433b3c83aefa1",
         "x-ms-return-client-request-id": "true"
@@ -186,13 +186,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00227ea4b339-f75f-4149-8ebe-658f37e564f4\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin980686438",
-        "$etag": "W/\u00227ea4b339-f75f-4149-8ebe-658f37e564f4\u0022",
+        "$etag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -200,16 +200,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;135050739",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0354929Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
           }
         }
       }
@@ -224,8 +224,8 @@
         "Content-Type": "application/json-patch\u002Bjson",
         "If-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "bb2024226b57be520857c22e527bf101",
         "x-ms-return-client-request-id": "true"
@@ -234,8 +234,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u0022f2f1573a-09ae-4b03-9284-08ffc358fc90\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022229cb6d3-0802-4743-a7e1-ac0f78ba7454\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -247,8 +247,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9f8e1c1b290d6e2a9ff71491c2f7bc68",
         "x-ms-return-client-request-id": "true"
@@ -257,7 +257,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -269,8 +269,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9af05bd8f0f7ba1cc6a01c837560e178",
         "x-ms-return-client-request-id": "true"
@@ -280,7 +280,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -297,8 +297,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ab9832b24facf993f9b11c6056c1fc10",
         "x-ms-return-client-request-id": "true"
@@ -307,7 +307,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_Lifecycle.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -102,12 +102,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;135050739\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;19848223\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;135050739\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.0775338\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;135050739\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.488859\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin980686438?api-version=2020-10-31",
@@ -117,7 +117,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -140,13 +139,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00223e2d22ec-6b58-4f95-9ed6-10b7fe868a42\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin980686438",
-        "$etag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
+        "$etag": "W/\u00223e2d22ec-6b58-4f95-9ed6-10b7fe868a42\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,16 +153,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;135050739",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           }
         }
       }
@@ -186,13 +185,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00223e2d22ec-6b58-4f95-9ed6-10b7fe868a42\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin980686438",
-        "$etag": "W/\u0022c8f7e0eb-1e02-407a-8dce-0d85030d9baf\u0022",
+        "$etag": "W/\u00223e2d22ec-6b58-4f95-9ed6-10b7fe868a42\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -200,16 +199,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;135050739",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1197778Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.5899479Z"
           }
         }
       }
@@ -234,8 +233,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022229cb6d3-0802-4743-a7e1-ac0f78ba7454\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022e6fc7c8d-47cf-416e-be09-0f68cb207cbd\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -257,7 +256,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -280,7 +279,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -307,7 +306,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_LifecycleAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -102,12 +102,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;124539051\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;14206246\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "192",
+        "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;124539051\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.999569\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;124539051\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.7113467\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1765057771?api-version=2020-10-31",
@@ -117,7 +117,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -140,13 +139,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022031caf4c-d6d5-4871-8a63-045e74f81685\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1765057771",
-        "$etag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
+        "$etag": "W/\u0022031caf4c-d6d5-4871-8a63-045e74f81685\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,16 +153,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;124539051",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           }
         }
       }
@@ -186,13 +185,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022031caf4c-d6d5-4871-8a63-045e74f81685\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1765057771",
-        "$etag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
+        "$etag": "W/\u0022031caf4c-d6d5-4871-8a63-045e74f81685\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -200,16 +199,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;124539051",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7596801Z"
           }
         }
       }
@@ -234,8 +233,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002237036326-d3bb-4c35-9cba-19a92debb560\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u002216352149-8204-4f1c-a409-69dd53286dbc\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -257,7 +256,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -280,7 +279,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -307,7 +306,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_LifecycleAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "aa56202560de16f9e34b92d3bca4d016",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "34f951b847bb5b40494fb417c22f2fa7",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "87d26a9f8786f17dcebf040ba36e7307",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -93,8 +93,8 @@
         "Content-Length": "804",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d1b900236ab715d84f941045fe201b62",
         "x-ms-return-client-request-id": "true"
@@ -102,12 +102,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;124539051\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;14206246\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;124539051\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.0325721\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;124539051\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.999569\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1765057771?api-version=2020-10-31",
@@ -119,8 +119,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6605112bf944ca317b42ec873c50a5e1",
         "x-ms-return-client-request-id": "true"
@@ -140,13 +140,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u0022a5c884a6-886e-4576-b485-b30493cbe99a\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1765057771",
-        "$etag": "W/\u0022a5c884a6-886e-4576-b485-b30493cbe99a\u0022",
+        "$etag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,16 +154,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;124539051",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           }
         }
       }
@@ -175,8 +175,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2f9e0f40d57634f391bc38f17738f2ad",
         "x-ms-return-client-request-id": "true"
@@ -186,13 +186,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u0022a5c884a6-886e-4576-b485-b30493cbe99a\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1765057771",
-        "$etag": "W/\u0022a5c884a6-886e-4576-b485-b30493cbe99a\u0022",
+        "$etag": "W/\u0022c6612f82-b8da-4578-b92c-39d2a2fe2852\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -200,16 +200,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;124539051",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.0964602Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.0874094Z"
           }
         }
       }
@@ -224,8 +224,8 @@
         "Content-Type": "application/json-patch\u002Bjson",
         "If-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "91dfa1a40d692ac3ceef55747d51d9ff",
         "x-ms-return-client-request-id": "true"
@@ -234,8 +234,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u0022af55c6ea-86fa-40bd-9f3a-c149808ec0b6\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002237036326-d3bb-4c35-9cba-19a92debb560\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -247,8 +247,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ee042fefec8255ec1ed0d487c13f5243",
         "x-ms-return-client-request-id": "true"
@@ -257,7 +257,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -269,8 +269,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9ae33e50137033774c7460877f7eb740",
         "x-ms-return-client-request-id": "true"
@@ -280,7 +280,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -297,8 +297,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "470238e30334b72bb58a7398383c688e",
         "x-ms-return-client-request-id": "true"
@@ -307,7 +307,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_Lifecycle.json
@@ -22,7 +22,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -45,7 +45,7 @@
       "ResponseHeaders": {
         "Content-Length": "179",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -70,18 +70,13 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "537",
+        "Content-Length": "372",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
-          {
-            "id": "someEventRouteId-962622312",
-            "endpointName": "someEventHubEndpoint",
-            "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
-          },
           {
             "id": "someEventRouteId-567112595",
             "endpointName": "someEventHubEndpoint",
@@ -113,7 +108,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -136,7 +131,7 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_Lifecycle.json
@@ -9,8 +9,8 @@
         "Content-Length": "165",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "a0db731f3e2efef81a26f02f26c2a1cd",
         "x-ms-return-client-request-id": "true"
@@ -22,7 +22,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -34,8 +34,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "83fefb58d596ab9d0c0ecaf831417947",
         "x-ms-return-client-request-id": "true"
@@ -45,7 +45,7 @@
       "ResponseHeaders": {
         "Content-Length": "179",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -61,8 +61,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "de354ff4334e73fc4311d77c9ab5d19e",
         "x-ms-return-client-request-id": "true"
@@ -70,25 +70,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "702",
+        "Content-Length": "537",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "someEventRouteId-702909932",
+            "id": "someEventRouteId-962622312",
             "endpointName": "someEventHubEndpoint",
             "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
           },
           {
             "id": "someEventRouteId-567112595",
-            "endpointName": "someEventHubEndpoint",
-            "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
-          },
-          {
-            "id": "someEventRouteId-962622312",
             "endpointName": "someEventHubEndpoint",
             "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
           },
@@ -108,8 +103,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6b725ae96df14a54d62f931f7300ccd8",
         "x-ms-return-client-request-id": "true"
@@ -118,7 +113,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -130,8 +125,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d63aa8adc28d247eff8a4084fd211156",
         "x-ms-return-client-request-id": "true"
@@ -141,7 +136,7 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_LifecycleAsync.json
@@ -9,8 +9,8 @@
         "Content-Length": "165",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "394c2288da7de3e1c90e57db9bfda7ed",
         "x-ms-return-client-request-id": "true"
@@ -22,7 +22,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -34,8 +34,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d0d372de6f45b7f008294ce1d3eeae23",
         "x-ms-return-client-request-id": "true"
@@ -45,7 +45,7 @@
       "ResponseHeaders": {
         "Content-Length": "180",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -61,8 +61,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1980b8996a4097cfe58f1797c214fe2c",
         "x-ms-return-client-request-id": "true"
@@ -70,25 +70,20 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "703",
+        "Content-Length": "538",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "someEventRouteId-702909932",
+            "id": "someEventRouteId-962622312",
             "endpointName": "someEventHubEndpoint",
             "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
           },
           {
             "id": "someEventRouteId-567112595",
-            "endpointName": "someEventHubEndpoint",
-            "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
-          },
-          {
-            "id": "someEventRouteId-962622312",
             "endpointName": "someEventHubEndpoint",
             "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
           },
@@ -108,8 +103,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6d79e5b7654019aa319530538d0010db",
         "x-ms-return-client-request-id": "true"
@@ -118,7 +113,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -130,8 +125,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "e241335f8e7c74aca23ceab65859f4f4",
         "x-ms-return-client-request-id": "true"
@@ -141,7 +136,7 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/EventRouteTests/EventRoutes_LifecycleAsync.json
@@ -22,7 +22,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -45,7 +45,7 @@
       "ResponseHeaders": {
         "Content-Length": "180",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -70,18 +70,13 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "538",
+        "Content-Length": "373",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
-          {
-            "id": "someEventRouteId-962622312",
-            "endpointName": "someEventHubEndpoint",
-            "filter": "type = \u0027Microsoft.DigitalTwins.Twin.Create\u0027 OR type = \u0027microsoft.iot.telemetry\u0027"
-          },
           {
             "id": "someEventRouteId-567112595",
             "endpointName": "someEventHubEndpoint",
@@ -113,7 +108,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -136,7 +131,7 @@
       "ResponseHeaders": {
         "Content-Length": "222",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_Deserializes.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_Deserializes.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -76,7 +76,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -134,7 +134,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -188,17 +188,133 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;144568920",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:46.8220488\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;144568920",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B114216032?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0af63be7a347d171ae9d513cd91a10cb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;114216032",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T17:04:44.3679245\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;114216032",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B120630867?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f3685bdd0c2b669e54ea61247e8e92f8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;144568920. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;120630867. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -214,21 +330,21 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f63be7cb470a71a3d1ae9d513cd91a10",
+        "x-ms-client-request-id": "df8a965f836840652abcaaa44b458b79",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;144568920\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;120630867\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;144568920\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.8220488\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;120630867\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.7069343\u002B00:00\u0022}]"
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B144568920?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B120630867?includeModelDefinition=true\u0026api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -237,7 +353,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5bdd77cbf3680c2b9e6654ea61247e8e",
+        "x-ms-client-request-id": "94bd2f41d8762fbb58a4f2b810ad2f0e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -245,11 +361,11 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "id": "dtmi:example:Ward;144568920",
+        "id": "dtmi:example:Ward;120630867",
         "description": {
           "en": "A separate partition in a building, made of rooms and hallways."
         },
@@ -257,9 +373,9 @@
           "en": "Ward"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-26T16:57:46.8220488\u002B00:00",
+        "uploadTime": "2020-10-26T17:04:50.7069343\u002B00:00",
         "model": {
-          "@id": "dtmi:example:Ward;144568920",
+          "@id": "dtmi:example:Ward;120630867",
           "@type": "Interface",
           "displayName": "Ward",
           "description": "A separate partition in a building, made of rooms and hallways.",

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_Deserializes.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_Deserializes.json
@@ -7,10 +7,184 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "9cca0e3f3e22af61924455f9bb7d8f8a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;128072960",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:16.4970528\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;128072960",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B145075813?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "045d34bbc7d414d40498d7a1eba9651a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;145075813",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:22.1939301\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;145075813",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B115429255?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ee935396907332eb262a83d82b7dc6d6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;115429255",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:40.9062605\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;115429255",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B144568920?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "fcb209cb476a87f51ea68a0da79bf0df",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -18,13 +192,13 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;128072960. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;144568920. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -37,33 +211,33 @@
         "Content-Length": "567",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5d34bbf9d404d4c7140498d7a1eba965",
+        "x-ms-client-request-id": "f63be7cb470a71a3d1ae9d513cd91a10",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;128072960\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;144568920\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;128072960\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.8844546\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;144568920\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.8220488\u002B00:00\u0022}]"
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B128072960?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B144568920?includeModelDefinition=true\u0026api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5396ef1aee939073eb32262a83d82b7d",
+        "x-ms-client-request-id": "5bdd77cbf3680c2b9e6654ea61247e8e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -71,11 +245,11 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "id": "dtmi:example:Ward;128072960",
+        "id": "dtmi:example:Ward;144568920",
         "description": {
           "en": "A separate partition in a building, made of rooms and hallways."
         },
@@ -83,9 +257,9 @@
           "en": "Ward"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-22T18:12:09.8844546\u002B00:00",
+        "uploadTime": "2020-10-26T16:57:46.8220488\u002B00:00",
         "model": {
-          "@id": "dtmi:example:Ward;128072960",
+          "@id": "dtmi:example:Ward;144568920",
           "@type": "Interface",
           "displayName": "Ward",
           "description": "A separate partition in a building, made of rooms and hallways.",

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_DeserializesAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_DeserializesAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -76,7 +76,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -134,7 +134,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -188,17 +188,133 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;110855032",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:46.1602423\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;110855032",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B194770428?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "406f8c41443eff3696e5ef3f36cfcf4f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;194770428",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T17:04:44.6628594\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;194770428",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B117640165?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b7bf70f3dd5bee3f6eab232a4dbadce7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;110855032. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;117640165. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -214,21 +330,21 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6f8c41de3e403644ff96e5ef3f36cfcf",
+        "x-ms-client-request-id": "68ea9a795ebce56ca821579c9385fbf3",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;110855032\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;117640165\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;110855032\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1602423\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;117640165\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6730782\u002B00:00\u0022}]"
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B110855032?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B117640165?includeModelDefinition=true\u0026api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -237,7 +353,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "70f3cf4fb7bfdd5b3fee6eab232a4dba",
+        "x-ms-client-request-id": "3593ecab2799afe53052d09813d4492a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -245,11 +361,11 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "id": "dtmi:example:Ward;110855032",
+        "id": "dtmi:example:Ward;117640165",
         "description": {
           "en": "A separate partition in a building, made of rooms and hallways."
         },
@@ -257,9 +373,9 @@
           "en": "Ward"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-26T16:57:46.1602423\u002B00:00",
+        "uploadTime": "2020-10-26T17:04:50.6730782\u002B00:00",
         "model": {
-          "@id": "dtmi:example:Ward;110855032",
+          "@id": "dtmi:example:Ward;117640165",
           "@type": "Interface",
           "displayName": "Ward",
           "description": "A separate partition in a building, made of rooms and hallways.",

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_DeserializesAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/ModelData_DisplayNameAndDescription_DeserializesAsync.json
@@ -7,10 +7,184 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "54fe6359764a230b8918c6353d55a63b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;110184439",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:16.4348538\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;110184439",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B186622131?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "251ebb6826a081718eab4727cd9120db",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;186622131",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:22.0059846\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;186622131",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B189540703?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c1cb1a14762925e70941824158dc77d8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;189540703",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:40.9703985\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;189540703",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B110855032?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a71cb09d3cb8d38cbbcac3fbbc87a659",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -18,13 +192,13 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;110184439. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;110855032. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -37,33 +211,33 @@
         "Content-Length": "567",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "1ebb6802a0257126818eab4727cd9120",
+        "x-ms-client-request-id": "6f8c41de3e403644ff96e5ef3f36cfcf",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;110184439\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;110855032\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;110184439\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:09.7923988\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;110855032\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1602423\u002B00:00\u0022}]"
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B110184439?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B110855032?includeModelDefinition=true\u0026api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "1a145fdbc1cb7629e7250941824158dc",
+        "x-ms-client-request-id": "70f3cf4fb7bfdd5b3fee6eab232a4dba",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -71,11 +245,11 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "id": "dtmi:example:Ward;110184439",
+        "id": "dtmi:example:Ward;110855032",
         "description": {
           "en": "A separate partition in a building, made of rooms and hallways."
         },
@@ -83,9 +257,9 @@
           "en": "Ward"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-22T18:12:09.7923988\u002B00:00",
+        "uploadTime": "2020-10-26T16:57:46.1602423\u002B00:00",
         "model": {
-          "@id": "dtmi:example:Ward;110184439",
+          "@id": "dtmi:example:Ward;110855032",
           "@type": "Interface",
           "displayName": "Ward",
           "description": "A separate partition in a building, made of rooms and hallways.",

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_Lifecycle.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5248405ff1dd213f48817b0ccb69f4e5",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c1a5487dcdba995d2fbb6b4bf8929f69",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "03ac214f6c5798c01ae8941cad97c92f",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -91,8 +91,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6599997c73a4b9ebad36d4d54feedba3",
         "x-ms-return-client-request-id": "true"
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -121,8 +121,8 @@
         "Content-Length": "1883",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "39d21aac25e4e4dc28a0e5c87c8224a2",
         "x-ms-return-client-request-id": "true"
@@ -132,10 +132,10 @@
       "ResponseHeaders": {
         "Content-Length": "627",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;11357\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.1467506\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;124597763\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.1468645\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;110485359\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.1469655\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;11357\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.1775918\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;124597763\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.1776866\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;110485359\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.1777649\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3ABuilding%3B11357?includeModelDefinition=true\u0026api-version=2020-10-31",
@@ -144,8 +144,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "0615641bb9cfadaac04aaa36ecc3cbf9",
         "x-ms-return-client-request-id": "true"
@@ -155,7 +155,7 @@
       "ResponseHeaders": {
         "Content-Length": "604",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -167,7 +167,7 @@
           "en": "Building"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-22T18:12:10.1467506\u002B00:00",
+        "uploadTime": "2020-10-26T16:57:47.1775918\u002B00:00",
         "model": {
           "@id": "dtmi:example:Building;11357",
           "@type": "Interface",
@@ -203,8 +203,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7c0078b9f6f657afbdb53c048d233c2b",
         "x-ms-return-client-request-id": "true"
@@ -212,830 +212,243 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "19291",
+        "Content-Length": "9016",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "dtmi:example:Ward;117201380",
+            "id": "dtmi:example:floor;18061580",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:46.8397819\u002B00:00"
+            "uploadTime": "2020-10-23T21:04:49.9562329\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;117945300",
+            "id": "dtmi:example:hvac;190873698",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:46.8663053\u002B00:00"
+            "uploadTime": "2020-10-23T21:04:49.9563495\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;192344694",
+            "id": "dtmi:example:floor;13646793",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:47.8377904\u002B00:00"
+            "uploadTime": "2020-10-23T21:07:40.0210793\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;110146969",
+            "id": "dtmi:example:hvac;110454409",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:47.911496\u002B00:00"
+            "uploadTime": "2020-10-23T21:07:40.0212307\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;110358961",
+            "id": "dtmi:example:room;119618957",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:03.3466104\u002B00:00"
+            "uploadTime": "2020-10-23T21:10:00.5330848\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;153429963",
+            "id": "dtmi:example:floor;12618979",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:03.3488931\u002B00:00"
+            "uploadTime": "2020-10-23T21:10:00.5332349\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;113791195",
+            "id": "dtmi:example:hvac;111631061",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:04.4165456\u002B00:00"
+            "uploadTime": "2020-10-23T21:10:00.5333315\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;119828941",
+            "id": "dtmi:example:room;112725529",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:04.528225\u002B00:00"
+            "uploadTime": "2020-10-23T21:16:05.7935769\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;121223480",
+            "id": "dtmi:example:floor;11622797",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:10.2438509\u002B00:00"
+            "uploadTime": "2020-10-23T21:16:05.7937496\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;156405718",
+            "id": "dtmi:example:hvac;119136797",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:10.3156012\u002B00:00"
+            "uploadTime": "2020-10-23T21:16:05.7938716\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;116187715",
+            "id": "dtmi:example:room;115056947",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:11.2424076\u002B00:00"
+            "uploadTime": "2020-10-23T21:17:40.6202896\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;115716399",
+            "id": "dtmi:example:floor;12596165",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:11.2482143\u002B00:00"
+            "uploadTime": "2020-10-23T21:17:40.6204228\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;116379663",
+            "id": "dtmi:example:hvac;187766340",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:30.270047\u002B00:00"
+            "uploadTime": "2020-10-23T21:17:40.6205169\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;134269724",
+            "id": "dtmi:example:room;158485519",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:30.6419061\u002B00:00"
+            "uploadTime": "2020-10-23T21:20:53.8157469\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;163984928",
+            "id": "dtmi:example:floor;12620956",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:31.281718\u002B00:00"
+            "uploadTime": "2020-10-23T21:20:53.8158838\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;112270814",
+            "id": "dtmi:example:hvac;197725463",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:31.3607126\u002B00:00"
+            "uploadTime": "2020-10-23T21:20:53.8159807\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;115839634",
+            "id": "dtmi:example:room;114333297",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.8216482\u002B00:00"
+            "uploadTime": "2020-10-23T21:22:05.3749092\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;115487117",
+            "id": "dtmi:example:floor;11489901",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.8203684\u002B00:00"
+            "uploadTime": "2020-10-23T21:22:05.3751023\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;16484",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.9321226\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;178238956",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.9323188\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11049",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0180026\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;121187561",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0186328\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11612",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0543166\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;113397379",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0544765\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;13695",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0741687\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;142401719",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0749039\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;146021574",
+            "id": "dtmi:example:hvac;113961423",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.7834728\u002B00:00"
+            "uploadTime": "2020-10-23T21:22:05.3752089\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;118780217",
+            "id": "dtmi:example:room;113317821",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.8122524\u002B00:00"
+            "uploadTime": "2020-10-23T22:23:44.6799238\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;11743",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:31:03.0141071\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;114158156",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:31:03.0143073\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;16324",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:34:25.4441348\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;134317903",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:34:25.4446608\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;12028",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:36:38.4068028\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;178470784",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:36:38.4069369\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11343",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:37:07.448205\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;162821718",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:37:07.448337\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;15882",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:38:33.065301\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;115212927",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:38:33.0659191\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11225",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:03:29.9089584\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;110073691",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:03:29.909106\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;12097",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:22.0591116\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;110896689",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:22.0597911\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;14583",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:42.5667379\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;192830056",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:42.5669223\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11582",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:38:16.6665586\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;156401669",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:38:16.6671015\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11945",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:46:29.0481849\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;118840194",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:46:29.0486295\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;19319",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:11:11.7015877\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;198180873",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:11:11.7017984\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11848",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:19:30.2821739\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;173141961",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:19:30.2826842\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;16567",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:10.7113554\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;118452655",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:10.7115186\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11640",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:48.1576019\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;118846960",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:48.1582678\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;17590",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:24:00.636487\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;113399338",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:24:00.6366351\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;111115207",
+            "id": "dtmi:example:room;121439350",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:52.7256038\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;198714551",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:52.794856\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;159707209",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:53.6855061\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;114049093",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:53.7104582\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;112171132",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:25.7851574\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;184825484",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:25.8725295\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;14889",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.1519669\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;112938792",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.1526475\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;187605742",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.4930489\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;115189459",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.58909\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;116886193",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:13.9800255\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;119435168",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:13.9836413\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;16889",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.4025185\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;114287215",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.402655\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;126317290",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.7433829\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;115653270",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.8456924\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;120341609",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:19.454391\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;163830990",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:19.5138177\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;121041532",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:20.4946386\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;121066768",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:20.5383296\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;139655150",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:46.9189835\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;116336332",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:46.9195885\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;118252371",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:47.8948052\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;175394095",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:48.0512757\u002B00:00"
+            "uploadTime": "2020-10-23T22:24:28.292651\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;110184439",
@@ -1046,7 +459,7 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.7923988\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:16.4348538\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;128072960",
@@ -1057,46 +470,120 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.8844546\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:16.4970528\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;11118",
-            "description": {},
+            "id": "dtmi:example:Ward;155773321",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "RoomWithWifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.8993363\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:17.4992313\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifi;120276595",
-            "description": {},
+            "id": "dtmi:example:Ward;116847374",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "Wifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.8994791\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:17.6834446\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;12093",
-            "description": {},
+            "id": "dtmi:example:Ward;186622131",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "RoomWithWifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9460153\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:22.0059846\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifi;196111479",
-            "description": {},
+            "id": "dtmi:example:Ward;145075813",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "Wifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9462247\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:22.1939301\u002B00:00"
           },
           {
-            "id": "dtmi:example:room;135050739",
+            "id": "dtmi:example:Ward;145121366",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:56:23.5220705\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;116421010",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:56:23.7523492\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;115429255",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:40.9062605\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;189540703",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:40.9703985\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;113005607",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:42.5086675\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;118728284",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:42.608936\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;113863769",
             "description": {
               "en": "An enclosure inside a building."
             },
@@ -1104,21 +591,10 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9717745\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:45.9755616\u002B00:00"
           },
           {
-            "id": "dtmi:example:floor;19932306",
-            "description": {
-              "en": "A building story."
-            },
-            "displayName": {
-              "en": "Floor"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9934006\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;137155543",
+            "id": "dtmi:example:room;120254295",
             "description": {
               "en": "An enclosure inside a building."
             },
@@ -1126,58 +602,7 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9935661\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:hvac;111092475",
-            "description": {
-              "en": "A heating, ventilation, and air conditioning unit."
-            },
-            "displayName": {
-              "en": "HVAC"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9937162\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;124539051",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0325721\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11736",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.04441\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;173948219",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.044563\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:floor;12904852",
-            "description": {
-              "en": "A building story."
-            },
-            "displayName": {
-              "en": "Floor"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0892434\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.051617\u002B00:00"
           },
           {
             "id": "dtmi:example:room;114513986",
@@ -1188,70 +613,10 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0894116\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.0718279\u002B00:00"
           },
           {
-            "id": "dtmi:example:hvac;113394842",
-            "description": {
-              "en": "A heating, ventilation, and air conditioning unit."
-            },
-            "displayName": {
-              "en": "HVAC"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.089552\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Building;16685",
-            "description": {
-              "en": "A free-standing structure."
-            },
-            "displayName": {
-              "en": "Building"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0999984\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Hvac;119998209",
-            "description": {
-              "en": "A heating, ventilation, and air conditioning unit."
-            },
-            "displayName": {
-              "en": "HVAC"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1001173\u002B00:00"
-          }
-        ],
-        "nextLink": "https://barustum-adt-10212020-2.api.wus2.digitaltwins.azure.net/Models?includeModelDefinition=False\u0026continuationToken=%5B%7B%22token%22%3A%22%2BRID%3A~D-IXAJ2n7rD0EgAAAAAABA%3D%3D%23RT%3A1%23TRC%3A100%23ISV%3A2%23IEO%3A65551%22,%22range%22%3A%7B%22min%22%3A%2205C1BF0F87C3E0%22,%22max%22%3A%2205C1C74BA5D368%22%7D%7D%5D\u0026api-version=2020-10-31"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/Models?includeModelDefinition=False\u0026continuationToken=%5B%7B%22token%22%3A%22%2BRID%3A~D-IXAJ2n7rD0EgAAAAAABA%3D%3D%23RT%3A1%23TRC%3A100%23ISV%3A2%23IEO%3A65551%22,%22range%22%3A%7B%22min%22%3A%2205C1BF0F87C3E0%22,%22max%22%3A%2205C1C74BA5D368%22%7D%7D%5D\u0026api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ebb93111d5d8f3d46f25789a7aa6f764",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "1191",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "id": "dtmi:example:Ward;116791127",
+            "id": "dtmi:example:Ward;110855032",
             "description": {
               "en": "A separate partition in a building, made of rooms and hallways."
             },
@@ -1259,25 +624,51 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1001975\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.1602423\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;11451",
-            "description": {},
+            "id": "dtmi:example:floor;19932306",
+            "description": {
+              "en": "A building story."
+            },
             "displayName": {
-              "en": "RoomWithWifi"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.11107\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.8034132\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifi;120658425",
-            "description": {},
+            "id": "dtmi:example:room;137155543",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
             "displayName": {
-              "en": "Wifi"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1112371\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.803554\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:hvac;111092475",
+            "description": {
+              "en": "A heating, ventilation, and air conditioning unit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:46.803719\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;144568920",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:46.8220488\u002B00:00"
           },
           {
             "id": "dtmi:example:Building;11357",
@@ -1288,7 +679,7 @@
               "en": "Building"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1467506\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:47.1775918\u002B00:00"
           },
           {
             "id": "dtmi:example:Hvac;124597763",
@@ -1299,7 +690,7 @@
               "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1468645\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:47.1776866\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;110485359",
@@ -1310,7 +701,7 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1469655\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:47.1777649\u002B00:00"
           }
         ],
         "nextLink": null
@@ -1325,17 +716,17 @@
         "Content-Length": "63",
         "Content-Type": "application/json-patch\u002Bjson",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "040eebd4a78125abb4be481a7ca61f9d",
+        "x-ms-client-request-id": "ebb93111d5d8f3d46f25789a7aa6f764",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": "[{ \u0022op\u0022: \u0022replace\u0022, \u0022path\u0022: \u0022/decommissioned\u0022, \u0022value\u0022: true }]",
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -1347,17 +738,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "ba247f0de00ae420a40d0dd17d15dc17",
+        "x-ms-client-request-id": "040eebd4a78125abb4be481a7ca61f9d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -1369,17 +760,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "a12fd8bd38146aa98693361a8cba76c9",
+        "x-ms-client-request-id": "ba247f0de00ae420a40d0dd17d15dc17",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -1391,17 +782,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "fb8cdb053d81f45acb2a5f739adaa89e",
+        "x-ms-client-request-id": "a12fd8bd38146aa98693361a8cba76c9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_Lifecycle.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -132,10 +132,10 @@
       "ResponseHeaders": {
         "Content-Length": "627",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;11357\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.1775918\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;124597763\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.1776866\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;110485359\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.1777649\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;11357\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.1650144\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;124597763\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.1651374\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;110485359\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.1652426\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3ABuilding%3B11357?includeModelDefinition=true\u0026api-version=2020-10-31",
@@ -155,7 +155,7 @@
       "ResponseHeaders": {
         "Content-Length": "604",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -167,7 +167,7 @@
           "en": "Building"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-26T16:57:47.1775918\u002B00:00",
+        "uploadTime": "2020-10-26T17:04:51.1650144\u002B00:00",
         "model": {
           "@id": "dtmi:example:Building;11357",
           "@type": "Interface",
@@ -212,9 +212,9 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "9016",
+        "Content-Length": "11824",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -583,39 +583,6 @@
             "uploadTime": "2020-10-26T16:57:42.608936\u002B00:00"
           },
           {
-            "id": "dtmi:example:room;113863769",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:45.9755616\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;120254295",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.051617\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;114513986",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.0718279\u002B00:00"
-          },
-          {
             "id": "dtmi:example:Ward;110855032",
             "description": {
               "en": "A separate partition in a building, made of rooms and hallways."
@@ -625,39 +592,6 @@
             },
             "decommissioned": false,
             "uploadTime": "2020-10-26T16:57:46.1602423\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:floor;19932306",
-            "description": {
-              "en": "A building story."
-            },
-            "displayName": {
-              "en": "Floor"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.8034132\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;137155543",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.803554\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:hvac;111092475",
-            "description": {
-              "en": "A heating, ventilation, and air conditioning unit."
-            },
-            "displayName": {
-              "en": "HVAC"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.803719\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;144568920",
@@ -671,6 +605,215 @@
             "uploadTime": "2020-10-26T16:57:46.8220488\u002B00:00"
           },
           {
+            "id": "dtmi:example:Ward;181743108",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:47.2857459\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;168945250",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:48.1108424\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;114216032",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:44.3679245\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;194770428",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:44.6628594\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;117942929",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:46.099361\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;113886965",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:46.2547833\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;120254295",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.5405338\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;113863769",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.5727642\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:floor;12904852",
+            "description": {
+              "en": "A building story."
+            },
+            "displayName": {
+              "en": "Floor"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6708214\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;117640165",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6730782\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;114513986",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6709975\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:hvac;113394842",
+            "description": {
+              "en": "A heating, ventilation, and air conditioning unit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6711672\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:floor;19932306",
+            "description": {
+              "en": "A building story."
+            },
+            "displayName": {
+              "en": "Floor"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6764853\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;137155543",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6766414\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:hvac;111092475",
+            "description": {
+              "en": "A heating, ventilation, and air conditioning unit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6768058\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;120630867",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.7069343\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;16685",
+            "description": {
+              "en": "A free-standing structure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": true,
+            "uploadTime": "2020-10-26T17:04:51.093357\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;119998209",
+            "description": {
+              "en": "A heating, ventilation, and air conditioning unit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:51.0934887\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;116791127",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:51.0935792\u002B00:00"
+          },
+          {
             "id": "dtmi:example:Building;11357",
             "description": {
               "en": "A free-standing structure."
@@ -679,7 +822,7 @@
               "en": "Building"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:47.1775918\u002B00:00"
+            "uploadTime": "2020-10-26T17:04:51.1650144\u002B00:00"
           },
           {
             "id": "dtmi:example:Hvac;124597763",
@@ -690,7 +833,7 @@
               "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:47.1776866\u002B00:00"
+            "uploadTime": "2020-10-26T17:04:51.1651374\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;110485359",
@@ -701,7 +844,7 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:47.1777649\u002B00:00"
+            "uploadTime": "2020-10-26T17:04:51.1652426\u002B00:00"
           }
         ],
         "nextLink": null
@@ -726,7 +869,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -748,7 +891,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -770,7 +913,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -792,7 +935,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_LifecycleAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f13af91b2e0e955b43a1d94ec94ed8d3",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f39927acea9602d863df90cb3ad5840a",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "170e8a49710b737458f9dbeaa0893681",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -91,8 +91,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "67e4d7a00f84ef61ab4ecbc908cc5443",
         "x-ms-return-client-request-id": "true"
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -121,8 +121,8 @@
         "Content-Length": "1883",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c44e050ea04025b67f3ef0fd18c2565a",
         "x-ms-return-client-request-id": "true"
@@ -132,10 +132,10 @@
       "ResponseHeaders": {
         "Content-Length": "627",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;16685\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.0999984\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;119998209\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.1001173\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;116791127\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.1001975\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;16685\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.5064137\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;119998209\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.5065678\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;116791127\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.5066609\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3ABuilding%3B16685?includeModelDefinition=true\u0026api-version=2020-10-31",
@@ -144,8 +144,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ad35374a53267ac4ac276022a9aa4f2d",
         "x-ms-return-client-request-id": "true"
@@ -155,7 +155,7 @@
       "ResponseHeaders": {
         "Content-Length": "604",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -167,7 +167,7 @@
           "en": "Building"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-22T18:12:10.0999984\u002B00:00",
+        "uploadTime": "2020-10-26T16:57:46.5064137\u002B00:00",
         "model": {
           "@id": "dtmi:example:Building;16685",
           "@type": "Interface",
@@ -203,8 +203,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8392a686bce7ffc120bfe7451e64d6e8",
         "x-ms-return-client-request-id": "true"
@@ -212,830 +212,243 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "19291",
+        "Content-Length": "8602",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "id": "dtmi:example:Ward;117201380",
+            "id": "dtmi:example:floor;18061580",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:46.8397819\u002B00:00"
+            "uploadTime": "2020-10-23T21:04:49.9562329\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;117945300",
+            "id": "dtmi:example:hvac;190873698",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:46.8663053\u002B00:00"
+            "uploadTime": "2020-10-23T21:04:49.9563495\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;192344694",
+            "id": "dtmi:example:floor;13646793",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:47.8377904\u002B00:00"
+            "uploadTime": "2020-10-23T21:07:40.0210793\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;110146969",
+            "id": "dtmi:example:hvac;110454409",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:21:47.911496\u002B00:00"
+            "uploadTime": "2020-10-23T21:07:40.0212307\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;110358961",
+            "id": "dtmi:example:room;119618957",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:03.3466104\u002B00:00"
+            "uploadTime": "2020-10-23T21:10:00.5330848\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;153429963",
+            "id": "dtmi:example:floor;12618979",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:03.3488931\u002B00:00"
+            "uploadTime": "2020-10-23T21:10:00.5332349\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;113791195",
+            "id": "dtmi:example:hvac;111631061",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:04.4165456\u002B00:00"
+            "uploadTime": "2020-10-23T21:10:00.5333315\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;119828941",
+            "id": "dtmi:example:room;112725529",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:30:04.528225\u002B00:00"
+            "uploadTime": "2020-10-23T21:16:05.7935769\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;121223480",
+            "id": "dtmi:example:floor;11622797",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:10.2438509\u002B00:00"
+            "uploadTime": "2020-10-23T21:16:05.7937496\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;156405718",
+            "id": "dtmi:example:hvac;119136797",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:10.3156012\u002B00:00"
+            "uploadTime": "2020-10-23T21:16:05.7938716\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;116187715",
+            "id": "dtmi:example:room;115056947",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:11.2424076\u002B00:00"
+            "uploadTime": "2020-10-23T21:17:40.6202896\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;115716399",
+            "id": "dtmi:example:floor;12596165",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:32:11.2482143\u002B00:00"
+            "uploadTime": "2020-10-23T21:17:40.6204228\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;116379663",
+            "id": "dtmi:example:hvac;187766340",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:30.270047\u002B00:00"
+            "uploadTime": "2020-10-23T21:17:40.6205169\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;134269724",
+            "id": "dtmi:example:room;158485519",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:30.6419061\u002B00:00"
+            "uploadTime": "2020-10-23T21:20:53.8157469\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;163984928",
+            "id": "dtmi:example:floor;12620956",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:31.281718\u002B00:00"
+            "uploadTime": "2020-10-23T21:20:53.8158838\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;112270814",
+            "id": "dtmi:example:hvac;197725463",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-21T16:33:31.3607126\u002B00:00"
+            "uploadTime": "2020-10-23T21:20:53.8159807\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;115839634",
+            "id": "dtmi:example:room;114333297",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.8216482\u002B00:00"
+            "uploadTime": "2020-10-23T21:22:05.3749092\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;115487117",
+            "id": "dtmi:example:floor;11489901",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A building story."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.8203684\u002B00:00"
+            "uploadTime": "2020-10-23T21:22:05.3751023\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;16484",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.9321226\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;178238956",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:45.9323188\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11049",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0180026\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;121187561",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0186328\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11612",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0543166\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;113397379",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0544765\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;13695",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0741687\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;142401719",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.0749039\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;146021574",
+            "id": "dtmi:example:hvac;113961423",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "A heating, ventilation, and air conditioning unit."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.7834728\u002B00:00"
+            "uploadTime": "2020-10-23T21:22:05.3752089\u002B00:00"
           },
           {
-            "id": "dtmi:example:Ward;118780217",
+            "id": "dtmi:example:room;113317821",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T07:30:46.8122524\u002B00:00"
+            "uploadTime": "2020-10-23T22:23:44.6799238\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;11743",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:31:03.0141071\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;114158156",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:31:03.0143073\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;16324",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:34:25.4441348\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;134317903",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:34:25.4446608\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;12028",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:36:38.4068028\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;178470784",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:36:38.4069369\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11343",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:37:07.448205\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;162821718",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:37:07.448337\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;15882",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:38:33.065301\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;115212927",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T07:38:33.0659191\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11225",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:03:29.9089584\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;110073691",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:03:29.909106\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;12097",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:22.0591116\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;110896689",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:22.0597911\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;14583",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:42.5667379\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;192830056",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:05:42.5669223\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11582",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:38:16.6665586\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;156401669",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:38:16.6671015\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11945",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:46:29.0481849\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;118840194",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T08:46:29.0486295\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;19319",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:11:11.7015877\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;198180873",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:11:11.7017984\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11848",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:19:30.2821739\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;173141961",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:19:30.2826842\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;16567",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:10.7113554\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;118452655",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:10.7115186\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11640",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:48.1576019\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;118846960",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:22:48.1582678\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;17590",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:24:00.636487\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;113399338",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:24:00.6366351\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;111115207",
+            "id": "dtmi:example:room;121439350",
             "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
+              "en": "An enclosure inside a building."
             },
             "displayName": {
-              "en": "Ward"
+              "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:52.7256038\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;198714551",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:52.794856\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;159707209",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:53.6855061\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;114049093",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T09:59:53.7104582\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;112171132",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:25.7851574\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;184825484",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:25.8725295\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;14889",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.1519669\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;112938792",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.1526475\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;187605742",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.4930489\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;115189459",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:00:26.58909\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;116886193",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:13.9800255\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;119435168",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:13.9836413\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;16889",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.4025185\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;114287215",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.402655\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;126317290",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.7433829\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;115653270",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T10:33:14.8456924\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;120341609",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:19.454391\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;163830990",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:19.5138177\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;121041532",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:20.4946386\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;121066768",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T11:28:20.5383296\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;139655150",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:46.9189835\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;116336332",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:46.9195885\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;118252371",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:47.8948052\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;175394095",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T17:53:48.0512757\u002B00:00"
+            "uploadTime": "2020-10-23T22:24:28.292651\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;110184439",
@@ -1046,7 +459,7 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.7923988\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:16.4348538\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;128072960",
@@ -1057,46 +470,120 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.8844546\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:16.4970528\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;11118",
-            "description": {},
+            "id": "dtmi:example:Ward;155773321",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "RoomWithWifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.8993363\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:17.4992313\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifi;120276595",
-            "description": {},
+            "id": "dtmi:example:Ward;116847374",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "Wifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.8994791\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:17.6834446\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifiroom;12093",
-            "description": {},
+            "id": "dtmi:example:Ward;186622131",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "RoomWithWifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9460153\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:22.0059846\u002B00:00"
           },
           {
-            "id": "dtmi:example:wifi;196111479",
-            "description": {},
+            "id": "dtmi:example:Ward;145075813",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
             "displayName": {
-              "en": "Wifi"
+              "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9462247\u002B00:00"
+            "uploadTime": "2020-10-26T16:56:22.1939301\u002B00:00"
           },
           {
-            "id": "dtmi:example:room;135050739",
+            "id": "dtmi:example:Ward;145121366",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:56:23.5220705\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;116421010",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:56:23.7523492\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;115429255",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:40.9062605\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;189540703",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:40.9703985\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;113005607",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:42.5086675\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;118728284",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:42.608936\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;113863769",
             "description": {
               "en": "An enclosure inside a building."
             },
@@ -1104,21 +591,10 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9717745\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:45.9755616\u002B00:00"
           },
           {
-            "id": "dtmi:example:floor;19932306",
-            "description": {
-              "en": "A building story."
-            },
-            "displayName": {
-              "en": "Floor"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9934006\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;137155543",
+            "id": "dtmi:example:room;120254295",
             "description": {
               "en": "An enclosure inside a building."
             },
@@ -1126,47 +602,7 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9935661\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:hvac;111092475",
-            "description": {
-              "en": "A heating, ventilation, and air conditioning unit."
-            },
-            "displayName": {
-              "en": "HVAC"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:09.9937162\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;124539051",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0325721\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11736",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.04441\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;173948219",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.044563\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.051617\u002B00:00"
           },
           {
             "id": "dtmi:example:floor;12904852",
@@ -1177,7 +613,7 @@
               "en": "Floor"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0892434\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.0716608\u002B00:00"
           },
           {
             "id": "dtmi:example:room;114513986",
@@ -1188,7 +624,7 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0894116\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.0718279\u002B00:00"
           },
           {
             "id": "dtmi:example:hvac;113394842",
@@ -1199,7 +635,18 @@
               "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.089552\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.0720338\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;110855032",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:46.1602423\u002B00:00"
           },
           {
             "id": "dtmi:example:Building;16685",
@@ -1210,7 +657,7 @@
               "en": "Building"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.0999984\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.5064137\u002B00:00"
           },
           {
             "id": "dtmi:example:Hvac;119998209",
@@ -1221,35 +668,8 @@
               "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1001173\u002B00:00"
-          }
-        ],
-        "nextLink": "https://barustum-adt-10212020-2.api.wus2.digitaltwins.azure.net/Models?includeModelDefinition=False\u0026continuationToken=%5B%7B%22token%22%3A%22%2BRID%3A~D-IXAJ2n7rD0EgAAAAAABA%3D%3D%23RT%3A1%23TRC%3A100%23ISV%3A2%23IEO%3A65551%22,%22range%22%3A%7B%22min%22%3A%2205C1BF0F87C3E0%22,%22max%22%3A%2205C1C74BA5D368%22%7D%7D%5D\u0026api-version=2020-10-31"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/Models?includeModelDefinition=False\u0026continuationToken=%5B%7B%22token%22%3A%22%2BRID%3A~D-IXAJ2n7rD0EgAAAAAABA%3D%3D%23RT%3A1%23TRC%3A100%23ISV%3A2%23IEO%3A65551%22,%22range%22%3A%7B%22min%22%3A%2205C1BF0F87C3E0%22,%22max%22%3A%2205C1C74BA5D368%22%7D%7D%5D\u0026api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "d07f70f8a796ba1d40d3171940947bd4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "1191",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
+            "uploadTime": "2020-10-26T16:57:46.5065678\u002B00:00"
+          },
           {
             "id": "dtmi:example:Ward;116791127",
             "description": {
@@ -1259,58 +679,7 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1001975\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifiroom;11451",
-            "description": {},
-            "displayName": {
-              "en": "RoomWithWifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.11107\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:wifi;120658425",
-            "description": {},
-            "displayName": {
-              "en": "Wifi"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1112371\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Building;11357",
-            "description": {
-              "en": "A free-standing structure."
-            },
-            "displayName": {
-              "en": "Building"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1467506\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Hvac;124597763",
-            "description": {
-              "en": "A heating, ventilation, and air conditioning unit."
-            },
-            "displayName": {
-              "en": "HVAC"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1468645\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:Ward;110485359",
-            "description": {
-              "en": "A separate partition in a building, made of rooms and hallways."
-            },
-            "displayName": {
-              "en": "Ward"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-22T18:12:10.1469655\u002B00:00"
+            "uploadTime": "2020-10-26T16:57:46.5066609\u002B00:00"
           }
         ],
         "nextLink": null
@@ -1325,17 +694,17 @@
         "Content-Length": "63",
         "Content-Type": "application/json-patch\u002Bjson",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "7177c3efd2308e7276358d666b7f5c48",
+        "x-ms-client-request-id": "d07f70f8a796ba1d40d3171940947bd4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": "[{ \u0022op\u0022: \u0022replace\u0022, \u0022path\u0022: \u0022/decommissioned\u0022, \u0022value\u0022: true }]",
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -1347,17 +716,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "382a78507f2bde9689d74314a4a8bf8c",
+        "x-ms-client-request-id": "7177c3efd2308e7276358d666b7f5c48",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -1369,17 +738,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5b56134465ec25b7fdf15a601ab64ec1",
+        "x-ms-client-request-id": "382a78507f2bde9689d74314a4a8bf8c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -1391,17 +760,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c8c8cf7742696fa92c98e7588f5de9cd",
+        "x-ms-client-request-id": "5b56134465ec25b7fdf15a601ab64ec1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_LifecycleAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -102,7 +102,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -130,12 +130,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Building;16685\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Building\u0022,    \u0022description\u0022: \u0022A free-standing structure.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022has\u0022,            \u0022target\u0022: \u0022dtmi:example:Floor;11005960\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022isEquippedWith\u0022,            \u0022target\u0022: \u0022dtmi:example:Hvac;119998209\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022AverageTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:Hvac;119998209\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022HVAC\u0022,    \u0022description\u0022: \u0022A heating, ventilation, and air conditioning unit.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Efficiency\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetTemperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022TargetHumidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022cools\u0022,            \u0022target\u0022: \u0022dtmi:example:Floor;11005960\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:Ward;116791127\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "627",
+        "Content-Length": "626",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;16685\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.5064137\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;119998209\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.5065678\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;116791127\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.5066609\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Building;16685\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A free-standing structure.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Building\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.093357\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Hvac;119998209\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A heating, ventilation, and air conditioning unit.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022HVAC\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.0934887\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:Ward;116791127\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.0935792\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3ABuilding%3B16685?includeModelDefinition=true\u0026api-version=2020-10-31",
@@ -153,9 +153,9 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "604",
+        "Content-Length": "603",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -167,7 +167,7 @@
           "en": "Building"
         },
         "decommissioned": false,
-        "uploadTime": "2020-10-26T16:57:46.5064137\u002B00:00",
+        "uploadTime": "2020-10-26T17:04:51.093357\u002B00:00",
         "model": {
           "@id": "dtmi:example:Building;16685",
           "@type": "Interface",
@@ -212,9 +212,9 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "8602",
+        "Content-Length": "11199",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -583,61 +583,6 @@
             "uploadTime": "2020-10-26T16:57:42.608936\u002B00:00"
           },
           {
-            "id": "dtmi:example:room;113863769",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:45.9755616\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;120254295",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.051617\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:floor;12904852",
-            "description": {
-              "en": "A building story."
-            },
-            "displayName": {
-              "en": "Floor"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.0716608\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:room;114513986",
-            "description": {
-              "en": "An enclosure inside a building."
-            },
-            "displayName": {
-              "en": "Room"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.0718279\u002B00:00"
-          },
-          {
-            "id": "dtmi:example:hvac;113394842",
-            "description": {
-              "en": "A heating, ventilation, and air conditioning unit."
-            },
-            "displayName": {
-              "en": "HVAC"
-            },
-            "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.0720338\u002B00:00"
-          },
-          {
             "id": "dtmi:example:Ward;110855032",
             "description": {
               "en": "A separate partition in a building, made of rooms and hallways."
@@ -649,6 +594,193 @@
             "uploadTime": "2020-10-26T16:57:46.1602423\u002B00:00"
           },
           {
+            "id": "dtmi:example:Ward;144568920",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:46.8220488\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;181743108",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:47.2857459\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;168945250",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T16:57:48.1108424\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;114216032",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:44.3679245\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;194770428",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:44.6628594\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;117942929",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:46.099361\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;113886965",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:46.2547833\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;120254295",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.5405338\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;113863769",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.5727642\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:floor;12904852",
+            "description": {
+              "en": "A building story."
+            },
+            "displayName": {
+              "en": "Floor"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6708214\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;117640165",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6730782\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;114513986",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6709975\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:hvac;113394842",
+            "description": {
+              "en": "A heating, ventilation, and air conditioning unit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6711672\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:floor;19932306",
+            "description": {
+              "en": "A building story."
+            },
+            "displayName": {
+              "en": "Floor"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6764853\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;137155543",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6766414\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:hvac;111092475",
+            "description": {
+              "en": "A heating, ventilation, and air conditioning unit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.6768058\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;120630867",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2020-10-26T17:04:50.7069343\u002B00:00"
+          },
+          {
             "id": "dtmi:example:Building;16685",
             "description": {
               "en": "A free-standing structure."
@@ -657,7 +789,7 @@
               "en": "Building"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.5064137\u002B00:00"
+            "uploadTime": "2020-10-26T17:04:51.093357\u002B00:00"
           },
           {
             "id": "dtmi:example:Hvac;119998209",
@@ -668,7 +800,7 @@
               "en": "HVAC"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.5065678\u002B00:00"
+            "uploadTime": "2020-10-26T17:04:51.0934887\u002B00:00"
           },
           {
             "id": "dtmi:example:Ward;116791127",
@@ -679,7 +811,7 @@
               "en": "Ward"
             },
             "decommissioned": false,
-            "uploadTime": "2020-10-26T16:57:46.5066609\u002B00:00"
+            "uploadTime": "2020-10-26T17:04:51.0935792\u002B00:00"
           }
         ],
         "nextLink": null
@@ -704,7 +836,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -726,7 +858,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -748,7 +880,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -770,7 +902,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictException.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictException.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -76,7 +76,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -134,7 +134,7 @@
       "ResponseHeaders": {
         "Content-Length": "612",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -188,17 +188,133 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;168945250",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:48.1108424\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;168945250",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B117942929?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "cb2140d35fb42ddfff2c45281d0b82a0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "612",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;117942929",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T17:04:46.099361\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;117942929",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B111018409?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f9139c339a4f2ccc643528cafd711554",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;168945250. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;111018409. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -214,18 +330,18 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "2140d3c3b4cbdf5f2dff2c45281d0b82",
+        "x-ms-client-request-id": "6e33507a620e4f9f0b1f8becf43d8c8c",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;168945250\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;111018409\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;168945250\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:48.1108424\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;111018409\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.9489911\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
@@ -239,21 +355,21 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "9c3306a0f9139a4fcc2c643528cafd71",
+        "x-ms-client-request-id": "701968f6ca51a684549f4f2ab66302bb",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;168945250\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;111018409\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 409,
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelIdAlreadyExists",
-          "message": "Some of the model ids already exist: dtmi:example:Ward;168945250. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
+          "message": "Some of the model ids already exist: dtmi:example:Ward;111018409. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
         }
       }
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictException.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictException.json
@@ -7,10 +7,184 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fe99a38ac6b7c6054f97a9a7f6419320",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;116847374",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:17.6834446\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;116847374",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B116421010?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8e172c74eb6be1675c2ff62fe04a9c42",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;116421010",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:23.7523492\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;116421010",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B118728284?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "49fe526eccc061376cbe22b93e24748f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "612",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;118728284",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:42.608936\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;118728284",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B168945250?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "392fff16b81e1d315b970e966f4c0d65",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -18,13 +192,13 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;116847374. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;168945250. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -37,21 +211,21 @@
         "Content-Length": "567",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "172c74146b8e67ebe15c2ff62fe04a9c",
+        "x-ms-client-request-id": "2140d3c3b4cbdf5f2dff2c45281d0b82",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;116847374\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;168945250\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;116847374\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.7036399\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;168945250\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:48.1108424\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
@@ -62,24 +236,24 @@
         "Content-Length": "567",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "526e324249feccc037616cbe22b93e24",
+        "x-ms-client-request-id": "9c3306a0f9139a4fcc2c643528cafd71",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;116847374\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;168945250\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 409,
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelIdAlreadyExists",
-          "message": "Some of the model ids already exist: dtmi:example:Ward;116847374. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
+          "message": "Some of the model ids already exist: dtmi:example:Ward;168945250. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
         }
       }
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictExceptionAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictExceptionAsync.json
@@ -7,10 +7,184 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d6aefe888904034dcc1935e4537abc9b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;155773321",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:17.4992313\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;155773321",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B145121366?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "e3d2a5cb1255eeffc2ac1cd41e6dc8f6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;145121366",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:56:23.5220705\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;145121366",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B113005607?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "723cc0e56bf6f802e49a6dee471d48f8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;113005607",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:42.5086675\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;113005607",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B181743108?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a534a2ffec33e7af42dc302eadab6ded",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -18,13 +192,13 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;155773321. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;181743108. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -37,21 +211,21 @@
         "Content-Length": "567",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d2a5cb6355e3ff12eec2ac1cd41e6dc8",
+        "x-ms-client-request-id": "5ffc9513d5f1d03aeb717891007b8fd4",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;155773321\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;181743108\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;155773321\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.6262894\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;181743108\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.2857459\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
@@ -62,24 +236,24 @@
         "Content-Length": "567",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c0e53ff6723c6bf602f8e49a6dee471d",
+        "x-ms-client-request-id": "256ef6dc9ac2d4b18c8bb48ed1c936ee",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;155773321\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;181743108\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 409,
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelIdAlreadyExists",
-          "message": "Some of the model ids already exist: dtmi:example:Ward;155773321. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
+          "message": "Some of the model ids already exist: dtmi:example:Ward;181743108. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
         }
       }
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictExceptionAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/ModelsTests/Models_ModelAlreadyExists_ThrowsConflictExceptionAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -76,7 +76,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -134,7 +134,7 @@
       "ResponseHeaders": {
         "Content-Length": "613",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -188,17 +188,133 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;181743108",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T16:57:47.2857459\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;181743108",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B113886965?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f15ffc953ad5ebd0717891007b8fd4dc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "613",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:Ward;113886965",
+        "description": {
+          "en": "A separate partition in a building, made of rooms and hallways."
+        },
+        "displayName": {
+          "en": "Ward"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-26T17:04:46.2547833\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:Ward;113886965",
+          "@type": "Interface",
+          "displayName": "Ward",
+          "description": "A separate partition in a building, made of rooms and hallways.",
+          "contents": [
+            {
+              "@type": "Property",
+              "name": "VisitorCount",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "HandWashPercentage",
+              "schema": "double"
+            },
+            {
+              "@type": "Relationship",
+              "name": "managedRooms"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3AWard%3B144973413?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9ac2256ed4b18b8cb48ed1c936ee0001",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelNotFound",
-          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;181743108. Check that the Model ID provided is valid by doing a Model_List API call."
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:Ward;144973413. Check that the Model ID provided is valid by doing a Model_List API call."
         }
       }
     },
@@ -214,18 +330,18 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5ffc9513d5f1d03aeb717891007b8fd4",
+        "x-ms-client-request-id": "994c88332a376468bac1741de6c64d5c",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;181743108\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;144973413\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "225",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;181743108\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:47.2857459\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:Ward;144973413\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022A separate partition in a building, made of rooms and hallways.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Ward\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.8353052\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
@@ -239,21 +355,21 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "256ef6dc9ac2d4b18c8bb48ed1c936ee",
+        "x-ms-client-request-id": "473db752792b27e3d26520abfe213b89",
         "x-ms-return-client-request-id": "true"
       },
-      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;181743108\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:Ward;144973413\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Ward\u0022,    \u0022description\u0022: \u0022A separate partition in a building, made of rooms and hallways.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022VisitorCount\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022HandWashPercentage\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022managedRooms\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 409,
       "ResponseHeaders": {
         "Content-Length": "230",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "ModelIdAlreadyExists",
-          "message": "Some of the model ids already exist: dtmi:example:Ward;181743108. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
+          "message": "Some of the model ids already exist: dtmi:example:Ward;144973413. Use Model_List API to view models that already exist. See the Swagger example (http://aka.ms/ModelListSwSmpl)."
         }
       }
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_Lifecycle.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f991ef6850b4d6f05168f7c990ed177b",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "419e2f1fb2c82734e25bf07265983212",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1b321d03cf1ffab0612711b9316e789d",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "279",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -93,8 +93,8 @@
         "Content-Length": "150",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "15ca6fc23ca0d25dd1f5ff64eccfc5b7",
         "x-ms-return-client-request-id": "true"
@@ -106,7 +106,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -120,8 +120,8 @@
         "Content-Length": "1139",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "49fae9a10072ed5f47678b226db1ec78",
         "x-ms-return-client-request-id": "true"
@@ -129,12 +129,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:wifiroom;11736\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022RoomWithWifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Component\u0022,            \u0022name\u0022: \u0022wifiAccessPoint\u0022,            \u0022schema\u0022: \u0022dtmi:example:wifi;173948219\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:wifi;173948219\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Wifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022RouterName\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Network\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ]}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "314",
+        "Content-Length": "317",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11736\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.04441\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;173948219\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.044563\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11736\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1362909\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;173948219\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1364286\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin1154827759?api-version=2020-10-31",
@@ -146,8 +146,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c2d5d2d4d947e063d4494edab1957457",
         "x-ms-return-client-request-id": "true"
@@ -172,13 +172,13 @@
       "ResponseHeaders": {
         "Content-Length": "666",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u002269eb16d3-8831-4c6b-95cf-2cbea90f8121\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00220ad032e7-5402-4df8-a268-42f99902597f\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin1154827759",
-        "$etag": "W/\u002269eb16d3-8831-4c6b-95cf-2cbea90f8121\u0022",
+        "$etag": "W/\u00220ad032e7-5402-4df8-a268-42f99902597f\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -188,26 +188,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-22T18:12:10.1085982Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-22T18:12:10.1085982Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;11736",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1085982Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1085982Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1085982Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1085982Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
           }
         }
       }
@@ -223,8 +223,8 @@
         "Message-Id": "8490024c-537e-c221-10dd-ce38b13a6420",
         "Telemetry-Source-Time": "01/01/01 0:00:00 \u002B00:00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1a90870802fac76f85197428b1853bb1",
         "x-ms-return-client-request-id": "true"
@@ -233,7 +233,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -249,8 +249,8 @@
         "Message-Id": "6ad533f2-6821-80f9-b012-b26a0b2a2f99",
         "Telemetry-Source-Time": "01/01/01 0:00:00 \u002B00:00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "29d12de45a05495d92c8fe64dff8108a",
         "x-ms-return-client-request-id": "true"
@@ -261,7 +261,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -273,8 +273,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "7d461da1f965a0ff8d0f69e75005bc5a",
         "x-ms-return-client-request-id": "true"
@@ -283,7 +283,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -295,8 +295,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "8343daea12b397abd68bd8586995a1b8",
         "x-ms-return-client-request-id": "true"
@@ -305,7 +305,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -317,8 +317,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "edc82802b1e4eb342e319cf6f176f98d",
         "x-ms-return-client-request-id": "true"
@@ -327,7 +327,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -339,8 +339,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "047aa40b8db48fd671afa7d921a637f8",
         "x-ms-return-client-request-id": "true"
@@ -349,7 +349,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_Lifecycle.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "279",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -106,7 +106,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -129,12 +129,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:wifiroom;11736\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022RoomWithWifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Component\u0022,            \u0022name\u0022: \u0022wifiAccessPoint\u0022,            \u0022schema\u0022: \u0022dtmi:example:wifi;173948219\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:wifi;173948219\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Wifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022RouterName\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Network\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ]}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "317",
+        "Content-Length": "316",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11736\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1362909\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;173948219\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1364286\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11736\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.6662939\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;173948219\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.666422\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin1154827759?api-version=2020-10-31",
@@ -144,7 +144,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "229",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -172,13 +171,13 @@
       "ResponseHeaders": {
         "Content-Length": "666",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00220ad032e7-5402-4df8-a268-42f99902597f\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u002207ac1516-8d97-4fcc-a7ff-38932c021507\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin1154827759",
-        "$etag": "W/\u00220ad032e7-5402-4df8-a268-42f99902597f\u0022",
+        "$etag": "W/\u002207ac1516-8d97-4fcc-a7ff-38932c021507\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -188,26 +187,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
+              "lastUpdateTime": "2020-10-26T17:04:50.7064102Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
+              "lastUpdateTime": "2020-10-26T17:04:50.7064102Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;11736",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7064102Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7064102Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7064102Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1880286Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7064102Z"
           }
         }
       }
@@ -233,7 +232,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -261,7 +260,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -283,7 +282,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -305,7 +304,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -327,7 +326,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -349,7 +348,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_LifecycleAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "1a86b1c41c4186b1494b92ce5ba07ed8",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "6369091152be006559de3e491f06d880",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -63,8 +63,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "630c5cbd1f316b3fdf80f9ed603a99b5",
         "x-ms-return-client-request-id": "true"
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -93,8 +93,8 @@
         "Content-Length": "150",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5ac796055e051a20e83d733c2a45b94e",
         "x-ms-return-client-request-id": "true"
@@ -106,7 +106,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -120,8 +120,8 @@
         "Content-Length": "1139",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "cc22e335dff529e9f7ded26b12f8a3a5",
         "x-ms-return-client-request-id": "true"
@@ -129,12 +129,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:wifiroom;11451\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022RoomWithWifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Component\u0022,            \u0022name\u0022: \u0022wifiAccessPoint\u0022,            \u0022schema\u0022: \u0022dtmi:example:wifi;120658425\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022},{    \u0022@id\u0022: \u0022dtmi:example:wifi;120658425\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022,    \u0022displayName\u0022: \u0022Wifi\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022RouterName\u0022,            \u0022schema\u0022: \u0022string\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Network\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ]}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "315",
+        "Content-Length": "317",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11451\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.11107\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120658425\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.1112371\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11451\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1027947\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120658425\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1029473\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin145661990?api-version=2020-10-31",
@@ -146,8 +146,8 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4200b793cbb8feb7eb4949e1cc2fb53a",
         "x-ms-return-client-request-id": "true"
@@ -172,13 +172,13 @@
       "ResponseHeaders": {
         "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "ETag": "W/\u00227c745a96-7daf-49d1-aea9-aa54be6fe68e\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00223cdb6f41-9097-4eaa-b858-251bd64db569\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin145661990",
-        "$etag": "W/\u00227c745a96-7daf-49d1-aea9-aa54be6fe68e\u0022",
+        "$etag": "W/\u00223cdb6f41-9097-4eaa-b858-251bd64db569\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -188,26 +188,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-22T18:12:10.1719833Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-22T18:12:10.1719833Z"
+              "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;11451",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1719833Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1719833Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1719833Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.1719833Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
           }
         }
       }
@@ -223,8 +223,8 @@
         "Message-Id": "572b9f3f-e977-2672-ac9e-62268cb407ef",
         "Telemetry-Source-Time": "01/01/01 0:00:00 \u002B00:00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "72a8ce9a774569952b23e1ac96075dc8",
         "x-ms-return-client-request-id": "true"
@@ -233,7 +233,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -249,8 +249,8 @@
         "Message-Id": "732c9729-4bcd-aa2d-44d9-951a68907236",
         "Telemetry-Source-Time": "01/01/01 0:00:00 \u002B00:00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fe475a414286c8f509c12c5307c690a5",
         "x-ms-return-client-request-id": "true"
@@ -261,7 +261,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -273,8 +273,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f4fd9a4093884e22a0fe2e6be27b009b",
         "x-ms-return-client-request-id": "true"
@@ -283,7 +283,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -295,8 +295,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "3b6aaab15fc0e742a2646a0b1fd9a37e",
         "x-ms-return-client-request-id": "true"
@@ -305,7 +305,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -317,8 +317,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ced9ef497d93adad37f95d881389e58d",
         "x-ms-return-client-request-id": "true"
@@ -327,7 +327,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -339,8 +339,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5ca190c1545ce1e55715522429162ec6",
         "x-ms-return-client-request-id": "true"
@@ -349,7 +349,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/PublishTelemetryTests/PublishTelemetry_LifecycleAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,7 +74,7 @@
       "ResponseHeaders": {
         "Content-Length": "278",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -106,7 +106,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -131,10 +131,10 @@
       "ResponseHeaders": {
         "Content-Length": "317",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11451\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1027947\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120658425\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.1029473\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:wifiroom;11451\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022RoomWithWifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.4174915\u002B00:00\u0022},{\u0022id\u0022:\u0022dtmi:example:wifi;120658425\u0022,\u0022description\u0022:{},\u0022displayName\u0022:{\u0022en\u0022:\u0022Wifi\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:51.4176955\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomWithWifiTwin145661990?api-version=2020-10-31",
@@ -144,7 +144,6 @@
         "Authorization": "Sanitized",
         "Content-Length": "229",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
@@ -172,13 +171,13 @@
       "ResponseHeaders": {
         "Content-Length": "665",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00223cdb6f41-9097-4eaa-b858-251bd64db569\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022f1ab5d0c-90a7-45af-8e59-16a21f1da415\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomWithWifiTwin145661990",
-        "$etag": "W/\u00223cdb6f41-9097-4eaa-b858-251bd64db569\u0022",
+        "$etag": "W/\u0022f1ab5d0c-90a7-45af-8e59-16a21f1da415\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -188,26 +187,26 @@
           "Network": "Room1",
           "$metadata": {
             "RouterName": {
-              "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
+              "lastUpdateTime": "2020-10-26T17:04:51.4767689Z"
             },
             "Network": {
-              "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
+              "lastUpdateTime": "2020-10-26T17:04:51.4767689Z"
             }
           }
         },
         "$metadata": {
           "$model": "dtmi:example:wifiroom;11451",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4767689Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4767689Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4767689Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.1448419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4767689Z"
           }
         }
       }
@@ -233,7 +232,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -261,7 +260,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -283,7 +282,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -305,7 +304,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -327,7 +326,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -349,7 +348,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorks.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorks.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "66d02ba6db7cebecdd827ac03559527d",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "5576585e8501fee9ae888120afaa7cac",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -65,8 +65,8 @@
         "Content-Length": "804",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "ae76d3316ef75d947e1137eadb0e7c96",
         "x-ms-return-client-request-id": "true"
@@ -76,10 +76,10 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;113863769\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.7798266\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;113863769\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.9755616\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1369668520?api-version=2020-10-31",
@@ -88,65 +88,24 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "f70daceba407e6a568cd526aca2dd8fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1369668520. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1369668520?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "db860314d1cec3f019d6f04eff23a00b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1369668520",
-        "$etag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+        "$etag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,31 +113,123 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1470142442?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin258863380?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6ffdc4782ab5d12fc78fa042f3b4e35e",
+        "x-ms-client-request-id": "cedb8603f0d119c3d6f04eff23a00bea",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin258863380",
+        "$etag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin379883128?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b56ffdc42f2ac7d18fa042f3b4e35eec",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin379883128",
+        "$etag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1062677703?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d9bbf60abc1ade4a30b456e7442d4780",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -186,18 +237,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1470142442. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1062677703. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1470142442?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1062677703?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -206,10 +257,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f60ac7ecd9bbbc1a4ade30b456e7442d",
+        "x-ms-client-request-id": "8edb6952d95e0a5607414f8026210cf0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -227,13 +278,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1470142442",
-        "$etag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
+        "$dtId": "roomTwin1062677703",
+        "$etag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -241,50 +292,50 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin581255239?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1462038290?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "db6952805e8e56d90a07414f8026210c",
+        "x-ms-client-request-id": "2f14955ba99e2540d7f97a7ae04a72fa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "Content-Length": "270",
+        "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin581255239. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1462038290. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin581255239?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1462038290?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -293,10 +344,97 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "955b12f02f14a99e4025d7f97a7ae04a",
+        "x-ms-client-request-id": "83796173685d9f31b0d2d86cc9b70fa7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1462038290",
+        "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin462997606?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3298e9d4b4509abf6987e0db8f26f7dd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "270",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin462997606. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin462997606?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "If-None-Match": "*",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "93c0b286b56d64f3757fcbd1d35b1fea",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -314,13 +452,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin581255239",
-        "$etag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
+        "$dtId": "roomTwin462997606",
+        "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -328,31 +466,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1115371378?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1543128019?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "796173fa5d8331689fb0d2d86cc9b70f",
+        "x-ms-client-request-id": "da600b1422c8b9ade8f3e051c321abe0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -360,18 +498,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1115371378. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1543128019. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1115371378?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1543128019?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -380,10 +518,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "e9d466a73298b450bf9a6987e0db8f26",
+        "x-ms-client-request-id": "4e04428ff914f61f33bcd1e8eec70e68",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -401,13 +539,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1115371378",
-        "$etag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
+        "$dtId": "roomTwin1543128019",
+        "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -415,31 +553,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1107764983?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1750846709?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c0b286dd6d93f3b564757fcbd1d35b1f",
+        "x-ms-client-request-id": "961b7a08bd021290d984c11213b15d1f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -447,18 +585,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1107764983. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1750846709. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1107764983?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1750846709?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -467,10 +605,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "0b14d3eada6022c8adb9e8f3e051c321",
+        "x-ms-client-request-id": "1a1844f0bf9beb1b6aa60b51c4cb21e5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -488,13 +626,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1107764983",
-        "$etag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
+        "$dtId": "roomTwin1750846709",
+        "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -502,205 +640,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1651185579?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin422308472?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "04428fe0144e1ff9f633bcd1e8eec70e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1651185579. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1651185579?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7a08f568961bbd029012d984c11213b1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "461",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin1651185579",
-        "$etag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1965876829?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "1844f01f9b1a1bbfeb6aa60b51c4cb21",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1965876829. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1965876829?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "bb5b78e590a68c4a85743b3a745ee320",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "461",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin1965876829",
-        "$etag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin829263883?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "82fdc8734ef5485a5f2f2b5cb23e4e0d",
+        "x-ms-client-request-id": "90a6bb5b8c4a74853b3a745ee3200b73",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -708,18 +672,18 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin829263883. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin422308472. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin829263883?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin422308472?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -728,10 +692,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "b79adb63b7f6a68fb793a55f84a68d86",
+        "x-ms-client-request-id": "f582fdc85a4e5f482f2b5cb23e4e0d63",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -749,13 +713,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin829263883",
-        "$etag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
+        "$dtId": "roomTwin422308472",
+        "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -763,118 +727,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin469162630?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1648554203?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "cefcdd00f09e00297247601e30d335ed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin469162630. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin469162630?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4982112d156838bb56ca61a8fbc3b8a2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "460",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002283d93d5f-bc48-4814-b97c-e390ea4c56fe\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin469162630",
-        "$etag": "W/\u002283d93d5f-bc48-4814-b97c-e390ea4c56fe\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5968981Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5968981Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5968981Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5968981Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2079625124?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5160b1d6c43f70ebb783702f8887c06f",
+        "x-ms-client-request-id": "b7f6b79aa68f93b7a55f84a68d868600",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -882,18 +759,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin2079625124. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1648554203. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2079625124?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1648554203?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -902,10 +779,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "0a9557711d3d22eac377d48e8105ae8e",
+        "x-ms-client-request-id": "9ecefcdd29f0720047601e30d335ed2d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -923,13 +800,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00227f5d7341-0152-434a-8fe9-484dcb675038\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin2079625124",
-        "$etag": "W/\u00227f5d7341-0152-434a-8fe9-484dcb675038\u0022",
+        "$dtId": "roomTwin1648554203",
+        "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -937,16 +814,277 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.7076339Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.7076339Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.7076339Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.7076339Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin817870353?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1568498238bbca5661a8fbc3b8a2a4d6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "270",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin817870353. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin817870353?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "If-None-Match": "*",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3f5160b1ebc4b77083702f8887c06f71",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin817870353",
+        "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1240738903?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1d3d0a9522ea77c3d48e8105ae8ebe79",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1240738903. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1240738903?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "If-None-Match": "*",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9cd4215a4cedd997b1914b09ce42a139",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1240738903",
+        "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1491061385?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6797226cc7b88e3ec8f05cefb1d4e171",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1491061385. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1491061385?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "If-None-Match": "*",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9a9f2d0e69d57348636c59d6b9a891ed",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1491061385",
+        "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
           }
         }
       }
@@ -960,10 +1098,10 @@
         "Content-Length": "38",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "215a79be9cd44ced97d9b1914b09ce42",
+        "x-ms-client-request-id": "6b427c4711265aa1960d255c3aea00bd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -971,4817 +1109,212 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "45693",
+        "Content-Length": "33956",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "20.169999999999998",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "15.100000000000001",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1498980297",
-            "$etag": "W/\u0022d9379766-dc49-4095-8469-7117a69534b0\u0022",
+            "$dtId": "roomTwin1495950345",
+            "$etag": "W/\u002205d2ae31-6929-4d7e-af04-4a44b4b31e8b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;112984610",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1381264736",
-            "$etag": "W/\u00229530fad8-8481-4207-a3a2-54f75c33e03f\u0022",
+            "$dtId": "roomTwin344050324",
+            "$etag": "W/\u0022f8d463fc-b497-42c5-9d24-8bf2eb63c8ac\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112462194",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin746222802",
-            "$etag": "W/\u00221c55bd1b-4dc3-48a5-a694-7504c7387b38\u0022",
+            "$dtId": "roomTwin427623005",
+            "$etag": "W/\u00221af94c6c-ba7b-43af-b731-3c747d441259\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;119618957",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin775031637",
-            "$etag": "W/\u0022f2e095ad-618a-44d8-ae54-fb1acaf9d041\u0022",
+            "$dtId": "roomTwin410651761",
+            "$etag": "W/\u00229de8f988-b123-411e-81d1-b9b2647c5bfa\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112725529",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1245991748",
-            "$etag": "W/\u0022b941c874-b71d-4d29-8987-55a489ce4757\u0022",
+            "$dtId": "roomTwin744180983",
+            "$etag": "W/\u002263bb6047-a862-4977-b4f0-c9890d2b3370\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;115056947",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1444644859",
-            "$etag": "W/\u00226102e256-e029-43c3-88e2-7fcdf1df31be\u0022",
+            "$dtId": "roomTwin1437249777",
+            "$etag": "W/\u0022ef65f3f3-9966-4092-bf4c-b466ccb270f9\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;158485519",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1163564709",
-            "$etag": "W/\u0022670f1a13-ef3c-4450-a0ec-6b9ec342415e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin936523733",
-            "$etag": "W/\u0022df870f13-0fce-4273-b8b2-1f0cc9360973\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1174159166",
-            "$etag": "W/\u0022660a990d-f9d7-4588-97dd-b5e45bc98086\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin86672577",
-            "$etag": "W/\u0022fd6efd7e-0d32-4bf7-a8cf-0bcd64ae75c6\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1870986745",
-            "$etag": "W/\u0022c7480283-c513-4b7e-9937-8074f62ace65\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1536838429",
-            "$etag": "W/\u0022bcbed22e-248a-43ee-9594-5fdf5c571cbd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin661851410",
-            "$etag": "W/\u0022af7780a2-175d-4891-a13f-df6c145fd88e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110247197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1085222686",
-            "$etag": "W/\u0022bf070c35-d9ff-46f0-ab3d-c96099615404\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;166246968",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420943146",
-            "$etag": "W/\u002221e209f9-0bf3-4a09-9cda-3f0bb04813b8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1338380856",
-            "$etag": "W/\u00224cd0743c-7862-43df-873a-4b41374d1544\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1785890025",
-            "$etag": "W/\u00225d658a38-9807-4a54-a993-3484b1bb15e1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1000297038",
-            "$etag": "W/\u00223aa0b952-daba-4ff9-bcb8-602da4399405\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1893330133",
-            "$etag": "W/\u00225ebe6eae-1a9d-46ed-acde-5e4da8aeea0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123218210",
-            "$etag": "W/\u002214760d80-a8ce-4843-b0e4-56e6e9f4dd27\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1520206458",
-            "$etag": "W/\u0022835208c2-4a55-4de7-b10e-dc4187d5882e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin92117139",
-            "$etag": "W/\u00224cc2ce94-15c6-4ae7-a020-4f9a9792ab09\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36128330",
-            "$etag": "W/\u00225adde61e-e412-49cf-a752-527bd8b3aba2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777097876",
-            "$etag": "W/\u0022e27281c3-f22a-47a9-82ee-7b0f0b267d48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470032629",
-            "$etag": "W/\u002256fc5f73-a1df-4e71-8bea-54ed682348af\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1800780114",
-            "$etag": "W/\u0022516b6d16-ef6d-47c8-8cfb-1854ca4835bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin27801422",
-            "$etag": "W/\u0022539467f6-fbb6-4360-a729-c39f353f3253\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1902584715",
-            "$etag": "W/\u00221884e5dc-2708-427a-9eaa-6d2e83841d06\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin96827413",
-            "$etag": "W/\u0022ef52e4c6-e6a3-4bb3-8005-997c3d9f44dd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin935053957",
-            "$etag": "W/\u002264c75c6e-a2a9-441b-beda-2b306818df87\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2074335826",
-            "$etag": "W/\u00221c81ad83-61b8-4fde-bea7-4f42e5e899ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123629177",
-            "$etag": "W/\u0022db3407f5-6797-483a-ac54-66cf8491c767\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1554813222",
-            "$etag": "W/\u0022817cabe6-9a22-4634-a34d-177273d33068\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1699890695",
-            "$etag": "W/\u00227084f858-2fd9-423c-9998-d831f293c5f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1088498238",
-            "$etag": "W/\u00221d4e9b50-b84b-45da-ab41-b40a11736140\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;158383040",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin894415666",
-            "$etag": "W/\u0022f5f49f19-15f2-45e1-ab5f-1f6ad65d49f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113309762",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148688568",
-            "$etag": "W/\u0022185a6e23-5cdc-43c3-9f98-bce142ef1635\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin605247566",
-            "$etag": "W/\u002285ec04a7-1fc5-4cb5-a028-fb7646cee045\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1738278687",
-            "$etag": "W/\u002265469fb8-0e42-4c50-88c4-9499db8d30d1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin883341753",
-            "$etag": "W/\u0022c6d743e3-2171-46df-9875-45107360b597\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin44768029",
-            "$etag": "W/\u0022e0bf97cb-0ca6-4f19-9c87-c12c508eb7eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1026080773",
-            "$etag": "W/\u0022be607bbe-b367-42de-b426-17d53b764e00\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1012130572",
-            "$etag": "W/\u0022e9d0ad86-5382-41dc-95e4-7365514401dc\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin314886311",
-            "$etag": "W/\u0022ed0846f6-8b98-44f6-8dab-96f5271ce59b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1045652022",
-            "$etag": "W/\u0022deb78b85-2b4d-4695-b234-c6dfae1bf0a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin516625160",
-            "$etag": "W/\u00226b21212e-eb4d-4ad9-aac3-ca364cb5e3e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1891959418",
-            "$etag": "W/\u0022183aa253-51e8-4af1-9bd5-3ea98350d1bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829360197",
-            "$etag": "W/\u0022243c49a4-115d-4669-a7cb-1ed898e2de78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin61707195",
-            "$etag": "W/\u0022e6422265-b580-4e10-afa7-a032f40d0aea\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783915272",
-            "$etag": "W/\u0022a43fd4d5-65cf-4b7b-81f6-80e88ff3f822\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1041693882",
-            "$etag": "W/\u002245a8e4ec-fdbc-4d18-8396-559141ddc01b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021340528",
-            "$etag": "W/\u002298a5b93f-4034-4738-a576-b128341aaf2e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1677577135",
-            "$etag": "W/\u00223040ab87-d137-4d12-a562-f450d3bb45a9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin124606454",
-            "$etag": "W/\u00223c60e1ac-b594-4cce-8c1a-718c37a715ef\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1154990313",
-            "$etag": "W/\u00223650ee8c-f86f-4c1a-900a-2c4f11e8ebc8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2132961076",
-            "$etag": "W/\u00227a0bf9a7-9d8a-4db6-8191-84220168680b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin57113376",
-            "$etag": "W/\u0022cfcf6f4c-808d-4ce1-8f81-667ef4e74b4a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116251683",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin619150749",
-            "$etag": "W/\u00223194e119-b36a-4efa-8af0-b99c24d45ff7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170550470",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin551511810",
-            "$etag": "W/\u00222d430b86-fa94-44cc-b68a-6df9644aceff\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin98472762",
-            "$etag": "W/\u00226c5eb657-d221-4ed2-82c1-0197f69a3f30\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin869013250",
-            "$etag": "W/\u0022a3c3dc57-4372-4c4f-bf36-feb06b12f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin722764700",
-            "$etag": "W/\u0022180669f5-37cf-454a-9ed9-5f7c29bd5c21\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2125813792",
-            "$etag": "W/\u00220c25d51f-a3a9-4a12-a66b-a3fef02f32c8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1564789991",
-            "$etag": "W/\u00222f754f56-075a-4ef8-a9e4-7e189ddc22bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin729153756",
-            "$etag": "W/\u0022400fe9ad-eb92-47f5-a772-ec2b5ead9606\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1489152938",
-            "$etag": "W/\u002228c2d505-7c3b-40d2-80e0-17f323c70679\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1637856858",
-            "$etag": "W/\u0022ec90109a-be27-4750-8548-cf61eec5aa0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1363211591",
-            "$etag": "W/\u0022dd52474a-d61e-4eb5-8e3b-3b99cdd61baf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin838663785",
-            "$etag": "W/\u00227c4b95c6-3be9-40ee-8e4e-a3e78574aa34\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1300086570",
-            "$etag": "W/\u0022f1ebf4ba-6b6b-4c6b-9f31-c539d71178d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin151462022",
-            "$etag": "W/\u002298d16ff0-f7bf-4254-9d03-c9a4cb58c201\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1308729416",
-            "$etag": "W/\u0022ba6f41ec-b8f2-490a-bc1e-ff5514196325\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1856167476",
-            "$etag": "W/\u0022a211c53e-af56-4cc8-b77d-724bd8558d33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1336007415",
-            "$etag": "W/\u00229687aa69-50b9-4d7b-84b2-6b85e192050a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin662815516",
-            "$etag": "W/\u002269473407-2871-4d05-8e0f-2431ce8eafc1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin94298757",
-            "$etag": "W/\u002262eb0428-71b3-4a77-84ac-5e64f19ceb78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1612778009",
-            "$etag": "W/\u0022c9da2088-b6f7-4767-848e-4e10cfeb9ee4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin856851558",
-            "$etag": "W/\u0022c623ba55-3c32-4a56-8574-65dd548ab6e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin229826714",
-            "$etag": "W/\u002238488fbd-d87b-42dc-93d0-916af0949b4b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111655996",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin526434890",
-            "$etag": "W/\u0022c19adbeb-77ce-4d0c-95d4-708d88de7b79\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;141760569",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin941711815",
-            "$etag": "W/\u0022eb738161-f2e0-4587-8cb5-29ad474cf93d\u0022",
+            "$dtId": "roomTwin586733773",
+            "$etag": "W/\u00223524936d-5b93-4952-b9bc-403660889807\u0022",
             "AverageTemperature": 75,
             "$metadata": {
-              "$model": "dtmi:example:floor;13675231",
+              "$model": "dtmi:example:floor;11489901",
               "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.0436535Z"
+                "lastUpdateTime": "2020-10-23T21:22:11.7284978Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1735182331",
-            "$etag": "W/\u00221c736187-8abb-499b-8063-cf15994d06b5\u0022",
+            "$dtId": "roomTwin1579359106",
+            "$etag": "W/\u00226c41c324-e714-4346-97ee-3d7a43ebf892\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;153048334",
+              "$model": "dtmi:example:room;113317821",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               }
             }
           },
           {
-            "$dtId": "hvacTwin1335730075",
-            "$etag": "W/\u0022addded86-bbbe-48c6-915a-c42cd3b17213\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114614787",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin2117646547",
-            "$etag": "W/\u00222dc91dfa-469e-431d-97b6-c088938f5370\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;17595302",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.2858058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin918788440",
-            "$etag": "W/\u0022de783261-56c0-4f53-8cbd-b0520b4d6f11\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140750981",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin895881838",
-            "$etag": "W/\u0022d3d51c9d-eddd-4113-8a52-efa9f2f11426\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin492624016",
-            "$etag": "W/\u0022e231036b-9573-4cf6-93bc-4f76168ba9c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin818663445",
-            "$etag": "W/\u0022166be958-7415-4134-a4f5-7c474985c5a3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin778426230",
-            "$etag": "W/\u002297b83dbf-0971-406c-b656-d9bb25d2fe70\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;110356330",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846657163",
-            "$etag": "W/\u0022d04aa87a-a541-4896-a7fe-5eab16c99744\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin169049424",
-            "$etag": "W/\u002211259cdf-2b5d-4824-b381-10316d5c8617\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2003290546",
-            "$etag": "W/\u0022c41115df-04d0-4c5a-bc58-0ae0e7a1bbca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1920637755",
-            "$etag": "W/\u0022b1c7a4c4-5bef-4d51-8f28-6a8a99a9b955\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin567255450",
-            "$etag": "W/\u00228b132e44-b0db-4d8a-b004-3410fbd9ec66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin466450821",
-            "$etag": "W/\u0022d142de37-2196-4bec-a201-fe3146f28272\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin652828980",
-            "$etag": "W/\u0022360ae1fa-aa9d-4bd4-b2bd-8302ffa69453\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1658744984",
-            "$etag": "W/\u0022bfbfbc70-049c-4ea8-9a7e-8240bc3b49ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1108577855",
-            "$etag": "W/\u00229e4d190d-271d-4ad8-9ea6-9fa8d412cf99\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin881848871",
-            "$etag": "W/\u0022fa12869e-c78e-4c94-8c0d-6fc358b6e852\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin34125080",
-            "$etag": "W/\u002282a0d23e-5444-4f11-ac2f-d15d1909237e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "400",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6c8939a19722b867c73e8ec8f05cefb1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "44551",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "19.939999999999998",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin716576755",
-            "$etag": "W/\u0022928a136b-494e-4965-99e9-128202587246\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1961257007",
-            "$etag": "W/\u00227a297279-19b8-447a-8396-194df0d8b0ae\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1791197485",
-            "$etag": "W/\u00221bf81066-9eb3-44f5-aa96-d5f7e20946e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1867071453",
-            "$etag": "W/\u0022342a88f2-0dcc-4575-aa58-315006cd4ef1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1641901809",
-            "$etag": "W/\u00226911c53c-1a10-4321-9bea-aeeeca373ff9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1133125955",
-            "$etag": "W/\u00226b21e7dc-b4e9-4087-9c14-5a0b4fb2b15b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin246922244",
-            "$etag": "W/\u002270fb7b44-ac8b-496d-a15c-e96448dfac66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;117012504",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1642617034",
-            "$etag": "W/\u0022f7cd24c9-808b-4aa1-9fc1-d774acdfac57\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115956238",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin1545002397",
-            "$etag": "W/\u0022ae4ea64f-5b12-4c7d-8a1d-13abaaa68bd4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;16329224",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9538711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin792160889",
-            "$etag": "W/\u00227b70c14e-a9b9-409d-b05d-8c3b3de34ea4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;15819678",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9854614Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin62721381",
-            "$etag": "W/\u0022abe2d779-e33d-48b7-832f-8326022a02eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110307862",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777965033",
-            "$etag": "W/\u00227ac6cc9c-0616-4b52-bde0-1a7b1d90920c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116838841",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin849612920",
-            "$etag": "W/\u002255796041-ffda-44e6-a4d5-a29bb1b25550\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;147745744",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin387213787",
-            "$etag": "W/\u0022303aaebf-8a01-4315-92b4-3f5aa59c7aae\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114856351",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1741612918",
-            "$etag": "W/\u0022af3841ce-ae9d-49c7-96c9-680c8c704cda\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36952557",
-            "$etag": "W/\u00225017547e-5cb7-4270-8732-0fd935c5f36f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1213006989",
-            "$etag": "W/\u002239424cf2-71fa-407b-8b28-63cf3b636731\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin326513034",
-            "$etag": "W/\u00225350ca2a-c97e-4c6e-b4e2-4db4cc81475c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1129721811",
-            "$etag": "W/\u00228dba5565-d060-4bad-a801-4f9bbc4ebdf0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1947553667",
-            "$etag": "W/\u00222d6acbd7-fcfd-40c3-80e1-a33bf5092293\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1548928947",
-            "$etag": "W/\u0022ee3e799c-7ec3-44a5-bf99-608ae6ed2d0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin356265635",
-            "$etag": "W/\u0022cddfa5c7-ba8d-4f3f-a5c7-49ed794ace2f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1989978078",
-            "$etag": "W/\u0022d8a52677-b719-4322-b2a3-797951f9dfa7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin863816413",
-            "$etag": "W/\u002235dced59-748a-497b-8436-fa6c7ecd7c98\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin240878892",
-            "$etag": "W/\u0022cea21915-9749-47be-a426-12523c767a8e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1466134063",
-            "$etag": "W/\u00224b6c3b89-c127-4389-9623-6600823c637a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin503181323",
-            "$etag": "W/\u0022343c3eeb-88f4-48e3-b6a3-502e67d17d19\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin392271939",
-            "$etag": "W/\u0022076c63c0-54bd-4d30-b79f-b8779d515826\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin496261044",
-            "$etag": "W/\u0022f30db489-e0f9-4a4e-af15-7be164045d7e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin277216622",
-            "$etag": "W/\u00226566f3cb-3282-4c34-bce7-f1fd53b6b79a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin815041708",
-            "$etag": "W/\u0022df1321a9-3cd1-4196-aec2-4d21b631ca88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2006012899",
-            "$etag": "W/\u0022e71c7453-81c2-472c-9f6e-ea913867dfdb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin446974150",
-            "$etag": "W/\u0022b00117ad-a23b-4de8-a474-7bd59421fbc0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1365881715",
-            "$etag": "W/\u00223179b0b2-935f-4f4b-a0ec-e41bb6e355f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin681325335",
-            "$etag": "W/\u0022217888d9-1f32-4fc6-82a2-33d958d48c88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;164255196",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1142241383",
-            "$etag": "W/\u0022a45ffefb-8f34-4c0a-add6-029f59e7617f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;177720708",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin825845031",
-            "$etag": "W/\u0022893f390d-bd64-4c1d-8d69-563fd59f8c4e\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11574869",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.0086720Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1278234179",
-            "$etag": "W/\u00225d49dfd5-ca5c-44b1-a4c6-747f37720a9c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116571386",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin761943018",
-            "$etag": "W/\u0022990146bb-c3b6-4c49-a75b-50507494bd16\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;170683712",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin944298631",
-            "$etag": "W/\u002298b1fda1-4a5e-4e6b-a2c8-75966dd516ef\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11611266",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.7888364Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783813120",
-            "$etag": "W/\u00220b45aca6-bc41-4732-b559-3ebab02a7323\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112884932",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin462228998",
-            "$etag": "W/\u002276c721ed-c6f3-4747-9745-25aced995423\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;187698996",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin12238764",
-            "$etag": "W/\u002211b2a2c7-b161-40cd-92d7-a40ff0cdeec4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;19256426",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.4582895Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin20436333",
-            "$etag": "W/\u0022f7f6a258-469b-46e5-a27b-363cdd21bad5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112740527",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin57116881",
-            "$etag": "W/\u002249f8c592-afc4-4e28-80a1-2dbcdc2797b4\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;181789456",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin394026428",
-            "$etag": "W/\u0022a3076bd7-cbeb-4789-bc6c-509e1847f6e3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin596581608",
-            "$etag": "W/\u0022473d9d87-f909-4e33-b722-66cdc90c5b9a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1684161797",
-            "$etag": "W/\u0022b9a14ed9-ce85-445a-85ae-3f80705534bf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1901267486",
-            "$etag": "W/\u0022c55a0283-f169-4e3b-b272-d9875a72ecdd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531586602",
-            "$etag": "W/\u00223e77b5c1-75a6-4c89-8048-04e0028cf6b9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148061498",
-            "$etag": "W/\u0022c43f33d8-1c82-4fc8-890b-22e7d8f5d9d4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin436096292",
-            "$etag": "W/\u002204b66e10-cace-4bed-8cfb-8d61e27f1c12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin154780388",
-            "$etag": "W/\u002283328534-f7c3-43b2-b38f-c72bc979eb05\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121341206",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2127865916",
-            "$etag": "W/\u002241d23a05-ab39-4bd0-befe-e8159958181f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin317362118",
-            "$etag": "W/\u002202c13fde-87db-4716-a76b-d47bf709ee97\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin795448273",
-            "$etag": "W/\u0022dddf6522-6705-4b5b-82e9-54b6d744e55b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1710347499",
-            "$etag": "W/\u00224096019c-3f62-4a1f-ae96-b87531ce1b77\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin288024548",
-            "$etag": "W/\u0022426e9bb8-9bce-474a-b00d-ddfdb1e241d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1380865941",
-            "$etag": "W/\u0022e4c1ba36-c62c-400a-ad86-1cc6cf417eab\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1205304854",
-            "$etag": "W/\u0022f1d5b58c-bfdf-428b-9b23-925a89563116\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1400981480",
-            "$etag": "W/\u0022e5a90477-8fde-4e02-a38c-5b04ffd5931a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651261841",
-            "$etag": "W/\u0022d3c1a5d2-e6a5-4ef4-8113-3017514680ce\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113490432",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846170454",
-            "$etag": "W/\u0022ec7b5277-9742-4275-967f-031a47256655\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin955395753",
-            "$etag": "W/\u0022e07bd3aa-8240-4129-a2d2-3d2480e20e5a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin251907959",
-            "$etag": "W/\u002270b9ed8a-f221-4273-bbb6-3086c7c08134\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1402000963",
-            "$etag": "W/\u00225537c1d2-d31d-4cce-9055-cd4db8037551\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1857138761",
-            "$etag": "W/\u002215d19e36-1f58-4471-b631-9cc6d82a01c5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531597311",
-            "$etag": "W/\u002288a3c17e-fb49-4a32-89a6-a1844bd8b5f0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin978222842",
-            "$etag": "W/\u00221e592604-2baa-44b9-bee5-c02e4febded7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1784653895",
-            "$etag": "W/\u00225a1eae7d-10b0-4e7a-b1b7-39360e9971e7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin860770335",
-            "$etag": "W/\u00227fe3ddd0-f34d-4be5-8f6e-78cda890ff8c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1701359617",
-            "$etag": "W/\u0022ab1f392a-6de1-4345-b64b-0f1f5419d92f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1587783567",
-            "$etag": "W/\u00220dd5eba4-5206-492d-8d01-934308ca6959\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin778324998",
-            "$etag": "W/\u0022f19c7ff2-115b-4127-a53f-ed6cf0f7e1e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1721371793",
-            "$etag": "W/\u0022e5f73835-efc9-4ab1-819f-8fb71f80b538\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1364369720",
-            "$etag": "W/\u0022ff0e66bb-a4cc-4c37-959d-2da828e160f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1445460884",
-            "$etag": "W/\u00220cb86433-53cc-49c9-b9ab-6448cec7afcd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1233820890",
-            "$etag": "W/\u00227e1a444e-e4f6-4416-99cb-1bdde45d8e73\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1573366635",
-            "$etag": "W/\u0022b6546bb2-b968-4178-9bdb-e2e5e002f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420514752",
-            "$etag": "W/\u00222c4d0208-068e-4126-abf9-79263c90e1db\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2115849553",
-            "$etag": "W/\u00221f455fa2-f401-4657-9e91-68a8be9d8f0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1984619459",
-            "$etag": "W/\u002290fe6812-eac8-4eba-bb1a-a6a7c06b097c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021579934",
-            "$etag": "W/\u00222355c543-f166-4805-b55f-d461d10778ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1393309463",
-            "$etag": "W/\u0022f0c4bcfc-283f-4897-b223-3b00b32a8cb5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2024624619",
-            "$etag": "W/\u0022e8338894-16a7-4f02-95ac-102569a5c0e5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin933351314",
-            "$etag": "W/\u002208cf970b-08ec-47b3-9224-032838969536\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1518012781",
-            "$etag": "W/\u00229d858eb7-7b5d-4eff-8c94-4c57c5dba129\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1179828134",
-            "$etag": "W/\u0022b25cf002-a500-42b5-a846-1d6cd81b3586\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;129779251",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1293663163",
-            "$etag": "W/\u002292c9e2ab-d24c-43da-abac-7633ed8535bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170920816",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin300828834",
-            "$etag": "W/\u00226663329b-53ec-45c7-8539-126c1273c68d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin456165914",
-            "$etag": "W/\u0022e4d8c25b-329e-4de2-8b7e-25c33f8e85a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin612612248",
-            "$etag": "W/\u00225a6f3040-d114-4c67-b612-5ee5198bc0f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829071132",
-            "$etag": "W/\u0022ec9774d1-b5a3-4394-9a9d-0be5660616c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin593110535",
-            "$etag": "W/\u00221ded5390-1f3f-402f-8749-ebc6cf6da95f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin199646658",
-            "$etag": "W/\u0022f831e71d-cee1-4d7a-ac7f-ca9426d1a01c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin461434088",
-            "$etag": "W/\u00221f00217f-5f02-400d-bdfb-9b07ab072f9d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin805249019",
-            "$etag": "W/\u0022efb00acf-a54a-48eb-b69b-3fc39662fc0d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin862791772",
-            "$etag": "W/\u002233cc79ef-1cf5-4b55-92c3-7760427c8c38\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin839672662",
-            "$etag": "W/\u00220440e839-1432-470e-805b-591e4afd0b12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin150497704",
-            "$etag": "W/\u002215e94910-9ee2-431c-906f-509451334a6d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "380",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0e71e1d49f2dd59a694873636c59d6b9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "12959",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "8.02",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin99161790",
-            "$etag": "W/\u0022e89b9c86-d478-41d6-9b3c-5505d1277b95\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin499786833",
-            "$etag": "W/\u0022563f9a30-99c8-4197-b31e-c4199e2865ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1813293646",
-            "$etag": "W/\u002244e3bd17-6bbc-44a4-b29c-334c10a6fe48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1776504490",
-            "$etag": "W/\u00226ecfacf8-3ce1-43a9-84c4-81ff36cb8cca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2000851912",
-            "$etag": "W/\u0022b4e60ad6-418e-4d47-86d2-70831e0559a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1130568982",
-            "$etag": "W/\u00223cd300f9-a8d1-460e-bc54-1bb4154625f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1407313670",
-            "$etag": "W/\u0022909d36c5-f041-4b52-8323-027f1050d23c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin515255931",
-            "$etag": "W/\u00226096bae3-8200-4d3a-af19-43c98c5fc9c0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1095480396",
-            "$etag": "W/\u00220be2e194-af2a-4dc1-9d0c-b2d51dea4c5d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin362889809",
-            "$etag": "W/\u0022e0bd3738-4244-4fef-9790-ffe6ba661b24\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;128737197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1921780853",
-            "$etag": "W/\u0022e7726775-9d63-40fc-af0c-cb92025bfafd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;157701634",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin537968733",
-            "$etag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
+            "$dtId": "roomTwin2008432736",
+            "$etag": "W/\u0022322fe163-968c-4989-aa8e-a3a4e448907b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;120254295",
+              "$model": "dtmi:example:room;121439350",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1369668520",
-            "$etag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+            "$etag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5789,45 +1322,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin873268829",
-            "$etag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1470142442",
-            "$etag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
+            "$etag": "W/\u00221eb68b8a-bf13-4720-80b6-a69fe4426840\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5835,22 +1345,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin152530184",
-            "$etag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
+            "$dtId": "roomTwin873268829",
+            "$etag": "W/\u00221464a0f1-2db0-4bee-aa03-2a79ccf25f90\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5858,137 +1368,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin581255239",
-            "$etag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1775617169",
-            "$etag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1115371378",
-            "$etag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin545487351",
-            "$etag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1107764983",
-            "$etag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1469731366",
-            "$etag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
+            "$etag": "W/\u00222845c406-2076-4575-8891-9417d5bffb6e\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5996,45 +1391,114 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1651185579",
-            "$etag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
+            "$dtId": "roomTwin152530184",
+            "$etag": "W/\u0022baf82ed1-133e-47f8-89aa-cd90ce1296d1\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;113863769",
+              "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin537968733",
+            "$etag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1775617169",
+            "$etag": "W/\u0022553a122e-a4d1-45ef-8ebb-cf9143db963c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin545487351",
+            "$etag": "W/\u00225b73646b-2193-441f-94d8-8038c015fafd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
               }
             }
           },
           {
             "$dtId": "roomTwin886314449",
-            "$etag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
+            "$etag": "W/\u0022552c47a7-cf72-4c83-88e3-a333dba19485\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6042,22 +1506,91 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin581255239",
+            "$etag": "W/\u0022418b00ea-8e3e-45f1-a9c4-df279018c5a4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1115371378",
+            "$etag": "W/\u0022ce9d5ab4-b7ed-4edb-a766-588dddfc7092\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1107764983",
+            "$etag": "W/\u002294127080-a0bc-4a3e-8e4c-2e22a9b7400f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               }
             }
           },
           {
             "$dtId": "roomTwin619580090",
-            "$etag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+            "$etag": "W/\u00223d4e535f-9a99-4d39-b9ef-5d8b2712102b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6065,22 +1598,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1965876829",
-            "$etag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
+            "$dtId": "roomTwin1651185579",
+            "$etag": "W/\u0022294e1038-72ab-4a19-b643-18b3cf5c1d37\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6088,45 +1621,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin829263883",
-            "$etag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1135525785",
-            "$etag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+            "$etag": "W/\u0022d281534a-cb4a-4d79-8d0d-ae6f7b7fa1f5\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6134,16 +1644,1166 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1105345787",
+            "$etag": "W/\u002240cf5ea0-b65a-4d1c-ab15-8558f01b6e73\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1965876829",
+            "$etag": "W/\u0022403065a8-8e71-469a-b528-339c0b4a8e35\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin829263883",
+            "$etag": "W/\u0022c3ece407-5fd5-436a-bfd7-dd10dc758e93\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin469162630",
+            "$etag": "W/\u0022bb0d50f4-fd31-42c5-ba91-74cdc790dd1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079625124",
+            "$etag": "W/\u002268eb8c04-fde5-4c9d-9b13-55c14d17a5a2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2121647958",
+            "$etag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin258863380",
+            "$etag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin565072308",
+            "$etag": "W/\u00229fbf9dbc-8eba-42a2-b690-7fd0a32239bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2047600035",
+            "$etag": "W/\u0022b2917b45-8fb8-4976-a59a-1a3c9bb7574f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1286738412",
+            "$etag": "W/\u00227d18a751-a241-4523-8d72-7e33196d97dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1189666982",
+            "$etag": "W/\u00222a2e4748-c4a8-4ce2-a755-68efd52528fa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin484073712",
+            "$etag": "W/\u00228468c658-1feb-4faf-8bfa-5379012e88a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin489387498",
+            "$etag": "W/\u00227ec14c16-e75b-4307-a18f-aa2bae497248\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin532106151",
+            "$etag": "W/\u0022c60c9190-89a5-451f-8b85-ee2165c86924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2060296123",
+            "$etag": "W/\u002231152dd5-003f-4f41-a193-eb503ae3988d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1162878836",
+            "$etag": "W/\u002261f15449-ef3b-4eaf-a667-247648c141b4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1225195112",
+            "$etag": "W/\u0022b4dfb1a8-4df1-4fdd-b65e-77175e5f8b85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin809589682",
+            "$etag": "W/\u0022b94a81ae-820b-442f-98aa-1a1210fcd8b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1312290533",
+            "$etag": "W/\u0022ba1ba1e3-6335-4748-98bb-0adb30f9a8c0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1882526098",
+            "$etag": "W/\u00223fb9fd3b-b10a-42a3-96cd-c97c516a445a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin424570723",
+            "$etag": "W/\u0022bd0955c9-221e-4024-b1e6-9a7377fdafcd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin74665732",
+            "$etag": "W/\u00222547770e-a761-4276-9a44-5ed7cab6d320\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin357005613",
+            "$etag": "W/\u0022d65324bf-9d35-49e3-b1f7-63ddb1b11d27\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079678761",
+            "$etag": "W/\u0022facc9bb8-5b4a-4355-a1e5-a0fed59798be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857070193",
+            "$etag": "W/\u0022344b1b43-9954-446a-9648-592ad0cd2b33\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1525191687",
+            "$etag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin644310332",
+            "$etag": "W/\u0022680af627-2e01-4ac8-af38-3cb3e79a7503\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1614607475",
+            "$etag": "W/\u0022f4c1ad67-fd8a-4c7a-944a-341c82ba5fe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1438249970",
+            "$etag": "W/\u002229634e48-7cc6-4291-9940-3248a57e5414\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1380454223",
+            "$etag": "W/\u00226c820be3-8744-4bde-8e25-2aa409b0d2f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin738047304",
+            "$etag": "W/\u0022737811d1-9aed-475d-b5c2-260cb281afbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin379883128",
+            "$etag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin64365696",
+            "$etag": "W/\u00226447225b-3ea7-44f0-a749-74d01de4b0f6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1753584378",
+            "$etag": "W/\u002267c15d28-08e0-4f21-b715-2f163b19f9a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2028986873",
+            "$etag": "W/\u0022d5811809-19fe-43ed-8074-f0595974de59\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin847442141",
+            "$etag": "W/\u002236fd1881-ac66-4f4b-b7a1-2b5ece25b67c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2106608761",
+            "$etag": "W/\u0022d1c30c84-1030-4cef-9d85-609d968aff40\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1662618080",
+            "$etag": "W/\u0022a7518287-834e-439b-9371-4442e4009ac9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin279835412",
+            "$etag": "W/\u00224fc1be2c-7a96-469e-aedf-8f90db26a9cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2001547295",
+            "$etag": "W/\u002265298c2f-3a64-4af4-bdd8-dc3b8c32c703\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin254397244",
+            "$etag": "W/\u00229a4458dc-c730-4129-86a1-fe7062161ba9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin312098304",
+            "$etag": "W/\u00228c00c75d-1d48-4e95-a038-7a57e29ddfb2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857257843",
+            "$etag": "W/\u002262efaa49-c478-42c4-adc4-bafcf161b386\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1017374329",
+            "$etag": "W/\u0022f4bc66c7-22da-4ae9-a2f3-4f2d15a84b44\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin187351254",
+            "$etag": "W/\u0022cb532999-1e35-4bea-ac08-1e6d35585fd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
           }
@@ -6161,10 +2821,10 @@
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "47ed91a8427c266b11a15a960d255c3a",
+        "x-ms-client-request-id": "14bf98699e0202b4da24044c6d67d41f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -6172,131 +2832,131 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2619",
+        "Content-Length": "2593",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "query-charge": "3.26",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1498980297",
-            "$etag": "W/\u0022d9379766-dc49-4095-8469-7117a69534b0\u0022",
+            "$dtId": "roomTwin1495950345",
+            "$etag": "W/\u002205d2ae31-6929-4d7e-af04-4a44b4b31e8b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;112984610",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1381264736",
-            "$etag": "W/\u00229530fad8-8481-4207-a3a2-54f75c33e03f\u0022",
+            "$dtId": "roomTwin344050324",
+            "$etag": "W/\u0022f8d463fc-b497-42c5-9d24-8bf2eb63c8ac\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112462194",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin746222802",
-            "$etag": "W/\u00221c55bd1b-4dc3-48a5-a694-7504c7387b38\u0022",
+            "$dtId": "roomTwin427623005",
+            "$etag": "W/\u00221af94c6c-ba7b-43af-b731-3c747d441259\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;119618957",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin775031637",
-            "$etag": "W/\u0022f2e095ad-618a-44d8-ae54-fb1acaf9d041\u0022",
+            "$dtId": "roomTwin410651761",
+            "$etag": "W/\u00229de8f988-b123-411e-81d1-b9b2647c5bfa\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112725529",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1245991748",
-            "$etag": "W/\u0022b941c874-b71d-4d29-8987-55a489ce4757\u0022",
+            "$dtId": "roomTwin744180983",
+            "$etag": "W/\u002263bb6047-a862-4977-b4f0-c9890d2b3370\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;115056947",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAiAAHA4P9DQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -6305,6006 +2965,112 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "410",
+        "Content-Length": "386",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "69bd00eabf9802149eb402da24044c6d",
+        "x-ms-client-request-id": "35a76e5e7692fd4a8c4404c744eb3879",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAiAAHA4P9DQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2619",
+        "Content-Length": "2367",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.13",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1444644859",
-            "$etag": "W/\u00226102e256-e029-43c3-88e2-7fcdf1df31be\u0022",
+            "$dtId": "roomTwin1437249777",
+            "$etag": "W/\u0022ef65f3f3-9966-4092-bf4c-b466ccb270f9\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;158485519",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1163564709",
-            "$etag": "W/\u0022670f1a13-ef3c-4450-a0ec-6b9ec342415e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin936523733",
-            "$etag": "W/\u0022df870f13-0fce-4273-b8b2-1f0cc9360973\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1174159166",
-            "$etag": "W/\u0022660a990d-f9d7-4588-97dd-b5e45bc98086\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin86672577",
-            "$etag": "W/\u0022fd6efd7e-0d32-4bf7-a8cf-0bcd64ae75c6\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAiAAHAAPxDQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5e1fd467a76e9235764afd8c4404c744",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAiAAHAAPxDQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2616",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1870986745",
-            "$etag": "W/\u0022c7480283-c513-4b7e-9937-8074f62ace65\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1536838429",
-            "$etag": "W/\u0022bcbed22e-248a-43ee-9594-5fdf5c571cbd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin661851410",
-            "$etag": "W/\u0022af7780a2-175d-4891-a13f-df6c145fd88e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110247197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1085222686",
-            "$etag": "W/\u0022bf070c35-d9ff-46f0-ab3d-c96099615404\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;166246968",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420943146",
-            "$etag": "W/\u002221e209f9-0bf3-4a09-9cda-3f0bb04813b8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAgAA\u002BAQ0ALguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6c7938eb6d9be8207ceba9c74091020d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAgAA\u002BAQ0ALguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2622",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1338380856",
-            "$etag": "W/\u00224cd0743c-7862-43df-873a-4b41374d1544\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1785890025",
-            "$etag": "W/\u00225d658a38-9807-4a54-a993-3484b1bb15e1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1000297038",
-            "$etag": "W/\u00223aa0b952-daba-4ff9-bcb8-602da4399405\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1893330133",
-            "$etag": "W/\u00225ebe6eae-1a9d-46ed-acde-5e4da8aeea0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123218210",
-            "$etag": "W/\u002214760d80-a8ce-4843-b0e4-56e6e9f4dd27\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAiABEA8P8zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "382eec55fd0642ccca2bf34ec288bd99",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAiABEA8P8zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1520206458",
-            "$etag": "W/\u0022835208c2-4a55-4de7-b10e-dc4187d5882e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin92117139",
-            "$etag": "W/\u00224cc2ce94-15c6-4ae7-a020-4f9a9792ab09\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36128330",
-            "$etag": "W/\u00225adde61e-e412-49cf-a752-527bd8b3aba2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777097876",
-            "$etag": "W/\u0022e27281c3-f22a-47a9-82ee-7b0f0b267d48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470032629",
-            "$etag": "W/\u002256fc5f73-a1df-4e71-8bea-54ed682348af\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAP4zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ebeebeede08afad1b436e283fd6d52e4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAP4zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1800780114",
-            "$etag": "W/\u0022516b6d16-ef6d-47c8-8cfb-1854ca4835bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin27801422",
-            "$etag": "W/\u0022539467f6-fbb6-4360-a729-c39f353f3253\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1902584715",
-            "$etag": "W/\u00221884e5dc-2708-427a-9eaa-6d2e83841d06\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin96827413",
-            "$etag": "W/\u0022ef52e4c6-e6a3-4bb3-8005-997c3d9f44dd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin935053957",
-            "$etag": "W/\u002264c75c6e-a2a9-441b-beda-2b306818df87\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAMAzQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5836ef488ed6ee3d6c36a1707ad226f3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAMAzQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2622",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin2074335826",
-            "$etag": "W/\u00221c81ad83-61b8-4fde-bea7-4f42e5e899ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123629177",
-            "$etag": "W/\u0022db3407f5-6797-483a-ac54-66cf8491c767\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1554813222",
-            "$etag": "W/\u0022817cabe6-9a22-4634-a34d-177273d33068\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1699890695",
-            "$etag": "W/\u00227084f858-2fd9-423c-9998-d831f293c5f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1088498238",
-            "$etag": "W/\u00221d4e9b50-b84b-45da-ab41-b40a11736140\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;158383040",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAiACEA\u002BP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "416",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "81da0f2e16a375821a3484d01b48455d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAiACEA\u002BP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2618",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin894415666",
-            "$etag": "W/\u0022f5f49f19-15f2-45e1-ab5f-1f6ad65d49f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113309762",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148688568",
-            "$etag": "W/\u0022185a6e23-5cdc-43c3-9f98-bce142ef1635\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin605247566",
-            "$etag": "W/\u002285ec04a7-1fc5-4cb5-a028-fb7646cee045\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1738278687",
-            "$etag": "W/\u002265469fb8-0e42-4c50-88c4-9499db8d30d1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin883341753",
-            "$etag": "W/\u0022c6d743e3-2171-46df-9875-45107360b597\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "d2050ed864515ec380007f543e617fe1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2619",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin44768029",
-            "$etag": "W/\u0022e0bf97cb-0ca6-4f19-9c87-c12c508eb7eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1026080773",
-            "$etag": "W/\u0022be607bbe-b367-42de-b426-17d53b764e00\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1012130572",
-            "$etag": "W/\u0022e9d0ad86-5382-41dc-95e4-7365514401dc\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin314886311",
-            "$etag": "W/\u0022ed0846f6-8b98-44f6-8dab-96f5271ce59b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1045652022",
-            "$etag": "W/\u0022deb78b85-2b4d-4695-b234-c6dfae1bf0a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAOAjQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ed54ee0fd09331416dc13ea10a6dd323",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAOAjQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2619",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin516625160",
-            "$etag": "W/\u00226b21212e-eb4d-4ad9-aac3-ca364cb5e3e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1891959418",
-            "$etag": "W/\u0022183aa253-51e8-4af1-9bd5-3ea98350d1bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829360197",
-            "$etag": "W/\u0022243c49a4-115d-4669-a7cb-1ed898e2de78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin61707195",
-            "$etag": "W/\u0022e6422265-b580-4e10-afa7-a032f40d0aea\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783915272",
-            "$etag": "W/\u0022a43fd4d5-65cf-4b7b-81f6-80e88ff3f822\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAiADEA/P8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "6c9744f153ccc9a14c7c01a2972d36b9",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAiADEA/P8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2622",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1041693882",
-            "$etag": "W/\u002245a8e4ec-fdbc-4d18-8396-559141ddc01b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021340528",
-            "$etag": "W/\u002298a5b93f-4034-4738-a576-b128341aaf2e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1677577135",
-            "$etag": "W/\u00223040ab87-d137-4d12-a562-f450d3bb45a9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin124606454",
-            "$etag": "W/\u00223c60e1ac-b594-4cce-8c1a-718c37a715ef\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1154990313",
-            "$etag": "W/\u00223650ee8c-f86f-4c1a-900a-2c4f11e8ebc8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk3AAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAiADEAgP8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "2cc0a2b457f308c9ccd3659026215413",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk3AAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAiADEAgP8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin2132961076",
-            "$etag": "W/\u00227a0bf9a7-9d8a-4db6-8191-84220168680b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin57113376",
-            "$etag": "W/\u0022cfcf6f4c-808d-4ce1-8f81-667ef4e74b4a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116251683",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin619150749",
-            "$etag": "W/\u00223194e119-b36a-4efa-8af0-b99c24d45ff7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170550470",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin551511810",
-            "$etag": "W/\u00222d430b86-fa94-44cc-b68a-6df9644aceff\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin98472762",
-            "$etag": "W/\u00226c5eb657-d221-4ed2-82c1-0197f69a3f30\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk8AAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAiADEAAPATQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "fa625b2d13c9bc154c8ba117cf9e9a3f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk8AAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAiADEAAPATQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2616",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin869013250",
-            "$etag": "W/\u0022a3c3dc57-4372-4c4f-bf36-feb06b12f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin722764700",
-            "$etag": "W/\u0022180669f5-37cf-454a-9ed9-5f7c29bd5c21\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2125813792",
-            "$etag": "W/\u00220c25d51f-a3a9-4a12-a66b-a3fef02f32c8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1564789991",
-            "$etag": "W/\u00222f754f56-075a-4ef8-a9e4-7e189ddc22bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin729153756",
-            "$etag": "W/\u0022400fe9ad-eb92-47f5-a772-ec2b5ead9606\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlBAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAgAEQA/v8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "408",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "67ed848aa6ad9a2f7a8f9ff8ee11a22b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlBAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAgAEQA/v8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2618",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1489152938",
-            "$etag": "W/\u002228c2d505-7c3b-40d2-80e0-17f323c70679\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1637856858",
-            "$etag": "W/\u0022ec90109a-be27-4750-8548-cf61eec5aa0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1363211591",
-            "$etag": "W/\u0022dd52474a-d61e-4eb5-8e3b-3b99cdd61baf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin838663785",
-            "$etag": "W/\u00227c4b95c6-3be9-40ee-8e4e-a3e78574aa34\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1300086570",
-            "$etag": "W/\u0022f1ebf4ba-6b6b-4c6b-9f31-c539d71178d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlGAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAwP8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "408",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "3b75ee273ccaa1f08d03df68b6b2392d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlGAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAwP8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin151462022",
-            "$etag": "W/\u002298d16ff0-f7bf-4254-9d03-c9a4cb58c201\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1308729416",
-            "$etag": "W/\u0022ba6f41ec-b8f2-490a-bc1e-ff5514196325\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1856167476",
-            "$etag": "W/\u0022a211c53e-af56-4cc8-b77d-724bd8558d33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1336007415",
-            "$etag": "W/\u00229687aa69-50b9-4d7b-84b2-6b85e192050a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin662815516",
-            "$etag": "W/\u002269473407-2871-4d05-8e0f-2431ce8eafc1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlLAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAAPgLguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "408",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a2062539ec3486662cc88039731cce3b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlLAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAAPgLguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2614",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin94298757",
-            "$etag": "W/\u002262eb0428-71b3-4a77-84ac-5e64f19ceb78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1612778009",
-            "$etag": "W/\u0022c9da2088-b6f7-4767-848e-4e10cfeb9ee4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin856851558",
-            "$etag": "W/\u0022c623ba55-3c32-4a56-8574-65dd548ab6e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin229826714",
-            "$etag": "W/\u002238488fbd-d87b-42dc-93d0-916af0949b4b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111655996",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin526434890",
-            "$etag": "W/\u0022c19adbeb-77ce-4d0c-95d4-708d88de7b79\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;141760569",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlQAAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAeAFMAC4Lr//8DFED/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "413",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e1ef75e95f284e74944bdaa9c7c7e3c7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlQAAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAeAFMAC4Lr//8DFED/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2010",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.09",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "floorTwin941711815",
-            "$etag": "W/\u0022eb738161-f2e0-4587-8cb5-29ad474cf93d\u0022",
+            "$dtId": "roomTwin586733773",
+            "$etag": "W/\u00223524936d-5b93-4952-b9bc-403660889807\u0022",
             "AverageTemperature": 75,
             "$metadata": {
-              "$model": "dtmi:example:floor;13675231",
+              "$model": "dtmi:example:floor;11489901",
               "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.0436535Z"
+                "lastUpdateTime": "2020-10-23T21:22:11.7284978Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1735182331",
-            "$etag": "W/\u00221c736187-8abb-499b-8063-cf15994d06b5\u0022",
+            "$dtId": "roomTwin1579359106",
+            "$etag": "W/\u00226c41c324-e714-4346-97ee-3d7a43ebf892\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;153048334",
+              "$model": "dtmi:example:room;113317821",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               }
             }
           },
           {
-            "$dtId": "hvacTwin1335730075",
-            "$etag": "W/\u0022addded86-bbbe-48c6-915a-c42cd3b17213\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114614787",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin2117646547",
-            "$etag": "W/\u00222dc91dfa-469e-431d-97b6-c088938f5370\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;17595302",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.2858058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin918788440",
-            "$etag": "W/\u0022de783261-56c0-4f53-8cbd-b0520b4d6f11\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140750981",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlgAAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAcAGIA6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "c8bf7155000b3bf687ef0f02bbb62e70",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlgAAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAcAGIA6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2465",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.15",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin895881838",
-            "$etag": "W/\u0022d3d51c9d-eddd-4113-8a52-efa9f2f11426\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin492624016",
-            "$etag": "W/\u0022e231036b-9573-4cf6-93bc-4f76168ba9c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin818663445",
-            "$etag": "W/\u0022166be958-7415-4134-a4f5-7c474985c5a3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin778426230",
-            "$etag": "W/\u002297b83dbf-0971-406c-b656-d9bb25d2fe70\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;110356330",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846657163",
-            "$etag": "W/\u0022d04aa87a-a541-4896-a7fe-5eab16c99744\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlnAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAgP//AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "407fa33558c3da05b0b70de911bcbf64",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlnAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAgP//AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2612",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin169049424",
-            "$etag": "W/\u002211259cdf-2b5d-4824-b381-10316d5c8617\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2003290546",
-            "$etag": "W/\u0022c41115df-04d0-4c5a-bc58-0ae0e7a1bbca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1920637755",
-            "$etag": "W/\u0022b1c7a4c4-5bef-4d51-8f28-6a8a99a9b955\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin567255450",
-            "$etag": "W/\u00228b132e44-b0db-4d8a-b004-3410fbd9ec66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin466450821",
-            "$etag": "W/\u0022d142de37-2196-4bec-a201-fe3146f28272\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlsAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAAPD/AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "01e3b9e4055de8307eb459394f7293dd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlsAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAAPD/AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2608",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin652828980",
-            "$etag": "W/\u0022360ae1fa-aa9d-4bd4-b2bd-8302ffa69453\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1658744984",
-            "$etag": "W/\u0022bfbfbc70-049c-4ea8-9a7e-8240bc3b49ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1108577855",
-            "$etag": "W/\u00229e4d190d-271d-4ad8-9ea6-9fa8d412cf99\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin881848871",
-            "$etag": "W/\u0022fa12869e-c78e-4c94-8c0d-6fc358b6e852\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin34125080",
-            "$etag": "W/\u002282a0d23e-5444-4f11-ac2f-d15d1909237e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "401",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "23736a1ca347fd046ce51753f20d29ca",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2611",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin716576755",
-            "$etag": "W/\u0022928a136b-494e-4965-99e9-128202587246\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1961257007",
-            "$etag": "W/\u00227a297279-19b8-447a-8396-194df0d8b0ae\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1791197485",
-            "$etag": "W/\u00221bf81066-9eb3-44f5-aa96-d5f7e20946e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1867071453",
-            "$etag": "W/\u0022342a88f2-0dcc-4575-aa58-315006cd4ef1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1641901809",
-            "$etag": "W/\u00226911c53c-1a10-4321-9bea-aeeeca373ff9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl2AAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AgEAAAAaAHEAwAMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "401",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "021daa2f2cd22f137396c10ffecb8a3e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl2AAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AgEAAAAaAHEAwAMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2152",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.1",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1133125955",
-            "$etag": "W/\u00226b21e7dc-b4e9-4087-9c14-5a0b4fb2b15b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin246922244",
-            "$etag": "W/\u002270fb7b44-ac8b-496d-a15c-e96448dfac66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;117012504",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1642617034",
-            "$etag": "W/\u0022f7cd24c9-808b-4aa1-9fc1-d774acdfac57\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115956238",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin1545002397",
-            "$etag": "W/\u0022ae4ea64f-5b12-4c7d-8a1d-13abaaa68bd4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;16329224",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9538711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin792160889",
-            "$etag": "W/\u00227b70c14e-a9b9-409d-b05d-8c3b3de34ea4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;15819678",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9854614Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmBAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AgEAAAAYAIUA/v//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "406",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a7cc2f249c48411db5e69477eedcf671",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmBAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AgEAAAAYAIUA/v//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2317",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.14",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin62721381",
-            "$etag": "W/\u0022abe2d779-e33d-48b7-832f-8326022a02eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110307862",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777965033",
-            "$etag": "W/\u00227ac6cc9c-0616-4b52-bde0-1a7b1d90920c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116838841",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin849612920",
-            "$etag": "W/\u002255796041-ffda-44e6-a4d5-a29bb1b25550\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;147745744",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin387213787",
-            "$etag": "W/\u0022303aaebf-8a01-4315-92b4-3f5aa59c7aae\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114856351",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1741612918",
-            "$etag": "W/\u0022af3841ce-ae9d-49c7-96c9-680c8c704cda\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmGAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAwP//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "406",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a50a8e8a9055ef0b5744afb1e2f4fea1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmGAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAwP//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2609",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin36952557",
-            "$etag": "W/\u00225017547e-5cb7-4270-8732-0fd935c5f36f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1213006989",
-            "$etag": "W/\u002239424cf2-71fa-407b-8b28-63cf3b636731\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin326513034",
-            "$etag": "W/\u00225350ca2a-c97e-4c6e-b4e2-4db4cc81475c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1129721811",
-            "$etag": "W/\u00228dba5565-d060-4bad-a801-4f9bbc4ebdf0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1947553667",
-            "$etag": "W/\u00222d6acbd7-fcfd-40c3-80e1-a33bf5092293\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmLAAAAAAAAAA==#RT:24#TRC:120#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAAPj/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "406",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "c22fd95a824193828ddc4dec989b4096",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmLAAAAAAAAAA==#RT:24#TRC:120#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAAPj/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2605",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1548928947",
-            "$etag": "W/\u0022ee3e799c-7ec3-44a5-bf99-608ae6ed2d0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin356265635",
-            "$etag": "W/\u0022cddfa5c7-ba8d-4f3f-a5c7-49ed794ace2f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1989978078",
-            "$etag": "W/\u0022d8a52677-b719-4322-b2a3-797951f9dfa7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin863816413",
-            "$etag": "W/\u002235dced59-748a-497b-8436-fa6c7ecd7c98\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin240878892",
-            "$etag": "W/\u0022cea21915-9749-47be-a426-12523c767a8e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmQAAAAAAAAAA==#RT:25#TRC:125#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "397",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "708450a0e5c193e924dc5004ec6c5ec0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmQAAAAAAAAAA==#RT:25#TRC:125#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2604",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1466134063",
-            "$etag": "W/\u00224b6c3b89-c127-4389-9623-6600823c637a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin503181323",
-            "$etag": "W/\u0022343c3eeb-88f4-48e3-b6a3-502e67d17d19\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin392271939",
-            "$etag": "W/\u0022076c63c0-54bd-4d30-b79f-b8779d515826\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin496261044",
-            "$etag": "W/\u0022f30db489-e0f9-4a4e-af15-7be164045d7e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin277216622",
-            "$etag": "W/\u00226566f3cb-3282-4c34-bce7-f1fd53b6b79a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmVAAAAAAAAAA==#RT:26#TRC:130#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA4A8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "397",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "141cf3e733ad082f0c761779431f57bb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmVAAAAAAAAAA==#RT:26#TRC:130#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA4A8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2605",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin815041708",
-            "$etag": "W/\u0022df1321a9-3cd1-4196-aec2-4d21b631ca88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2006012899",
-            "$etag": "W/\u0022e71c7453-81c2-472c-9f6e-ea913867dfdb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin446974150",
-            "$etag": "W/\u0022b00117ad-a23b-4de8-a474-7bd59421fbc0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1365881715",
-            "$etag": "W/\u00223179b0b2-935f-4f4b-a0ec-e41bb6e355f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin681325335",
-            "$etag": "W/\u0022217888d9-1f32-4fc6-82a2-33d958d48c88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;164255196",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmaAAAAAAAAAA==#RT:27#TRC:135#ISV:2#IEO:65551#FPC:AgEAAAAWAJQAAAwA4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "397",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "921018038e7075e0f09b9d64327da621",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmaAAAAAAAAAA==#RT:27#TRC:135#ISV:2#IEO:65551#FPC:AgEAAAAWAJQAAAwA4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "1998",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.09",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1142241383",
-            "$etag": "W/\u0022a45ffefb-8f34-4c0a-add6-029f59e7617f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;177720708",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin825845031",
-            "$etag": "W/\u0022893f390d-bd64-4c1d-8d69-563fd59f8c4e\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11574869",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.0086720Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1278234179",
-            "$etag": "W/\u00225d49dfd5-ca5c-44b1-a4c6-747f37720a9c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116571386",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin761943018",
-            "$etag": "W/\u0022990146bb-c3b6-4c49-a75b-50507494bd16\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;170683712",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin944298631",
-            "$etag": "W/\u002298b1fda1-4a5e-4e6b-a2c8-75966dd516ef\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11611266",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.7888364Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBm4AAAAAAAAAA==#RT:28#TRC:140#ISV:2#IEO:65551#FPC:AgEAAAASALIAAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "398",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a4048c7d2b7e6ce9207c644acd6f4f05",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBm4AAAAAAAAAA==#RT:28#TRC:140#ISV:2#IEO:65551#FPC:AgEAAAASALIAAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2073",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.11",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin783813120",
-            "$etag": "W/\u00220b45aca6-bc41-4732-b559-3ebab02a7323\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112884932",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin462228998",
-            "$etag": "W/\u002276c721ed-c6f3-4747-9745-25aced995423\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;187698996",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin12238764",
-            "$etag": "W/\u002211b2a2c7-b161-40cd-92d7-a40ff0cdeec4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;19256426",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.4582895Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin20436333",
-            "$etag": "W/\u0022f7f6a258-469b-46e5-a27b-363cdd21bad5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112740527",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin57116881",
-            "$etag": "W/\u002249f8c592-afc4-4e28-80a1-2dbcdc2797b4\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;181789456",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnFAAAAAAAAAA==#RT:29#TRC:145#ISV:2#IEO:65551#FPC:AgEAAAAQAMEAIMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "389",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "d4009484cc5b595013a6241295cad68e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnFAAAAAAAAAA==#RT:29#TRC:145#ISV:2#IEO:65551#FPC:AgEAAAAQAMEAIMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2593",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin394026428",
-            "$etag": "W/\u0022a3076bd7-cbeb-4789-bc6c-509e1847f6e3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin596581608",
-            "$etag": "W/\u0022473d9d87-f909-4e33-b722-66cdc90c5b9a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1684161797",
-            "$etag": "W/\u0022b9a14ed9-ce85-445a-85ae-3f80705534bf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1901267486",
-            "$etag": "W/\u0022c55a0283-f169-4e3b-b272-d9875a72ecdd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531586602",
-            "$etag": "W/\u00223e77b5c1-75a6-4c89-8048-04e0028cf6b9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnSAAAAAAAAAA==#RT:30#TRC:150#ISV:2#IEO:65551#FPC:AgEAAAAOANQA/P8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "385",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "b7fbf6d0b31ad73c2fa371f42996a880",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnSAAAAAAAAAA==#RT:30#TRC:150#ISV:2#IEO:65551#FPC:AgEAAAAOANQA/P8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2592",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin148061498",
-            "$etag": "W/\u0022c43f33d8-1c82-4fc8-890b-22e7d8f5d9d4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin436096292",
-            "$etag": "W/\u002204b66e10-cace-4bed-8cfb-8d61e27f1c12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin154780388",
-            "$etag": "W/\u002283328534-f7c3-43b2-b38f-c72bc979eb05\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121341206",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2127865916",
-            "$etag": "W/\u002241d23a05-ab39-4bd0-befe-e8159958181f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin317362118",
-            "$etag": "W/\u002202c13fde-87db-4716-a76b-d47bf709ee97\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnXAAAAAAAAAA==#RT:31#TRC:155#ISV:2#IEO:65551#FPC:AgEAAAAOANQAgP8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "385",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9ddf984bd17db0c53cab91d707d7d656",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnXAAAAAAAAAA==#RT:31#TRC:155#ISV:2#IEO:65551#FPC:AgEAAAAOANQAgP8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2594",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin795448273",
-            "$etag": "W/\u0022dddf6522-6705-4b5b-82e9-54b6d744e55b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1710347499",
-            "$etag": "W/\u00224096019c-3f62-4a1f-ae96-b87531ce1b77\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin288024548",
-            "$etag": "W/\u0022426e9bb8-9bce-474a-b00d-ddfdb1e241d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1380865941",
-            "$etag": "W/\u0022e4c1ba36-c62c-400a-ad86-1cc6cf417eab\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1205304854",
-            "$etag": "W/\u0022f1d5b58c-bfdf-428b-9b23-925a89563116\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBncAAAAAAAAAA==#RT:32#TRC:160#ISV:2#IEO:65551#FPC:AgEAAAAOANQAAPAPAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "385",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "d679d6a59874d1eb5828a5b75b5c2f7c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBncAAAAAAAAAA==#RT:32#TRC:160#ISV:2#IEO:65551#FPC:AgEAAAAOANQAAPAPAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2593",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:11 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1400981480",
-            "$etag": "W/\u0022e5a90477-8fde-4e02-a38c-5b04ffd5931a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651261841",
-            "$etag": "W/\u0022d3c1a5d2-e6a5-4ef4-8113-3017514680ce\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113490432",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846170454",
-            "$etag": "W/\u0022ec7b5277-9742-4275-967f-031a47256655\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin955395753",
-            "$etag": "W/\u0022e07bd3aa-8240-4129-a2d2-3d2480e20e5a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin251907959",
-            "$etag": "W/\u002270b9ed8a-f221-4273-bbb6-3086c7c08134\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnhAAAAAAAAAA==#RT:33#TRC:165#ISV:2#IEO:65551#FPC:AgEAAAAMAOMADgDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "390",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "fdc6a4fe38eafe10314b7a6f2164d057",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnhAAAAAAAAAA==#RT:33#TRC:165#ISV:2#IEO:65551#FPC:AgEAAAAMAOMADgDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1402000963",
-            "$etag": "W/\u00225537c1d2-d31d-4cce-9055-cd4db8037551\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1857138761",
-            "$etag": "W/\u002215d19e36-1f58-4471-b631-9cc6d82a01c5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531597311",
-            "$etag": "W/\u002288a3c17e-fb49-4a32-89a6-a1844bd8b5f0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin978222842",
-            "$etag": "W/\u00221e592604-2baa-44b9-bee5-c02e4febded7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1784653895",
-            "$etag": "W/\u00225a1eae7d-10b0-4e7a-b1b7-39360e9971e7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn4AAAAAAAAAA==#RT:34#TRC:170#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "534e1bcdd21cb20cad0e45542c0e55e0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn4AAAAAAAAAA==#RT:34#TRC:170#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin860770335",
-            "$etag": "W/\u00227fe3ddd0-f34d-4be5-8f6e-78cda890ff8c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1701359617",
-            "$etag": "W/\u0022ab1f392a-6de1-4345-b64b-0f1f5419d92f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1587783567",
-            "$etag": "W/\u00220dd5eba4-5206-492d-8d01-934308ca6959\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin778324998",
-            "$etag": "W/\u0022f19c7ff2-115b-4127-a53f-ed6cf0f7e1e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1721371793",
-            "$etag": "W/\u0022e5f73835-efc9-4ab1-819f-8fb71f80b538\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn9AAAAAAAAAA==#RT:35#TRC:175#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAOD/jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "62d9147bd9106c6bc57aa5291e7bb0f3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn9AAAAAAAAAA==#RT:35#TRC:175#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAOD/jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2587",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1364369720",
-            "$etag": "W/\u0022ff0e66bb-a4cc-4c37-959d-2da828e160f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1445460884",
-            "$etag": "W/\u00220cb86433-53cc-49c9-b9ab-6448cec7afcd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1233820890",
-            "$etag": "W/\u00227e1a444e-e4f6-4416-99cb-1bdde45d8e73\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1573366635",
-            "$etag": "W/\u0022b6546bb2-b968-4178-9bdb-e2e5e002f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420514752",
-            "$etag": "W/\u00222c4d0208-068e-4126-abf9-79263c90e1db\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkCAQAAAAAAAA==#RT:36#TRC:180#ISV:2#IEO:65551#FPC:AgEAAAAIAAEB/I8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "377",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "40ea4d58dc0d2c60981450dcf3bbd222",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkCAQAAAAAAAA==#RT:36#TRC:180#ISV:2#IEO:65551#FPC:AgEAAAAIAAEB/I8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2588",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin2115849553",
-            "$etag": "W/\u00221f455fa2-f401-4657-9e91-68a8be9d8f0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1984619459",
-            "$etag": "W/\u002290fe6812-eac8-4eba-bb1a-a6a7c06b097c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021579934",
-            "$etag": "W/\u00222355c543-f166-4805-b55f-d461d10778ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1393309463",
-            "$etag": "W/\u0022f0c4bcfc-283f-4897-b223-3b00b32a8cb5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2024624619",
-            "$etag": "W/\u0022e8338894-16a7-4f02-95ac-102569a5c0e5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkHAQAAAAAAAA==#RT:37#TRC:185#ISV:2#IEO:65551#FPC:AgEAAAAIAAEBgI8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "377",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0cf49af66d8bf347afe18da12ce29431",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkHAQAAAAAAAA==#RT:37#TRC:185#ISV:2#IEO:65551#FPC:AgEAAAAIAAEBgI8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin933351314",
-            "$etag": "W/\u002208cf970b-08ec-47b3-9224-032838969536\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1518012781",
-            "$etag": "W/\u00229d858eb7-7b5d-4eff-8c94-4c57c5dba129\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1179828134",
-            "$etag": "W/\u0022b25cf002-a500-42b5-a846-1d6cd81b3586\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;129779251",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1293663163",
-            "$etag": "W/\u002292c9e2ab-d24c-43da-abac-7633ed8535bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170920816",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin300828834",
-            "$etag": "W/\u00226663329b-53ec-45c7-8539-126c1273c68d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAQAAAAAAAA==#RT:38#TRC:190#ISV:2#IEO:65551#FPC:AQ8BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "dffc515d14239ed2b4accafc888e7909",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAQAAAAAAAA==#RT:38#TRC:190#ISV:2#IEO:65551#FPC:AQ8BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2588",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin456165914",
-            "$etag": "W/\u0022e4d8c25b-329e-4de2-8b7e-25c33f8e85a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin612612248",
-            "$etag": "W/\u00225a6f3040-d114-4c67-b612-5ee5198bc0f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829071132",
-            "$etag": "W/\u0022ec9774d1-b5a3-4394-9a9d-0be5660616c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin593110535",
-            "$etag": "W/\u00221ded5390-1f3f-402f-8749-ebc6cf6da95f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin199646658",
-            "$etag": "W/\u0022f831e71d-cee1-4d7a-ac7f-ca9426d1a01c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAQAAAAAAAA==#RT:39#TRC:195#ISV:2#IEO:65551#FPC:ARQBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "833382a8a387ea6706f6902c4ebeffb5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAQAAAAAAAA==#RT:39#TRC:195#ISV:2#IEO:65551#FPC:ARQBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2587",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin461434088",
-            "$etag": "W/\u00221f00217f-5f02-400d-bdfb-9b07ab072f9d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin805249019",
-            "$etag": "W/\u0022efb00acf-a54a-48eb-b69b-3fc39662fc0d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin862791772",
-            "$etag": "W/\u002233cc79ef-1cf5-4b55-92c3-7760427c8c38\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin839672662",
-            "$etag": "W/\u00220440e839-1432-470e-805b-591e4afd0b12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin150497704",
-            "$etag": "W/\u002215e94910-9ee2-431c-906f-509451334a6d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:40#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a17e1f7ff2bfe1ffc75558dea24a6b20",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:40#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2589",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin99161790",
-            "$etag": "W/\u0022e89b9c86-d478-41d6-9b3c-5505d1277b95\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin499786833",
-            "$etag": "W/\u0022563f9a30-99c8-4197-b31e-c4199e2865ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1813293646",
-            "$etag": "W/\u002244e3bd17-6bbc-44a4-b29c-334c10a6fe48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1776504490",
-            "$etag": "W/\u00226ecfacf8-3ce1-43a9-84c4-81ff36cb8cca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2000851912",
-            "$etag": "W/\u0022b4e60ad6-418e-4d47-86d2-70831e0559a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAQAAAAAAAA==#RT:41#TRC:205#ISV:2#IEO:65551#FPC:AR4BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "aaf9846710afbaa9ea12d92d83a54ff5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAQAAAAAAAA==#RT:41#TRC:205#ISV:2#IEO:65551#FPC:AR4BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1130568982",
-            "$etag": "W/\u00223cd300f9-a8d1-460e-bc54-1bb4154625f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1407313670",
-            "$etag": "W/\u0022909d36c5-f041-4b52-8323-027f1050d23c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin515255931",
-            "$etag": "W/\u00226096bae3-8200-4d3a-af19-43c98c5fc9c0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1095480396",
-            "$etag": "W/\u00220be2e194-af2a-4dc1-9d0c-b2d51dea4c5d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin362889809",
-            "$etag": "W/\u0022e0bd3738-4244-4fef-9790-ffe6ba661b24\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;128737197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAQAAAAAAAA==#RT:42#TRC:210#ISV:2#IEO:65551#FPC:ASMBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "697c15acd710b64a8351bc324a8947bb",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAQAAAAAAAA==#RT:42#TRC:210#ISV:2#IEO:65551#FPC:ASMBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1921780853",
-            "$etag": "W/\u0022e7726775-9d63-40fc-af0c-cb92025bfafd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;157701634",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin537968733",
-            "$etag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
+            "$dtId": "roomTwin2008432736",
+            "$etag": "W/\u0022322fe163-968c-4989-aa8e-a3a4e448907b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;120254295",
+              "$model": "dtmi:example:room;121439350",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1369668520",
-            "$etag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+            "$etag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12312,67 +3078,21 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin873268829",
-            "$etag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470142442",
-            "$etag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAQAAAAAAAA==#RT:43#TRC:215#ISV:2#IEO:65551#FPC:ASgBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -12381,32 +3101,101 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "381",
+        "Content-Length": "387",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "cac46f8b55c56f0576c3b7ac19d15d21",
+        "x-ms-client-request-id": "206d9b6c7ce8a9ebc74091020d55ec2e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAQAAAAAAAA==#RT:43#TRC:215#ISV:2#IEO:65551#FPC:ASgBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2589",
+        "Content-Length": "2591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
+            "$dtId": "roomTwin1470142442",
+            "$etag": "W/\u00221eb68b8a-bf13-4720-80b6-a69fe4426840\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin873268829",
+            "$etag": "W/\u00221464a0f1-2db0-4bee-aa03-2a79ccf25f90\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1469731366",
+            "$etag": "W/\u00222845c406-2076-4575-8891-9417d5bffb6e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              }
+            }
+          },
+          {
             "$dtId": "roomTwin152530184",
-            "$etag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
+            "$etag": "W/\u0022baf82ed1-133e-47f8-89aa-cd90ce1296d1\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12414,45 +3203,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin581255239",
-            "$etag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1775617169",
-            "$etag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
+            "$dtId": "roomTwin537968733",
+            "$etag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12460,67 +3226,21 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1115371378",
-            "$etag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin545487351",
-            "$etag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAQAAAAAAAA==#RT:44#TRC:220#ISV:2#IEO:65551#FPC:AS0BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -12529,24 +3249,172 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "381",
+        "Content-Length": "383",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "8d31620502cd90103942265d54776f60",
+        "x-ms-client-request-id": "ccfd0638ca42f32b4ec288bd99edbeee",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAQAAAAAAAA==#RT:44#TRC:220#ISV:2#IEO:65551#FPC:AS0BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2590",
+        "Content-Length": "2591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1775617169",
+            "$etag": "W/\u0022553a122e-a4d1-45ef-8ebb-cf9143db963c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin545487351",
+            "$etag": "W/\u00225b73646b-2193-441f-94d8-8038c015fafd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin886314449",
+            "$etag": "W/\u0022552c47a7-cf72-4c83-88e3-a333dba19485\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin581255239",
+            "$etag": "W/\u0022418b00ea-8e3e-45f1-a9c4-df279018c5a4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1115371378",
+            "$etag": "W/\u0022ce9d5ab4-b7ed-4edb-a766-588dddfc7092\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "383",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d1e08aebb4fae23683fd6d52e448ef36",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -12554,7 +3422,7 @@
         "value": [
           {
             "$dtId": "roomTwin1107764983",
-            "$etag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
+            "$etag": "W/\u002294127080-a0bc-4a3e-8e4c-2e22a9b7400f\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12562,91 +3430,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1469731366",
-            "$etag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651185579",
-            "$etag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin886314449",
-            "$etag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               }
             }
           },
           {
             "$dtId": "roomTwin619580090",
-            "$etag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+            "$etag": "W/\u00223d4e535f-9a99-4d39-b9ef-5d8b2712102b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12654,21 +3453,90 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1651185579",
+            "$etag": "W/\u0022294e1038-72ab-4a19-b643-18b3cf5c1d37\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1135525785",
+            "$etag": "W/\u0022d281534a-cb4a-4d79-8d0d-ae6f7b7fa1f5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1105345787",
+            "$etag": "W/\u002240cf5ea0-b65a-4d1c-ab15-8558f01b6e73\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAQAAAAAAAA==#RT:45#TRC:225#ISV:2#IEO:65551#FPC:ATIBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -12677,32 +3545,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "381",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "13a11dca85e157300f0df24c1f9d9cb1",
+        "x-ms-client-request-id": "3d8ed6586ceea136707ad226f32e0fda",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAQAAAAAAAA==#RT:45#TRC:225#ISV:2#IEO:65551#FPC:ATIBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "1421",
+        "Content-Length": "2586",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "2.98",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.16",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
             "$dtId": "roomTwin1965876829",
-            "$etag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
+            "$etag": "W/\u0022403065a8-8e71-469a-b528-339c0b4a8e35\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12710,22 +3578,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               }
             }
           },
           {
             "$dtId": "roomTwin829263883",
-            "$etag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
+            "$etag": "W/\u0022c3ece407-5fd5-436a-bfd7-dd10dc758e93\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12733,22 +3601,147 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1135525785",
-            "$etag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+            "$dtId": "roomTwin469162630",
+            "$etag": "W/\u0022bb0d50f4-fd31-42c5-ba91-74cdc790dd1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079625124",
+            "$etag": "W/\u002268eb8c04-fde5-4c9d-9b13-55c14d17a5a2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "379",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8216a3811a758434d01b48455dd80e05",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2121647958",
+            "$etag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12756,16 +3749,1246 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin258863380",
+            "$etag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin565072308",
+            "$etag": "W/\u00229fbf9dbc-8eba-42a2-b690-7fd0a32239bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2047600035",
+            "$etag": "W/\u0022b2917b45-8fb8-4976-a59a-1a3c9bb7574f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "379",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c36451d2805e7f00543e617fe10fee54",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2587",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1286738412",
+            "$etag": "W/\u00227d18a751-a241-4523-8d72-7e33196d97dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1189666982",
+            "$etag": "W/\u00222a2e4748-c4a8-4ce2-a755-68efd52528fa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin484073712",
+            "$etag": "W/\u00228468c658-1feb-4faf-8bfa-5379012e88a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin489387498",
+            "$etag": "W/\u00227ec14c16-e75b-4307-a18f-aa2bae497248\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin532106151",
+            "$etag": "W/\u0022c60c9190-89a5-451f-8b85-ee2165c86924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "41d093ed6d313ec1a10a6dd323f14497",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2585",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin2060296123",
+            "$etag": "W/\u002231152dd5-003f-4f41-a193-eb503ae3988d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1162878836",
+            "$etag": "W/\u002261f15449-ef3b-4eaf-a667-247648c141b4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1225195112",
+            "$etag": "W/\u0022b4dfb1a8-4df1-4fdd-b65e-77175e5f8b85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin809589682",
+            "$etag": "W/\u0022b94a81ae-820b-442f-98aa-1a1210fcd8b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1312290533",
+            "$etag": "W/\u0022ba1ba1e3-6335-4748-98bb-0adb30f9a8c0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a153cc6c4cc9017ca2972d36b9b4a2c0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2587",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.16",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1882526098",
+            "$etag": "W/\u00223fb9fd3b-b10a-42a3-96cd-c97c516a445a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin424570723",
+            "$etag": "W/\u0022bd0955c9-221e-4024-b1e6-9a7377fdafcd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin74665732",
+            "$etag": "W/\u00222547770e-a761-4276-9a44-5ed7cab6d320\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin357005613",
+            "$etag": "W/\u0022d65324bf-9d35-49e3-b1f7-63ddb1b11d27\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079678761",
+            "$etag": "W/\u0022facc9bb8-5b4a-4355-a1e5-a0fed59798be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c957f32ccc0865d390262154132d5b62",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin857070193",
+            "$etag": "W/\u0022344b1b43-9954-446a-9648-592ad0cd2b33\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1525191687",
+            "$etag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin644310332",
+            "$etag": "W/\u0022680af627-2e01-4ac8-af38-3cb3e79a7503\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1513c9fa4cbca18b17cf9e9a3f8a84ed",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1614607475",
+            "$etag": "W/\u0022f4c1ad67-fd8a-4c7a-944a-341c82ba5fe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1438249970",
+            "$etag": "W/\u002229634e48-7cc6-4291-9940-3248a57e5414\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1380454223",
+            "$etag": "W/\u00226c820be3-8744-4bde-8e25-2aa409b0d2f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin738047304",
+            "$etag": "W/\u0022737811d1-9aed-475d-b5c2-260cb281afbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin379883128",
+            "$etag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "2fa6ad677a9a9f8ff8ee11a22b27ee75",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin64365696",
+            "$etag": "W/\u00226447225b-3ea7-44f0-a749-74d01de4b0f6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1753584378",
+            "$etag": "W/\u002267c15d28-08e0-4f21-b715-2f163b19f9a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2028986873",
+            "$etag": "W/\u0022d5811809-19fe-43ed-8074-f0595974de59\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin847442141",
+            "$etag": "W/\u002236fd1881-ac66-4f4b-b7a1-2b5ece25b67c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2106608761",
+            "$etag": "W/\u0022d1c30c84-1030-4cef-9d85-609d968aff40\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f03cca3b8da1df0368b6b2392d392506",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1662618080",
+            "$etag": "W/\u0022a7518287-834e-439b-9371-4442e4009ac9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin279835412",
+            "$etag": "W/\u00224fc1be2c-7a96-469e-aedf-8f90db26a9cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2001547295",
+            "$etag": "W/\u002265298c2f-3a64-4af4-bdd8-dc3b8c32c703\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin254397244",
+            "$etag": "W/\u00229a4458dc-c730-4129-86a1-fe7062161ba9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin312098304",
+            "$etag": "W/\u00228c00c75d-1d48-4e95-a038-7a57e29ddfb2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "66ec34a22c8680c839731cce3be975ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1882",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.07",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin857257843",
+            "$etag": "W/\u002262efaa49-c478-42c4-adc4-bafcf161b386\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1017374329",
+            "$etag": "W/\u0022f4bc66c7-22da-4ae9-a2f3-4f2d15a84b44\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin187351254",
+            "$etag": "W/\u0022cb532999-1e35-4bea-ac08-1e6d35585fd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
           }
@@ -12780,17 +5003,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "e82c9af4b95789ee5f3491822fa81bff",
+        "x-ms-client-request-id": "745f28e1944eda4ba9c7c7e3c75571bf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:48 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorks.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorks.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -76,10 +76,10 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;113863769\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:45.9755616\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;113863769\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.5727642\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1369668520?api-version=2020-10-31",
@@ -99,7 +99,7 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "ETag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -145,7 +145,7 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "ETag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -191,7 +191,7 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "ETag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -233,52 +233,11 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1062677703. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1062677703?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "8edb6952d95e0a5607414f8026210cf0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "ETag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -307,7 +266,7 @@
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1462038290?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1274856786?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -316,7 +275,53 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "2f14955ba99e2540d7f97a7ae04a72fa",
+        "x-ms-client-request-id": "5e8edb6956d9070a414f8026210cf012",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
+        "ETag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1274856786",
+        "$etag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1395057243?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9e2f149540a9d725f97a7ae04a72fa73",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -324,30 +329,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1462038290. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1395057243. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1462038290?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1395057243?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "83796173685d9f31b0d2d86cc9b70fa7",
+        "x-ms-client-request-id": "5d8379613168b09fd2d86cc9b70fa766",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -365,13 +369,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u002206e11e90-ddf6-4d23-bfda-68705ea88c2d\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1462038290",
-        "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+        "$dtId": "roomTwin1395057243",
+        "$etag": "W/\u002206e11e90-ddf6-4d23-bfda-68705ea88c2d\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -379,22 +383,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7688995Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7688995Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7688995Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+            "lastUpdateTime": "2020-10-26T17:04:50.7688995Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin462997606?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1703205844?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -403,7 +407,179 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "3298e9d4b4509abf6987e0db8f26f7dd",
+        "x-ms-client-request-id": "503298e9bfb4699a87e0db8f26f7dd86",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1703205844. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1703205844?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6d93c0b2f3b575647fcbd1d35b1fead3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00228717403f-b5af-4fd4-a033-6c3163a1d950\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1703205844",
+        "$etag": "W/\u00228717403f-b5af-4fd4-a033-6c3163a1d950\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8534743Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8534743Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8534743Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8534743Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1468314132?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c8da600bad22e8b9f3e051c321abe08f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1468314132. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1468314132?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "144e04421ff933f6bcd1e8eec70e68f5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00225bb054cc-8c83-496b-9ecb-54e7805617ea\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1468314132",
+        "$etag": "W/\u00225bb054cc-8c83-496b-9ecb-54e7805617ea\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9590543Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9590543Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9590543Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9590543Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin568965640?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "02961b7a90bdd91284c11213b15d1ff0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -411,30 +587,29 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin462997606. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin568965640. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin462997606?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin568965640?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "93c0b286b56d64f3757fcbd1d35b1fea",
+        "x-ms-client-request-id": "9b1a18441bbf6aeba60b51c4cb21e578",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -452,13 +627,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022b078dafb-adff-4a16-8525-766a41a76e64\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin462997606",
-        "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+        "$dtId": "roomTwin568965640",
+        "$etag": "W/\u0022b078dafb-adff-4a16-8525-766a41a76e64\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -466,22 +641,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.0961297Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.0961297Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.0961297Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.0961297Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1543128019?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin680946523?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -490,181 +665,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "da600b1422c8b9ade8f3e051c321abe0",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1543128019. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1543128019?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "4e04428ff914f61f33bcd1e8eec70e68",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "461",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin1543128019",
-        "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1750846709?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "961b7a08bd021290d984c11213b15d1f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1750846709. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1750846709?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1a1844f0bf9beb1b6aa60b51c4cb21e5",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "461",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin1750846709",
-        "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin422308472?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "90a6bb5b8c4a74853b3a745ee3200b73",
+        "x-ms-client-request-id": "4a90a6bb858c3b743a745ee3200b73c8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -672,30 +673,29 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin422308472. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin680946523. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin422308472?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin680946523?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f582fdc85a4e5f482f2b5cb23e4e0d63",
+        "x-ms-client-request-id": "4ef582fd485a2f5f2b5cb23e4e0d63db",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -713,13 +713,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00227018e9bb-62d6-4abd-b82f-81be50f01f32\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin422308472",
-        "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+        "$dtId": "roomTwin680946523",
+        "$etag": "W/\u00227018e9bb-62d6-4abd-b82f-81be50f01f32\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -727,22 +727,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.1849045Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.1849045Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.1849045Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.1849045Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1648554203?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin301296282?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -751,94 +751,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "b7f6b79aa68f93b7a55f84a68d868600",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1648554203. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1648554203?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "9ecefcdd29f0720047601e30d335ed2d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "461",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin1648554203",
-        "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;113863769",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin817870353?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "1568498238bbca5661a8fbc3b8a2a4d6",
+        "x-ms-client-request-id": "8fb7f6b7b7a6a5935f84a68d868600dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -846,30 +759,29 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin817870353. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin301296282. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin817870353?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin301296282?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "3f5160b1ebc4b77083702f8887c06f71",
+        "x-ms-client-request-id": "f09ecefc00294772601e30d335ed2d11",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -887,13 +799,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u002286a4d96a-b3f4-40f5-860f-f10d8a3578d7\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin817870353",
-        "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+        "$dtId": "roomTwin301296282",
+        "$etag": "W/\u002286a4d96a-b3f4-40f5-860f-f10d8a3578d7\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -901,22 +813,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2690365Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2690365Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2690365Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2690365Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1240738903?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1272937602?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -925,7 +837,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "1d3d0a9522ea77c3d48e8105ae8ebe79",
+        "x-ms-client-request-id": "bb156849563861caa8fbc3b8a2a4d6b1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -933,30 +845,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1240738903. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1272937602. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1240738903?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1272937602?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "9cd4215a4cedd997b1914b09ce42a139",
+        "x-ms-client-request-id": "c43f516070eb83b7702f8887c06f7157",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -974,13 +885,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022793c3633-736a-4ca6-9600-f1d01dad1f58\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1240738903",
-        "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+        "$dtId": "roomTwin1272937602",
+        "$etag": "W/\u0022793c3633-736a-4ca6-9600-f1d01dad1f58\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -988,22 +899,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3508762Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3508762Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3508762Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3508762Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1491061385?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1153470101?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1012,7 +923,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6797226cc7b88e3ec8f05cefb1d4e171",
+        "x-ms-client-request-id": "ea1d3d0ac322d4778e8105ae8ebe795a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1020,30 +931,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1491061385. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1153470101. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1491061385?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1153470101?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "9a9f2d0e69d57348636c59d6b9a891ed",
+        "x-ms-client-request-id": "ed9cd421974cb1d9914b09ce42a13989",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1061,13 +971,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "ETag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022e9a5aca6-b276-4a8f-afe3-73a4594ea0bc\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1491061385",
-        "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+        "$dtId": "roomTwin1153470101",
+        "$etag": "W/\u0022e9a5aca6-b276-4a8f-afe3-73a4594ea0bc\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -1075,16 +985,188 @@
         "$metadata": {
           "$model": "dtmi:example:room;113863769",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4300357Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4300357Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4300357Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.4300357Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin754347372?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b86797223ec7c88ef05cefb1d4e1710e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "270",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin754347372. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin754347372?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d59a9f2d486963736c59d6b9a891ed47",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "ETag": "W/\u002232c6fb1c-2ecc-4cde-823b-620a6ce2ce22\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin754347372",
+        "$etag": "W/\u002232c6fb1c-2ecc-4cde-823b-620a6ce2ce22\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:51.5212661Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:51.5212661Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:51.5212661Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:51.5212661Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin150831996?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "11266b425aa10d96255c3aea00bd6998",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "270",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin150831996. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin150831996?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9e0214bf02b424da044c6d67d41f5e6e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "ETag": "W/\u0022e117ce8d-ccbf-43fa-ad29-7268f335fa3a\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin150831996",
+        "$etag": "W/\u0022e117ce8d-ccbf-43fa-ad29-7268f335fa3a\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;113863769",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:51.6241926Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:51.6241926Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:51.6241926Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:51.6241926Z"
           }
         }
       }
@@ -1101,7 +1183,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "6b427c4711265aa1960d255c3aea00bd",
+        "x-ms-client-request-id": "769235a7fd4a448c04c744eb38796c9b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1109,10 +1191,10 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "33956",
+        "Content-Length": "46198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "query-charge": "15.100000000000001",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "query-charge": "20.23",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -2806,6 +2888,1073 @@
                 "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
+          },
+          {
+            "$dtId": "roomTwin363377363",
+            "$etag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2146208947",
+            "$etag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1062677703",
+            "$etag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin324722902",
+            "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1462038290",
+            "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin462997606",
+            "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1012472014",
+            "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1543128019",
+            "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin955385887",
+            "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin672739146",
+            "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1750846709",
+            "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin422308472",
+            "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1661689683",
+            "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1648554203",
+            "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin528003268",
+            "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin817870353",
+            "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1251286994",
+            "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1240738903",
+            "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1738906707",
+            "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1491061385",
+            "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1776075638",
+            "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin619913832",
+            "$etag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1410570626",
+            "$etag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1067365890",
+            "$etag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin757295793",
+            "$etag": "W/\u00220b31dafa-a92e-4139-91c2-cea3a0de96e7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin633630133",
+            "$etag": "W/\u0022a194cd57-9a12-40a8-8641-eef149c38829\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "376",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "7ce8206da9eb40c791020d55ec2e3806",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "8803",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "query-charge": "4.48",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1052658490",
+            "$etag": "W/\u00225ddb7fae-81be-4b0b-920f-26947783a711\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1626036685",
+            "$etag": "W/\u002288043f16-cc41-41fa-a4c2-89b79dc679b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin687114800",
+            "$etag": "W/\u0022e40bc758-5024-403f-be36-b991984dd165\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1274856786",
+            "$etag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1098941419",
+            "$etag": "W/\u002233a4b889-0aba-4d63-b65d-a42a40e4c456\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin125346931",
+            "$etag": "W/\u0022af62467a-acb1-4395-8c26-eb38dfc9874b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin345229702",
+            "$etag": "W/\u002255c487c4-984f-465f-bc95-125288661377\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin904769627",
+            "$etag": "W/\u0022f0e97abe-4660-4e4e-8ae7-ce9a7cc4eabc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin840530319",
+            "$etag": "W/\u00227b0aed29-4924-4edb-a4f6-57b379179e7a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin19991913",
+            "$etag": "W/\u00227b4544bb-5313-421d-821b-0b47810f6ed1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1846282992",
+            "$etag": "W/\u0022e96b7675-5265-486e-a565-51c09f86292e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1501230847",
+            "$etag": "W/\u00226802e3a6-b98a-4da6-b472-4b02220454d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2112889309",
+            "$etag": "W/\u0022a8b818f4-cac5-4152-af3b-6501b11b2a20\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1261829064",
+            "$etag": "W/\u0022d227561c-e41d-4503-b9b9-e6c04d18d682\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin20831578",
+            "$etag": "W/\u002228e89f63-cbd8-432d-8408-cbe836c136a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2061740721",
+            "$etag": "W/\u0022809c12e1-14b3-49ab-8d2a-f138e6e9f5bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin59174272",
+            "$etag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1511973902",
+            "$etag": "W/\u0022e512e115-b43b-493d-b71e-8e7d617e48de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1357107878",
+            "$etag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              }
+            }
           }
         ],
         "continuationToken": null
@@ -2824,7 +3973,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "14bf98699e0202b4da24044c6d67d41f",
+        "x-ms-client-request-id": "ca42ccfdf32bc24e88bd99edbeeeeb8a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2832,9 +3981,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2593",
+        "Content-Length": "2601",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.26",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -2956,7 +4105,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAWAAbA4PedBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -2965,24 +4114,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "386",
+        "Content-Length": "394",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "35a76e5e7692fd4a8c4404c744eb3879",
+        "x-ms-client-request-id": "b4fad1e0e236fd836d52e448ef3658d6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAWAAbA4PedBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2367",
+        "Content-Length": "2375",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.13",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3092,7 +4241,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAWAAbAAPSdBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3101,24 +4250,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "387",
+        "Content-Length": "395",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "206d9b6c7ce8a9ebc74091020d55ec2e",
+        "x-ms-client-request-id": "6cee3d8ea1367a70d226f32e0fda81a3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAWAAbAAPSdBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2591",
+        "Content-Length": "2599",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3240,7 +4389,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAUABIAnQTggRJAAw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3249,24 +4398,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "383",
+        "Content-Length": "391",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "ccfd0638ca42f32b4ec288bd99edbeee",
+        "x-ms-client-request-id": "1a75821684341bd048455dd80e05d251",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAUABIAnQTggRJAAw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2591",
+        "Content-Length": "2599",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3388,7 +4537,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAUABqABMDggf//Aw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3397,24 +4546,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "383",
+        "Content-Length": "391",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d1e08aebb4fae23683fd6d52e448ef36",
+        "x-ms-client-request-id": "805ec3647f003e54617fe10fee54ed93",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAUABqABMDggf//Aw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2589",
+        "Content-Length": "2597",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3536,7 +4685,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAQAC\u002BAEkADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3545,24 +4694,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "384",
+        "Content-Length": "392",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "3d8ed6586ceea136707ad226f32e0fda",
+        "x-ms-client-request-id": "6d3141d03ec10aa16dd323f144976ccc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAQAC\u002BAEkADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2586",
+        "Content-Length": "2594",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.16",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3684,7 +4833,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAQADMA8P8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3693,24 +4842,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "379",
+        "Content-Length": "387",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "8216a3811a758434d01b48455dd80e05",
+        "x-ms-client-request-id": "4cc9a153017c97a22d36b9b4a2c02cf3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAQADMA8P8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2588",
+        "Content-Length": "2596",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3832,7 +4981,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAP4DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3841,24 +4990,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "379",
+        "Content-Length": "387",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c36451d2805e7f00543e617fe10fee54",
+        "x-ms-client-request-id": "cc08c95765d326902154132d5b62fac9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAP4DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2587",
+        "Content-Length": "2595",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3980,7 +5129,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAMADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3989,24 +5138,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "384",
+        "Content-Length": "392",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "41d093ed6d313ec1a10a6dd323f14497",
+        "x-ms-client-request-id": "4cbc1513a18bcf179e9a3f8a84ed67ad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAMADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2585",
+        "Content-Length": "2593",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4128,7 +5277,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAOAEIAAA7M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4137,24 +5286,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "375",
+        "Content-Length": "383",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "a153cc6c4cc9017ca2972d36b9b4a2c0",
+        "x-ms-client-request-id": "7a9a2fa69f8feef811a22b27ee753bca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAOAEIAAA7M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2587",
+        "Content-Length": "2591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.16",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4276,7 +5425,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAwP8jQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4285,24 +5434,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c957f32ccc0865d390262154132d5b62",
+        "x-ms-client-request-id": "8da1f03cdf03b668b2392d392506a234",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAwP8jQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2589",
+        "Content-Length": "2593",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4424,7 +5573,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAAPgjQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4433,24 +5582,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "1513c9fa4cbca18b17cf9e9a3f8a84ed",
+        "x-ms-client-request-id": "2c8666ec80c873391cce3be975efe128",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAAPgjQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "2589",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4572,7 +5721,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAKAGAAI0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4588,17 +5737,17 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "2fa6ad677a9a9f8ff8ee11a22b27ee75",
+        "x-ms-client-request-id": "944e745fda4bc7a9c7e3c75571bfc80b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAKAGAAI0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2588",
+        "Content-Length": "2592",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4720,7 +5869,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAMAGEA4P8TQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4729,24 +5878,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f03cca3b8da1df0368b6b2392d392506",
+        "x-ms-client-request-id": "873bf6000fefbb02b62e7035a37f40c3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAMAGEA4P8TQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2588",
+        "Content-Length": "2592",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4868,7 +6017,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAMAGEAAPwTQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4877,25 +6026,25 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "66ec34a22c8680c839731cce3be975ef",
+        "x-ms-client-request-id": "b0da05580db711e9bcbf64e4b9e3015d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAMAGEAAPwTQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "1882",
+        "Content-Length": "2588",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "query-charge": "3.07",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -4991,6 +6140,1338 @@
                 "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
+          },
+          {
+            "$dtId": "roomTwin363377363",
+            "$etag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZvAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAKAG\u002BAE0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "385",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "7ee8300559b44f397293dd1c6a732347",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZvAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAKAG\u002BAE0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin2146208947",
+            "$etag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1062677703",
+            "$etag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin324722902",
+            "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1462038290",
+            "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin462997606",
+            "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ0AAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAKAHQA8P9/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6cfd04a317e5f2530d29ca2faa1d02d2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ0AAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAKAHQA8P9/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1012472014",
+            "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1543128019",
+            "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin955385887",
+            "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin672739146",
+            "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1750846709",
+            "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ5AAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAP5/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "732f132cc196fe0fcb8a3e242fcca748",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ5AAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAP5/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin422308472",
+            "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1661689683",
+            "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1648554203",
+            "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin528003268",
+            "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin817870353",
+            "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ\u002BAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAMB/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "385",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "b5411d9c94e6ee77dcf6718a8e0aa555",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ\u002BAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAMB/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2587",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1251286994",
+            "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1240738903",
+            "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1738906707",
+            "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1491061385",
+            "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1776075638",
+            "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaDAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAeFEk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "376",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "57ef0b90af44e2b1f4fea15ad92fc241",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaDAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAeFEk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2585",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin619913832",
+            "$etag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1410570626",
+            "$etag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1067365890",
+            "$etag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin757295793",
+            "$etag": "W/\u00220b31dafa-a92e-4139-91c2-cea3a0de96e7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin633630133",
+            "$etag": "W/\u0022a194cd57-9a12-40a8-8641-eef149c38829\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "377",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8d9382824ddc98ec9b4096a0508470c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2591",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1052658490",
+            "$etag": "W/\u00225ddb7fae-81be-4b0b-920f-26947783a711\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1626036685",
+            "$etag": "W/\u002288043f16-cc41-41fa-a4c2-89b79dc679b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin687114800",
+            "$etag": "W/\u0022e40bc758-5024-403f-be36-b991984dd165\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1274856786",
+            "$etag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1098941419",
+            "$etag": "W/\u002233a4b889-0aba-4d63-b65d-a42a40e4c456\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjacAAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AZwAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "381",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "2493e9e550dcec046c5ec0e7f31c14ad",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjacAAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AZwAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2586",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.16",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin125346931",
+            "$etag": "W/\u0022af62467a-acb1-4395-8c26-eb38dfc9874b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin345229702",
+            "$etag": "W/\u002255c487c4-984f-465f-bc95-125288661377\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin904769627",
+            "$etag": "W/\u0022f0e97abe-4660-4e4e-8ae7-ce9a7cc4eabc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin840530319",
+            "$etag": "W/\u00227b0aed29-4924-4edb-a4f6-57b379179e7a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin19991913",
+            "$etag": "W/\u00227b4544bb-5313-421d-821b-0b47810f6ed1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjahAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AaEAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "381",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0c082f33177643791f57bb0318109270",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjahAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AaEAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2590",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1846282992",
+            "$etag": "W/\u0022e96b7675-5265-486e-a565-51c09f86292e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1501230847",
+            "$etag": "W/\u00226802e3a6-b98a-4da6-b472-4b02220454d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2112889309",
+            "$etag": "W/\u0022a8b818f4-cac5-4152-af3b-6501b11b2a20\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1261829064",
+            "$etag": "W/\u0022d227561c-e41d-4503-b9b9-e6c04d18d682\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin20831578",
+            "$etag": "W/\u002228e89f63-cbd8-432d-8408-cbe836c136a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjamAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AaYAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "381",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f075e08e9d9b32647da6217d8c04a47e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjamAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AaYAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1882",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.07",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin2061740721",
+            "$etag": "W/\u0022809c12e1-14b3-49ab-8d2a-f138e6e9f5bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin59174272",
+            "$etag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1511973902",
+            "$etag": "W/\u0022e512e115-b43b-493d-b71e-8e7d617e48de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1357107878",
+            "$etag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              }
+            }
           }
         ],
         "continuationToken": null
@@ -5006,14 +7487,14 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "745f28e1944eda4ba9c7c7e3c75571bf",
+        "x-ms-client-request-id": "206ce92b647ccd4a6f4f05849400d45b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:48 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorksAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorksAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "c2e3d6d57f9e6f1eb9c0539ba80f819d",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "3cc2797a442f5ae57c268464e415ab44",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -65,8 +65,8 @@
         "Content-Length": "804",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "2c7c4a140cfb87d46a66255b0ab3d527",
         "x-ms-return-client-request-id": "true"
@@ -74,12 +74,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;120254295\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;13983924\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "193",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;120254295\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:10.6855169\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;120254295\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.051617\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin537968733?api-version=2020-10-31",
@@ -88,65 +88,24 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "517b20c4a624fd91672158990ad4aaa7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:09 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin537968733. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin537968733?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "05c594560970a46e3ad1c81f8a50c950",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin537968733",
-        "$etag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
+        "$etag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,86 +113,45 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+            "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin873268829?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2121647958?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "30f51f07f0f2eaa32f94ea7bed60917b",
+        "x-ms-client-request-id": "7005c5946e093aa4d1c81f8a50c9505d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin873268829. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin873268829?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "101fb3b4ec21b1bbd61652dd72731758",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "460",
+        "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin873268829",
-        "$etag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
+        "$dtId": "roomTwin2121647958",
+        "$etag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -241,86 +159,45 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+            "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+            "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+            "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+            "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin152530184?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1525191687?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "b5b5023c647621a31b417484294d7137",
+        "x-ms-client-request-id": "f230f51fa3f02fea94ea7bed60917bb4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin152530184. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin152530184?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a99cd6a33b3f641a435adc9dc578bc7d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "460",
+        "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin152530184",
-        "$etag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
+        "$dtId": "roomTwin1525191687",
+        "$etag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -328,31 +205,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+            "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+            "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+            "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+            "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1775617169?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2146208947?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "dc5db1733dc57b4fef06ab462dadc9e1",
+        "x-ms-client-request-id": "ec21101fb1bb16d652dd72731758083c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -360,18 +237,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1775617169. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin2146208947. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1775617169?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2146208947?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -380,10 +257,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "7b9dcea6c8aee70050721c87065ba285",
+        "x-ms-client-request-id": "76b5b502a3641b21417484294d7137a3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -401,13 +278,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1775617169",
-        "$etag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
+        "$dtId": "roomTwin2146208947",
+        "$etag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -415,31 +292,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin545487351?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin324722902?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "139bb5f2de5a4c982d50356f1d16ac13",
+        "x-ms-client-request-id": "3b3fa99c641a5a43dc9dc578bc7d9173",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -447,18 +324,18 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin545487351. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin324722902. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin545487351?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin324722902?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -467,10 +344,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "1fa91fbbe201b0ab768b5321c8759363",
+        "x-ms-client-request-id": "c5dc5db14f3def7b06ab462dadc9e1a6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -488,13 +365,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin545487351",
-        "$etag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
+        "$dtId": "roomTwin324722902",
+        "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -502,31 +379,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1469731366?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1012472014?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "2df83a4f4bce04f02f8077cb78335b6f",
+        "x-ms-client-request-id": "c8ae7b9de70072501c87065ba285f7f2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -534,18 +411,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1469731366. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1012472014. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1469731366?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1012472014?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -554,10 +431,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f93c4a74f566090fea9ccf8a7683b8bd",
+        "x-ms-client-request-id": "5a139bb598de2d4c50356f1d16ac13bb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -575,13 +452,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1469731366",
-        "$etag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
+        "$dtId": "roomTwin1012472014",
+        "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -589,31 +466,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin886314449?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin955385887?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "b4dbcd48ede5b9d31ad26234e5fd57f7",
+        "x-ms-client-request-id": "e2011fa9b0ab8b765321c8759363264f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -621,18 +498,18 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin886314449. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin955385887. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin886314449?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin955385887?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -641,10 +518,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "572b53b2c06a2a5aee42317b658eabc8",
+        "x-ms-client-request-id": "ce2df83af04b2f048077cb78335b6f74",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -662,13 +539,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin886314449",
-        "$etag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
+        "$dtId": "roomTwin955385887",
+        "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -676,31 +553,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin619580090?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin672739146?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "7f6530f98fba685c3f4b22add5059f77",
+        "x-ms-client-request-id": "f566f93c090f9ceacf8a7683b8bdd148",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -708,18 +585,18 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin619580090. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin672739146. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin619580090?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin672739146?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -728,10 +605,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "8d2fc49266657387b0c6a2bc57548c27",
+        "x-ms-client-request-id": "e5b4dbcdd3ed1ab9d26234e5fd57f7b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -749,13 +626,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin619580090",
-        "$etag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+        "$dtId": "roomTwin672739146",
+        "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -763,31 +640,31 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1135525785?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1661689683?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f1cdeb79f777cec4ef2b74377d193d92",
+        "x-ms-client-request-id": "c06a572b2a5a42ee317b658eabc8baf9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -795,18 +672,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1135525785. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1661689683. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1135525785?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1661689683?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -815,10 +692,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "7bc9d204543ba893f2cef4eca010ebbf",
+        "x-ms-client-request-id": "ba7f65305c8f3f684b22add5059f7792",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -836,13 +713,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "ETag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1135525785",
-        "$etag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+        "$dtId": "roomTwin1661689683",
+        "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -850,50 +727,50 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1105345787?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin528003268?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d2195b141b866bccbe753b123b33ad65",
+        "x-ms-client-request-id": "66658d2f7387c6b0a2bc57548c279979",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "Content-Length": "271",
+        "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1105345787. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin528003268. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1105345787?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin528003268?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -902,10 +779,97 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c28153295eab582524ffa803d82ddf40",
+        "x-ms-client-request-id": "77f1cdebc4f7efce2b74377d193d9204",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "ETag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin528003268",
+        "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1251286994?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "543b7bc9a893cef2f4eca010ebbffb14",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1251286994. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1251286994?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "If-None-Match": "*",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "86d2195bcc1bbe6b753b123b33ad6529",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -923,13 +887,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:10 GMT",
-        "ETag": "W/\u00225f3effb8-87f4-4967-b07c-f2c042d57b13\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "ETag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1105345787",
-        "$etag": "W/\u00225f3effb8-87f4-4967-b07c-f2c042d57b13\u0022",
+        "$dtId": "roomTwin1251286994",
+        "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -937,16 +901,190 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:11.6420960Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:11.6420960Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:11.6420960Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:11.6420960Z"
+            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1738906707?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5eabc2815825ff24a803d82ddf40b53c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1738906707. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1738906707?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "If-None-Match": "*",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "bf23bd69b77e10fd7cdf5795b69b4686",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "ETag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1738906707",
+        "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1776075638?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "4ffd69bc36b5adc18672c8929196fb5d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1776075638. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1776075638?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "If-None-Match": "*",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "42efcaffd56ac4ca9be246008f490dbc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "ETag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1776075638",
+        "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
           }
         }
       }
@@ -960,10 +1098,10 @@
         "Content-Length": "38",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "bd693cb5bf23b77efd107cdf5795b69b",
+        "x-ms-client-request-id": "d622b652ecb787b36112f745347dea48",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -971,4817 +1109,212 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "45693",
+        "Content-Length": "33956",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "20.169999999999998",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "query-charge": "15.100000000000001",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1498980297",
-            "$etag": "W/\u0022d9379766-dc49-4095-8469-7117a69534b0\u0022",
+            "$dtId": "roomTwin1495950345",
+            "$etag": "W/\u002205d2ae31-6929-4d7e-af04-4a44b4b31e8b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;112984610",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1381264736",
-            "$etag": "W/\u00229530fad8-8481-4207-a3a2-54f75c33e03f\u0022",
+            "$dtId": "roomTwin344050324",
+            "$etag": "W/\u0022f8d463fc-b497-42c5-9d24-8bf2eb63c8ac\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112462194",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin746222802",
-            "$etag": "W/\u00221c55bd1b-4dc3-48a5-a694-7504c7387b38\u0022",
+            "$dtId": "roomTwin427623005",
+            "$etag": "W/\u00221af94c6c-ba7b-43af-b731-3c747d441259\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;119618957",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin775031637",
-            "$etag": "W/\u0022f2e095ad-618a-44d8-ae54-fb1acaf9d041\u0022",
+            "$dtId": "roomTwin410651761",
+            "$etag": "W/\u00229de8f988-b123-411e-81d1-b9b2647c5bfa\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112725529",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1245991748",
-            "$etag": "W/\u0022b941c874-b71d-4d29-8987-55a489ce4757\u0022",
+            "$dtId": "roomTwin744180983",
+            "$etag": "W/\u002263bb6047-a862-4977-b4f0-c9890d2b3370\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;115056947",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1444644859",
-            "$etag": "W/\u00226102e256-e029-43c3-88e2-7fcdf1df31be\u0022",
+            "$dtId": "roomTwin1437249777",
+            "$etag": "W/\u0022ef65f3f3-9966-4092-bf4c-b466ccb270f9\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;158485519",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1163564709",
-            "$etag": "W/\u0022670f1a13-ef3c-4450-a0ec-6b9ec342415e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin936523733",
-            "$etag": "W/\u0022df870f13-0fce-4273-b8b2-1f0cc9360973\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1174159166",
-            "$etag": "W/\u0022660a990d-f9d7-4588-97dd-b5e45bc98086\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin86672577",
-            "$etag": "W/\u0022fd6efd7e-0d32-4bf7-a8cf-0bcd64ae75c6\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1870986745",
-            "$etag": "W/\u0022c7480283-c513-4b7e-9937-8074f62ace65\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1536838429",
-            "$etag": "W/\u0022bcbed22e-248a-43ee-9594-5fdf5c571cbd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin661851410",
-            "$etag": "W/\u0022af7780a2-175d-4891-a13f-df6c145fd88e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110247197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1085222686",
-            "$etag": "W/\u0022bf070c35-d9ff-46f0-ab3d-c96099615404\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;166246968",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420943146",
-            "$etag": "W/\u002221e209f9-0bf3-4a09-9cda-3f0bb04813b8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1338380856",
-            "$etag": "W/\u00224cd0743c-7862-43df-873a-4b41374d1544\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1785890025",
-            "$etag": "W/\u00225d658a38-9807-4a54-a993-3484b1bb15e1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1000297038",
-            "$etag": "W/\u00223aa0b952-daba-4ff9-bcb8-602da4399405\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1893330133",
-            "$etag": "W/\u00225ebe6eae-1a9d-46ed-acde-5e4da8aeea0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123218210",
-            "$etag": "W/\u002214760d80-a8ce-4843-b0e4-56e6e9f4dd27\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1520206458",
-            "$etag": "W/\u0022835208c2-4a55-4de7-b10e-dc4187d5882e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin92117139",
-            "$etag": "W/\u00224cc2ce94-15c6-4ae7-a020-4f9a9792ab09\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36128330",
-            "$etag": "W/\u00225adde61e-e412-49cf-a752-527bd8b3aba2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777097876",
-            "$etag": "W/\u0022e27281c3-f22a-47a9-82ee-7b0f0b267d48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470032629",
-            "$etag": "W/\u002256fc5f73-a1df-4e71-8bea-54ed682348af\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1800780114",
-            "$etag": "W/\u0022516b6d16-ef6d-47c8-8cfb-1854ca4835bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin27801422",
-            "$etag": "W/\u0022539467f6-fbb6-4360-a729-c39f353f3253\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1902584715",
-            "$etag": "W/\u00221884e5dc-2708-427a-9eaa-6d2e83841d06\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin96827413",
-            "$etag": "W/\u0022ef52e4c6-e6a3-4bb3-8005-997c3d9f44dd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin935053957",
-            "$etag": "W/\u002264c75c6e-a2a9-441b-beda-2b306818df87\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2074335826",
-            "$etag": "W/\u00221c81ad83-61b8-4fde-bea7-4f42e5e899ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123629177",
-            "$etag": "W/\u0022db3407f5-6797-483a-ac54-66cf8491c767\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1554813222",
-            "$etag": "W/\u0022817cabe6-9a22-4634-a34d-177273d33068\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1699890695",
-            "$etag": "W/\u00227084f858-2fd9-423c-9998-d831f293c5f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1088498238",
-            "$etag": "W/\u00221d4e9b50-b84b-45da-ab41-b40a11736140\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;158383040",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin894415666",
-            "$etag": "W/\u0022f5f49f19-15f2-45e1-ab5f-1f6ad65d49f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113309762",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148688568",
-            "$etag": "W/\u0022185a6e23-5cdc-43c3-9f98-bce142ef1635\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin605247566",
-            "$etag": "W/\u002285ec04a7-1fc5-4cb5-a028-fb7646cee045\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1738278687",
-            "$etag": "W/\u002265469fb8-0e42-4c50-88c4-9499db8d30d1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin883341753",
-            "$etag": "W/\u0022c6d743e3-2171-46df-9875-45107360b597\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin44768029",
-            "$etag": "W/\u0022e0bf97cb-0ca6-4f19-9c87-c12c508eb7eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1026080773",
-            "$etag": "W/\u0022be607bbe-b367-42de-b426-17d53b764e00\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1012130572",
-            "$etag": "W/\u0022e9d0ad86-5382-41dc-95e4-7365514401dc\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin314886311",
-            "$etag": "W/\u0022ed0846f6-8b98-44f6-8dab-96f5271ce59b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1045652022",
-            "$etag": "W/\u0022deb78b85-2b4d-4695-b234-c6dfae1bf0a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin516625160",
-            "$etag": "W/\u00226b21212e-eb4d-4ad9-aac3-ca364cb5e3e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1891959418",
-            "$etag": "W/\u0022183aa253-51e8-4af1-9bd5-3ea98350d1bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829360197",
-            "$etag": "W/\u0022243c49a4-115d-4669-a7cb-1ed898e2de78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin61707195",
-            "$etag": "W/\u0022e6422265-b580-4e10-afa7-a032f40d0aea\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783915272",
-            "$etag": "W/\u0022a43fd4d5-65cf-4b7b-81f6-80e88ff3f822\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1041693882",
-            "$etag": "W/\u002245a8e4ec-fdbc-4d18-8396-559141ddc01b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021340528",
-            "$etag": "W/\u002298a5b93f-4034-4738-a576-b128341aaf2e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1677577135",
-            "$etag": "W/\u00223040ab87-d137-4d12-a562-f450d3bb45a9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin124606454",
-            "$etag": "W/\u00223c60e1ac-b594-4cce-8c1a-718c37a715ef\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1154990313",
-            "$etag": "W/\u00223650ee8c-f86f-4c1a-900a-2c4f11e8ebc8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2132961076",
-            "$etag": "W/\u00227a0bf9a7-9d8a-4db6-8191-84220168680b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin57113376",
-            "$etag": "W/\u0022cfcf6f4c-808d-4ce1-8f81-667ef4e74b4a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116251683",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin619150749",
-            "$etag": "W/\u00223194e119-b36a-4efa-8af0-b99c24d45ff7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170550470",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin551511810",
-            "$etag": "W/\u00222d430b86-fa94-44cc-b68a-6df9644aceff\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin98472762",
-            "$etag": "W/\u00226c5eb657-d221-4ed2-82c1-0197f69a3f30\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin869013250",
-            "$etag": "W/\u0022a3c3dc57-4372-4c4f-bf36-feb06b12f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin722764700",
-            "$etag": "W/\u0022180669f5-37cf-454a-9ed9-5f7c29bd5c21\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2125813792",
-            "$etag": "W/\u00220c25d51f-a3a9-4a12-a66b-a3fef02f32c8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1564789991",
-            "$etag": "W/\u00222f754f56-075a-4ef8-a9e4-7e189ddc22bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin729153756",
-            "$etag": "W/\u0022400fe9ad-eb92-47f5-a772-ec2b5ead9606\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1489152938",
-            "$etag": "W/\u002228c2d505-7c3b-40d2-80e0-17f323c70679\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1637856858",
-            "$etag": "W/\u0022ec90109a-be27-4750-8548-cf61eec5aa0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1363211591",
-            "$etag": "W/\u0022dd52474a-d61e-4eb5-8e3b-3b99cdd61baf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin838663785",
-            "$etag": "W/\u00227c4b95c6-3be9-40ee-8e4e-a3e78574aa34\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1300086570",
-            "$etag": "W/\u0022f1ebf4ba-6b6b-4c6b-9f31-c539d71178d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin151462022",
-            "$etag": "W/\u002298d16ff0-f7bf-4254-9d03-c9a4cb58c201\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1308729416",
-            "$etag": "W/\u0022ba6f41ec-b8f2-490a-bc1e-ff5514196325\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1856167476",
-            "$etag": "W/\u0022a211c53e-af56-4cc8-b77d-724bd8558d33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1336007415",
-            "$etag": "W/\u00229687aa69-50b9-4d7b-84b2-6b85e192050a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin662815516",
-            "$etag": "W/\u002269473407-2871-4d05-8e0f-2431ce8eafc1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin94298757",
-            "$etag": "W/\u002262eb0428-71b3-4a77-84ac-5e64f19ceb78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1612778009",
-            "$etag": "W/\u0022c9da2088-b6f7-4767-848e-4e10cfeb9ee4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin856851558",
-            "$etag": "W/\u0022c623ba55-3c32-4a56-8574-65dd548ab6e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin229826714",
-            "$etag": "W/\u002238488fbd-d87b-42dc-93d0-916af0949b4b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111655996",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin526434890",
-            "$etag": "W/\u0022c19adbeb-77ce-4d0c-95d4-708d88de7b79\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;141760569",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin941711815",
-            "$etag": "W/\u0022eb738161-f2e0-4587-8cb5-29ad474cf93d\u0022",
+            "$dtId": "roomTwin586733773",
+            "$etag": "W/\u00223524936d-5b93-4952-b9bc-403660889807\u0022",
             "AverageTemperature": 75,
             "$metadata": {
-              "$model": "dtmi:example:floor;13675231",
+              "$model": "dtmi:example:floor;11489901",
               "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.0436535Z"
+                "lastUpdateTime": "2020-10-23T21:22:11.7284978Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1735182331",
-            "$etag": "W/\u00221c736187-8abb-499b-8063-cf15994d06b5\u0022",
+            "$dtId": "roomTwin1579359106",
+            "$etag": "W/\u00226c41c324-e714-4346-97ee-3d7a43ebf892\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;153048334",
+              "$model": "dtmi:example:room;113317821",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               }
             }
           },
           {
-            "$dtId": "hvacTwin1335730075",
-            "$etag": "W/\u0022addded86-bbbe-48c6-915a-c42cd3b17213\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114614787",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin2117646547",
-            "$etag": "W/\u00222dc91dfa-469e-431d-97b6-c088938f5370\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;17595302",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.2858058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin918788440",
-            "$etag": "W/\u0022de783261-56c0-4f53-8cbd-b0520b4d6f11\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140750981",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin895881838",
-            "$etag": "W/\u0022d3d51c9d-eddd-4113-8a52-efa9f2f11426\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin492624016",
-            "$etag": "W/\u0022e231036b-9573-4cf6-93bc-4f76168ba9c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin818663445",
-            "$etag": "W/\u0022166be958-7415-4134-a4f5-7c474985c5a3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin778426230",
-            "$etag": "W/\u002297b83dbf-0971-406c-b656-d9bb25d2fe70\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;110356330",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846657163",
-            "$etag": "W/\u0022d04aa87a-a541-4896-a7fe-5eab16c99744\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin169049424",
-            "$etag": "W/\u002211259cdf-2b5d-4824-b381-10316d5c8617\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2003290546",
-            "$etag": "W/\u0022c41115df-04d0-4c5a-bc58-0ae0e7a1bbca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1920637755",
-            "$etag": "W/\u0022b1c7a4c4-5bef-4d51-8f28-6a8a99a9b955\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin567255450",
-            "$etag": "W/\u00228b132e44-b0db-4d8a-b004-3410fbd9ec66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin466450821",
-            "$etag": "W/\u0022d142de37-2196-4bec-a201-fe3146f28272\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin652828980",
-            "$etag": "W/\u0022360ae1fa-aa9d-4bd4-b2bd-8302ffa69453\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1658744984",
-            "$etag": "W/\u0022bfbfbc70-049c-4ea8-9a7e-8240bc3b49ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1108577855",
-            "$etag": "W/\u00229e4d190d-271d-4ad8-9ea6-9fa8d412cf99\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin881848871",
-            "$etag": "W/\u0022fa12869e-c78e-4c94-8c0d-6fc358b6e852\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin34125080",
-            "$etag": "W/\u002282a0d23e-5444-4f11-ac2f-d15d1909237e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "400",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "bc768646fd69b54f36c1ad8672c89291",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "44551",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "19.939999999999998",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin716576755",
-            "$etag": "W/\u0022928a136b-494e-4965-99e9-128202587246\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1961257007",
-            "$etag": "W/\u00227a297279-19b8-447a-8396-194df0d8b0ae\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1791197485",
-            "$etag": "W/\u00221bf81066-9eb3-44f5-aa96-d5f7e20946e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1867071453",
-            "$etag": "W/\u0022342a88f2-0dcc-4575-aa58-315006cd4ef1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1641901809",
-            "$etag": "W/\u00226911c53c-1a10-4321-9bea-aeeeca373ff9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1133125955",
-            "$etag": "W/\u00226b21e7dc-b4e9-4087-9c14-5a0b4fb2b15b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin246922244",
-            "$etag": "W/\u002270fb7b44-ac8b-496d-a15c-e96448dfac66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;117012504",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1642617034",
-            "$etag": "W/\u0022f7cd24c9-808b-4aa1-9fc1-d774acdfac57\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115956238",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin1545002397",
-            "$etag": "W/\u0022ae4ea64f-5b12-4c7d-8a1d-13abaaa68bd4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;16329224",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9538711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin792160889",
-            "$etag": "W/\u00227b70c14e-a9b9-409d-b05d-8c3b3de34ea4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;15819678",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9854614Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin62721381",
-            "$etag": "W/\u0022abe2d779-e33d-48b7-832f-8326022a02eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110307862",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777965033",
-            "$etag": "W/\u00227ac6cc9c-0616-4b52-bde0-1a7b1d90920c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116838841",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin849612920",
-            "$etag": "W/\u002255796041-ffda-44e6-a4d5-a29bb1b25550\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;147745744",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin387213787",
-            "$etag": "W/\u0022303aaebf-8a01-4315-92b4-3f5aa59c7aae\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114856351",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1741612918",
-            "$etag": "W/\u0022af3841ce-ae9d-49c7-96c9-680c8c704cda\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36952557",
-            "$etag": "W/\u00225017547e-5cb7-4270-8732-0fd935c5f36f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1213006989",
-            "$etag": "W/\u002239424cf2-71fa-407b-8b28-63cf3b636731\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin326513034",
-            "$etag": "W/\u00225350ca2a-c97e-4c6e-b4e2-4db4cc81475c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1129721811",
-            "$etag": "W/\u00228dba5565-d060-4bad-a801-4f9bbc4ebdf0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1947553667",
-            "$etag": "W/\u00222d6acbd7-fcfd-40c3-80e1-a33bf5092293\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1548928947",
-            "$etag": "W/\u0022ee3e799c-7ec3-44a5-bf99-608ae6ed2d0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin356265635",
-            "$etag": "W/\u0022cddfa5c7-ba8d-4f3f-a5c7-49ed794ace2f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1989978078",
-            "$etag": "W/\u0022d8a52677-b719-4322-b2a3-797951f9dfa7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin863816413",
-            "$etag": "W/\u002235dced59-748a-497b-8436-fa6c7ecd7c98\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin240878892",
-            "$etag": "W/\u0022cea21915-9749-47be-a426-12523c767a8e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1466134063",
-            "$etag": "W/\u00224b6c3b89-c127-4389-9623-6600823c637a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin503181323",
-            "$etag": "W/\u0022343c3eeb-88f4-48e3-b6a3-502e67d17d19\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin392271939",
-            "$etag": "W/\u0022076c63c0-54bd-4d30-b79f-b8779d515826\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin496261044",
-            "$etag": "W/\u0022f30db489-e0f9-4a4e-af15-7be164045d7e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin277216622",
-            "$etag": "W/\u00226566f3cb-3282-4c34-bce7-f1fd53b6b79a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin815041708",
-            "$etag": "W/\u0022df1321a9-3cd1-4196-aec2-4d21b631ca88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2006012899",
-            "$etag": "W/\u0022e71c7453-81c2-472c-9f6e-ea913867dfdb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin446974150",
-            "$etag": "W/\u0022b00117ad-a23b-4de8-a474-7bd59421fbc0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1365881715",
-            "$etag": "W/\u00223179b0b2-935f-4f4b-a0ec-e41bb6e355f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin681325335",
-            "$etag": "W/\u0022217888d9-1f32-4fc6-82a2-33d958d48c88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;164255196",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1142241383",
-            "$etag": "W/\u0022a45ffefb-8f34-4c0a-add6-029f59e7617f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;177720708",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin825845031",
-            "$etag": "W/\u0022893f390d-bd64-4c1d-8d69-563fd59f8c4e\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11574869",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.0086720Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1278234179",
-            "$etag": "W/\u00225d49dfd5-ca5c-44b1-a4c6-747f37720a9c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116571386",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin761943018",
-            "$etag": "W/\u0022990146bb-c3b6-4c49-a75b-50507494bd16\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;170683712",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin944298631",
-            "$etag": "W/\u002298b1fda1-4a5e-4e6b-a2c8-75966dd516ef\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11611266",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.7888364Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783813120",
-            "$etag": "W/\u00220b45aca6-bc41-4732-b559-3ebab02a7323\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112884932",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin462228998",
-            "$etag": "W/\u002276c721ed-c6f3-4747-9745-25aced995423\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;187698996",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin12238764",
-            "$etag": "W/\u002211b2a2c7-b161-40cd-92d7-a40ff0cdeec4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;19256426",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.4582895Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin20436333",
-            "$etag": "W/\u0022f7f6a258-469b-46e5-a27b-363cdd21bad5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112740527",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin57116881",
-            "$etag": "W/\u002249f8c592-afc4-4e28-80a1-2dbcdc2797b4\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;181789456",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin394026428",
-            "$etag": "W/\u0022a3076bd7-cbeb-4789-bc6c-509e1847f6e3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin596581608",
-            "$etag": "W/\u0022473d9d87-f909-4e33-b722-66cdc90c5b9a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1684161797",
-            "$etag": "W/\u0022b9a14ed9-ce85-445a-85ae-3f80705534bf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1901267486",
-            "$etag": "W/\u0022c55a0283-f169-4e3b-b272-d9875a72ecdd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531586602",
-            "$etag": "W/\u00223e77b5c1-75a6-4c89-8048-04e0028cf6b9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148061498",
-            "$etag": "W/\u0022c43f33d8-1c82-4fc8-890b-22e7d8f5d9d4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin436096292",
-            "$etag": "W/\u002204b66e10-cace-4bed-8cfb-8d61e27f1c12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin154780388",
-            "$etag": "W/\u002283328534-f7c3-43b2-b38f-c72bc979eb05\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121341206",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2127865916",
-            "$etag": "W/\u002241d23a05-ab39-4bd0-befe-e8159958181f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin317362118",
-            "$etag": "W/\u002202c13fde-87db-4716-a76b-d47bf709ee97\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin795448273",
-            "$etag": "W/\u0022dddf6522-6705-4b5b-82e9-54b6d744e55b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1710347499",
-            "$etag": "W/\u00224096019c-3f62-4a1f-ae96-b87531ce1b77\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin288024548",
-            "$etag": "W/\u0022426e9bb8-9bce-474a-b00d-ddfdb1e241d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1380865941",
-            "$etag": "W/\u0022e4c1ba36-c62c-400a-ad86-1cc6cf417eab\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1205304854",
-            "$etag": "W/\u0022f1d5b58c-bfdf-428b-9b23-925a89563116\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1400981480",
-            "$etag": "W/\u0022e5a90477-8fde-4e02-a38c-5b04ffd5931a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651261841",
-            "$etag": "W/\u0022d3c1a5d2-e6a5-4ef4-8113-3017514680ce\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113490432",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846170454",
-            "$etag": "W/\u0022ec7b5277-9742-4275-967f-031a47256655\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin955395753",
-            "$etag": "W/\u0022e07bd3aa-8240-4129-a2d2-3d2480e20e5a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin251907959",
-            "$etag": "W/\u002270b9ed8a-f221-4273-bbb6-3086c7c08134\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1402000963",
-            "$etag": "W/\u00225537c1d2-d31d-4cce-9055-cd4db8037551\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1857138761",
-            "$etag": "W/\u002215d19e36-1f58-4471-b631-9cc6d82a01c5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531597311",
-            "$etag": "W/\u002288a3c17e-fb49-4a32-89a6-a1844bd8b5f0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin978222842",
-            "$etag": "W/\u00221e592604-2baa-44b9-bee5-c02e4febded7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1784653895",
-            "$etag": "W/\u00225a1eae7d-10b0-4e7a-b1b7-39360e9971e7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin860770335",
-            "$etag": "W/\u00227fe3ddd0-f34d-4be5-8f6e-78cda890ff8c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1701359617",
-            "$etag": "W/\u0022ab1f392a-6de1-4345-b64b-0f1f5419d92f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1587783567",
-            "$etag": "W/\u00220dd5eba4-5206-492d-8d01-934308ca6959\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin778324998",
-            "$etag": "W/\u0022f19c7ff2-115b-4127-a53f-ed6cf0f7e1e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1721371793",
-            "$etag": "W/\u0022e5f73835-efc9-4ab1-819f-8fb71f80b538\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1364369720",
-            "$etag": "W/\u0022ff0e66bb-a4cc-4c37-959d-2da828e160f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1445460884",
-            "$etag": "W/\u00220cb86433-53cc-49c9-b9ab-6448cec7afcd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1233820890",
-            "$etag": "W/\u00227e1a444e-e4f6-4416-99cb-1bdde45d8e73\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1573366635",
-            "$etag": "W/\u0022b6546bb2-b968-4178-9bdb-e2e5e002f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420514752",
-            "$etag": "W/\u00222c4d0208-068e-4126-abf9-79263c90e1db\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2115849553",
-            "$etag": "W/\u00221f455fa2-f401-4657-9e91-68a8be9d8f0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1984619459",
-            "$etag": "W/\u002290fe6812-eac8-4eba-bb1a-a6a7c06b097c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021579934",
-            "$etag": "W/\u00222355c543-f166-4805-b55f-d461d10778ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1393309463",
-            "$etag": "W/\u0022f0c4bcfc-283f-4897-b223-3b00b32a8cb5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2024624619",
-            "$etag": "W/\u0022e8338894-16a7-4f02-95ac-102569a5c0e5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin933351314",
-            "$etag": "W/\u002208cf970b-08ec-47b3-9224-032838969536\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1518012781",
-            "$etag": "W/\u00229d858eb7-7b5d-4eff-8c94-4c57c5dba129\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1179828134",
-            "$etag": "W/\u0022b25cf002-a500-42b5-a846-1d6cd81b3586\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;129779251",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1293663163",
-            "$etag": "W/\u002292c9e2ab-d24c-43da-abac-7633ed8535bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170920816",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin300828834",
-            "$etag": "W/\u00226663329b-53ec-45c7-8539-126c1273c68d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin456165914",
-            "$etag": "W/\u0022e4d8c25b-329e-4de2-8b7e-25c33f8e85a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin612612248",
-            "$etag": "W/\u00225a6f3040-d114-4c67-b612-5ee5198bc0f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829071132",
-            "$etag": "W/\u0022ec9774d1-b5a3-4394-9a9d-0be5660616c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin593110535",
-            "$etag": "W/\u00221ded5390-1f3f-402f-8749-ebc6cf6da95f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin199646658",
-            "$etag": "W/\u0022f831e71d-cee1-4d7a-ac7f-ca9426d1a01c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin461434088",
-            "$etag": "W/\u00221f00217f-5f02-400d-bdfb-9b07ab072f9d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin805249019",
-            "$etag": "W/\u0022efb00acf-a54a-48eb-b69b-3fc39662fc0d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin862791772",
-            "$etag": "W/\u002233cc79ef-1cf5-4b55-92c3-7760427c8c38\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin839672662",
-            "$etag": "W/\u00220440e839-1432-470e-805b-591e4afd0b12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin150497704",
-            "$etag": "W/\u002215e94910-9ee2-431c-906f-509451334a6d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "380",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ff5dfb96efca6a42d5cac49be246008f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "12959",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "8.02",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin99161790",
-            "$etag": "W/\u0022e89b9c86-d478-41d6-9b3c-5505d1277b95\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin499786833",
-            "$etag": "W/\u0022563f9a30-99c8-4197-b31e-c4199e2865ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1813293646",
-            "$etag": "W/\u002244e3bd17-6bbc-44a4-b29c-334c10a6fe48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1776504490",
-            "$etag": "W/\u00226ecfacf8-3ce1-43a9-84c4-81ff36cb8cca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2000851912",
-            "$etag": "W/\u0022b4e60ad6-418e-4d47-86d2-70831e0559a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1130568982",
-            "$etag": "W/\u00223cd300f9-a8d1-460e-bc54-1bb4154625f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1407313670",
-            "$etag": "W/\u0022909d36c5-f041-4b52-8323-027f1050d23c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin515255931",
-            "$etag": "W/\u00226096bae3-8200-4d3a-af19-43c98c5fc9c0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1095480396",
-            "$etag": "W/\u00220be2e194-af2a-4dc1-9d0c-b2d51dea4c5d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin362889809",
-            "$etag": "W/\u0022e0bd3738-4244-4fef-9790-ffe6ba661b24\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;128737197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1921780853",
-            "$etag": "W/\u0022e7726775-9d63-40fc-af0c-cb92025bfafd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;157701634",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin537968733",
-            "$etag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
+            "$dtId": "roomTwin2008432736",
+            "$etag": "W/\u0022322fe163-968c-4989-aa8e-a3a4e448907b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;120254295",
+              "$model": "dtmi:example:room;121439350",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1369668520",
-            "$etag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+            "$etag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5789,45 +1322,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin873268829",
-            "$etag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1470142442",
-            "$etag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
+            "$etag": "W/\u00221eb68b8a-bf13-4720-80b6-a69fe4426840\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5835,22 +1345,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin152530184",
-            "$etag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
+            "$dtId": "roomTwin873268829",
+            "$etag": "W/\u00221464a0f1-2db0-4bee-aa03-2a79ccf25f90\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5858,137 +1368,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin581255239",
-            "$etag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1775617169",
-            "$etag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1115371378",
-            "$etag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin545487351",
-            "$etag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1107764983",
-            "$etag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1469731366",
-            "$etag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
+            "$etag": "W/\u00222845c406-2076-4575-8891-9417d5bffb6e\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5996,45 +1391,114 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1651185579",
-            "$etag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
+            "$dtId": "roomTwin152530184",
+            "$etag": "W/\u0022baf82ed1-133e-47f8-89aa-cd90ce1296d1\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;113863769",
+              "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin537968733",
+            "$etag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1775617169",
+            "$etag": "W/\u0022553a122e-a4d1-45ef-8ebb-cf9143db963c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin545487351",
+            "$etag": "W/\u00225b73646b-2193-441f-94d8-8038c015fafd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
               }
             }
           },
           {
             "$dtId": "roomTwin886314449",
-            "$etag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
+            "$etag": "W/\u0022552c47a7-cf72-4c83-88e3-a333dba19485\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6042,22 +1506,91 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin581255239",
+            "$etag": "W/\u0022418b00ea-8e3e-45f1-a9c4-df279018c5a4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1115371378",
+            "$etag": "W/\u0022ce9d5ab4-b7ed-4edb-a766-588dddfc7092\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1107764983",
+            "$etag": "W/\u002294127080-a0bc-4a3e-8e4c-2e22a9b7400f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               }
             }
           },
           {
             "$dtId": "roomTwin619580090",
-            "$etag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+            "$etag": "W/\u00223d4e535f-9a99-4d39-b9ef-5d8b2712102b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6065,22 +1598,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1965876829",
-            "$etag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
+            "$dtId": "roomTwin1651185579",
+            "$etag": "W/\u0022294e1038-72ab-4a19-b643-18b3cf5c1d37\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6088,45 +1621,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin829263883",
-            "$etag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1135525785",
-            "$etag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+            "$etag": "W/\u0022d281534a-cb4a-4d79-8d0d-ae6f7b7fa1f5\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -6134,16 +1644,1166 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1105345787",
+            "$etag": "W/\u002240cf5ea0-b65a-4d1c-ab15-8558f01b6e73\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1965876829",
+            "$etag": "W/\u0022403065a8-8e71-469a-b528-339c0b4a8e35\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin829263883",
+            "$etag": "W/\u0022c3ece407-5fd5-436a-bfd7-dd10dc758e93\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin469162630",
+            "$etag": "W/\u0022bb0d50f4-fd31-42c5-ba91-74cdc790dd1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079625124",
+            "$etag": "W/\u002268eb8c04-fde5-4c9d-9b13-55c14d17a5a2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2121647958",
+            "$etag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin258863380",
+            "$etag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin565072308",
+            "$etag": "W/\u00229fbf9dbc-8eba-42a2-b690-7fd0a32239bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2047600035",
+            "$etag": "W/\u0022b2917b45-8fb8-4976-a59a-1a3c9bb7574f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1286738412",
+            "$etag": "W/\u00227d18a751-a241-4523-8d72-7e33196d97dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1189666982",
+            "$etag": "W/\u00222a2e4748-c4a8-4ce2-a755-68efd52528fa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin484073712",
+            "$etag": "W/\u00228468c658-1feb-4faf-8bfa-5379012e88a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin489387498",
+            "$etag": "W/\u00227ec14c16-e75b-4307-a18f-aa2bae497248\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin532106151",
+            "$etag": "W/\u0022c60c9190-89a5-451f-8b85-ee2165c86924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2060296123",
+            "$etag": "W/\u002231152dd5-003f-4f41-a193-eb503ae3988d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1162878836",
+            "$etag": "W/\u002261f15449-ef3b-4eaf-a667-247648c141b4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1225195112",
+            "$etag": "W/\u0022b4dfb1a8-4df1-4fdd-b65e-77175e5f8b85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin809589682",
+            "$etag": "W/\u0022b94a81ae-820b-442f-98aa-1a1210fcd8b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1312290533",
+            "$etag": "W/\u0022ba1ba1e3-6335-4748-98bb-0adb30f9a8c0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1882526098",
+            "$etag": "W/\u00223fb9fd3b-b10a-42a3-96cd-c97c516a445a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin424570723",
+            "$etag": "W/\u0022bd0955c9-221e-4024-b1e6-9a7377fdafcd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin74665732",
+            "$etag": "W/\u00222547770e-a761-4276-9a44-5ed7cab6d320\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin357005613",
+            "$etag": "W/\u0022d65324bf-9d35-49e3-b1f7-63ddb1b11d27\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079678761",
+            "$etag": "W/\u0022facc9bb8-5b4a-4355-a1e5-a0fed59798be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857070193",
+            "$etag": "W/\u0022344b1b43-9954-446a-9648-592ad0cd2b33\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1525191687",
+            "$etag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin644310332",
+            "$etag": "W/\u0022680af627-2e01-4ac8-af38-3cb3e79a7503\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1614607475",
+            "$etag": "W/\u0022f4c1ad67-fd8a-4c7a-944a-341c82ba5fe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1438249970",
+            "$etag": "W/\u002229634e48-7cc6-4291-9940-3248a57e5414\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1380454223",
+            "$etag": "W/\u00226c820be3-8744-4bde-8e25-2aa409b0d2f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin738047304",
+            "$etag": "W/\u0022737811d1-9aed-475d-b5c2-260cb281afbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin379883128",
+            "$etag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin64365696",
+            "$etag": "W/\u00226447225b-3ea7-44f0-a749-74d01de4b0f6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1753584378",
+            "$etag": "W/\u002267c15d28-08e0-4f21-b715-2f163b19f9a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2028986873",
+            "$etag": "W/\u0022d5811809-19fe-43ed-8074-f0595974de59\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin847442141",
+            "$etag": "W/\u002236fd1881-ac66-4f4b-b7a1-2b5ece25b67c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2106608761",
+            "$etag": "W/\u0022d1c30c84-1030-4cef-9d85-609d968aff40\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1662618080",
+            "$etag": "W/\u0022a7518287-834e-439b-9371-4442e4009ac9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin279835412",
+            "$etag": "W/\u00224fc1be2c-7a96-469e-aedf-8f90db26a9cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2001547295",
+            "$etag": "W/\u002265298c2f-3a64-4af4-bdd8-dc3b8c32c703\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin254397244",
+            "$etag": "W/\u00229a4458dc-c730-4129-86a1-fe7062161ba9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin312098304",
+            "$etag": "W/\u00228c00c75d-1d48-4e95-a038-7a57e29ddfb2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857257843",
+            "$etag": "W/\u002262efaa49-c478-42c4-adc4-bafcf161b386\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1017374329",
+            "$etag": "W/\u0022f4bc66c7-22da-4ae9-a2f3-4f2d15a84b44\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin187351254",
+            "$etag": "W/\u0022cb532999-1e35-4bea-ac08-1e6d35585fd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
           }
@@ -6161,10 +2821,10 @@
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "52bc0d4922b6b7d6ecb3876112f74534",
+        "x-ms-client-request-id": "d0b6375c4356e60c9f38b4d3f0c11e3d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -6172,131 +2832,131 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2619",
+        "Content-Length": "2593",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "query-charge": "3.26",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1498980297",
-            "$etag": "W/\u0022d9379766-dc49-4095-8469-7117a69534b0\u0022",
+            "$dtId": "roomTwin1495950345",
+            "$etag": "W/\u002205d2ae31-6929-4d7e-af04-4a44b4b31e8b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;112984610",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1381264736",
-            "$etag": "W/\u00229530fad8-8481-4207-a3a2-54f75c33e03f\u0022",
+            "$dtId": "roomTwin344050324",
+            "$etag": "W/\u0022f8d463fc-b497-42c5-9d24-8bf2eb63c8ac\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112462194",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin746222802",
-            "$etag": "W/\u00221c55bd1b-4dc3-48a5-a694-7504c7387b38\u0022",
+            "$dtId": "roomTwin427623005",
+            "$etag": "W/\u00221af94c6c-ba7b-43af-b731-3c747d441259\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;119618957",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin775031637",
-            "$etag": "W/\u0022f2e095ad-618a-44d8-ae54-fb1acaf9d041\u0022",
+            "$dtId": "roomTwin410651761",
+            "$etag": "W/\u00229de8f988-b123-411e-81d1-b9b2647c5bfa\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112725529",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1245991748",
-            "$etag": "W/\u0022b941c874-b71d-4d29-8987-55a489ce4757\u0022",
+            "$dtId": "roomTwin744180983",
+            "$etag": "W/\u002263bb6047-a862-4977-b4f0-c9890d2b3370\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;115056947",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAiAAHA4P9DQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -6305,6006 +2965,112 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "410",
+        "Content-Length": "386",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5c48ea7db63756d0430ce69f38b4d3f0",
+        "x-ms-client-request-id": "da400b64247413a61768e157de848f1d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAiAAHA4P9DQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2619",
+        "Content-Length": "2367",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "query-charge": "3.13",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1444644859",
-            "$etag": "W/\u00226102e256-e029-43c3-88e2-7fcdf1df31be\u0022",
+            "$dtId": "roomTwin1437249777",
+            "$etag": "W/\u0022ef65f3f3-9966-4092-bf4c-b466ccb270f9\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;158485519",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1163564709",
-            "$etag": "W/\u0022670f1a13-ef3c-4450-a0ec-6b9ec342415e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin936523733",
-            "$etag": "W/\u0022df870f13-0fce-4273-b8b2-1f0cc9360973\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1174159166",
-            "$etag": "W/\u0022660a990d-f9d7-4588-97dd-b5e45bc98086\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin86672577",
-            "$etag": "W/\u0022fd6efd7e-0d32-4bf7-a8cf-0bcd64ae75c6\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAiAAHAAPxDQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "643d1ec1400b74da24a6131768e157de",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAiAAHAAPxDQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2616",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1870986745",
-            "$etag": "W/\u0022c7480283-c513-4b7e-9937-8074f62ace65\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1536838429",
-            "$etag": "W/\u0022bcbed22e-248a-43ee-9594-5fdf5c571cbd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin661851410",
-            "$etag": "W/\u0022af7780a2-175d-4891-a13f-df6c145fd88e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110247197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1085222686",
-            "$etag": "W/\u0022bf070c35-d9ff-46f0-ab3d-c96099615404\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;166246968",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420943146",
-            "$etag": "W/\u002221e209f9-0bf3-4a09-9cda-3f0bb04813b8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAgAA\u002BAQ0ALguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f71d8f84a3fd92573d660eaa3b367f37",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAgAA\u002BAQ0ALguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2622",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1338380856",
-            "$etag": "W/\u00224cd0743c-7862-43df-873a-4b41374d1544\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1785890025",
-            "$etag": "W/\u00225d658a38-9807-4a54-a993-3484b1bb15e1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1000297038",
-            "$etag": "W/\u00223aa0b952-daba-4ff9-bcb8-602da4399405\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1893330133",
-            "$etag": "W/\u00225ebe6eae-1a9d-46ed-acde-5e4da8aeea0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123218210",
-            "$etag": "W/\u002214760d80-a8ce-4843-b0e4-56e6e9f4dd27\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAiABEA8P8zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f39f96dfe0ba3d2910d43791a3b8ee62",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAiABEA8P8zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1520206458",
-            "$etag": "W/\u0022835208c2-4a55-4de7-b10e-dc4187d5882e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin92117139",
-            "$etag": "W/\u00224cc2ce94-15c6-4ae7-a020-4f9a9792ab09\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36128330",
-            "$etag": "W/\u00225adde61e-e412-49cf-a752-527bd8b3aba2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777097876",
-            "$etag": "W/\u0022e27281c3-f22a-47a9-82ee-7b0f0b267d48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470032629",
-            "$etag": "W/\u002256fc5f73-a1df-4e71-8bea-54ed682348af\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAP4zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a81b08b4dc961df2c7ab26a5313038ee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAP4zQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1800780114",
-            "$etag": "W/\u0022516b6d16-ef6d-47c8-8cfb-1854ca4835bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin27801422",
-            "$etag": "W/\u0022539467f6-fbb6-4360-a729-c39f353f3253\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1902584715",
-            "$etag": "W/\u00221884e5dc-2708-427a-9eaa-6d2e83841d06\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin96827413",
-            "$etag": "W/\u0022ef52e4c6-e6a3-4bb3-8005-997c3d9f44dd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin935053957",
-            "$etag": "W/\u002264c75c6e-a2a9-441b-beda-2b306818df87\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAMAzQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "d138db266441a32466e0e7296cc5ee84",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAiABEAAMAzQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2622",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin2074335826",
-            "$etag": "W/\u00221c81ad83-61b8-4fde-bea7-4f42e5e899ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123629177",
-            "$etag": "W/\u0022db3407f5-6797-483a-ac54-66cf8491c767\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1554813222",
-            "$etag": "W/\u0022817cabe6-9a22-4634-a34d-177273d33068\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1699890695",
-            "$etag": "W/\u00227084f858-2fd9-423c-9998-d831f293c5f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1088498238",
-            "$etag": "W/\u00221d4e9b50-b84b-45da-ab41-b40a11736140\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;158383040",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAiACEA\u002BP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "416",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "33f5ac77d61b02a0a4822c0eba830bdf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAiACEA\u002BP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2618",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin894415666",
-            "$etag": "W/\u0022f5f49f19-15f2-45e1-ab5f-1f6ad65d49f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113309762",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148688568",
-            "$etag": "W/\u0022185a6e23-5cdc-43c3-9f98-bce142ef1635\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin605247566",
-            "$etag": "W/\u002285ec04a7-1fc5-4cb5-a028-fb7646cee045\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1738278687",
-            "$etag": "W/\u002265469fb8-0e42-4c50-88c4-9499db8d30d1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin883341753",
-            "$etag": "W/\u0022c6d743e3-2171-46df-9875-45107360b597\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "c76a499c1c805020e47741b6f5c9b101",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAP8jQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2619",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin44768029",
-            "$etag": "W/\u0022e0bf97cb-0ca6-4f19-9c87-c12c508eb7eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1026080773",
-            "$etag": "W/\u0022be607bbe-b367-42de-b426-17d53b764e00\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1012130572",
-            "$etag": "W/\u0022e9d0ad86-5382-41dc-95e4-7365514401dc\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin314886311",
-            "$etag": "W/\u0022ed0846f6-8b98-44f6-8dab-96f5271ce59b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1045652022",
-            "$etag": "W/\u0022deb78b85-2b4d-4695-b234-c6dfae1bf0a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAOAjQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "411",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "852da2bc043b50d23a352dbf3715e9e3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAiACEAAOAjQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2619",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin516625160",
-            "$etag": "W/\u00226b21212e-eb4d-4ad9-aac3-ca364cb5e3e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1891959418",
-            "$etag": "W/\u0022183aa253-51e8-4af1-9bd5-3ea98350d1bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829360197",
-            "$etag": "W/\u0022243c49a4-115d-4669-a7cb-1ed898e2de78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin61707195",
-            "$etag": "W/\u0022e6422265-b580-4e10-afa7-a032f40d0aea\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783915272",
-            "$etag": "W/\u0022a43fd4d5-65cf-4b7b-81f6-80e88ff3f822\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAiADEA/P8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "228d07d4275a5a048ba44fa494ea0dda",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAiADEA/P8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2622",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1041693882",
-            "$etag": "W/\u002245a8e4ec-fdbc-4d18-8396-559141ddc01b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021340528",
-            "$etag": "W/\u002298a5b93f-4034-4738-a576-b128341aaf2e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1677577135",
-            "$etag": "W/\u00223040ab87-d137-4d12-a562-f450d3bb45a9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin124606454",
-            "$etag": "W/\u00223c60e1ac-b594-4cce-8c1a-718c37a715ef\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1154990313",
-            "$etag": "W/\u00223650ee8c-f86f-4c1a-900a-2c4f11e8ebc8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk3AAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAiADEAgP8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "17522ad0865597a4761a8c4bef6118ce",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk3AAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAiADEAgP8TQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin2132961076",
-            "$etag": "W/\u00227a0bf9a7-9d8a-4db6-8191-84220168680b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin57113376",
-            "$etag": "W/\u0022cfcf6f4c-808d-4ce1-8f81-667ef4e74b4a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116251683",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin619150749",
-            "$etag": "W/\u00223194e119-b36a-4efa-8af0-b99c24d45ff7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170550470",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin551511810",
-            "$etag": "W/\u00222d430b86-fa94-44cc-b68a-6df9644aceff\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin98472762",
-            "$etag": "W/\u00226c5eb657-d221-4ed2-82c1-0197f69a3f30\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk8AAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAiADEAAPATQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "412",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "ede15e8d8f3b95a69dd2f996b52ebb50",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBk8AAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAiADEAAPATQAuC6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2616",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin869013250",
-            "$etag": "W/\u0022a3c3dc57-4372-4c4f-bf36-feb06b12f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin722764700",
-            "$etag": "W/\u0022180669f5-37cf-454a-9ed9-5f7c29bd5c21\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2125813792",
-            "$etag": "W/\u00220c25d51f-a3a9-4a12-a66b-a3fef02f32c8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1564789991",
-            "$etag": "W/\u00222f754f56-075a-4ef8-a9e4-7e189ddc22bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin729153756",
-            "$etag": "W/\u0022400fe9ad-eb92-47f5-a772-ec2b5ead9606\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlBAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAgAEQA/v8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "408",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0cee5227d1c34e8d63f6ab3f9ab96b2a",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlBAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAgAEQA/v8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2618",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1489152938",
-            "$etag": "W/\u002228c2d505-7c3b-40d2-80e0-17f323c70679\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1637856858",
-            "$etag": "W/\u0022ec90109a-be27-4750-8548-cf61eec5aa0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1363211591",
-            "$etag": "W/\u0022dd52474a-d61e-4eb5-8e3b-3b99cdd61baf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin838663785",
-            "$etag": "W/\u00227c4b95c6-3be9-40ee-8e4e-a3e78574aa34\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1300086570",
-            "$etag": "W/\u0022f1ebf4ba-6b6b-4c6b-9f31-c539d71178d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlGAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAwP8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "408",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "3616808b1f08419f83bc7a828c0de148",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlGAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAwP8Lguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2617",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin151462022",
-            "$etag": "W/\u002298d16ff0-f7bf-4254-9d03-c9a4cb58c201\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1308729416",
-            "$etag": "W/\u0022ba6f41ec-b8f2-490a-bc1e-ff5514196325\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1856167476",
-            "$etag": "W/\u0022a211c53e-af56-4cc8-b77d-724bd8558d33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1336007415",
-            "$etag": "W/\u00229687aa69-50b9-4d7b-84b2-6b85e192050a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin662815516",
-            "$etag": "W/\u002269473407-2871-4d05-8e0f-2431ce8eafc1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlLAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAAPgLguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "408",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9c233b5f0c72bc0bd1938a45e366fae4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlLAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAgAEQAAPgLguv//wMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2614",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin94298757",
-            "$etag": "W/\u002262eb0428-71b3-4a77-84ac-5e64f19ceb78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1612778009",
-            "$etag": "W/\u0022c9da2088-b6f7-4767-848e-4e10cfeb9ee4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin856851558",
-            "$etag": "W/\u0022c623ba55-3c32-4a56-8574-65dd548ab6e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin229826714",
-            "$etag": "W/\u002238488fbd-d87b-42dc-93d0-916af0949b4b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111655996",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin526434890",
-            "$etag": "W/\u0022c19adbeb-77ce-4d0c-95d4-708d88de7b79\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;141760569",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlQAAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAeAFMAC4Lr//8DFED/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "413",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "350bcf6784180748b3ad8806570ac156",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlQAAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAeAFMAC4Lr//8DFED/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2010",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.09",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "floorTwin941711815",
-            "$etag": "W/\u0022eb738161-f2e0-4587-8cb5-29ad474cf93d\u0022",
+            "$dtId": "roomTwin586733773",
+            "$etag": "W/\u00223524936d-5b93-4952-b9bc-403660889807\u0022",
             "AverageTemperature": 75,
             "$metadata": {
-              "$model": "dtmi:example:floor;13675231",
+              "$model": "dtmi:example:floor;11489901",
               "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.0436535Z"
+                "lastUpdateTime": "2020-10-23T21:22:11.7284978Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1735182331",
-            "$etag": "W/\u00221c736187-8abb-499b-8063-cf15994d06b5\u0022",
+            "$dtId": "roomTwin1579359106",
+            "$etag": "W/\u00226c41c324-e714-4346-97ee-3d7a43ebf892\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;153048334",
+              "$model": "dtmi:example:room;113317821",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               }
             }
           },
           {
-            "$dtId": "hvacTwin1335730075",
-            "$etag": "W/\u0022addded86-bbbe-48c6-915a-c42cd3b17213\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114614787",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.6287818Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin2117646547",
-            "$etag": "W/\u00222dc91dfa-469e-431d-97b6-c088938f5370\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;17595302",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.2858058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin918788440",
-            "$etag": "W/\u0022de783261-56c0-4f53-8cbd-b0520b4d6f11\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140750981",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlgAAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAcAGIA6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "5ee06314cf957fb77559657495595d1d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlgAAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAcAGIA6///AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2465",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.15",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin895881838",
-            "$etag": "W/\u0022d3d51c9d-eddd-4113-8a52-efa9f2f11426\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin492624016",
-            "$etag": "W/\u0022e231036b-9573-4cf6-93bc-4f76168ba9c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin818663445",
-            "$etag": "W/\u0022166be958-7415-4134-a4f5-7c474985c5a3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin778426230",
-            "$etag": "W/\u002297b83dbf-0971-406c-b656-d9bb25d2fe70\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;110356330",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6490711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846657163",
-            "$etag": "W/\u0022d04aa87a-a541-4896-a7fe-5eab16c99744\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlnAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAgP//AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "bd1b95c2ac02da30f31be9c5830564c6",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlnAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAgP//AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2612",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin169049424",
-            "$etag": "W/\u002211259cdf-2b5d-4824-b381-10316d5c8617\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2003290546",
-            "$etag": "W/\u0022c41115df-04d0-4c5a-bc58-0ae0e7a1bbca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1920637755",
-            "$etag": "W/\u0022b1c7a4c4-5bef-4d51-8f28-6a8a99a9b955\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin567255450",
-            "$etag": "W/\u00228b132e44-b0db-4d8a-b004-3410fbd9ec66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin466450821",
-            "$etag": "W/\u0022d142de37-2196-4bec-a201-fe3146f28272\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlsAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAAPD/AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "803033d29c86974f178bbfbe1fd37159",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlsAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAcAGIAAPD/AxRA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2608",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin652828980",
-            "$etag": "W/\u0022360ae1fa-aa9d-4bd4-b2bd-8302ffa69453\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1658744984",
-            "$etag": "W/\u0022bfbfbc70-049c-4ea8-9a7e-8240bc3b49ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1108577855",
-            "$etag": "W/\u00229e4d190d-271d-4ad8-9ea6-9fa8d412cf99\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin881848871",
-            "$etag": "W/\u0022fa12869e-c78e-4c94-8c0d-6fc358b6e852\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin34125080",
-            "$etag": "W/\u002282a0d23e-5444-4f11-ac2f-d15d1909237e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "401",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "c2446b4f03ef675433056b79e5f2fc6f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBlxAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHEA/gMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2611",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin716576755",
-            "$etag": "W/\u0022928a136b-494e-4965-99e9-128202587246\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1961257007",
-            "$etag": "W/\u00227a297279-19b8-447a-8396-194df0d8b0ae\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1791197485",
-            "$etag": "W/\u00221bf81066-9eb3-44f5-aa96-d5f7e20946e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1867071453",
-            "$etag": "W/\u0022342a88f2-0dcc-4575-aa58-315006cd4ef1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1641901809",
-            "$etag": "W/\u00226911c53c-1a10-4321-9bea-aeeeca373ff9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl2AAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AgEAAAAaAHEAwAMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "401",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "62a29ff5dd2826964683a576ec71bb1f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl2AAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AgEAAAAaAHEAwAMUQP8PAOAABzjAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2152",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.1",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1133125955",
-            "$etag": "W/\u00226b21e7dc-b4e9-4087-9c14-5a0b4fb2b15b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin246922244",
-            "$etag": "W/\u002270fb7b44-ac8b-496d-a15c-e96448dfac66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;117012504",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1642617034",
-            "$etag": "W/\u0022f7cd24c9-808b-4aa1-9fc1-d774acdfac57\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115956238",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin1545002397",
-            "$etag": "W/\u0022ae4ea64f-5b12-4c7d-8a1d-13abaaa68bd4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;16329224",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9538711Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin792160889",
-            "$etag": "W/\u00227b70c14e-a9b9-409d-b05d-8c3b3de34ea4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;15819678",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:25.9854614Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmBAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AgEAAAAYAIUA/v//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "406",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "17758fa9a2c1cfd6dfc94d8031d5b225",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmBAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AgEAAAAYAIUA/v//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2317",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.14",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin62721381",
-            "$etag": "W/\u0022abe2d779-e33d-48b7-832f-8326022a02eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110307862",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777965033",
-            "$etag": "W/\u00227ac6cc9c-0616-4b52-bde0-1a7b1d90920c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116838841",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin849612920",
-            "$etag": "W/\u002255796041-ffda-44e6-a4d5-a29bb1b25550\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;147745744",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1247486Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin387213787",
-            "$etag": "W/\u0022303aaebf-8a01-4315-92b4-3f5aa59c7aae\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;114856351",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.1234186Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1741612918",
-            "$etag": "W/\u0022af3841ce-ae9d-49c7-96c9-680c8c704cda\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmGAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAwP//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "406",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "80c8508e0f317131d51d7b6b5ddd7bc1",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmGAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAwP//DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2609",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin36952557",
-            "$etag": "W/\u00225017547e-5cb7-4270-8732-0fd935c5f36f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1213006989",
-            "$etag": "W/\u002239424cf2-71fa-407b-8b28-63cf3b636731\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin326513034",
-            "$etag": "W/\u00225350ca2a-c97e-4c6e-b4e2-4db4cc81475c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1129721811",
-            "$etag": "W/\u00228dba5565-d060-4bad-a801-4f9bbc4ebdf0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1947553667",
-            "$etag": "W/\u00222d6acbd7-fcfd-40c3-80e1-a33bf5092293\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmLAAAAAAAAAA==#RT:24#TRC:120#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAAPj/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "406",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "56cf4b4ae57c52aec8d2835f9015f571",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmLAAAAAAAAAA==#RT:24#TRC:120#ISV:2#IEO:65551#FPC:AgEAAAAYAIUAAPj/DwDgAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2605",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1548928947",
-            "$etag": "W/\u0022ee3e799c-7ec3-44a5-bf99-608ae6ed2d0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin356265635",
-            "$etag": "W/\u0022cddfa5c7-ba8d-4f3f-a5c7-49ed794ace2f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1989978078",
-            "$etag": "W/\u0022d8a52677-b719-4322-b2a3-797951f9dfa7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin863816413",
-            "$etag": "W/\u002235dced59-748a-497b-8436-fa6c7ecd7c98\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin240878892",
-            "$etag": "W/\u0022cea21915-9749-47be-a426-12523c767a8e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmQAAAAAAAAAA==#RT:25#TRC:125#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "397",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9ce780d13ba99aee5e0342a3276b7101",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmQAAAAAAAAAA==#RT:25#TRC:125#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA/w8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2604",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1466134063",
-            "$etag": "W/\u00224b6c3b89-c127-4389-9623-6600823c637a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin503181323",
-            "$etag": "W/\u0022343c3eeb-88f4-48e3-b6a3-502e67d17d19\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin392271939",
-            "$etag": "W/\u0022076c63c0-54bd-4d30-b79f-b8779d515826\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin496261044",
-            "$etag": "W/\u0022f30db489-e0f9-4a4e-af15-7be164045d7e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin277216622",
-            "$etag": "W/\u00226566f3cb-3282-4c34-bce7-f1fd53b6b79a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmVAAAAAAAAAA==#RT:26#TRC:130#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA4A8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "397",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "e5368c4d5b05a9a8a176b75e8cd1e1bf",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmVAAAAAAAAAA==#RT:26#TRC:130#ISV:2#IEO:65551#FPC:AgEAAAAWAJQA4A8A4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2605",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin815041708",
-            "$etag": "W/\u0022df1321a9-3cd1-4196-aec2-4d21b631ca88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2006012899",
-            "$etag": "W/\u0022e71c7453-81c2-472c-9f6e-ea913867dfdb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin446974150",
-            "$etag": "W/\u0022b00117ad-a23b-4de8-a474-7bd59421fbc0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1365881715",
-            "$etag": "W/\u00223179b0b2-935f-4f4b-a0ec-e41bb6e355f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin681325335",
-            "$etag": "W/\u0022217888d9-1f32-4fc6-82a2-33d958d48c88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;164255196",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmaAAAAAAAAAA==#RT:27#TRC:135#ISV:2#IEO:65551#FPC:AgEAAAAWAJQAAAwA4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "397",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "dc9a0a28def50e185c35f779a30b2b5d",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBmaAAAAAAAAAA==#RT:27#TRC:135#ISV:2#IEO:65551#FPC:AgEAAAAWAJQAAAwA4AAHOMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "1998",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.09",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1142241383",
-            "$etag": "W/\u0022a45ffefb-8f34-4c0a-add6-029f59e7617f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;177720708",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin825845031",
-            "$etag": "W/\u0022893f390d-bd64-4c1d-8d69-563fd59f8c4e\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11574869",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.0086720Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1278234179",
-            "$etag": "W/\u00225d49dfd5-ca5c-44b1-a4c6-747f37720a9c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116571386",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin761943018",
-            "$etag": "W/\u0022990146bb-c3b6-4c49-a75b-50507494bd16\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;170683712",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.2024177Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin944298631",
-            "$etag": "W/\u002298b1fda1-4a5e-4e6b-a2c8-75966dd516ef\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;11611266",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.7888364Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBm4AAAAAAAAAA==#RT:28#TRC:140#ISV:2#IEO:65551#FPC:AgEAAAASALIAAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "398",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "041181610fde756bd73efb32838f0d8c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBm4AAAAAAAAAA==#RT:28#TRC:140#ISV:2#IEO:65551#FPC:AgEAAAASALIAAAc4wBNADwDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2073",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.11",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin783813120",
-            "$etag": "W/\u00220b45aca6-bc41-4732-b559-3ebab02a7323\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112884932",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin462228998",
-            "$etag": "W/\u002276c721ed-c6f3-4747-9745-25aced995423\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;187698996",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:08:30.1071483Z"
-              }
-            }
-          },
-          {
-            "$dtId": "floorTwin12238764",
-            "$etag": "W/\u002211b2a2c7-b161-40cd-92d7-a40ff0cdeec4\u0022",
-            "AverageTemperature": 75,
-            "$metadata": {
-              "$model": "dtmi:example:floor;19256426",
-              "AverageTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.4582895Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin20436333",
-            "$etag": "W/\u0022f7f6a258-469b-46e5-a27b-363cdd21bad5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112740527",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              }
-            }
-          },
-          {
-            "$dtId": "hvacTwin57116881",
-            "$etag": "W/\u002249f8c592-afc4-4e28-80a1-2dbcdc2797b4\u0022",
-            "TargetTemperature": 80,
-            "TargetHumidity": 25,
-            "$metadata": {
-              "$model": "dtmi:example:hvac;181789456",
-              "TargetTemperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              },
-              "TargetHumidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.8436628Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnFAAAAAAAAAA==#RT:29#TRC:145#ISV:2#IEO:65551#FPC:AgEAAAAQAMEAIMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "389",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "1c7a822294d06f0b742789cf632f0695",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnFAAAAAAAAAA==#RT:29#TRC:145#ISV:2#IEO:65551#FPC:AgEAAAAQAMEAIMATQA8AwP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2593",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin394026428",
-            "$etag": "W/\u0022a3076bd7-cbeb-4789-bc6c-509e1847f6e3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin596581608",
-            "$etag": "W/\u0022473d9d87-f909-4e33-b722-66cdc90c5b9a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1684161797",
-            "$etag": "W/\u0022b9a14ed9-ce85-445a-85ae-3f80705534bf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1901267486",
-            "$etag": "W/\u0022c55a0283-f169-4e3b-b272-d9875a72ecdd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531586602",
-            "$etag": "W/\u00223e77b5c1-75a6-4c89-8048-04e0028cf6b9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnSAAAAAAAAAA==#RT:30#TRC:150#ISV:2#IEO:65551#FPC:AgEAAAAOANQA/P8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "385",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "0bfd5a4bddbf19e09f2405b7e3e58bcd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnSAAAAAAAAAA==#RT:30#TRC:150#ISV:2#IEO:65551#FPC:AgEAAAAOANQA/P8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2592",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin148061498",
-            "$etag": "W/\u0022c43f33d8-1c82-4fc8-890b-22e7d8f5d9d4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin436096292",
-            "$etag": "W/\u002204b66e10-cace-4bed-8cfb-8d61e27f1c12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin154780388",
-            "$etag": "W/\u002283328534-f7c3-43b2-b38f-c72bc979eb05\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121341206",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2127865916",
-            "$etag": "W/\u002241d23a05-ab39-4bd0-befe-e8159958181f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin317362118",
-            "$etag": "W/\u002202c13fde-87db-4716-a76b-d47bf709ee97\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnXAAAAAAAAAA==#RT:31#TRC:155#ISV:2#IEO:65551#FPC:AgEAAAAOANQAgP8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "385",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "20566a280e91cc8c75a290b7859b11a8",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnXAAAAAAAAAA==#RT:31#TRC:155#ISV:2#IEO:65551#FPC:AgEAAAAOANQAgP8PAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2594",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin795448273",
-            "$etag": "W/\u0022dddf6522-6705-4b5b-82e9-54b6d744e55b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1710347499",
-            "$etag": "W/\u00224096019c-3f62-4a1f-ae96-b87531ce1b77\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin288024548",
-            "$etag": "W/\u0022426e9bb8-9bce-474a-b00d-ddfdb1e241d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1380865941",
-            "$etag": "W/\u0022e4c1ba36-c62c-400a-ad86-1cc6cf417eab\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1205304854",
-            "$etag": "W/\u0022f1d5b58c-bfdf-428b-9b23-925a89563116\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBncAAAAAAAAAA==#RT:32#TRC:160#ISV:2#IEO:65551#FPC:AgEAAAAOANQAAPAPAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "385",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "28e76537029245cda1607dac8f538b8e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBncAAAAAAAAAA==#RT:32#TRC:160#ISV:2#IEO:65551#FPC:AgEAAAAOANQAAPAPAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2593",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1400981480",
-            "$etag": "W/\u0022e5a90477-8fde-4e02-a38c-5b04ffd5931a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651261841",
-            "$etag": "W/\u0022d3c1a5d2-e6a5-4ef4-8113-3017514680ce\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113490432",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846170454",
-            "$etag": "W/\u0022ec7b5277-9742-4275-967f-031a47256655\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin955395753",
-            "$etag": "W/\u0022e07bd3aa-8240-4129-a2d2-3d2480e20e5a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin251907959",
-            "$etag": "W/\u002270b9ed8a-f221-4273-bbb6-3086c7c08134\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnhAAAAAAAAAA==#RT:33#TRC:165#ISV:2#IEO:65551#FPC:AgEAAAAMAOMADgDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "390",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f9a7bc9ce5d83c04ce30951d4c299303",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBnhAAAAAAAAAA==#RT:33#TRC:165#ISV:2#IEO:65551#FPC:AgEAAAAMAOMADgDA//\u002BPIUA/AA==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1402000963",
-            "$etag": "W/\u00225537c1d2-d31d-4cce-9055-cd4db8037551\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1857138761",
-            "$etag": "W/\u002215d19e36-1f58-4471-b631-9cc6d82a01c5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531597311",
-            "$etag": "W/\u002288a3c17e-fb49-4a32-89a6-a1844bd8b5f0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin978222842",
-            "$etag": "W/\u00221e592604-2baa-44b9-bee5-c02e4febded7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1784653895",
-            "$etag": "W/\u00225a1eae7d-10b0-4e7a-b1b7-39360e9971e7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn4AAAAAAAAAA==#RT:34#TRC:170#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "7e805c1262fd253a9d117e3091df3c21",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn4AAAAAAAAAA==#RT:34#TRC:170#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAP//jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin860770335",
-            "$etag": "W/\u00227fe3ddd0-f34d-4be5-8f6e-78cda890ff8c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1701359617",
-            "$etag": "W/\u0022ab1f392a-6de1-4345-b64b-0f1f5419d92f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1587783567",
-            "$etag": "W/\u00220dd5eba4-5206-492d-8d01-934308ca6959\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin778324998",
-            "$etag": "W/\u0022f19c7ff2-115b-4127-a53f-ed6cf0f7e1e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1721371793",
-            "$etag": "W/\u0022e5f73835-efc9-4ab1-819f-8fb71f80b538\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn9AAAAAAAAAA==#RT:35#TRC:175#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAOD/jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "c91a011718f451cf60ab5a616cb0f878",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBn9AAAAAAAAAA==#RT:35#TRC:175#ISV:2#IEO:65551#FPC:AgEAAAAKAPIAAOD/jyFAPwA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2587",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1364369720",
-            "$etag": "W/\u0022ff0e66bb-a4cc-4c37-959d-2da828e160f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1445460884",
-            "$etag": "W/\u00220cb86433-53cc-49c9-b9ab-6448cec7afcd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1233820890",
-            "$etag": "W/\u00227e1a444e-e4f6-4416-99cb-1bdde45d8e73\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1573366635",
-            "$etag": "W/\u0022b6546bb2-b968-4178-9bdb-e2e5e002f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420514752",
-            "$etag": "W/\u00222c4d0208-068e-4126-abf9-79263c90e1db\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkCAQAAAAAAAA==#RT:36#TRC:180#ISV:2#IEO:65551#FPC:AgEAAAAIAAEB/I8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "377",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "329979cc0dd3399081815bc667d4aaee",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkCAQAAAAAAAA==#RT:36#TRC:180#ISV:2#IEO:65551#FPC:AgEAAAAIAAEB/I8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2588",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin2115849553",
-            "$etag": "W/\u00221f455fa2-f401-4657-9e91-68a8be9d8f0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1984619459",
-            "$etag": "W/\u002290fe6812-eac8-4eba-bb1a-a6a7c06b097c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021579934",
-            "$etag": "W/\u00222355c543-f166-4805-b55f-d461d10778ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1393309463",
-            "$etag": "W/\u0022f0c4bcfc-283f-4897-b223-3b00b32a8cb5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2024624619",
-            "$etag": "W/\u0022e8338894-16a7-4f02-95ac-102569a5c0e5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkHAQAAAAAAAA==#RT:37#TRC:185#ISV:2#IEO:65551#FPC:AgEAAAAIAAEBgI8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "377",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4b0673f3c90efa0f8d2e1d5208d9b9ed",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkHAQAAAAAAAA==#RT:37#TRC:185#ISV:2#IEO:65551#FPC:AgEAAAAIAAEBgI8hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin933351314",
-            "$etag": "W/\u002208cf970b-08ec-47b3-9224-032838969536\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1518012781",
-            "$etag": "W/\u00229d858eb7-7b5d-4eff-8c94-4c57c5dba129\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1179828134",
-            "$etag": "W/\u0022b25cf002-a500-42b5-a846-1d6cd81b3586\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;129779251",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1293663163",
-            "$etag": "W/\u002292c9e2ab-d24c-43da-abac-7633ed8535bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170920816",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin300828834",
-            "$etag": "W/\u00226663329b-53ec-45c7-8539-126c1273c68d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAQAAAAAAAA==#RT:38#TRC:190#ISV:2#IEO:65551#FPC:AQ8BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "176306190a46094e70e14872bd08ea8c",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkPAQAAAAAAAA==#RT:38#TRC:190#ISV:2#IEO:65551#FPC:AQ8BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2588",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin456165914",
-            "$etag": "W/\u0022e4d8c25b-329e-4de2-8b7e-25c33f8e85a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin612612248",
-            "$etag": "W/\u00225a6f3040-d114-4c67-b612-5ee5198bc0f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829071132",
-            "$etag": "W/\u0022ec9774d1-b5a3-4394-9a9d-0be5660616c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin593110535",
-            "$etag": "W/\u00221ded5390-1f3f-402f-8749-ebc6cf6da95f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin199646658",
-            "$etag": "W/\u0022f831e71d-cee1-4d7a-ac7f-ca9426d1a01c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAQAAAAAAAA==#RT:39#TRC:195#ISV:2#IEO:65551#FPC:ARQBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "f96d6b01adaa036a6a9fa5a5ef3e30a7",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkUAQAAAAAAAA==#RT:39#TRC:195#ISV:2#IEO:65551#FPC:ARQBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2587",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.16",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin461434088",
-            "$etag": "W/\u00221f00217f-5f02-400d-bdfb-9b07ab072f9d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin805249019",
-            "$etag": "W/\u0022efb00acf-a54a-48eb-b69b-3fc39662fc0d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin862791772",
-            "$etag": "W/\u002233cc79ef-1cf5-4b55-92c3-7760427c8c38\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin839672662",
-            "$etag": "W/\u00220440e839-1432-470e-805b-591e4afd0b12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin150497704",
-            "$etag": "W/\u002215e94910-9ee2-431c-906f-509451334a6d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:40#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "60ac6dc89271e9a825fcda2c819c3d84",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkZAQAAAAAAAA==#RT:40#TRC:200#ISV:2#IEO:65551#FPC:ARkBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2589",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin99161790",
-            "$etag": "W/\u0022e89b9c86-d478-41d6-9b3c-5505d1277b95\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin499786833",
-            "$etag": "W/\u0022563f9a30-99c8-4197-b31e-c4199e2865ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1813293646",
-            "$etag": "W/\u002244e3bd17-6bbc-44a4-b29c-334c10a6fe48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1776504490",
-            "$etag": "W/\u00226ecfacf8-3ce1-43a9-84c4-81ff36cb8cca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2000851912",
-            "$etag": "W/\u0022b4e60ad6-418e-4d47-86d2-70831e0559a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAQAAAAAAAA==#RT:41#TRC:205#ISV:2#IEO:65551#FPC:AR4BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "9c519143bf6b6c439c60ada664a81932",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkeAQAAAAAAAA==#RT:41#TRC:205#ISV:2#IEO:65551#FPC:AR4BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1130568982",
-            "$etag": "W/\u00223cd300f9-a8d1-460e-bc54-1bb4154625f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1407313670",
-            "$etag": "W/\u0022909d36c5-f041-4b52-8323-027f1050d23c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin515255931",
-            "$etag": "W/\u00226096bae3-8200-4d3a-af19-43c98c5fc9c0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1095480396",
-            "$etag": "W/\u00220be2e194-af2a-4dc1-9d0c-b2d51dea4c5d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin362889809",
-            "$etag": "W/\u0022e0bd3738-4244-4fef-9790-ffe6ba661b24\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;128737197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAQAAAAAAAA==#RT:42#TRC:210#ISV:2#IEO:65551#FPC:ASMBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "381",
-        "Content-Type": "application/json",
-        "max-items-per-page": "5",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "4fa9a0b0895b6e1bc383d3add23d81cd",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkjAQAAAAAAAA==#RT:42#TRC:210#ISV:2#IEO:65551#FPC:ASMBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "2590",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "3.17",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1921780853",
-            "$etag": "W/\u0022e7726775-9d63-40fc-af0c-cb92025bfafd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;157701634",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin537968733",
-            "$etag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
+            "$dtId": "roomTwin2008432736",
+            "$etag": "W/\u0022322fe163-968c-4989-aa8e-a3a4e448907b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;120254295",
+              "$model": "dtmi:example:room;121439350",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1369668520",
-            "$etag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+            "$etag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12312,67 +3078,21 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin873268829",
-            "$etag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470142442",
-            "$etag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAQAAAAAAAA==#RT:43#TRC:215#ISV:2#IEO:65551#FPC:ASgBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -12381,32 +3101,101 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "381",
+        "Content-Length": "387",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5e61216294ed083b2a40c410e501847c",
+        "x-ms-client-request-id": "57a3fdf73d920e66aa3b367f37df969f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkoAQAAAAAAAA==#RT:43#TRC:215#ISV:2#IEO:65551#FPC:ASgBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2589",
+        "Content-Length": "2591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
+            "$dtId": "roomTwin1470142442",
+            "$etag": "W/\u00221eb68b8a-bf13-4720-80b6-a69fe4426840\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin873268829",
+            "$etag": "W/\u00221464a0f1-2db0-4bee-aa03-2a79ccf25f90\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1469731366",
+            "$etag": "W/\u00222845c406-2076-4575-8891-9417d5bffb6e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
+              }
+            }
+          },
+          {
             "$dtId": "roomTwin152530184",
-            "$etag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
+            "$etag": "W/\u0022baf82ed1-133e-47f8-89aa-cd90ce1296d1\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12414,45 +3203,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin581255239",
-            "$etag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1775617169",
-            "$etag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
+            "$dtId": "roomTwin537968733",
+            "$etag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12460,67 +3226,21 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1115371378",
-            "$etag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin545487351",
-            "$etag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAQAAAAAAAA==#RT:44#TRC:220#ISV:2#IEO:65551#FPC:AS0BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -12529,24 +3249,172 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "381",
+        "Content-Length": "383",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "e07ca7e2edf3ba2876e2d9e8eb95995f",
+        "x-ms-client-request-id": "29e0baf3103d37d491a3b8ee62b4081b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBktAQAAAAAAAA==#RT:44#TRC:220#ISV:2#IEO:65551#FPC:AS0BAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2590",
+        "Content-Length": "2591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1775617169",
+            "$etag": "W/\u0022553a122e-a4d1-45ef-8ebb-cf9143db963c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin545487351",
+            "$etag": "W/\u00225b73646b-2193-441f-94d8-8038c015fafd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin886314449",
+            "$etag": "W/\u0022552c47a7-cf72-4c83-88e3-a333dba19485\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin581255239",
+            "$etag": "W/\u0022418b00ea-8e3e-45f1-a9c4-df279018c5a4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1115371378",
+            "$etag": "W/\u0022ce9d5ab4-b7ed-4edb-a766-588dddfc7092\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "383",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f2dc96a8c71d26aba5313038ee26db38",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -12554,7 +3422,7 @@
         "value": [
           {
             "$dtId": "roomTwin1107764983",
-            "$etag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
+            "$etag": "W/\u002294127080-a0bc-4a3e-8e4c-2e22a9b7400f\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12562,91 +3430,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1469731366",
-            "$etag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651185579",
-            "$etag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin886314449",
-            "$etag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               }
             }
           },
           {
             "$dtId": "roomTwin619580090",
-            "$etag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+            "$etag": "W/\u00223d4e535f-9a99-4d39-b9ef-5d8b2712102b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12654,21 +3453,90 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1651185579",
+            "$etag": "W/\u0022294e1038-72ab-4a19-b643-18b3cf5c1d37\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1135525785",
+            "$etag": "W/\u0022d281534a-cb4a-4d79-8d0d-ae6f7b7fa1f5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1105345787",
+            "$etag": "W/\u002240cf5ea0-b65a-4d1c-ab15-8558f01b6e73\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
               }
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAQAAAAAAAA==#RT:45#TRC:225#ISV:2#IEO:65551#FPC:ATIBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -12677,32 +3545,32 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "381",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "4344dfdebb471c4565a0241bc50a89c1",
+        "x-ms-client-request-id": "246441d166a3e7e0296cc5ee8477acf5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBkyAQAAAAAAAA==#RT:45#TRC:225#ISV:2#IEO:65551#FPC:ATIBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "1421",
+        "Content-Length": "2586",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "2.98",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "query-charge": "3.16",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
             "$dtId": "roomTwin1965876829",
-            "$etag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
+            "$etag": "W/\u0022403065a8-8e71-469a-b528-339c0b4a8e35\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12710,22 +3578,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
               }
             }
           },
           {
             "$dtId": "roomTwin829263883",
-            "$etag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
+            "$etag": "W/\u0022c3ece407-5fd5-436a-bfd7-dd10dc758e93\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12733,22 +3601,147 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1135525785",
-            "$etag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+            "$dtId": "roomTwin469162630",
+            "$etag": "W/\u0022bb0d50f4-fd31-42c5-ba91-74cdc790dd1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079625124",
+            "$etag": "W/\u002268eb8c04-fde5-4c9d-9b13-55c14d17a5a2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "379",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a0d61b33a4022c820eba830bdf9c496a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2121647958",
+            "$etag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -12756,16 +3749,1246 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin258863380",
+            "$etag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin565072308",
+            "$etag": "W/\u00229fbf9dbc-8eba-42a2-b690-7fd0a32239bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2047600035",
+            "$etag": "W/\u0022b2917b45-8fb8-4976-a59a-1a3c9bb7574f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "379",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "201c80c7e4504177b6f5c9b101bca22d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2587",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1286738412",
+            "$etag": "W/\u00227d18a751-a241-4523-8d72-7e33196d97dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1189666982",
+            "$etag": "W/\u00222a2e4748-c4a8-4ce2-a755-68efd52528fa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin484073712",
+            "$etag": "W/\u00228468c658-1feb-4faf-8bfa-5379012e88a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin489387498",
+            "$etag": "W/\u00227ec14c16-e75b-4307-a18f-aa2bae497248\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin532106151",
+            "$etag": "W/\u0022c60c9190-89a5-451f-8b85-ee2165c86924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "384",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d2043b853a502d35bf3715e9e3d4078d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2585",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin2060296123",
+            "$etag": "W/\u002231152dd5-003f-4f41-a193-eb503ae3988d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1162878836",
+            "$etag": "W/\u002261f15449-ef3b-4eaf-a667-247648c141b4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1225195112",
+            "$etag": "W/\u0022b4dfb1a8-4df1-4fdd-b65e-77175e5f8b85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin809589682",
+            "$etag": "W/\u0022b94a81ae-820b-442f-98aa-1a1210fcd8b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1312290533",
+            "$etag": "W/\u0022ba1ba1e3-6335-4748-98bb-0adb30f9a8c0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "375",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "04275a228b5a4fa4a494ea0ddad02a52",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2587",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.16",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1882526098",
+            "$etag": "W/\u00223fb9fd3b-b10a-42a3-96cd-c97c516a445a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin424570723",
+            "$etag": "W/\u0022bd0955c9-221e-4024-b1e6-9a7377fdafcd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin74665732",
+            "$etag": "W/\u00222547770e-a761-4276-9a44-5ed7cab6d320\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin357005613",
+            "$etag": "W/\u0022d65324bf-9d35-49e3-b1f7-63ddb1b11d27\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079678761",
+            "$etag": "W/\u0022facc9bb8-5b4a-4355-a1e5-a0fed59798be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a486551776978c1a4bef6118ce8d5ee1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin857070193",
+            "$etag": "W/\u0022344b1b43-9954-446a-9648-592ad0cd2b33\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1525191687",
+            "$etag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin644310332",
+            "$etag": "W/\u0022680af627-2e01-4ac8-af38-3cb3e79a7503\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a68f3bed9d95f9d296b52ebb502752ee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1614607475",
+            "$etag": "W/\u0022f4c1ad67-fd8a-4c7a-944a-341c82ba5fe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1438249970",
+            "$etag": "W/\u002229634e48-7cc6-4291-9940-3248a57e5414\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1380454223",
+            "$etag": "W/\u00226c820be3-8744-4bde-8e25-2aa409b0d2f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin738047304",
+            "$etag": "W/\u0022737811d1-9aed-475d-b5c2-260cb281afbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin379883128",
+            "$etag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8dd1c30c634eabf63f9ab96b2a8b8016",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin64365696",
+            "$etag": "W/\u00226447225b-3ea7-44f0-a749-74d01de4b0f6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1753584378",
+            "$etag": "W/\u002267c15d28-08e0-4f21-b715-2f163b19f9a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2028986873",
+            "$etag": "W/\u0022d5811809-19fe-43ed-8074-f0595974de59\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin847442141",
+            "$etag": "W/\u002236fd1881-ac66-4f4b-b7a1-2b5ece25b67c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2106608761",
+            "$etag": "W/\u0022d1c30c84-1030-4cef-9d85-609d968aff40\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "9f1f083683417abc828c0de1485f3b23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1662618080",
+            "$etag": "W/\u0022a7518287-834e-439b-9371-4442e4009ac9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin279835412",
+            "$etag": "W/\u00224fc1be2c-7a96-469e-aedf-8f90db26a9cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2001547295",
+            "$etag": "W/\u002265298c2f-3a64-4af4-bdd8-dc3b8c32c703\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin254397244",
+            "$etag": "W/\u00229a4458dc-c730-4129-86a1-fe7062161ba9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin312098304",
+            "$etag": "W/\u00228c00c75d-1d48-4e95-a038-7a57e29ddfb2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0b0c729cd1bc8a9345e366fae467cf0b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1882",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "3.07",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin857257843",
+            "$etag": "W/\u002262efaa49-c478-42c4-adc4-bafcf161b386\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1017374329",
+            "$etag": "W/\u0022f4bc66c7-22da-4ae9-a2f3-4f2d15a84b44\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin187351254",
+            "$etag": "W/\u0022cb532999-1e35-4bea-ac08-1e6d35585fd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
           }
@@ -12780,17 +5003,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "2bca57fea1c074daf8a7e80aba531d94",
+        "x-ms-client-request-id": "48841835b30788ad06570ac1561463e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorksAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_PaginationWorksAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,12 +74,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;120254295\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;13983924\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "192",
+        "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;120254295\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:46.051617\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;120254295\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:50.5405338\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin537968733?api-version=2020-10-31",
@@ -99,7 +99,7 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "ETag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -145,7 +145,7 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "ETag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -191,7 +191,7 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:49 GMT",
         "ETag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -233,52 +233,11 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin2146208947. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2146208947?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "76b5b502a3641b21417484294d7137a3",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "ETag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -307,7 +266,7 @@
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin324722902?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1067365890?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -316,7 +275,397 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "3b3fa99c641a5a43dc9dc578bc7d9173",
+        "x-ms-client-request-id": "6476b5b521a3411b7484294d7137a3d6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1067365890",
+        "$etag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin8891804?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1a3b3fa94364dc5a9dc578bc7d9173b1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "268",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin8891804. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin8891804?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3dc5dc5d7b4f06efab462dadc9e1a6ce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "458",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00220afa1fb6-32ae-4e19-a6d3-ca5d571c2a1d\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin8891804",
+        "$etag": "W/\u00220afa1fb6-32ae-4e19-a6d3-ca5d571c2a1d\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8946544Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8946544Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8946544Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:50.8946544Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin68441501?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "00c8ae7b50e71c7287065ba285f7f2b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "269",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin68441501. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin68441501?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "de5a139b4c98502d356f1d16ac13bb1f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "459",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022258f1d07-bd94-43d6-83c6-60d07c610932\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin68441501",
+        "$etag": "W/\u0022258f1d07-bd94-43d6-83c6-60d07c610932\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9848644Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9848644Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9848644Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:50.9848644Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1677201065?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "abe2011f76b0538b21c8759363264f3a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1677201065. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1677201065?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "4bce2df804f0802f77cb78335b6f744a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022a496e2b3-f4ba-41c4-9ae5-084d9c1eb45a\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1677201065",
+        "$etag": "W/\u0022a496e2b3-f4ba-41c4-9ae5-084d9c1eb45a\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:51.0912295Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:51.0912295Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:51.0912295Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:51.0912295Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin28709180?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0ff566f9ea09cf9c8a7683b8bdd148cd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "269",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin28709180. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin28709180?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ede5b4dbb9d3d21a6234e5fd57f7b253",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "459",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022b02dc860-5771-4226-bca6-7be2191b9b79\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin28709180",
+        "$etag": "W/\u0022b02dc860-5771-4226-bca6-7be2191b9b79\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;120254295",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:51.1697284Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:51.1697284Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:51.1697284Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:51.1697284Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin316240427?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5ac06a57ee2a31427b658eabc8baf930",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -324,30 +673,29 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin324722902. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin316240427. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin324722902?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin316240427?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c5dc5db14f3def7b06ab462dadc9e1a6",
+        "x-ms-client-request-id": "8fba7f65685c4b3f22add5059f7792c4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -365,13 +713,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00223ddccb5e-b665-4291-bc0a-e7d0231100ba\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin324722902",
-        "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+        "$dtId": "roomTwin316240427",
+        "$etag": "W/\u00223ddccb5e-b665-4291-bc0a-e7d0231100ba\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -379,22 +727,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2518251Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2518251Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2518251Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.2518251Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1012472014?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2096689967?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -403,7 +751,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "c8ae7b9de70072501c87065ba285f7f2",
+        "x-ms-client-request-id": "8766658db073a2c6bc57548c279979eb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -411,30 +759,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1012472014. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin2096689967. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1012472014?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2096689967?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5a139bb598de2d4c50356f1d16ac13bb",
+        "x-ms-client-request-id": "f777f1cdcec42bef74377d193d9204d2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -452,13 +799,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022ed16466f-bc4a-4af6-a106-1d8a75d1fc74\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1012472014",
-        "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+        "$dtId": "roomTwin2096689967",
+        "$etag": "W/\u0022ed16466f-bc4a-4af6-a106-1d8a75d1fc74\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -466,22 +813,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3325161Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3325161Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3325161Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.3325161Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin955385887?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1850161353?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -490,181 +837,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "e2011fa9b0ab8b765321c8759363264f",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin955385887. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin955385887?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "ce2df83af04b2f048077cb78335b6f74",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "460",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin955385887",
-        "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin672739146?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "f566f93c090f9ceacf8a7683b8bdd148",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin672739146. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin672739146?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "e5b4dbcdd3ed1ab9d26234e5fd57f7b2",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "460",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin672739146",
-        "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1661689683?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "c06a572b2a5a42ee317b658eabc8baf9",
+        "x-ms-client-request-id": "93543b7bf2a8f4ceeca010ebbffb145b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -672,30 +845,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1661689683. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1850161353. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1661689683?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1850161353?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "ba7f65305c8f3f684b22add5059f7792",
+        "x-ms-client-request-id": "1b86d2196bcc75be3b123b33ad652953",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -713,13 +885,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "ETag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u0022d0de9025-1b2b-463e-92d0-71953e416da6\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1661689683",
-        "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+        "$dtId": "roomTwin1850161353",
+        "$etag": "W/\u0022d0de9025-1b2b-463e-92d0-71953e416da6\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -727,22 +899,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.5230271Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.5230271Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.5230271Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.5230271Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin528003268?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1230073985?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -751,94 +923,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "66658d2f7387c6b0a2bc57548c279979",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:45 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin528003268. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin528003268?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "77f1cdebc4f7efce2b74377d193d9204",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "460",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "ETag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "$dtId": "roomTwin528003268",
-        "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1",
-        "$metadata": {
-          "$model": "dtmi:example:room;120254295",
-          "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
-          },
-          "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
-          },
-          "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
-          },
-          "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
-          }
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1251286994?api-version=2020-10-31",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "543b7bc9a893cef2f4eca010ebbffb14",
+        "x-ms-client-request-id": "255eabc22458a8ff03d82ddf40b53c69",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -846,30 +931,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1251286994. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1230073985. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1251286994?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1230073985?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "86d2195bcc1bbe6b753b123b33ad6529",
+        "x-ms-client-request-id": "7ebf23bdfdb77c10df5795b69b468676",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -887,13 +971,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "ETag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:50 GMT",
+        "ETag": "W/\u00226c28c18b-9001-4bcd-9f54-611935d7a536\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1251286994",
-        "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+        "$dtId": "roomTwin1230073985",
+        "$etag": "W/\u00226c28c18b-9001-4bcd-9f54-611935d7a536\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -901,22 +985,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.6239247Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.6239247Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.6239247Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.6239247Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1738906707?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1160429756?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -925,7 +1009,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "5eabc2815825ff24a803d82ddf40b53c",
+        "x-ms-client-request-id": "b54ffd69c13686ad72c8929196fb5dff",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -933,30 +1017,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1738906707. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1160429756. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1738906707?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1160429756?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "bf23bd69b77e10fd7cdf5795b69b4686",
+        "x-ms-client-request-id": "6a42efcacad59bc4e246008f490dbc52",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -974,13 +1057,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "ETag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "ETag": "W/\u002225b9fa4a-1952-49d4-b477-7fbe87badecc\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1738906707",
-        "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+        "$dtId": "roomTwin1160429756",
+        "$etag": "W/\u002225b9fa4a-1952-49d4-b477-7fbe87badecc\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -988,22 +1071,22 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.7279422Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.7279422Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.7279422Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.7279422Z"
           }
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1776075638?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1531137718?api-version=2020-10-31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -1012,7 +1095,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "4ffd69bc36b5adc18672c8929196fb5d",
+        "x-ms-client-request-id": "ecb7d62287b31261f745347dea485c37",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -1020,30 +1103,29 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1776075638. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1531137718. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1776075638?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1531137718?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "If-None-Match": "*",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "42efcaffd56ac4ca9be246008f490dbc",
+        "x-ms-client-request-id": "4356d0b6e60c389fb4d3f0c11e3d640b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1061,13 +1143,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "ETag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "ETag": "W/\u00227a9d2014-8513-44cb-863d-0ba5e9210a6d\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1776075638",
-        "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+        "$dtId": "roomTwin1531137718",
+        "$etag": "W/\u00227a9d2014-8513-44cb-863d-0ba5e9210a6d\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -1075,16 +1157,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;120254295",
           "Temperature": {
-            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.8093302Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.8093302Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.8093302Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+            "lastUpdateTime": "2020-10-26T17:04:51.8093302Z"
           }
         }
       }
@@ -1101,7 +1183,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d622b652ecb787b36112f745347dea48",
+        "x-ms-client-request-id": "2474da4013a66817e157de848f1df7fd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -1109,10 +1191,10 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "33956",
+        "Content-Length": "46198",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
-        "query-charge": "15.100000000000001",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "query-charge": "20.23",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -2806,6 +2888,1073 @@
                 "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
+          },
+          {
+            "$dtId": "roomTwin363377363",
+            "$etag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2146208947",
+            "$etag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1062677703",
+            "$etag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin324722902",
+            "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1462038290",
+            "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin462997606",
+            "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1012472014",
+            "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1543128019",
+            "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin955385887",
+            "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin672739146",
+            "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1750846709",
+            "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin422308472",
+            "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1661689683",
+            "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1648554203",
+            "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin528003268",
+            "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin817870353",
+            "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1251286994",
+            "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1240738903",
+            "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1738906707",
+            "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1491061385",
+            "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1776075638",
+            "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin619913832",
+            "$etag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1410570626",
+            "$etag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1067365890",
+            "$etag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin757295793",
+            "$etag": "W/\u00220b31dafa-a92e-4139-91c2-cea3a0de96e7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin633630133",
+            "$etag": "W/\u0022a194cd57-9a12-40a8-8641-eef149c38829\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "376",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "3d9257a30e663baa367f37df969ff3ba",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "8803",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
+        "query-charge": "4.48",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1052658490",
+            "$etag": "W/\u00225ddb7fae-81be-4b0b-920f-26947783a711\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1626036685",
+            "$etag": "W/\u002288043f16-cc41-41fa-a4c2-89b79dc679b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin687114800",
+            "$etag": "W/\u0022e40bc758-5024-403f-be36-b991984dd165\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1274856786",
+            "$etag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1098941419",
+            "$etag": "W/\u002233a4b889-0aba-4d63-b65d-a42a40e4c456\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin125346931",
+            "$etag": "W/\u0022af62467a-acb1-4395-8c26-eb38dfc9874b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin345229702",
+            "$etag": "W/\u002255c487c4-984f-465f-bc95-125288661377\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin904769627",
+            "$etag": "W/\u0022f0e97abe-4660-4e4e-8ae7-ce9a7cc4eabc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin840530319",
+            "$etag": "W/\u00227b0aed29-4924-4edb-a4f6-57b379179e7a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin19991913",
+            "$etag": "W/\u00227b4544bb-5313-421d-821b-0b47810f6ed1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1846282992",
+            "$etag": "W/\u0022e96b7675-5265-486e-a565-51c09f86292e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1501230847",
+            "$etag": "W/\u00226802e3a6-b98a-4da6-b472-4b02220454d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2112889309",
+            "$etag": "W/\u0022a8b818f4-cac5-4152-af3b-6501b11b2a20\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1261829064",
+            "$etag": "W/\u0022d227561c-e41d-4503-b9b9-e6c04d18d682\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin20831578",
+            "$etag": "W/\u002228e89f63-cbd8-432d-8408-cbe836c136a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2061740721",
+            "$etag": "W/\u0022809c12e1-14b3-49ab-8d2a-f138e6e9f5bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin59174272",
+            "$etag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1511973902",
+            "$etag": "W/\u0022e512e115-b43b-493d-b71e-8e7d617e48de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1357107878",
+            "$etag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              }
+            }
           }
         ],
         "continuationToken": null
@@ -2824,7 +3973,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d0b6375c4356e60c9f38b4d3f0c11e3d",
+        "x-ms-client-request-id": "103d29e037d4a391b8ee62b4081ba896",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -2832,9 +3981,9 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2593",
+        "Content-Length": "2601",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.26",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -2956,7 +4105,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAWAAbA4PedBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -2965,24 +4114,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "386",
+        "Content-Length": "394",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "da400b64247413a61768e157de848f1d",
+        "x-ms-client-request-id": "c71df2dc26ab31a53038ee26db38d141",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAQAAfA4PedBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYFAAAAAAAAAA==#RT:1#TRC:5#ISV:2#IEO:65551#FPC:AgEAAAAWAAbA4PedBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2367",
+        "Content-Length": "2375",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.13",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3092,7 +4241,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAWAAbAAPSdBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3101,24 +4250,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "387",
+        "Content-Length": "395",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "57a3fdf73d920e66aa3b367f37df969f",
+        "x-ms-client-request-id": "66a32464e7e06c29c5ee8477acf5331b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAQAAfAAPSdBOCB//8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYKAAAAAAAAAA==#RT:2#TRC:10#ISV:2#IEO:65551#FPC:AgEAAAAWAAbAAPSdBOCB//8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2591",
+        "Content-Length": "2599",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3240,7 +4389,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAUABIAnQTggRJAAw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3249,24 +4398,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "383",
+        "Content-Length": "391",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "29e0baf3103d37d491a3b8ee62b4081b",
+        "x-ms-client-request-id": "a402a0d62c82ba0e830bdf9c496ac780",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAOABIAnQTggRNAAw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYQAAAAAAAAAA==#RT:3#TRC:15#ISV:2#IEO:65551#FPC:AgEAAAAUABIAnQTggRJAAw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2591",
+        "Content-Length": "2599",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3388,7 +4537,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAUABqABMDggf//Aw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3397,24 +4546,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "383",
+        "Content-Length": "391",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "f2dc96a8c71d26aba5313038ee26db38",
+        "x-ms-client-request-id": "e450201c4177f5b6c9b101bca22d853b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAOABqABcDggf//Aw/M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYaAAAAAAAAAA==#RT:4#TRC:20#ISV:2#IEO:65551#FPC:AgEAAAAUABqABMDggf//Aw/M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2589",
+        "Content-Length": "2597",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3536,7 +4685,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAQAC\u002BAEkADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3545,24 +4694,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "384",
+        "Content-Length": "392",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "246441d166a3e7e0296cc5ee8477acf5",
+        "x-ms-client-request-id": "3a50d2042d3537bf15e9e3d4078d225a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAKAC\u002BAE0ADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjYvAAAAAAAAAA==#RT:5#TRC:25#ISV:2#IEO:65551#FPC:AgEAAAAQAC\u002BAEkADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2586",
+        "Content-Length": "2594",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.16",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3684,7 +4833,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAQADMA8P8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3693,24 +4842,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "379",
+        "Content-Length": "387",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "a0d61b33a4022c820eba830bdf9c496a",
+        "x-ms-client-request-id": "8b5a04274fa494a4ea0ddad02a521755",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAKADQA8P8DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY0AAAAAAAAAA==#RT:6#TRC:30#ISV:2#IEO:65551#FPC:AgEAAAAQADMA8P8DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2588",
+        "Content-Length": "2596",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3832,7 +4981,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAP4DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3841,24 +4990,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "379",
+        "Content-Length": "387",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "201c80c7e4504177b6f5c9b101bca22d",
+        "x-ms-client-request-id": "7697a4868c1aef4b6118ce8d5ee1ed3b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAP4DD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY5AAAAAAAAAA==#RT:7#TRC:35#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAP4DD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2587",
+        "Content-Length": "2595",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -3980,7 +5129,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAMADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -3989,24 +5138,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "384",
+        "Content-Length": "392",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d2043b853a502d35bf3715e9e3d4078d",
+        "x-ms-client-request-id": "9d95a68ff9d2b5962ebb502752ee0cc3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAKADQAAMADD8z//38=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjY\u002BAAAAAAAAAA==#RT:8#TRC:40#ISV:2#IEO:65551#FPC:AgEAAAAQADMAAMADD8z/I0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2585",
+        "Content-Length": "2593",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:46 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4128,7 +5277,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAOAEIAAA7M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4137,24 +5286,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "375",
+        "Content-Length": "383",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "04275a228b5a4fa4a494ea0ddad02a52",
+        "x-ms-client-request-id": "634e8dd1abf69a3fb96b2a8b80163608",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAIAEMAAA7M//9/\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZJAAAAAAAAAA==#RT:9#TRC:45#ISV:2#IEO:65551#FPC:AgEAAAAOAEIAAA7M/yNAf1Ek8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2587",
+        "Content-Length": "2591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.16",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4276,7 +5425,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAwP8jQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4285,24 +5434,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "a486551776978c1a4bef6118ce8d5ee1",
+        "x-ms-client-request-id": "83419f1f7abc8c820de1485f3b239c72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AVYAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZWAAAAAAAAAA==#RT:10#TRC:50#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAwP8jQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2589",
+        "Content-Length": "2593",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4424,7 +5573,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAAPgjQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4433,24 +5582,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "a68f3bed9d95f9d296b52ebb502752ee",
+        "x-ms-client-request-id": "d1bc0b0c8a93e34566fae467cf0b3518",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AVsAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZbAAAAAAAAAA==#RT:11#TRC:55#ISV:2#IEO:65551#FPC:AgEAAAAMAFEAAPgjQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "2589",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4572,7 +5721,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAKAGAAI0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4588,17 +5737,17 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "8dd1c30c634eabf63f9ab96b2a8b8016",
+        "x-ms-client-request-id": "b307488488ad57060ac1561463e05e95",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AWAAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZgAAAAAAAAAA==#RT:12#TRC:60#ISV:2#IEO:65551#FPC:AgEAAAAKAGAAI0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2588",
+        "Content-Length": "2592",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:51 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4720,7 +5869,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAMAGEA4P8TQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4729,24 +5878,24 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "9f1f083683417abc828c0de1485f3b23",
+        "x-ms-client-request-id": "757fb7cf65599574595d1dc2951bbd02",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AWUAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZlAAAAAAAAAA==#RT:13#TRC:65#ISV:2#IEO:65551#FPC:AgEAAAAMAGEA4P8TQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "2588",
+        "Content-Length": "2592",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -4868,7 +6017,7 @@
             }
           }
         ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAMAGEAAPwTQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       }
     },
     {
@@ -4877,25 +6026,25 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "380",
+        "Content-Length": "384",
         "Content-Type": "application/json",
         "max-items-per-page": "5",
         "User-Agent": [
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "0b0c729cd1bc8a9345e366fae467cf0b",
+        "x-ms-client-request-id": "f3da30ace91b83c50564c6d233308086",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AWoAAAAAAAAAbgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZqAAAAAAAAAA==#RT:14#TRC:70#ISV:2#IEO:65551#FPC:AgEAAAAMAGEAAPwTQH9RJPL/Bw==\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "1882",
+        "Content-Length": "2588",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "query-charge": "3.07",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -4991,6 +6140,1338 @@
                 "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
+          },
+          {
+            "$dtId": "roomTwin363377363",
+            "$etag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZvAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAKAG\u002BAE0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "385",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "17974f9cbf8b1fbed371594f6b44c2ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZvAAAAAAAAAA==#RT:15#TRC:75#ISV:2#IEO:65551#FPC:AgEAAAAKAG\u002BAE0B/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin2146208947",
+            "$etag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1062677703",
+            "$etag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin324722902",
+            "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1462038290",
+            "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin462997606",
+            "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ0AAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAKAHQA8P9/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "336754036b05e579f2fc6ff59fa26228",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ0AAAAAAAAAA==#RT:16#TRC:80#ISV:2#IEO:65551#FPC:AgEAAAAKAHQA8P9/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2589",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1012472014",
+            "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1543128019",
+            "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin955385887",
+            "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin672739146",
+            "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1750846709",
+            "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ5AAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAP5/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "380",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "462696dda583ec7671bb1fa98f7517c1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ5AAAAAAAAAA==#RT:17#TRC:85#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAP5/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2588",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin422308472",
+            "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1661689683",
+            "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1648554203",
+            "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin528003268",
+            "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin817870353",
+            "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ\u002BAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAMB/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "385",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "dfcfd6a24dc93180d5b2258e50c88031",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjZ\u002BAAAAAAAAAA==#RT:18#TRC:90#ISV:2#IEO:65551#FPC:AgEAAAAKAHQAAMB/USTy/wc=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2587",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1251286994",
+            "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1240738903",
+            "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1738906707",
+            "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1491061385",
+            "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1776075638",
+            "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaDAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAeFEk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "376",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d571310f7b1d5d6bdd7bc14a4bcf567c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaDAAAAAAAAAA==#RT:19#TRC:95#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAeFEk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2585",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin619913832",
+            "$etag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1410570626",
+            "$etag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1067365890",
+            "$etag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin757295793",
+            "$etag": "W/\u00220b31dafa-a92e-4139-91c2-cea3a0de96e7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin633630133",
+            "$etag": "W/\u0022a194cd57-9a12-40a8-8641-eef149c38829\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "377",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c852aee583d2905f15f571d180e79ca9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaMAAAAAAAAAA==#RT:20#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAIMAAFAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2591",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1052658490",
+            "$etag": "W/\u00225ddb7fae-81be-4b0b-920f-26947783a711\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1626036685",
+            "$etag": "W/\u002288043f16-cc41-41fa-a4c2-89b79dc679b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin687114800",
+            "$etag": "W/\u0022e40bc758-5024-403f-be36-b991984dd165\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1274856786",
+            "$etag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1098941419",
+            "$etag": "W/\u002233a4b889-0aba-4d63-b65d-a42a40e4c456\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjacAAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AZwAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "381",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5e9aee3b420327a36b71014d8c36e505",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjacAAAAAAAAAA==#RT:21#TRC:105#ISV:2#IEO:65551#FPC:AZwAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2586",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.16",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin125346931",
+            "$etag": "W/\u0022af62467a-acb1-4395-8c26-eb38dfc9874b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin345229702",
+            "$etag": "W/\u002255c487c4-984f-465f-bc95-125288661377\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin904769627",
+            "$etag": "W/\u0022f0e97abe-4660-4e4e-8ae7-ce9a7cc4eabc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin840530319",
+            "$etag": "W/\u00227b0aed29-4924-4edb-a4f6-57b379179e7a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin19991913",
+            "$etag": "W/\u00227b4544bb-5313-421d-821b-0b47810f6ed1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjahAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AaEAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "381",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "a1a9a85bb7768c5ed1e1bf280a9adcf5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjahAAAAAAAAAA==#RT:22#TRC:110#ISV:2#IEO:65551#FPC:AaEAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "2590",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.17",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1846282992",
+            "$etag": "W/\u0022e96b7675-5265-486e-a565-51c09f86292e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1501230847",
+            "$etag": "W/\u00226802e3a6-b98a-4da6-b472-4b02220454d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2112889309",
+            "$etag": "W/\u0022a8b818f4-cac5-4152-af3b-6501b11b2a20\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1261829064",
+            "$etag": "W/\u0022d227561c-e41d-4503-b9b9-e6c04d18d682\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin20831578",
+            "$etag": "W/\u002228e89f63-cbd8-432d-8408-cbe836c136a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjamAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AaYAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "381",
+        "Content-Type": "application/json",
+        "max-items-per-page": "5",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "5c0e18def735a3790b2b5d61811104de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjamAAAAAAAAAA==#RT:23#TRC:115#ISV:2#IEO:65551#FPC:AaYAAAAAAAAAqgAAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "1882",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "3.07",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin2061740721",
+            "$etag": "W/\u0022809c12e1-14b3-49ab-8d2a-f138e6e9f5bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin59174272",
+            "$etag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1511973902",
+            "$etag": "W/\u0022e512e115-b43b-493d-b71e-8e7d617e48de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1357107878",
+            "$etag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              }
+            }
           }
         ],
         "continuationToken": null
@@ -5006,14 +7487,14 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "48841835b30788ad06570ac1561463e0",
+        "x-ms-client-request-id": "d7756b0ffb3e83328f0d8c22827a1cd0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_Success.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_Success.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -76,10 +76,10 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;180130729\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:48.2700117\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;180130729\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:52.9793515\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin77902172?api-version=2020-10-31",
@@ -99,7 +99,7 @@
       "ResponseHeaders": {
         "Content-Length": "459",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -145,7 +145,7 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -191,7 +191,7 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -233,52 +233,11 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "270",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin619913832. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin619913832?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "4d12b0a61915fcc9836462b81b10f483",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;180130729"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -307,6 +266,138 @@
       }
     },
     {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1357107878?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "154d12b0c91983fc6462b81b10f483e3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "ETag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1357107878",
+        "$etag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;180130729",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1118154999?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "062a8dccc47a8946c5cd47bf55f33c25",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1118154999. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1118154999?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "acc5d7be015286c748a4057dc5682cce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;180130729"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "ETag": "W/\u0022361f6bd9-de53-4a38-b91f-54b4661fa7eb\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1118154999",
+        "$etag": "W/\u0022361f6bd9-de53-4a38-b91f-54b4661fa7eb\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;180130729",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:53.2312260Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:53.2312260Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:53.2312260Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:53.2312260Z"
+          }
+        }
+      }
+    },
+    {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -318,7 +409,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "8dccf7e3062ac47a4689c5cd47bf55f3",
+        "x-ms-client-request-id": "da331968a06c4d35068c53fbb4c40f6e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -326,10 +417,10 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "33725",
+        "Content-Length": "46453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "query-charge": "15.530000000000001",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "20.91",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -2012,6 +2103,1073 @@
                 "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
+          },
+          {
+            "$dtId": "roomTwin363377363",
+            "$etag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2146208947",
+            "$etag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1062677703",
+            "$etag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin324722902",
+            "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1462038290",
+            "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin462997606",
+            "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1012472014",
+            "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1543128019",
+            "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin955385887",
+            "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin672739146",
+            "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1750846709",
+            "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin422308472",
+            "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1661689683",
+            "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1648554203",
+            "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin528003268",
+            "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin817870353",
+            "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1251286994",
+            "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1240738903",
+            "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1738906707",
+            "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1491061385",
+            "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1776075638",
+            "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin619913832",
+            "$etag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1410570626",
+            "$etag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1067365890",
+            "$etag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin757295793",
+            "$etag": "W/\u00220b31dafa-a92e-4139-91c2-cea3a0de96e7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin633630133",
+            "$etag": "W/\u0022a194cd57-9a12-40a8-8641-eef149c38829\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1052658490",
+            "$etag": "W/\u00225ddb7fae-81be-4b0b-920f-26947783a711\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaOAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAI6AAsAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "400",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "1d51f67c36becaa5c5a3bdd6bfc9c45d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaOAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAI6AAsAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "8341",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "query-charge": "4.48",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1626036685",
+            "$etag": "W/\u002288043f16-cc41-41fa-a4c2-89b79dc679b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin687114800",
+            "$etag": "W/\u0022e40bc758-5024-403f-be36-b991984dd165\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1274856786",
+            "$etag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1098941419",
+            "$etag": "W/\u002233a4b889-0aba-4d63-b65d-a42a40e4c456\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin125346931",
+            "$etag": "W/\u0022af62467a-acb1-4395-8c26-eb38dfc9874b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin345229702",
+            "$etag": "W/\u002255c487c4-984f-465f-bc95-125288661377\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin904769627",
+            "$etag": "W/\u0022f0e97abe-4660-4e4e-8ae7-ce9a7cc4eabc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin840530319",
+            "$etag": "W/\u00227b0aed29-4924-4edb-a4f6-57b379179e7a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin19991913",
+            "$etag": "W/\u00227b4544bb-5313-421d-821b-0b47810f6ed1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1846282992",
+            "$etag": "W/\u0022e96b7675-5265-486e-a565-51c09f86292e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1501230847",
+            "$etag": "W/\u00226802e3a6-b98a-4da6-b472-4b02220454d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2112889309",
+            "$etag": "W/\u0022a8b818f4-cac5-4152-af3b-6501b11b2a20\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1261829064",
+            "$etag": "W/\u0022d227561c-e41d-4503-b9b9-e6c04d18d682\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin20831578",
+            "$etag": "W/\u002228e89f63-cbd8-432d-8408-cbe836c136a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2061740721",
+            "$etag": "W/\u0022809c12e1-14b3-49ab-8d2a-f138e6e9f5bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin59174272",
+            "$etag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1511973902",
+            "$etag": "W/\u0022e512e115-b43b-493d-b71e-8e7d617e48de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1357107878",
+            "$etag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              }
+            }
           }
         ],
         "continuationToken": null
@@ -2027,14 +3185,14 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "d7be253cacc50152c78648a4057dc568",
+        "x-ms-client-request-id": "3b5778a061c01eb8a178a5c6aecbd284",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_Success.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_Success.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b9ca1fd8ec40a90b8d26d9a58145dec3",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "53d8872f713948a15966c72f58e80f24",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -65,8 +65,8 @@
         "Content-Length": "804",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "34488d2bdad7002adebc15c4e9714919",
         "x-ms-return-client-request-id": "true"
@@ -76,10 +76,10 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;180130729\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:13.7027767\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;180130729\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:48.2700117\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin77902172?api-version=2020-10-31",
@@ -88,29 +88,167 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "b993bcd49eed28ad70e7854479343eca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "459",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin77902172",
+        "$etag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;180130729",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1837133952?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "8f96b85655cbd75d757c5bdd5fe71dad",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1837133952",
+        "$etag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;180130729",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin363377363?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "6b7c2c84ef3d0b9a66f2a4bc6488d7fa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin363377363",
+        "$etag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;180130729",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin619913832?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "cc83901a6709e1357821524b11ff6796",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "Content-Length": "269",
+        "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin77902172. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin619913832. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin77902172?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin619913832?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -119,10 +257,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "96b85680cb8f5d55d7757c5bdd5fe71d",
+        "x-ms-client-request-id": "4d12b0a61915fcc9836462b81b10f483",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -138,15 +276,15 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "459",
+        "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "ETag": "W/\u00226e001df7-0c9d-4997-8df4-ef85197f3f37\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin77902172",
-        "$etag": "W/\u00226e001df7-0c9d-4997-8df4-ef85197f3f37\u0022",
+        "$dtId": "roomTwin619913832",
+        "$etag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,16 +292,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;180130729",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:13.8087398Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:13.8087398Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:13.8087398Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:13.8087398Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
           }
         }
       }
@@ -177,10 +315,10 @@
         "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "2c84d3ad6b7cef3d9a0b66f2a4bc6488",
+        "x-ms-client-request-id": "8dccf7e3062ac47a4689c5cd47bf55f3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -188,4603 +326,201 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "46466",
+        "Content-Length": "33725",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:12 GMT",
-        "query-charge": "20.91",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "15.530000000000001",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1498980297",
-            "$etag": "W/\u0022d9379766-dc49-4095-8469-7117a69534b0\u0022",
+            "$dtId": "roomTwin1495950345",
+            "$etag": "W/\u002205d2ae31-6929-4d7e-af04-4a44b4b31e8b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;112984610",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1381264736",
-            "$etag": "W/\u00229530fad8-8481-4207-a3a2-54f75c33e03f\u0022",
+            "$dtId": "roomTwin344050324",
+            "$etag": "W/\u0022f8d463fc-b497-42c5-9d24-8bf2eb63c8ac\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112462194",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin746222802",
-            "$etag": "W/\u00221c55bd1b-4dc3-48a5-a694-7504c7387b38\u0022",
+            "$dtId": "roomTwin427623005",
+            "$etag": "W/\u00221af94c6c-ba7b-43af-b731-3c747d441259\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;119618957",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin775031637",
-            "$etag": "W/\u0022f2e095ad-618a-44d8-ae54-fb1acaf9d041\u0022",
+            "$dtId": "roomTwin410651761",
+            "$etag": "W/\u00229de8f988-b123-411e-81d1-b9b2647c5bfa\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112725529",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1245991748",
-            "$etag": "W/\u0022b941c874-b71d-4d29-8987-55a489ce4757\u0022",
+            "$dtId": "roomTwin744180983",
+            "$etag": "W/\u002263bb6047-a862-4977-b4f0-c9890d2b3370\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;115056947",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1444644859",
-            "$etag": "W/\u00226102e256-e029-43c3-88e2-7fcdf1df31be\u0022",
+            "$dtId": "roomTwin1437249777",
+            "$etag": "W/\u0022ef65f3f3-9966-4092-bf4c-b466ccb270f9\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;158485519",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1163564709",
-            "$etag": "W/\u0022670f1a13-ef3c-4450-a0ec-6b9ec342415e\u0022",
+            "$dtId": "roomTwin1579359106",
+            "$etag": "W/\u00226c41c324-e714-4346-97ee-3d7a43ebf892\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;113317821",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin936523733",
-            "$etag": "W/\u0022df870f13-0fce-4273-b8b2-1f0cc9360973\u0022",
+            "$dtId": "roomTwin2008432736",
+            "$etag": "W/\u0022322fe163-968c-4989-aa8e-a3a4e448907b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;121439350",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1174159166",
-            "$etag": "W/\u0022660a990d-f9d7-4588-97dd-b5e45bc98086\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin86672577",
-            "$etag": "W/\u0022fd6efd7e-0d32-4bf7-a8cf-0bcd64ae75c6\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1870986745",
-            "$etag": "W/\u0022c7480283-c513-4b7e-9937-8074f62ace65\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1536838429",
-            "$etag": "W/\u0022bcbed22e-248a-43ee-9594-5fdf5c571cbd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin661851410",
-            "$etag": "W/\u0022af7780a2-175d-4891-a13f-df6c145fd88e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110247197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1085222686",
-            "$etag": "W/\u0022bf070c35-d9ff-46f0-ab3d-c96099615404\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;166246968",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420943146",
-            "$etag": "W/\u002221e209f9-0bf3-4a09-9cda-3f0bb04813b8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1338380856",
-            "$etag": "W/\u00224cd0743c-7862-43df-873a-4b41374d1544\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1785890025",
-            "$etag": "W/\u00225d658a38-9807-4a54-a993-3484b1bb15e1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1000297038",
-            "$etag": "W/\u00223aa0b952-daba-4ff9-bcb8-602da4399405\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1893330133",
-            "$etag": "W/\u00225ebe6eae-1a9d-46ed-acde-5e4da8aeea0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123218210",
-            "$etag": "W/\u002214760d80-a8ce-4843-b0e4-56e6e9f4dd27\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1520206458",
-            "$etag": "W/\u0022835208c2-4a55-4de7-b10e-dc4187d5882e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin92117139",
-            "$etag": "W/\u00224cc2ce94-15c6-4ae7-a020-4f9a9792ab09\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36128330",
-            "$etag": "W/\u00225adde61e-e412-49cf-a752-527bd8b3aba2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777097876",
-            "$etag": "W/\u0022e27281c3-f22a-47a9-82ee-7b0f0b267d48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470032629",
-            "$etag": "W/\u002256fc5f73-a1df-4e71-8bea-54ed682348af\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1800780114",
-            "$etag": "W/\u0022516b6d16-ef6d-47c8-8cfb-1854ca4835bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin27801422",
-            "$etag": "W/\u0022539467f6-fbb6-4360-a729-c39f353f3253\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1902584715",
-            "$etag": "W/\u00221884e5dc-2708-427a-9eaa-6d2e83841d06\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin96827413",
-            "$etag": "W/\u0022ef52e4c6-e6a3-4bb3-8005-997c3d9f44dd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin935053957",
-            "$etag": "W/\u002264c75c6e-a2a9-441b-beda-2b306818df87\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2074335826",
-            "$etag": "W/\u00221c81ad83-61b8-4fde-bea7-4f42e5e899ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123629177",
-            "$etag": "W/\u0022db3407f5-6797-483a-ac54-66cf8491c767\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1554813222",
-            "$etag": "W/\u0022817cabe6-9a22-4634-a34d-177273d33068\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1699890695",
-            "$etag": "W/\u00227084f858-2fd9-423c-9998-d831f293c5f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1088498238",
-            "$etag": "W/\u00221d4e9b50-b84b-45da-ab41-b40a11736140\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;158383040",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin894415666",
-            "$etag": "W/\u0022f5f49f19-15f2-45e1-ab5f-1f6ad65d49f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113309762",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148688568",
-            "$etag": "W/\u0022185a6e23-5cdc-43c3-9f98-bce142ef1635\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin605247566",
-            "$etag": "W/\u002285ec04a7-1fc5-4cb5-a028-fb7646cee045\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1738278687",
-            "$etag": "W/\u002265469fb8-0e42-4c50-88c4-9499db8d30d1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin883341753",
-            "$etag": "W/\u0022c6d743e3-2171-46df-9875-45107360b597\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin44768029",
-            "$etag": "W/\u0022e0bf97cb-0ca6-4f19-9c87-c12c508eb7eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1026080773",
-            "$etag": "W/\u0022be607bbe-b367-42de-b426-17d53b764e00\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1012130572",
-            "$etag": "W/\u0022e9d0ad86-5382-41dc-95e4-7365514401dc\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin314886311",
-            "$etag": "W/\u0022ed0846f6-8b98-44f6-8dab-96f5271ce59b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1045652022",
-            "$etag": "W/\u0022deb78b85-2b4d-4695-b234-c6dfae1bf0a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin516625160",
-            "$etag": "W/\u00226b21212e-eb4d-4ad9-aac3-ca364cb5e3e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1891959418",
-            "$etag": "W/\u0022183aa253-51e8-4af1-9bd5-3ea98350d1bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829360197",
-            "$etag": "W/\u0022243c49a4-115d-4669-a7cb-1ed898e2de78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin61707195",
-            "$etag": "W/\u0022e6422265-b580-4e10-afa7-a032f40d0aea\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783915272",
-            "$etag": "W/\u0022a43fd4d5-65cf-4b7b-81f6-80e88ff3f822\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1041693882",
-            "$etag": "W/\u002245a8e4ec-fdbc-4d18-8396-559141ddc01b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021340528",
-            "$etag": "W/\u002298a5b93f-4034-4738-a576-b128341aaf2e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1677577135",
-            "$etag": "W/\u00223040ab87-d137-4d12-a562-f450d3bb45a9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin124606454",
-            "$etag": "W/\u00223c60e1ac-b594-4cce-8c1a-718c37a715ef\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1154990313",
-            "$etag": "W/\u00223650ee8c-f86f-4c1a-900a-2c4f11e8ebc8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2132961076",
-            "$etag": "W/\u00227a0bf9a7-9d8a-4db6-8191-84220168680b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin57113376",
-            "$etag": "W/\u0022cfcf6f4c-808d-4ce1-8f81-667ef4e74b4a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116251683",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin619150749",
-            "$etag": "W/\u00223194e119-b36a-4efa-8af0-b99c24d45ff7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170550470",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin551511810",
-            "$etag": "W/\u00222d430b86-fa94-44cc-b68a-6df9644aceff\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin98472762",
-            "$etag": "W/\u00226c5eb657-d221-4ed2-82c1-0197f69a3f30\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin869013250",
-            "$etag": "W/\u0022a3c3dc57-4372-4c4f-bf36-feb06b12f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin722764700",
-            "$etag": "W/\u0022180669f5-37cf-454a-9ed9-5f7c29bd5c21\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2125813792",
-            "$etag": "W/\u00220c25d51f-a3a9-4a12-a66b-a3fef02f32c8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1564789991",
-            "$etag": "W/\u00222f754f56-075a-4ef8-a9e4-7e189ddc22bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin729153756",
-            "$etag": "W/\u0022400fe9ad-eb92-47f5-a772-ec2b5ead9606\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1489152938",
-            "$etag": "W/\u002228c2d505-7c3b-40d2-80e0-17f323c70679\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1637856858",
-            "$etag": "W/\u0022ec90109a-be27-4750-8548-cf61eec5aa0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1363211591",
-            "$etag": "W/\u0022dd52474a-d61e-4eb5-8e3b-3b99cdd61baf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin838663785",
-            "$etag": "W/\u00227c4b95c6-3be9-40ee-8e4e-a3e78574aa34\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1300086570",
-            "$etag": "W/\u0022f1ebf4ba-6b6b-4c6b-9f31-c539d71178d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin151462022",
-            "$etag": "W/\u002298d16ff0-f7bf-4254-9d03-c9a4cb58c201\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1308729416",
-            "$etag": "W/\u0022ba6f41ec-b8f2-490a-bc1e-ff5514196325\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1856167476",
-            "$etag": "W/\u0022a211c53e-af56-4cc8-b77d-724bd8558d33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1336007415",
-            "$etag": "W/\u00229687aa69-50b9-4d7b-84b2-6b85e192050a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin662815516",
-            "$etag": "W/\u002269473407-2871-4d05-8e0f-2431ce8eafc1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin94298757",
-            "$etag": "W/\u002262eb0428-71b3-4a77-84ac-5e64f19ceb78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1612778009",
-            "$etag": "W/\u0022c9da2088-b6f7-4767-848e-4e10cfeb9ee4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin856851558",
-            "$etag": "W/\u0022c623ba55-3c32-4a56-8574-65dd548ab6e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin229826714",
-            "$etag": "W/\u002238488fbd-d87b-42dc-93d0-916af0949b4b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111655996",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin526434890",
-            "$etag": "W/\u0022c19adbeb-77ce-4d0c-95d4-708d88de7b79\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;141760569",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1735182331",
-            "$etag": "W/\u00221c736187-8abb-499b-8063-cf15994d06b5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;153048334",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin918788440",
-            "$etag": "W/\u0022de783261-56c0-4f53-8cbd-b0520b4d6f11\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140750981",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin895881838",
-            "$etag": "W/\u0022d3d51c9d-eddd-4113-8a52-efa9f2f11426\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin492624016",
-            "$etag": "W/\u0022e231036b-9573-4cf6-93bc-4f76168ba9c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin818663445",
-            "$etag": "W/\u0022166be958-7415-4134-a4f5-7c474985c5a3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846657163",
-            "$etag": "W/\u0022d04aa87a-a541-4896-a7fe-5eab16c99744\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin169049424",
-            "$etag": "W/\u002211259cdf-2b5d-4824-b381-10316d5c8617\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2003290546",
-            "$etag": "W/\u0022c41115df-04d0-4c5a-bc58-0ae0e7a1bbca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1920637755",
-            "$etag": "W/\u0022b1c7a4c4-5bef-4d51-8f28-6a8a99a9b955\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin567255450",
-            "$etag": "W/\u00228b132e44-b0db-4d8a-b004-3410fbd9ec66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin466450821",
-            "$etag": "W/\u0022d142de37-2196-4bec-a201-fe3146f28272\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin652828980",
-            "$etag": "W/\u0022360ae1fa-aa9d-4bd4-b2bd-8302ffa69453\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1658744984",
-            "$etag": "W/\u0022bfbfbc70-049c-4ea8-9a7e-8240bc3b49ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1108577855",
-            "$etag": "W/\u00229e4d190d-271d-4ad8-9ea6-9fa8d412cf99\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin881848871",
-            "$etag": "W/\u0022fa12869e-c78e-4c94-8c0d-6fc358b6e852\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin34125080",
-            "$etag": "W/\u002282a0d23e-5444-4f11-ac2f-d15d1909237e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin716576755",
-            "$etag": "W/\u0022928a136b-494e-4965-99e9-128202587246\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1961257007",
-            "$etag": "W/\u00227a297279-19b8-447a-8396-194df0d8b0ae\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1791197485",
-            "$etag": "W/\u00221bf81066-9eb3-44f5-aa96-d5f7e20946e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1867071453",
-            "$etag": "W/\u0022342a88f2-0dcc-4575-aa58-315006cd4ef1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl1AAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHYA4APM//8PAEAAAhDAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "424",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "1a68fad7839009cc6735e17821524b11",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl1AAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHYA4APM//8PAEAAAhDAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "46450",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
-        "query-charge": "20.72",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1641901809",
-            "$etag": "W/\u00226911c53c-1a10-4321-9bea-aeeeca373ff9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1133125955",
-            "$etag": "W/\u00226b21e7dc-b4e9-4087-9c14-5a0b4fb2b15b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin246922244",
-            "$etag": "W/\u002270fb7b44-ac8b-496d-a15c-e96448dfac66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;117012504",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1642617034",
-            "$etag": "W/\u0022f7cd24c9-808b-4aa1-9fc1-d774acdfac57\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115956238",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin62721381",
-            "$etag": "W/\u0022abe2d779-e33d-48b7-832f-8326022a02eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110307862",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777965033",
-            "$etag": "W/\u00227ac6cc9c-0616-4b52-bde0-1a7b1d90920c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116838841",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1741612918",
-            "$etag": "W/\u0022af3841ce-ae9d-49c7-96c9-680c8c704cda\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36952557",
-            "$etag": "W/\u00225017547e-5cb7-4270-8732-0fd935c5f36f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1213006989",
-            "$etag": "W/\u002239424cf2-71fa-407b-8b28-63cf3b636731\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin326513034",
-            "$etag": "W/\u00225350ca2a-c97e-4c6e-b4e2-4db4cc81475c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1129721811",
-            "$etag": "W/\u00228dba5565-d060-4bad-a801-4f9bbc4ebdf0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1947553667",
-            "$etag": "W/\u00222d6acbd7-fcfd-40c3-80e1-a33bf5092293\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1548928947",
-            "$etag": "W/\u0022ee3e799c-7ec3-44a5-bf99-608ae6ed2d0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin356265635",
-            "$etag": "W/\u0022cddfa5c7-ba8d-4f3f-a5c7-49ed794ace2f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1989978078",
-            "$etag": "W/\u0022d8a52677-b719-4322-b2a3-797951f9dfa7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin863816413",
-            "$etag": "W/\u002235dced59-748a-497b-8436-fa6c7ecd7c98\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin240878892",
-            "$etag": "W/\u0022cea21915-9749-47be-a426-12523c767a8e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1466134063",
-            "$etag": "W/\u00224b6c3b89-c127-4389-9623-6600823c637a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin503181323",
-            "$etag": "W/\u0022343c3eeb-88f4-48e3-b6a3-502e67d17d19\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin392271939",
-            "$etag": "W/\u0022076c63c0-54bd-4d30-b79f-b8779d515826\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin496261044",
-            "$etag": "W/\u0022f30db489-e0f9-4a4e-af15-7be164045d7e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin277216622",
-            "$etag": "W/\u00226566f3cb-3282-4c34-bce7-f1fd53b6b79a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin815041708",
-            "$etag": "W/\u0022df1321a9-3cd1-4196-aec2-4d21b631ca88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2006012899",
-            "$etag": "W/\u0022e71c7453-81c2-472c-9f6e-ea913867dfdb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin446974150",
-            "$etag": "W/\u0022b00117ad-a23b-4de8-a474-7bd59421fbc0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1365881715",
-            "$etag": "W/\u00223179b0b2-935f-4f4b-a0ec-e41bb6e355f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin681325335",
-            "$etag": "W/\u0022217888d9-1f32-4fc6-82a2-33d958d48c88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;164255196",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1142241383",
-            "$etag": "W/\u0022a45ffefb-8f34-4c0a-add6-029f59e7617f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;177720708",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1278234179",
-            "$etag": "W/\u00225d49dfd5-ca5c-44b1-a4c6-747f37720a9c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116571386",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783813120",
-            "$etag": "W/\u00220b45aca6-bc41-4732-b559-3ebab02a7323\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112884932",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin20436333",
-            "$etag": "W/\u0022f7f6a258-469b-46e5-a27b-363cdd21bad5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112740527",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin394026428",
-            "$etag": "W/\u0022a3076bd7-cbeb-4789-bc6c-509e1847f6e3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin596581608",
-            "$etag": "W/\u0022473d9d87-f909-4e33-b722-66cdc90c5b9a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1684161797",
-            "$etag": "W/\u0022b9a14ed9-ce85-445a-85ae-3f80705534bf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1901267486",
-            "$etag": "W/\u0022c55a0283-f169-4e3b-b272-d9875a72ecdd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531586602",
-            "$etag": "W/\u00223e77b5c1-75a6-4c89-8048-04e0028cf6b9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148061498",
-            "$etag": "W/\u0022c43f33d8-1c82-4fc8-890b-22e7d8f5d9d4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin436096292",
-            "$etag": "W/\u002204b66e10-cace-4bed-8cfb-8d61e27f1c12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin154780388",
-            "$etag": "W/\u002283328534-f7c3-43b2-b38f-c72bc979eb05\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121341206",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2127865916",
-            "$etag": "W/\u002241d23a05-ab39-4bd0-befe-e8159958181f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin317362118",
-            "$etag": "W/\u002202c13fde-87db-4716-a76b-d47bf709ee97\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin795448273",
-            "$etag": "W/\u0022dddf6522-6705-4b5b-82e9-54b6d744e55b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1710347499",
-            "$etag": "W/\u00224096019c-3f62-4a1f-ae96-b87531ce1b77\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin288024548",
-            "$etag": "W/\u0022426e9bb8-9bce-474a-b00d-ddfdb1e241d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1380865941",
-            "$etag": "W/\u0022e4c1ba36-c62c-400a-ad86-1cc6cf417eab\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1205304854",
-            "$etag": "W/\u0022f1d5b58c-bfdf-428b-9b23-925a89563116\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1400981480",
-            "$etag": "W/\u0022e5a90477-8fde-4e02-a38c-5b04ffd5931a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651261841",
-            "$etag": "W/\u0022d3c1a5d2-e6a5-4ef4-8113-3017514680ce\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113490432",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846170454",
-            "$etag": "W/\u0022ec7b5277-9742-4275-967f-031a47256655\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin955395753",
-            "$etag": "W/\u0022e07bd3aa-8240-4129-a2d2-3d2480e20e5a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin251907959",
-            "$etag": "W/\u002270b9ed8a-f221-4273-bbb6-3086c7c08134\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1402000963",
-            "$etag": "W/\u00225537c1d2-d31d-4cce-9055-cd4db8037551\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1857138761",
-            "$etag": "W/\u002215d19e36-1f58-4471-b631-9cc6d82a01c5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531597311",
-            "$etag": "W/\u002288a3c17e-fb49-4a32-89a6-a1844bd8b5f0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin978222842",
-            "$etag": "W/\u00221e592604-2baa-44b9-bee5-c02e4febded7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1784653895",
-            "$etag": "W/\u00225a1eae7d-10b0-4e7a-b1b7-39360e9971e7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin860770335",
-            "$etag": "W/\u00227fe3ddd0-f34d-4be5-8f6e-78cda890ff8c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1701359617",
-            "$etag": "W/\u0022ab1f392a-6de1-4345-b64b-0f1f5419d92f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1587783567",
-            "$etag": "W/\u00220dd5eba4-5206-492d-8d01-934308ca6959\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin778324998",
-            "$etag": "W/\u0022f19c7ff2-115b-4127-a53f-ed6cf0f7e1e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1721371793",
-            "$etag": "W/\u0022e5f73835-efc9-4ab1-819f-8fb71f80b538\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1364369720",
-            "$etag": "W/\u0022ff0e66bb-a4cc-4c37-959d-2da828e160f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1445460884",
-            "$etag": "W/\u00220cb86433-53cc-49c9-b9ab-6448cec7afcd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1233820890",
-            "$etag": "W/\u00227e1a444e-e4f6-4416-99cb-1bdde45d8e73\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1573366635",
-            "$etag": "W/\u0022b6546bb2-b968-4178-9bdb-e2e5e002f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420514752",
-            "$etag": "W/\u00222c4d0208-068e-4126-abf9-79263c90e1db\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2115849553",
-            "$etag": "W/\u00221f455fa2-f401-4657-9e91-68a8be9d8f0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1984619459",
-            "$etag": "W/\u002290fe6812-eac8-4eba-bb1a-a6a7c06b097c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021579934",
-            "$etag": "W/\u00222355c543-f166-4805-b55f-d461d10778ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1393309463",
-            "$etag": "W/\u0022f0c4bcfc-283f-4897-b223-3b00b32a8cb5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2024624619",
-            "$etag": "W/\u0022e8338894-16a7-4f02-95ac-102569a5c0e5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin933351314",
-            "$etag": "W/\u002208cf970b-08ec-47b3-9224-032838969536\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1518012781",
-            "$etag": "W/\u00229d858eb7-7b5d-4eff-8c94-4c57c5dba129\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1179828134",
-            "$etag": "W/\u0022b25cf002-a500-42b5-a846-1d6cd81b3586\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;129779251",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1293663163",
-            "$etag": "W/\u002292c9e2ab-d24c-43da-abac-7633ed8535bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170920816",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin300828834",
-            "$etag": "W/\u00226663329b-53ec-45c7-8539-126c1273c68d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin456165914",
-            "$etag": "W/\u0022e4d8c25b-329e-4de2-8b7e-25c33f8e85a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin612612248",
-            "$etag": "W/\u00225a6f3040-d114-4c67-b612-5ee5198bc0f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829071132",
-            "$etag": "W/\u0022ec9774d1-b5a3-4394-9a9d-0be5660616c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin593110535",
-            "$etag": "W/\u00221ded5390-1f3f-402f-8749-ebc6cf6da95f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin199646658",
-            "$etag": "W/\u0022f831e71d-cee1-4d7a-ac7f-ca9426d1a01c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin461434088",
-            "$etag": "W/\u00221f00217f-5f02-400d-bdfb-9b07ab072f9d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin805249019",
-            "$etag": "W/\u0022efb00acf-a54a-48eb-b69b-3fc39662fc0d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin862791772",
-            "$etag": "W/\u002233cc79ef-1cf5-4b55-92c3-7760427c8c38\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin839672662",
-            "$etag": "W/\u00220440e839-1432-470e-805b-591e4afd0b12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin150497704",
-            "$etag": "W/\u002215e94910-9ee2-431c-906f-509451334a6d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin99161790",
-            "$etag": "W/\u0022e89b9c86-d478-41d6-9b3c-5505d1277b95\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin499786833",
-            "$etag": "W/\u0022563f9a30-99c8-4197-b31e-c4199e2865ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1813293646",
-            "$etag": "W/\u002244e3bd17-6bbc-44a4-b29c-334c10a6fe48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1776504490",
-            "$etag": "W/\u00226ecfacf8-3ce1-43a9-84c4-81ff36cb8cca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2000851912",
-            "$etag": "W/\u0022b4e60ad6-418e-4d47-86d2-70831e0559a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1130568982",
-            "$etag": "W/\u00223cd300f9-a8d1-460e-bc54-1bb4154625f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1407313670",
-            "$etag": "W/\u0022909d36c5-f041-4b52-8323-027f1050d23c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin515255931",
-            "$etag": "W/\u00226096bae3-8200-4d3a-af19-43c98c5fc9c0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1095480396",
-            "$etag": "W/\u00220be2e194-af2a-4dc1-9d0c-b2d51dea4c5d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin362889809",
-            "$etag": "W/\u0022e0bd3738-4244-4fef-9790-ffe6ba661b24\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;128737197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1921780853",
-            "$etag": "W/\u0022e7726775-9d63-40fc-af0c-cb92025bfafd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;157701634",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin537968733",
-            "$etag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1369668520",
-            "$etag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+            "$etag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -4792,22 +528,45 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1470142442",
+            "$etag": "W/\u00221eb68b8a-bf13-4720-80b6-a69fe4426840\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               }
             }
           },
           {
             "$dtId": "roomTwin873268829",
-            "$etag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
+            "$etag": "W/\u00221464a0f1-2db0-4bee-aa03-2a79ccf25f90\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -4815,215 +574,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBknAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:AScBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "a69667ff12b0154d19c9fc836462b81b",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBknAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:AScBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "6498",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
-        "query-charge": "4.09",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1470142442",
-            "$etag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin152530184",
-            "$etag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin581255239",
-            "$etag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1775617169",
-            "$etag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1115371378",
-            "$etag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin545487351",
-            "$etag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1107764983",
-            "$etag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1469731366",
-            "$etag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
+            "$etag": "W/\u00222845c406-2076-4575-8891-9417d5bffb6e\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5031,45 +597,114 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1651185579",
-            "$etag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
+            "$dtId": "roomTwin152530184",
+            "$etag": "W/\u0022baf82ed1-133e-47f8-89aa-cd90ce1296d1\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;113863769",
+              "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin537968733",
+            "$etag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1775617169",
+            "$etag": "W/\u0022553a122e-a4d1-45ef-8ebb-cf9143db963c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin545487351",
+            "$etag": "W/\u00225b73646b-2193-441f-94d8-8038c015fafd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
               }
             }
           },
           {
             "$dtId": "roomTwin886314449",
-            "$etag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
+            "$etag": "W/\u0022552c47a7-cf72-4c83-88e3-a333dba19485\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5077,22 +712,91 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin581255239",
+            "$etag": "W/\u0022418b00ea-8e3e-45f1-a9c4-df279018c5a4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1115371378",
+            "$etag": "W/\u0022ce9d5ab4-b7ed-4edb-a766-588dddfc7092\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1107764983",
+            "$etag": "W/\u002294127080-a0bc-4a3e-8e4c-2e22a9b7400f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               }
             }
           },
           {
             "$dtId": "roomTwin619580090",
-            "$etag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+            "$etag": "W/\u00223d4e535f-9a99-4d39-b9ef-5d8b2712102b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5100,22 +804,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1965876829",
-            "$etag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
+            "$dtId": "roomTwin1651185579",
+            "$etag": "W/\u0022294e1038-72ab-4a19-b643-18b3cf5c1d37\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5123,45 +827,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin829263883",
-            "$etag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1135525785",
-            "$etag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+            "$etag": "W/\u0022d281534a-cb4a-4d79-8d0d-ae6f7b7fa1f5\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5169,16 +850,1166 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1105345787",
+            "$etag": "W/\u002240cf5ea0-b65a-4d1c-ab15-8558f01b6e73\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1965876829",
+            "$etag": "W/\u0022403065a8-8e71-469a-b528-339c0b4a8e35\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin829263883",
+            "$etag": "W/\u0022c3ece407-5fd5-436a-bfd7-dd10dc758e93\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin469162630",
+            "$etag": "W/\u0022bb0d50f4-fd31-42c5-ba91-74cdc790dd1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079625124",
+            "$etag": "W/\u002268eb8c04-fde5-4c9d-9b13-55c14d17a5a2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2121647958",
+            "$etag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin258863380",
+            "$etag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin565072308",
+            "$etag": "W/\u00229fbf9dbc-8eba-42a2-b690-7fd0a32239bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2047600035",
+            "$etag": "W/\u0022b2917b45-8fb8-4976-a59a-1a3c9bb7574f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1286738412",
+            "$etag": "W/\u00227d18a751-a241-4523-8d72-7e33196d97dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1189666982",
+            "$etag": "W/\u00222a2e4748-c4a8-4ce2-a755-68efd52528fa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin484073712",
+            "$etag": "W/\u00228468c658-1feb-4faf-8bfa-5379012e88a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin489387498",
+            "$etag": "W/\u00227ec14c16-e75b-4307-a18f-aa2bae497248\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin532106151",
+            "$etag": "W/\u0022c60c9190-89a5-451f-8b85-ee2165c86924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2060296123",
+            "$etag": "W/\u002231152dd5-003f-4f41-a193-eb503ae3988d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1162878836",
+            "$etag": "W/\u002261f15449-ef3b-4eaf-a667-247648c141b4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1225195112",
+            "$etag": "W/\u0022b4dfb1a8-4df1-4fdd-b65e-77175e5f8b85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin809589682",
+            "$etag": "W/\u0022b94a81ae-820b-442f-98aa-1a1210fcd8b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1312290533",
+            "$etag": "W/\u0022ba1ba1e3-6335-4748-98bb-0adb30f9a8c0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1882526098",
+            "$etag": "W/\u00223fb9fd3b-b10a-42a3-96cd-c97c516a445a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin424570723",
+            "$etag": "W/\u0022bd0955c9-221e-4024-b1e6-9a7377fdafcd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin74665732",
+            "$etag": "W/\u00222547770e-a761-4276-9a44-5ed7cab6d320\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin357005613",
+            "$etag": "W/\u0022d65324bf-9d35-49e3-b1f7-63ddb1b11d27\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079678761",
+            "$etag": "W/\u0022facc9bb8-5b4a-4355-a1e5-a0fed59798be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857070193",
+            "$etag": "W/\u0022344b1b43-9954-446a-9648-592ad0cd2b33\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1525191687",
+            "$etag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin644310332",
+            "$etag": "W/\u0022680af627-2e01-4ac8-af38-3cb3e79a7503\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1614607475",
+            "$etag": "W/\u0022f4c1ad67-fd8a-4c7a-944a-341c82ba5fe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1438249970",
+            "$etag": "W/\u002229634e48-7cc6-4291-9940-3248a57e5414\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1380454223",
+            "$etag": "W/\u00226c820be3-8744-4bde-8e25-2aa409b0d2f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin738047304",
+            "$etag": "W/\u0022737811d1-9aed-475d-b5c2-260cb281afbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin379883128",
+            "$etag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin64365696",
+            "$etag": "W/\u00226447225b-3ea7-44f0-a749-74d01de4b0f6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1753584378",
+            "$etag": "W/\u002267c15d28-08e0-4f21-b715-2f163b19f9a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2028986873",
+            "$etag": "W/\u0022d5811809-19fe-43ed-8074-f0595974de59\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin847442141",
+            "$etag": "W/\u002236fd1881-ac66-4f4b-b7a1-2b5ece25b67c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2106608761",
+            "$etag": "W/\u0022d1c30c84-1030-4cef-9d85-609d968aff40\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1662618080",
+            "$etag": "W/\u0022a7518287-834e-439b-9371-4442e4009ac9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin279835412",
+            "$etag": "W/\u00224fc1be2c-7a96-469e-aedf-8f90db26a9cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2001547295",
+            "$etag": "W/\u002265298c2f-3a64-4af4-bdd8-dc3b8c32c703\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin254397244",
+            "$etag": "W/\u00229a4458dc-c730-4129-86a1-fe7062161ba9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin312098304",
+            "$etag": "W/\u00228c00c75d-1d48-4e95-a038-7a57e29ddfb2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857257843",
+            "$etag": "W/\u002262efaa49-c478-42c4-adc4-bafcf161b386\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1017374329",
+            "$etag": "W/\u0022f4bc66c7-22da-4ae9-a2f3-4f2d15a84b44\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin187351254",
+            "$etag": "W/\u0022cb532999-1e35-4bea-ac08-1e6d35585fd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
           }
@@ -5193,17 +2024,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "e383f410ccf72a8d067ac44689c5cd47",
+        "x-ms-client-request-id": "d7be253cacc50152c78648a4057dc568",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:13 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_SuccessAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_SuccessAsync.json
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -74,12 +74,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;123439021\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;12337958\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "192",
+        "Content-Length": "190",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;123439021\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:48.322853\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;123439021\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T17:04:53.2479\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1982570493?api-version=2020-10-31",
@@ -99,7 +99,7 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -145,7 +145,7 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -191,7 +191,7 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -233,52 +233,11 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
-      "StatusCode": 404,
-      "ResponseHeaders": {
-        "Content-Length": "271",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "error": {
-          "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1410570626. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
-        }
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1410570626?api-version=2020-10-31",
-      "RequestMethod": "PUT",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "154",
-        "Content-Type": "application/json",
-        "If-None-Match": "*",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
-        ],
-        "x-ms-client-request-id": "b86f8e8061350528b3535a609681535e",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "$dtId": null,
-        "$etag": null,
-        "$metadata": {
-          "$model": "dtmi:example:room;123439021"
-        },
-        "Temperature": 80,
-        "Humidity": 25,
-        "IsOccupied": true,
-        "EmployeeId": "Employee1"
-      },
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
         "ETag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
@@ -307,6 +266,138 @@
       }
     },
     {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin59174272?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "35b86f8e2861b305535a609681535e77",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "459",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "ETag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin59174272",
+        "$etag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;123439021",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin151639911?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "739eb3e84186b9562bd674aecd0fbede",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "270",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:52 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin151639911. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin151639911?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "d45188e5994c117a57c8f70179707352",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;123439021"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:53 GMT",
+        "ETag": "W/\u002254257157-3b68-498a-8ec6-8ded1f570a0c\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin151639911",
+        "$etag": "W/\u002254257157-3b68-498a-8ec6-8ded1f570a0c\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;123439021",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T17:04:53.5099059Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T17:04:53.5099059Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T17:04:53.5099059Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T17:04:53.5099059Z"
+          }
+        }
+      }
+    },
+    {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
       "RequestMethod": "POST",
       "RequestHeaders": {
@@ -318,7 +409,7 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "b3e86777739e418656b92bd674aecd0f",
+        "x-ms-client-request-id": "a99a3d190c102e07627c35529104864b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -326,10 +417,10 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "33725",
+        "Content-Length": "46453",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
-        "query-charge": "15.530000000000001",
+        "Date": "Mon, 26 Oct 2020 17:04:53 GMT",
+        "query-charge": "20.91",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -2012,6 +2103,1073 @@
                 "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
+          },
+          {
+            "$dtId": "roomTwin363377363",
+            "$etag": "W/\u0022ad77294f-1d23-44ad-af85-a7e1a58d868c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.9666070Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2146208947",
+            "$etag": "W/\u00225835d863-4ea6-4ad7-a831-985a7c81ced7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2178127Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1062677703",
+            "$etag": "W/\u00225e977d72-2d41-456b-8ea5-ae401b39bf0a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.2375516Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin324722902",
+            "$etag": "W/\u002214c5c5ce-59b5-4a4c-a6aa-1e41ab2171c7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3162395Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1462038290",
+            "$etag": "W/\u0022297e8e3d-fa21-48d2-8ad0-5140dad410aa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.3375425Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin462997606",
+            "$etag": "W/\u0022520d9d8f-26a0-49eb-bf4a-97089ee3b215\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4134025Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1012472014",
+            "$etag": "W/\u00222ff06d59-f560-40d9-bf73-d2957887b818\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.4251067Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1543128019",
+            "$etag": "W/\u0022e3395b82-f93a-41fb-8903-89de4b68a5bf\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5127224Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin955385887",
+            "$etag": "W/\u00223128b366-23a9-4a19-ab7e-b2fcbef9af3e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5196597Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin672739146",
+            "$etag": "W/\u0022dd179afe-3a30-4f55-bcfc-b529538ed18b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.5922633Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1750846709",
+            "$etag": "W/\u002251a2b553-2d6d-427e-8779-d27e3d15bfd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.6432310Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin422308472",
+            "$etag": "W/\u00228ea17c08-4542-4f10-8e98-f4a044b3a616\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7315470Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1661689683",
+            "$etag": "W/\u0022fcd235a2-c5fe-46ee-9cbd-4f70b90a0d2d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.7373797Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1648554203",
+            "$etag": "W/\u0022fe961330-5592-47a0-8433-11baa6cafa72\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8193971Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin528003268",
+            "$etag": "W/\u00222af11057-a459-4406-84dc-82a12ad38106\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.8364606Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin817870353",
+            "$etag": "W/\u0022781ecf84-02fb-4a64-9959-6c1286246ee6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9075377Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1251286994",
+            "$etag": "W/\u002204f4c379-5934-4788-8c96-0de3beba29b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9149657Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1240738903",
+            "$etag": "W/\u0022f210ec66-b4c9-488d-bcdc-bf8948f84bd9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:46.9950539Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1738906707",
+            "$etag": "W/\u00226e952007-ad31-492e-a7c2-62ad7d4b54e9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0006358Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1491061385",
+            "$etag": "W/\u00224c895d19-e817-4c79-8aaf-8e4769287e97\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.0845454Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1776075638",
+            "$etag": "W/\u002258d54f8d-5e34-4060-b955-8a486d30f447\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:47.1112419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin619913832",
+            "$etag": "W/\u00220f62adc9-a00b-423a-bc62-54588da70511\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4645598Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1410570626",
+            "$etag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1067365890",
+            "$etag": "W/\u002249dafe72-a4f4-4986-9a66-94b82f4fdd32\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.3105798Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin757295793",
+            "$etag": "W/\u00220b31dafa-a92e-4139-91c2-cea3a0de96e7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.4685160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin633630133",
+            "$etag": "W/\u0022a194cd57-9a12-40a8-8641-eef149c38829\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.6151517Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1052658490",
+            "$etag": "W/\u00225ddb7fae-81be-4b0b-920f-26947783a711\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.7270156Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaOAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAI6AAsAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "400",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "ca9cb7a1a30c4f1a398c1bbd495440ba",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAJ4MUjaOAAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAIAI6AAsAk8v8H\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "8341",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 17:04:53 GMT",
+        "query-charge": "4.48",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin1626036685",
+            "$etag": "W/\u002288043f16-cc41-41fa-a4c2-89b79dc679b6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.8491024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin687114800",
+            "$etag": "W/\u0022e40bc758-5024-403f-be36-b991984dd165\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:44.9562298Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1274856786",
+            "$etag": "W/\u00225799d61b-4453-46c0-81c4-fcf3f4570f4a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0095068Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1098941419",
+            "$etag": "W/\u002233a4b889-0aba-4d63-b65d-a42a40e4c456\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.0583183Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin125346931",
+            "$etag": "W/\u0022af62467a-acb1-4395-8c26-eb38dfc9874b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1523262Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin345229702",
+            "$etag": "W/\u002255c487c4-984f-465f-bc95-125288661377\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2563196Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin904769627",
+            "$etag": "W/\u0022f0e97abe-4660-4e4e-8ae7-ce9a7cc4eabc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.1721294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin840530319",
+            "$etag": "W/\u00227b0aed29-4924-4edb-a4f6-57b379179e7a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.3779044Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin19991913",
+            "$etag": "W/\u00227b4544bb-5313-421d-821b-0b47810f6ed1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.2933660Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1846282992",
+            "$etag": "W/\u0022e96b7675-5265-486e-a565-51c09f86292e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4896902Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1501230847",
+            "$etag": "W/\u00226802e3a6-b98a-4da6-b472-4b02220454d2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.4099335Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2112889309",
+            "$etag": "W/\u0022a8b818f4-cac5-4152-af3b-6501b11b2a20\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.7530673Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1261829064",
+            "$etag": "W/\u0022d227561c-e41d-4503-b9b9-e6c04d18d682\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.6451385Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin20831578",
+            "$etag": "W/\u002228e89f63-cbd8-432d-8408-cbe836c136a9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.9475741Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2061740721",
+            "$etag": "W/\u0022809c12e1-14b3-49ab-8d2a-f138e6e9f5bb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:45.8509513Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin59174272",
+            "$etag": "W/\u0022dc826323-ef03-4ecd-8712-8941cfcb5412\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:47.9236813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1511973902",
+            "$etag": "W/\u0022e512e115-b43b-493d-b71e-8e7d617e48de\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:46.0886398Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1357107878",
+            "$etag": "W/\u00227ce2ee84-70b9-4669-881b-b191b7816f06\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T17:04:48.5105656Z"
+              }
+            }
           }
         ],
         "continuationToken": null
@@ -2027,14 +3185,14 @@
           "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
           "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "88e5debed451994c7a1157c8f7017970",
+        "x-ms-client-request-id": "8f9421631574d8ce802372d063288052",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "Date": "Mon, 26 Oct 2020 17:04:53 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_SuccessAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/QueryTests/Query_ValidQuery_SuccessAsync.json
@@ -7,8 +7,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "fa97b3e673c1795cb4d508fd78961ec8",
         "x-ms-return-client-request-id": "true"
@@ -18,7 +18,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -35,8 +35,8 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "4a164ce3e3b36b015cbff77b83d297fd",
         "x-ms-return-client-request-id": "true"
@@ -46,7 +46,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -65,8 +65,8 @@
         "Content-Length": "804",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "d5f4d0f8f700f2d06348c4fd82796841",
         "x-ms-return-client-request-id": "true"
@@ -74,12 +74,12 @@
       "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;123439021\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;12337958\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
       "StatusCode": 201,
       "ResponseHeaders": {
-        "Content-Length": "191",
+        "Content-Length": "192",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;123439021\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-22T18:12:14.06075\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;123439021\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-26T16:57:48.322853\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1982570493?api-version=2020-10-31",
@@ -88,10 +88,148 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
         "x-ms-client-request-id": "33de3ee132da95cf8e65b364fd310370",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1982570493",
+        "$etag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;123439021",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1266490367?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "f32ac67fecc5237ce76b1f04e9e256b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1266490367",
+        "$etag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;123439021",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1904515709?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "c9b893a29d1e402471921c8d6517c18c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1904515709",
+        "$etag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;123439021",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1410570626?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+        ],
+        "x-ms-client-request-id": "0a17a2fa521b0f62f2c7b091a4835dae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
@@ -99,18 +237,18 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "error": {
           "code": "DigitalTwinNotFound",
-          "message": "There is no digital twin instance that exists with the ID roomTwin1982570493. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+          "message": "There is no digital twin instance that exists with the ID roomTwin1410570626. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
         }
       }
     },
     {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1982570493?api-version=2020-10-31",
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1410570626?api-version=2020-10-31",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -119,10 +257,10 @@
         "Content-Type": "application/json",
         "If-None-Match": "*",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "2ac67fffc5f37cec23e76b1f04e9e256",
+        "x-ms-client-request-id": "b86f8e8061350528b3535a609681535e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -140,13 +278,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
-        "ETag": "W/\u002235ed5c07-e6cc-4732-99bd-7146df8ec4d6\u0022",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "ETag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
-        "$dtId": "roomTwin1982570493",
-        "$etag": "W/\u002235ed5c07-e6cc-4732-99bd-7146df8ec4d6\u0022",
+        "$dtId": "roomTwin1410570626",
+        "$etag": "W/\u0022daced9e9-5fad-4328-ba39-6e7d6e195d58\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -154,16 +292,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;123439021",
           "Temperature": {
-            "lastUpdateTime": "2020-10-22T18:12:14.1714262Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-22T18:12:14.1714262Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-22T18:12:14.1714262Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-22T18:12:14.1714262Z"
+            "lastUpdateTime": "2020-10-26T16:57:48.4828141Z"
           }
         }
       }
@@ -177,10 +315,10 @@
         "Content-Length": "62",
         "Content-Type": "application/json",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "93a27db5c9b89d1e244071921c8d6517",
+        "x-ms-client-request-id": "b3e86777739e418656b92bd674aecd0f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -188,4603 +326,201 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "46466",
+        "Content-Length": "33725",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
-        "query-charge": "20.91",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
+        "query-charge": "15.530000000000001",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "value": [
           {
-            "$dtId": "roomTwin1498980297",
-            "$etag": "W/\u0022d9379766-dc49-4095-8469-7117a69534b0\u0022",
+            "$dtId": "roomTwin1495950345",
+            "$etag": "W/\u002205d2ae31-6929-4d7e-af04-4a44b4b31e8b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;112984610",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6135616Z"
+                "lastUpdateTime": "2020-10-23T21:04:50.2177669Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1381264736",
-            "$etag": "W/\u00229530fad8-8481-4207-a3a2-54f75c33e03f\u0022",
+            "$dtId": "roomTwin344050324",
+            "$etag": "W/\u0022f8d463fc-b497-42c5-9d24-8bf2eb63c8ac\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112462194",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.6280233Z"
+                "lastUpdateTime": "2020-10-23T21:07:40.1690347Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin746222802",
-            "$etag": "W/\u00221c55bd1b-4dc3-48a5-a694-7504c7387b38\u0022",
+            "$dtId": "roomTwin427623005",
+            "$etag": "W/\u00221af94c6c-ba7b-43af-b731-3c747d441259\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;119618957",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7128839Z"
+                "lastUpdateTime": "2020-10-23T21:10:04.2422987Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin775031637",
-            "$etag": "W/\u0022f2e095ad-618a-44d8-ae54-fb1acaf9d041\u0022",
+            "$dtId": "roomTwin410651761",
+            "$etag": "W/\u00229de8f988-b123-411e-81d1-b9b2647c5bfa\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;112725529",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.7519778Z"
+                "lastUpdateTime": "2020-10-23T21:16:07.6922287Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1245991748",
-            "$etag": "W/\u0022b941c874-b71d-4d29-8987-55a489ce4757\u0022",
+            "$dtId": "roomTwin744180983",
+            "$etag": "W/\u002263bb6047-a862-4977-b4f0-c9890d2b3370\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;115056947",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8040935Z"
+                "lastUpdateTime": "2020-10-23T21:17:42.6969774Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1444644859",
-            "$etag": "W/\u00226102e256-e029-43c3-88e2-7fcdf1df31be\u0022",
+            "$dtId": "roomTwin1437249777",
+            "$etag": "W/\u0022ef65f3f3-9966-4092-bf4c-b466ccb270f9\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;158485519",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.8474909Z"
+                "lastUpdateTime": "2020-10-23T21:20:58.7466947Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1163564709",
-            "$etag": "W/\u0022670f1a13-ef3c-4450-a0ec-6b9ec342415e\u0022",
+            "$dtId": "roomTwin1579359106",
+            "$etag": "W/\u00226c41c324-e714-4346-97ee-3d7a43ebf892\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;119270198",
+              "$model": "dtmi:example:room;113317821",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9002058Z"
+                "lastUpdateTime": "2020-10-23T22:23:51.8870999Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin936523733",
-            "$etag": "W/\u0022df870f13-0fce-4273-b8b2-1f0cc9360973\u0022",
+            "$dtId": "roomTwin2008432736",
+            "$etag": "W/\u0022322fe163-968c-4989-aa8e-a3a4e448907b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;130763254",
+              "$model": "dtmi:example:room;121439350",
               "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9434775Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1174159166",
-            "$etag": "W/\u0022660a990d-f9d7-4588-97dd-b5e45bc98086\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:47.9911440Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin86672577",
-            "$etag": "W/\u0022fd6efd7e-0d32-4bf7-a8cf-0bcd64ae75c6\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0451115Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1870986745",
-            "$etag": "W/\u0022c7480283-c513-4b7e-9937-8074f62ace65\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119270198",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.0830751Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1536838429",
-            "$etag": "W/\u0022bcbed22e-248a-43ee-9594-5fdf5c571cbd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;130763254",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.2501988Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin661851410",
-            "$etag": "W/\u0022af7780a2-175d-4891-a13f-df6c145fd88e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110247197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:48.9725916Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1085222686",
-            "$etag": "W/\u0022bf070c35-d9ff-46f0-ab3d-c96099615404\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;166246968",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:21:49.1112180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420943146",
-            "$etag": "W/\u002221e209f9-0bf3-4a09-9cda-3f0bb04813b8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.0662763Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1338380856",
-            "$etag": "W/\u00224cd0743c-7862-43df-873a-4b41374d1544\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.1759120Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1785890025",
-            "$etag": "W/\u00225d658a38-9807-4a54-a993-3484b1bb15e1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.2911509Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1000297038",
-            "$etag": "W/\u00223aa0b952-daba-4ff9-bcb8-602da4399405\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3104022Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1893330133",
-            "$etag": "W/\u00225ebe6eae-1a9d-46ed-acde-5e4da8aeea0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3909572Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123218210",
-            "$etag": "W/\u002214760d80-a8ce-4843-b0e4-56e6e9f4dd27\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.3970721Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1520206458",
-            "$etag": "W/\u0022835208c2-4a55-4de7-b10e-dc4187d5882e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4750812Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin92117139",
-            "$etag": "W/\u00224cc2ce94-15c6-4ae7-a020-4f9a9792ab09\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.4899160Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36128330",
-            "$etag": "W/\u00225adde61e-e412-49cf-a752-527bd8b3aba2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5514978Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777097876",
-            "$etag": "W/\u0022e27281c3-f22a-47a9-82ee-7b0f0b267d48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.5885055Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1470032629",
-            "$etag": "W/\u002256fc5f73-a1df-4e71-8bea-54ed682348af\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6260701Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1800780114",
-            "$etag": "W/\u0022516b6d16-ef6d-47c8-8cfb-1854ca4835bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.6904977Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin27801422",
-            "$etag": "W/\u0022539467f6-fbb6-4360-a729-c39f353f3253\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7362907Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1902584715",
-            "$etag": "W/\u00221884e5dc-2708-427a-9eaa-6d2e83841d06\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.7858209Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin96827413",
-            "$etag": "W/\u0022ef52e4c6-e6a3-4bb3-8005-997c3d9f44dd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8356624Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin935053957",
-            "$etag": "W/\u002264c75c6e-a2a9-441b-beda-2b306818df87\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.8621466Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2074335826",
-            "$etag": "W/\u00221c81ad83-61b8-4fde-bea7-4f42e5e899ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121271310",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9133304Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2123629177",
-            "$etag": "W/\u0022db3407f5-6797-483a-ac54-66cf8491c767\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:04.9651482Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1554813222",
-            "$etag": "W/\u0022817cabe6-9a22-4634-a34d-177273d33068\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.0408589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1699890695",
-            "$etag": "W/\u00227084f858-2fd9-423c-9998-d831f293c5f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;199213367",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.1494382Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1088498238",
-            "$etag": "W/\u00221d4e9b50-b84b-45da-ab41-b40a11736140\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;158383040",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.6294344Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin894415666",
-            "$etag": "W/\u0022f5f49f19-15f2-45e1-ab5f-1f6ad65d49f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113309762",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:30:05.8668662Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148688568",
-            "$etag": "W/\u0022185a6e23-5cdc-43c3-9f98-bce142ef1635\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0130642Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin605247566",
-            "$etag": "W/\u002285ec04a7-1fc5-4cb5-a028-fb7646cee045\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.0439296Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1738278687",
-            "$etag": "W/\u002265469fb8-0e42-4c50-88c4-9499db8d30d1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1061474Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin883341753",
-            "$etag": "W/\u0022c6d743e3-2171-46df-9875-45107360b597\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1880074Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin44768029",
-            "$etag": "W/\u0022e0bf97cb-0ca6-4f19-9c87-c12c508eb7eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.1961580Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1026080773",
-            "$etag": "W/\u0022be607bbe-b367-42de-b426-17d53b764e00\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.2840394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1012130572",
-            "$etag": "W/\u0022e9d0ad86-5382-41dc-95e4-7365514401dc\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3009377Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin314886311",
-            "$etag": "W/\u0022ed0846f6-8b98-44f6-8dab-96f5271ce59b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.3987606Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1045652022",
-            "$etag": "W/\u0022deb78b85-2b4d-4695-b234-c6dfae1bf0a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.4038035Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin516625160",
-            "$etag": "W/\u00226b21212e-eb4d-4ad9-aac3-ca364cb5e3e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5026747Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1891959418",
-            "$etag": "W/\u0022183aa253-51e8-4af1-9bd5-3ea98350d1bb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5520941Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829360197",
-            "$etag": "W/\u0022243c49a4-115d-4669-a7cb-1ed898e2de78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.5924925Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin61707195",
-            "$etag": "W/\u0022e6422265-b580-4e10-afa7-a032f40d0aea\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6604138Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783915272",
-            "$etag": "W/\u0022a43fd4d5-65cf-4b7b-81f6-80e88ff3f822\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.6810379Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1041693882",
-            "$etag": "W/\u002245a8e4ec-fdbc-4d18-8396-559141ddc01b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7613669Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021340528",
-            "$etag": "W/\u002298a5b93f-4034-4738-a576-b128341aaf2e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.7909313Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1677577135",
-            "$etag": "W/\u00223040ab87-d137-4d12-a562-f450d3bb45a9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;184435776",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8561469Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin124606454",
-            "$etag": "W/\u00223c60e1ac-b594-4cce-8c1a-718c37a715ef\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:11.8954588Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1154990313",
-            "$etag": "W/\u00223650ee8c-f86f-4c1a-900a-2c4f11e8ebc8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.0259087Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2132961076",
-            "$etag": "W/\u00227a0bf9a7-9d8a-4db6-8191-84220168680b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120041944",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.1526492Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin57113376",
-            "$etag": "W/\u0022cfcf6f4c-808d-4ce1-8f81-667ef4e74b4a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116251683",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:12.7147457Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin619150749",
-            "$etag": "W/\u00223194e119-b36a-4efa-8af0-b99c24d45ff7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170550470",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:32:13.1710109Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin551511810",
-            "$etag": "W/\u00222d430b86-fa94-44cc-b68a-6df9644aceff\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9613495Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin98472762",
-            "$etag": "W/\u00226c5eb657-d221-4ed2-82c1-0197f69a3f30\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:30.9734619Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin869013250",
-            "$etag": "W/\u0022a3c3dc57-4372-4c4f-bf36-feb06b12f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0798212Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin722764700",
-            "$etag": "W/\u0022180669f5-37cf-454a-9ed9-5f7c29bd5c21\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.0896436Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2125813792",
-            "$etag": "W/\u00220c25d51f-a3a9-4a12-a66b-a3fef02f32c8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1948861Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1564789991",
-            "$etag": "W/\u00222f754f56-075a-4ef8-a9e4-7e189ddc22bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.1953796Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin729153756",
-            "$etag": "W/\u0022400fe9ad-eb92-47f5-a772-ec2b5ead9606\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.2862692Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1489152938",
-            "$etag": "W/\u002228c2d505-7c3b-40d2-80e0-17f323c70679\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3067944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1637856858",
-            "$etag": "W/\u0022ec90109a-be27-4750-8548-cf61eec5aa0b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.3863181Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1363211591",
-            "$etag": "W/\u0022dd52474a-d61e-4eb5-8e3b-3b99cdd61baf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4044894Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin838663785",
-            "$etag": "W/\u00227c4b95c6-3be9-40ee-8e4e-a3e78574aa34\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.4588519Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1300086570",
-            "$etag": "W/\u0022f1ebf4ba-6b6b-4c6b-9f31-c539d71178d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5133634Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin151462022",
-            "$etag": "W/\u002298d16ff0-f7bf-4254-9d03-c9a4cb58c201\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5522553Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1308729416",
-            "$etag": "W/\u0022ba6f41ec-b8f2-490a-bc1e-ff5514196325\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.5890058Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1856167476",
-            "$etag": "W/\u0022a211c53e-af56-4cc8-b77d-724bd8558d33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6413268Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1336007415",
-            "$etag": "W/\u00229687aa69-50b9-4d7b-84b2-6b85e192050a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.6999534Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin662815516",
-            "$etag": "W/\u002269473407-2871-4d05-8e0f-2431ce8eafc1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.7494481Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin94298757",
-            "$etag": "W/\u002262eb0428-71b3-4a77-84ac-5e64f19ceb78\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115900942",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8121966Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1612778009",
-            "$etag": "W/\u0022c9da2088-b6f7-4767-848e-4e10cfeb9ee4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.8226190Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin856851558",
-            "$etag": "W/\u0022c623ba55-3c32-4a56-8574-65dd548ab6e0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112427398",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:31.9224182Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin229826714",
-            "$etag": "W/\u002238488fbd-d87b-42dc-93d0-916af0949b4b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111655996",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6190589Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin526434890",
-            "$etag": "W/\u0022c19adbeb-77ce-4d0c-95d4-708d88de7b79\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;141760569",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-21T16:33:32.6582418Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1735182331",
-            "$etag": "W/\u00221c736187-8abb-499b-8063-cf15994d06b5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;153048334",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:25.3435640Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin918788440",
-            "$etag": "W/\u0022de783261-56c0-4f53-8cbd-b0520b4d6f11\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140750981",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.3477130Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin895881838",
-            "$etag": "W/\u0022d3d51c9d-eddd-4113-8a52-efa9f2f11426\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5350121Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin492624016",
-            "$etag": "W/\u0022e231036b-9573-4cf6-93bc-4f76168ba9c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.5754124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin818663445",
-            "$etag": "W/\u0022166be958-7415-4134-a4f5-7c474985c5a3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6280811Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846657163",
-            "$etag": "W/\u0022d04aa87a-a541-4896-a7fe-5eab16c99744\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.6781590Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin169049424",
-            "$etag": "W/\u002211259cdf-2b5d-4824-b381-10316d5c8617\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7284515Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2003290546",
-            "$etag": "W/\u0022c41115df-04d0-4c5a-bc58-0ae0e7a1bbca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.7968047Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1920637755",
-            "$etag": "W/\u0022b1c7a4c4-5bef-4d51-8f28-6a8a99a9b955\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8219822Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin567255450",
-            "$etag": "W/\u00228b132e44-b0db-4d8a-b004-3410fbd9ec66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8972232Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin466450821",
-            "$etag": "W/\u0022d142de37-2196-4bec-a201-fe3146f28272\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.8995081Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin652828980",
-            "$etag": "W/\u0022360ae1fa-aa9d-4bd4-b2bd-8302ffa69453\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:53.9893412Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1658744984",
-            "$etag": "W/\u0022bfbfbc70-049c-4ea8-9a7e-8240bc3b49ad\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0099774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1108577855",
-            "$etag": "W/\u00229e4d190d-271d-4ad8-9ea6-9fa8d412cf99\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0929770Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin881848871",
-            "$etag": "W/\u0022fa12869e-c78e-4c94-8c0d-6fc358b6e852\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.0957441Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin34125080",
-            "$etag": "W/\u002282a0d23e-5444-4f11-ac2f-d15d1909237e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.1574788Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin716576755",
-            "$etag": "W/\u0022928a136b-494e-4965-99e9-128202587246\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2278833Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1961257007",
-            "$etag": "W/\u00227a297279-19b8-447a-8396-194df0d8b0ae\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.2740202Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1791197485",
-            "$etag": "W/\u00221bf81066-9eb3-44f5-aa96-d5f7e20946e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.3096760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1867071453",
-            "$etag": "W/\u0022342a88f2-0dcc-4575-aa58-315006cd4ef1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;138659705",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4045873Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl1AAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHYA4APM//8PAEAAAhDAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "424",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "fa828cc117a21b0a52620ff2c7b091a4",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBl1AAAAAAAAAA==#RT:4#TRC:100#ISV:2#IEO:65551#FPC:AgEAAAAaAHYA4APM//8PAEAAAhDAE0APAMD//48hQD8A\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "46450",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
-        "query-charge": "20.72",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1641901809",
-            "$etag": "W/\u00226911c53c-1a10-4321-9bea-aeeeca373ff9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.4057853Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1133125955",
-            "$etag": "W/\u00226b21e7dc-b4e9-4087-9c14-5a0b4fb2b15b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;150457406",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:54.5220513Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin246922244",
-            "$etag": "W/\u002270fb7b44-ac8b-496d-a15c-e96448dfac66\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;117012504",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:55.5997353Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1642617034",
-            "$etag": "W/\u0022f7cd24c9-808b-4aa1-9fc1-d774acdfac57\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115956238",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T09:59:56.2618099Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin62721381",
-            "$etag": "W/\u0022abe2d779-e33d-48b7-832f-8326022a02eb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110307862",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0634655Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin777965033",
-            "$etag": "W/\u00227ac6cc9c-0616-4b52-bde0-1a7b1d90920c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116838841",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.0393089Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1741612918",
-            "$etag": "W/\u0022af3841ce-ae9d-49c7-96c9-680c8c704cda\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4086774Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin36952557",
-            "$etag": "W/\u00225017547e-5cb7-4270-8732-0fd935c5f36f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.4048433Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1213006989",
-            "$etag": "W/\u002239424cf2-71fa-407b-8b28-63cf3b636731\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5040767Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin326513034",
-            "$etag": "W/\u00225350ca2a-c97e-4c6e-b4e2-4db4cc81475c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5027394Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1129721811",
-            "$etag": "W/\u00228dba5565-d060-4bad-a801-4f9bbc4ebdf0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5977896Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1947553667",
-            "$etag": "W/\u00222d6acbd7-fcfd-40c3-80e1-a33bf5092293\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.5777743Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1548928947",
-            "$etag": "W/\u0022ee3e799c-7ec3-44a5-bf99-608ae6ed2d0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6708710Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin356265635",
-            "$etag": "W/\u0022cddfa5c7-ba8d-4f3f-a5c7-49ed794ace2f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.6660696Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1989978078",
-            "$etag": "W/\u0022d8a52677-b719-4322-b2a3-797951f9dfa7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7587494Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin863816413",
-            "$etag": "W/\u002235dced59-748a-497b-8436-fa6c7ecd7c98\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.7346960Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin240878892",
-            "$etag": "W/\u0022cea21915-9749-47be-a426-12523c767a8e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8551888Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1466134063",
-            "$etag": "W/\u00224b6c3b89-c127-4389-9623-6600823c637a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.8418652Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin503181323",
-            "$etag": "W/\u0022343c3eeb-88f4-48e3-b6a3-502e67d17d19\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9483434Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin392271939",
-            "$etag": "W/\u0022076c63c0-54bd-4d30-b79f-b8779d515826\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9026174Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin496261044",
-            "$etag": "W/\u0022f30db489-e0f9-4a4e-af15-7be164045d7e\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0404061Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin277216622",
-            "$etag": "W/\u00226566f3cb-3282-4c34-bce7-f1fd53b6b79a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:26.9665918Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin815041708",
-            "$etag": "W/\u0022df1321a9-3cd1-4196-aec2-4d21b631ca88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;115618851",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1248310Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2006012899",
-            "$etag": "W/\u0022e71c7453-81c2-472c-9f6e-ea913867dfdb\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.0494567Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin446974150",
-            "$etag": "W/\u0022b00117ad-a23b-4de8-a474-7bd59421fbc0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.2152273Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1365881715",
-            "$etag": "W/\u00223179b0b2-935f-4f4b-a0ec-e41bb6e355f3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;119837620",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:27.1265180Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin681325335",
-            "$etag": "W/\u0022217888d9-1f32-4fc6-82a2-33d958d48c88\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;164255196",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.4289944Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1142241383",
-            "$etag": "W/\u0022a45ffefb-8f34-4c0a-add6-029f59e7617f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;177720708",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:00:28.3481393Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1278234179",
-            "$etag": "W/\u00225d49dfd5-ca5c-44b1-a4c6-747f37720a9c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;116571386",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:06:16.1168582Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin783813120",
-            "$etag": "W/\u00220b45aca6-bc41-4732-b559-3ebab02a7323\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112884932",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:08:29.9521926Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin20436333",
-            "$etag": "W/\u0022f7f6a258-469b-46e5-a27b-363cdd21bad5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;112740527",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:11:33.6734378Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin394026428",
-            "$etag": "W/\u0022a3076bd7-cbeb-4789-bc6c-509e1847f6e3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.9608621Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin596581608",
-            "$etag": "W/\u0022473d9d87-f909-4e33-b722-66cdc90c5b9a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1987533Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1684161797",
-            "$etag": "W/\u0022b9a14ed9-ce85-445a-85ae-3f80705534bf\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075532Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1901267486",
-            "$etag": "W/\u0022c55a0283-f169-4e3b-b272-d9875a72ecdd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8975116Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531586602",
-            "$etag": "W/\u00223e77b5c1-75a6-4c89-8048-04e0028cf6b9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8854753Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin148061498",
-            "$etag": "W/\u0022c43f33d8-1c82-4fc8-890b-22e7d8f5d9d4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4144879Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin436096292",
-            "$etag": "W/\u002204b66e10-cace-4bed-8cfb-8d61e27f1c12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.7093303Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin154780388",
-            "$etag": "W/\u002283328534-f7c3-43b2-b38f-c72bc979eb05\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;121341206",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:16.9120385Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2127865916",
-            "$etag": "W/\u002241d23a05-ab39-4bd0-befe-e8159958181f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.0532570Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin317362118",
-            "$etag": "W/\u002202c13fde-87db-4716-a76b-d47bf709ee97\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.1639687Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin795448273",
-            "$etag": "W/\u0022dddf6522-6705-4b5b-82e9-54b6d744e55b\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5062623Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1710347499",
-            "$etag": "W/\u00224096019c-3f62-4a1f-ae96-b87531ce1b77\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2955524Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin288024548",
-            "$etag": "W/\u0022426e9bb8-9bce-474a-b00d-ddfdb1e241d5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.6071401Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1380865941",
-            "$etag": "W/\u0022e4c1ba36-c62c-400a-ad86-1cc6cf417eab\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7067969Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1205304854",
-            "$etag": "W/\u0022f1d5b58c-bfdf-428b-9b23-925a89563116\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.8075427Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1400981480",
-            "$etag": "W/\u0022e5a90477-8fde-4e02-a38c-5b04ffd5931a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:14.7016958Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1651261841",
-            "$etag": "W/\u0022d3c1a5d2-e6a5-4ef4-8113-3017514680ce\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113490432",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:17.1910462Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin846170454",
-            "$etag": "W/\u0022ec7b5277-9742-4275-967f-031a47256655\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.2677675Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin955395753",
-            "$etag": "W/\u0022e07bd3aa-8240-4129-a2d2-3d2480e20e5a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.3586205Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin251907959",
-            "$etag": "W/\u002270b9ed8a-f221-4273-bbb6-3086c7c08134\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.4304152Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1402000963",
-            "$etag": "W/\u00225537c1d2-d31d-4cce-9055-cd4db8037551\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;111394930",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.5041871Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1857138761",
-            "$etag": "W/\u002215d19e36-1f58-4471-b631-9cc6d82a01c5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;114962699",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T10:33:15.8136795Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin531597311",
-            "$etag": "W/\u002288a3c17e-fb49-4a32-89a6-a1844bd8b5f0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.2320337Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin978222842",
-            "$etag": "W/\u00221e592604-2baa-44b9-bee5-c02e4febded7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4376455Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1784653895",
-            "$etag": "W/\u00225a1eae7d-10b0-4e7a-b1b7-39360e9971e7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.4555358Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin860770335",
-            "$etag": "W/\u00227fe3ddd0-f34d-4be5-8f6e-78cda890ff8c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5381020Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1701359617",
-            "$etag": "W/\u0022ab1f392a-6de1-4345-b64b-0f1f5419d92f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.5458627Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1587783567",
-            "$etag": "W/\u00220dd5eba4-5206-492d-8d01-934308ca6959\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6361090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin778324998",
-            "$etag": "W/\u0022f19c7ff2-115b-4127-a53f-ed6cf0f7e1e9\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.6774201Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1721371793",
-            "$etag": "W/\u0022e5f73835-efc9-4ab1-819f-8fb71f80b538\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.7583880Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1364369720",
-            "$etag": "W/\u0022ff0e66bb-a4cc-4c37-959d-2da828e160f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8397203Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1445460884",
-            "$etag": "W/\u00220cb86433-53cc-49c9-b9ab-6448cec7afcd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.8396971Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1233820890",
-            "$etag": "W/\u00227e1a444e-e4f6-4416-99cb-1bdde45d8e73\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9479124Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1573366635",
-            "$etag": "W/\u0022b6546bb2-b968-4178-9bdb-e2e5e002f306\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:20.9549316Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin420514752",
-            "$etag": "W/\u00222c4d0208-068e-4126-abf9-79263c90e1db\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0280503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2115849553",
-            "$etag": "W/\u00221f455fa2-f401-4657-9e91-68a8be9d8f0c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.0675617Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1984619459",
-            "$etag": "W/\u002290fe6812-eac8-4eba-bb1a-a6a7c06b097c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1316663Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2021579934",
-            "$etag": "W/\u00222355c543-f166-4805-b55f-d461d10778ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.1358307Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1393309463",
-            "$etag": "W/\u0022f0c4bcfc-283f-4897-b223-3b00b32a8cb5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3188004Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2024624619",
-            "$etag": "W/\u0022e8338894-16a7-4f02-95ac-102569a5c0e5\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.3238445Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin933351314",
-            "$etag": "W/\u002208cf970b-08ec-47b3-9224-032838969536\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;140432177",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.4861737Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1518012781",
-            "$etag": "W/\u00229d858eb7-7b5d-4eff-8c94-4c57c5dba129\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;110864333",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:21.5035461Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1179828134",
-            "$etag": "W/\u0022b25cf002-a500-42b5-a846-1d6cd81b3586\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;129779251",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.0060014Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1293663163",
-            "$etag": "W/\u002292c9e2ab-d24c-43da-abac-7633ed8535bd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;170920816",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T11:28:23.7446236Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin300828834",
-            "$etag": "W/\u00226663329b-53ec-45c7-8539-126c1273c68d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.8743848Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin456165914",
-            "$etag": "W/\u0022e4d8c25b-329e-4de2-8b7e-25c33f8e85a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:47.9390844Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin612612248",
-            "$etag": "W/\u00225a6f3040-d114-4c67-b612-5ee5198bc0f7\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0217512Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1829071132",
-            "$etag": "W/\u0022ec9774d1-b5a3-4394-9a9d-0be5660616c3\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.0964924Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin593110535",
-            "$etag": "W/\u00221ded5390-1f3f-402f-8749-ebc6cf6da95f\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1226024Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin199646658",
-            "$etag": "W/\u0022f831e71d-cee1-4d7a-ac7f-ca9426d1a01c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.1911724Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin461434088",
-            "$etag": "W/\u00221f00217f-5f02-400d-bdfb-9b07ab072f9d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2231760Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin805249019",
-            "$etag": "W/\u0022efb00acf-a54a-48eb-b69b-3fc39662fc0d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.2844778Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin862791772",
-            "$etag": "W/\u002233cc79ef-1cf5-4b55-92c3-7760427c8c38\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3004165Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin839672662",
-            "$etag": "W/\u00220440e839-1432-470e-805b-591e4afd0b12\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3810093Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin150497704",
-            "$etag": "W/\u002215e94910-9ee2-431c-906f-509451334a6d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.3812890Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin99161790",
-            "$etag": "W/\u0022e89b9c86-d478-41d6-9b3c-5505d1277b95\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4826897Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin499786833",
-            "$etag": "W/\u0022563f9a30-99c8-4197-b31e-c4199e2865ba\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.4815090Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1813293646",
-            "$etag": "W/\u002244e3bd17-6bbc-44a4-b29c-334c10a6fe48\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5790460Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1776504490",
-            "$etag": "W/\u00226ecfacf8-3ce1-43a9-84c4-81ff36cb8cca\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.5864983Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin2000851912",
-            "$etag": "W/\u0022b4e60ad6-418e-4d47-86d2-70831e0559a8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.6908472Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1130568982",
-            "$etag": "W/\u00223cd300f9-a8d1-460e-bc54-1bb4154625f1\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;118077946",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7164717Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1407313670",
-            "$etag": "W/\u0022909d36c5-f041-4b52-8323-027f1050d23c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.7518218Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin515255931",
-            "$etag": "W/\u00226096bae3-8200-4d3a-af19-43c98c5fc9c0\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8248507Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1095480396",
-            "$etag": "W/\u00220be2e194-af2a-4dc1-9d0c-b2d51dea4c5d\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;187056368",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:48.8976384Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin362889809",
-            "$etag": "W/\u0022e0bd3738-4244-4fef-9790-ffe6ba661b24\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;128737197",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.2242591Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1921780853",
-            "$etag": "W/\u0022e7726775-9d63-40fc-af0c-cb92025bfafd\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;157701634",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T17:53:50.4378365Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin537968733",
-            "$etag": "W/\u002200375bd3-cdbc-4f82-9ffd-5ee6edea29f4\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.7736364Z"
+                "lastUpdateTime": "2020-10-23T22:24:28.9734048Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1369668520",
-            "$etag": "W/\u002209d966d5-1ce5-4a97-bbc2-f42e48993d09\u0022",
+            "$etag": "W/\u0022c9cfdf66-7b27-437e-adcb-cab05b938c6c\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -4792,22 +528,45 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8547161Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.7635679Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1470142442",
+            "$etag": "W/\u00221eb68b8a-bf13-4720-80b6-a69fe4426840\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.1425007Z"
               }
             }
           },
           {
             "$dtId": "roomTwin873268829",
-            "$etag": "W/\u00223696ceca-6aeb-4625-88e2-e9365d4ef450\u0022",
+            "$etag": "W/\u00221464a0f1-2db0-4bee-aa03-2a79ccf25f90\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -4815,215 +574,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.8607449Z"
-              }
-            }
-          }
-        ],
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBknAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:AScBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      }
-    },
-    {
-      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
-      "RequestMethod": "POST",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "Sanitized",
-        "Content-Length": "404",
-        "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
-        ],
-        "x-ms-client-request-id": "80ae5d836f8e35b8612805b3535a6096",
-        "x-ms-return-client-request-id": "true"
-      },
-      "RequestBody": {
-        "continuationToken": "{\u0022_t\u0022:2,\u0022_s\u0022:null,\u0022_rc\u0022:\u0022[{\\\u0022token\\\u0022:\\\u0022\u002BRID:~WftkAP4hqBknAQAAAAAAAA==#RT:8#TRC:200#ISV:2#IEO:65551#FPC:AScBAAAAAAAANQEAAAAAAAA=\\\u0022,\\\u0022range\\\u0022:{\\\u0022min\\\u0022:\\\u0022\\\u0022,\\\u0022max\\\u0022:\\\u0022FF\\\u0022}}]\u0022,\u0022_q\u0022:\u0022SELECT * FROM digitaltwins where IsOccupied = true\u0022}"
-      },
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Content-Length": "6498",
-        "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
-        "query-charge": "4.09",
-        "Strict-Transport-Security": "max-age=2592000"
-      },
-      "ResponseBody": {
-        "value": [
-          {
-            "$dtId": "roomTwin1470142442",
-            "$etag": "W/\u0022e0c071a5-56eb-4d3f-9c41-7abf15288c33\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9430913Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin152530184",
-            "$etag": "W/\u0022356b4a0d-002c-411b-ae3e-ad7d07cce5a2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:10.9697920Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin581255239",
-            "$etag": "W/\u0022ce19d712-6355-4f82-90af-dacb3393bf7c\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.0342503Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1775617169",
-            "$etag": "W/\u0022fe7d6ab1-191d-4db1-90e6-cf86cd62166a\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1000363Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1115371378",
-            "$etag": "W/\u0022ade7489d-2c2b-4669-aa06-186821a289e8\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1365127Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin545487351",
-            "$etag": "W/\u002219371169-16e8-4e5d-9d45-86f18670be94\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;120254295",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.1752868Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin1107764983",
-            "$etag": "W/\u0022b79d8002-96e2-4b9b-a48e-03bb806b3ce2\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2239910Z"
+                "lastUpdateTime": "2020-10-26T16:56:16.9164262Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1469731366",
-            "$etag": "W/\u00223bc3cf43-23bf-484f-a59f-9dc1c46b8b83\u0022",
+            "$etag": "W/\u00222845c406-2076-4575-8891-9417d5bffb6e\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5031,45 +597,114 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.2454473Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.4708472Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1651185579",
-            "$etag": "W/\u0022c2d3ffa1-4d9f-4315-b9e7-b9b15eb6b559\u0022",
+            "$dtId": "roomTwin152530184",
+            "$etag": "W/\u0022baf82ed1-133e-47f8-89aa-cd90ce1296d1\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
             "EmployeeId": "Employee1",
             "$metadata": {
-              "$model": "dtmi:example:room;113863769",
+              "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3234232Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.1213615Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin537968733",
+            "$etag": "W/\u00229bfbe99a-3784-425e-ba96-fe46e0de2602\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:16.6552838Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1775617169",
+            "$etag": "W/\u0022553a122e-a4d1-45ef-8ebb-cf9143db963c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3178991Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin545487351",
+            "$etag": "W/\u00225b73646b-2193-441f-94d8-8038c015fafd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3886707Z"
               }
             }
           },
           {
             "$dtId": "roomTwin886314449",
-            "$etag": "W/\u0022e0926412-6a71-42fa-a6bb-e9b8dad6c83f\u0022",
+            "$etag": "W/\u0022552c47a7-cf72-4c83-88e3-a333dba19485\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5077,22 +712,91 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.3462098Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.7242509Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin581255239",
+            "$etag": "W/\u0022418b00ea-8e3e-45f1-a9c4-df279018c5a4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.3493386Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1115371378",
+            "$etag": "W/\u0022ce9d5ab4-b7ed-4edb-a766-588dddfc7092\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.7195620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1107764983",
+            "$etag": "W/\u002294127080-a0bc-4a3e-8e4c-2e22a9b7400f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:17.8432855Z"
               }
             }
           },
           {
             "$dtId": "roomTwin619580090",
-            "$etag": "W/\u002215d56393-92e8-450e-979c-039d1151e81e\u0022",
+            "$etag": "W/\u00223d4e535f-9a99-4d39-b9ef-5d8b2712102b\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5100,22 +804,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4147085Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.8466731Z"
               }
             }
           },
           {
-            "$dtId": "roomTwin1965876829",
-            "$etag": "W/\u00223bcaf103-d370-44e1-a2fa-7bd73a172490\u0022",
+            "$dtId": "roomTwin1651185579",
+            "$etag": "W/\u0022294e1038-72ab-4a19-b643-18b3cf5c1d37\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5123,45 +827,22 @@
             "$metadata": {
               "$model": "dtmi:example:room;113863769",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.4420425Z"
-              }
-            }
-          },
-          {
-            "$dtId": "roomTwin829263883",
-            "$etag": "W/\u002296bebe1f-ab4d-40dc-aafc-a87365921f29\u0022",
-            "Temperature": 80,
-            "Humidity": 25,
-            "IsOccupied": true,
-            "EmployeeId": "Employee1",
-            "$metadata": {
-              "$model": "dtmi:example:room;113863769",
-              "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
-              },
-              "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5315020Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9302826Z"
               }
             }
           },
           {
             "$dtId": "roomTwin1135525785",
-            "$etag": "W/\u0022138d8003-09a5-44cd-b185-e9c0ade6537d\u0022",
+            "$etag": "W/\u0022d281534a-cb4a-4d79-8d0d-ae6f7b7fa1f5\u0022",
             "Temperature": 80,
             "Humidity": 25,
             "IsOccupied": true,
@@ -5169,16 +850,1166 @@
             "$metadata": {
               "$model": "dtmi:example:room;120254295",
               "Temperature": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "Humidity": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "IsOccupied": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
               },
               "EmployeeId": {
-                "lastUpdateTime": "2020-10-22T18:12:11.5377802Z"
+                "lastUpdateTime": "2020-10-26T16:56:17.9909368Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1105345787",
+            "$etag": "W/\u002240cf5ea0-b65a-4d1c-ab15-8558f01b6e73\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0762146Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1965876829",
+            "$etag": "W/\u0022403065a8-8e71-469a-b528-339c0b4a8e35\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.0345832Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin829263883",
+            "$etag": "W/\u0022c3ece407-5fd5-436a-bfd7-dd10dc758e93\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.1454149Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin469162630",
+            "$etag": "W/\u0022bb0d50f4-fd31-42c5-ba91-74cdc790dd1c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.2266474Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079625124",
+            "$etag": "W/\u002268eb8c04-fde5-4c9d-9b13-55c14d17a5a2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:18.3366733Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin77902172",
+            "$etag": "W/\u002211ac094d-3591-4098-bbf0-560ccafb8862\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.4270620Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1982570493",
+            "$etag": "W/\u002276250cee-8993-46a4-b9ed-20d47138be10\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:19.0062124Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2121647958",
+            "$etag": "W/\u0022682c6854-eb59-4b7a-b0b2-23f4fb357f78\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5077074Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin258863380",
+            "$etag": "W/\u0022f53e9a9b-16f5-4156-b376-1aa9dd23e838\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.5381572Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin565072308",
+            "$etag": "W/\u00229fbf9dbc-8eba-42a2-b690-7fd0a32239bc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6051383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2047600035",
+            "$etag": "W/\u0022b2917b45-8fb8-4976-a59a-1a3c9bb7574f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7178725Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1286738412",
+            "$etag": "W/\u00227d18a751-a241-4523-8d72-7e33196d97dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.6692943Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1189666982",
+            "$etag": "W/\u00222a2e4748-c4a8-4ce2-a755-68efd52528fa\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8339651Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin484073712",
+            "$etag": "W/\u00228468c658-1feb-4faf-8bfa-5379012e88a8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.7838762Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin489387498",
+            "$etag": "W/\u00227ec14c16-e75b-4307-a18f-aa2bae497248\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.9880892Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin532106151",
+            "$etag": "W/\u0022c60c9190-89a5-451f-8b85-ee2165c86924\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:22.8891608Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2060296123",
+            "$etag": "W/\u002231152dd5-003f-4f41-a193-eb503ae3988d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.0033038Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1162878836",
+            "$etag": "W/\u002261f15449-ef3b-4eaf-a667-247648c141b4\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1317506Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1225195112",
+            "$etag": "W/\u0022b4dfb1a8-4df1-4fdd-b65e-77175e5f8b85\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.1415535Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin809589682",
+            "$etag": "W/\u0022b94a81ae-820b-442f-98aa-1a1210fcd8b1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2497548Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1312290533",
+            "$etag": "W/\u0022ba1ba1e3-6335-4748-98bb-0adb30f9a8c0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.2637419Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1882526098",
+            "$etag": "W/\u00223fb9fd3b-b10a-42a3-96cd-c97c516a445a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3528327Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin424570723",
+            "$etag": "W/\u0022bd0955c9-221e-4024-b1e6-9a7377fdafcd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.3580160Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin74665732",
+            "$etag": "W/\u00222547770e-a761-4276-9a44-5ed7cab6d320\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4514222Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin357005613",
+            "$etag": "W/\u0022d65324bf-9d35-49e3-b1f7-63ddb1b11d27\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.4738804Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2079678761",
+            "$etag": "W/\u0022facc9bb8-5b4a-4355-a1e5-a0fed59798be\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.5574604Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857070193",
+            "$etag": "W/\u0022344b1b43-9954-446a-9648-592ad0cd2b33\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:23.6026739Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1837133952",
+            "$etag": "W/\u002213d5244f-6f92-44a9-92f0-95a58df577a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;180130729",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.1551734Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1266490367",
+            "$etag": "W/\u0022e32bf024-85eb-4095-aedb-aa6385608e38\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:56:25.2339355Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1525191687",
+            "$etag": "W/\u00225175f719-342b-4532-9f0a-f74a7a348a89\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:40.9632066Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin644310332",
+            "$etag": "W/\u0022680af627-2e01-4ac8-af38-3cb3e79a7503\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.0635147Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1614607475",
+            "$etag": "W/\u0022f4c1ad67-fd8a-4c7a-944a-341c82ba5fe2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.1774050Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1438249970",
+            "$etag": "W/\u002229634e48-7cc6-4291-9940-3248a57e5414\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.2934680Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1380454223",
+            "$etag": "W/\u00226c820be3-8744-4bde-8e25-2aa409b0d2f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.3974578Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin738047304",
+            "$etag": "W/\u0022737811d1-9aed-475d-b5c2-260cb281afbb\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5193294Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin379883128",
+            "$etag": "W/\u0022a8ff6946-ee58-45dd-bef8-d189e86281a6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.5374829Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin64365696",
+            "$etag": "W/\u00226447225b-3ea7-44f0-a749-74d01de4b0f6\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6328701Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1753584378",
+            "$etag": "W/\u002267c15d28-08e0-4f21-b715-2f163b19f9a7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7503383Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2028986873",
+            "$etag": "W/\u0022d5811809-19fe-43ed-8074-f0595974de59\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.6474217Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin847442141",
+            "$etag": "W/\u002236fd1881-ac66-4f4b-b7a1-2b5ece25b67c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8600085Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2106608761",
+            "$etag": "W/\u0022d1c30c84-1030-4cef-9d85-609d968aff40\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.7556447Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1662618080",
+            "$etag": "W/\u0022a7518287-834e-439b-9371-4442e4009ac9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9683165Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin279835412",
+            "$etag": "W/\u00224fc1be2c-7a96-469e-aedf-8f90db26a9cc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.8767260Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2001547295",
+            "$etag": "W/\u002265298c2f-3a64-4af4-bdd8-dc3b8c32c703\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.0764189Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin254397244",
+            "$etag": "W/\u00229a4458dc-c730-4129-86a1-fe7062161ba9\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;120254295",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:41.9843599Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin312098304",
+            "$etag": "W/\u00228c00c75d-1d48-4e95-a038-7a57e29ddfb2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.3112661Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin857257843",
+            "$etag": "W/\u002262efaa49-c478-42c4-adc4-bafcf161b386\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.1846023Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1017374329",
+            "$etag": "W/\u0022f4bc66c7-22da-4ae9-a2f3-4f2d15a84b44\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.5813740Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin187351254",
+            "$etag": "W/\u0022cb532999-1e35-4bea-ac08-1e6d35585fd2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;113863769",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:42.4811460Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1904515709",
+            "$etag": "W/\u002298bdf707-1431-4138-b18a-db71a81142dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;123439021",
+              "Temperature": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2020-10-26T16:57:43.4598136Z"
               }
             }
           }
@@ -5193,17 +2024,17 @@
         "Accept": "application/json",
         "Authorization": "Sanitized",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201022.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19042 )"
+          "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201026.1",
+          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
         ],
-        "x-ms-client-request-id": "775e5381e8679eb373864156b92bd674",
+        "x-ms-client-request-id": "88e5debed451994c7a1157c8f7017970",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Thu, 22 Oct 2020 18:12:14 GMT",
+        "Date": "Mon, 26 Oct 2020 16:57:47 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []


### PR DESCRIPTION
The generator is currently using the only valid enum value for the IfNonMatch header by default and attaching it to every request.
That means users cannot specify whether or not they want the overwrite functionality. 

This PR removes the enum section of the IfNonMatch definition of the swagger so it would be generated as an option that users can pass in.