### PR TITLE
Fix Azure.Core paging interceptor logic

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/UseSyncMethodsInterceptor.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/UseSyncMethodsInterceptor.cs
@@ -260,7 +260,7 @@ namespace Azure.Core.TestFramework
             public override async IAsyncEnumerable<Page<T>> AsPages(string continuationToken = default, int? pageSizeHint = default)
 #pragma warning restore 1998
             {
-                foreach (Page<T> page in _enumerable.AsPages())
+                foreach (Page<T> page in _enumerable.AsPages(continuationToken, pageSizeHint))
                 {
                     yield return page;
                 }


### PR DESCRIPTION
If AsPages is called with a continuation token or pageSizeHint, it should be propagated into the actual .AsPages call