### PR TITLE
[Storage][Webjobs] Blob trigger parallelization knob

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Host
     public partial class BlobsOptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
     {
         public BlobsOptions() { }
-        public bool CentralizedPoisonQueue { get { throw null; } set { } }
+        public int MaxDegreeOfParallelism { get { throw null; } set { } }
         public string Format() { throw null; }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
 
 namespace Microsoft.Azure.WebJobs.Host
 {
@@ -12,18 +14,33 @@ namespace Microsoft.Azure.WebJobs.Host
     /// </summary>
     public class BlobsOptions : IOptionsFormatter
     {
+        private int _maxDegreeOfParallelism;
+
         /// <summary>
         /// Constructs a new instance.
         /// </summary>
         public BlobsOptions()
         {
-            // TODO
-            MaxDegreeOfParallelism = 1;
+            _maxDegreeOfParallelism = 8 * SkuUtility.ProcessorCount;
         }
 
         /// <summary>
+        /// Gets or sets the maximum number of blob changes that may be processed by concurrently.
         /// </summary>
-        public int MaxDegreeOfParallelism { get; set; }
+        public int MaxDegreeOfParallelism
+        {
+            get { return _maxDegreeOfParallelism; }
+
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _maxDegreeOfParallelism = value;
+            }
+        }
 
         /// <inheritdoc/>
         public string Format()

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
@@ -17,25 +17,20 @@ namespace Microsoft.Azure.WebJobs.Host
         /// </summary>
         public BlobsOptions()
         {
-            CentralizedPoisonQueue = false;
+            // TODO
+            MaxDegreeOfParallelism = 1;
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether a single centralized
-        /// poison queue for poison blobs should be used (in the primary
-        /// storage account) or whether the poison queue for a blob triggered
-        /// function should be co-located with the target blob container.
-        /// This comes into play only when using multiple storage accounts via
-        /// <see cref="StorageAccountAttribute"/>. The default is false.
         /// </summary>
-        public bool CentralizedPoisonQueue { get; set; }
+        public int MaxDegreeOfParallelism { get; set; }
 
         /// <inheritdoc/>
         public string Format()
         {
             JObject options = new JObject
             {
-                { nameof(CentralizedPoisonQueue), CentralizedPoisonQueue }
+                { nameof(MaxDegreeOfParallelism), MaxDegreeOfParallelism }
             };
 
             return options.ToString(Formatting.Indented);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
@@ -109,18 +109,10 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
                     _queueOptions, _exceptionHandler, _loggerFactory, sharedBlobListener.BlobWritterWatcher, _functionDescriptor));
             var queueListener = new BlobListener(sharedBlobQueueListener);
 
-            // determine which client to use for the poison queue
+            // the client to use for the poison queue
             // by default this should target the same storage account
             // as the blob container we're monitoring
             var poisonQueueClient = targetQueueClient;
-            if (
-                // _dataAccount.Type != StorageAccountType.GeneralPurpose || $$$
-                _blobsOptions.CentralizedPoisonQueue)
-            {
-                // use the primary storage account if the centralize flag is true,
-                // or if the target storage account doesn't support queues
-                poisonQueueClient = primaryQueueClient;
-            }
 
             // Register our function with the shared blob queue listener
             RegisterWithSharedBlobQueueListenerAsync(sharedBlobQueueListener, targetBlobClient, poisonQueueClient);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobListenerFactory.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
     {
         private const string SingletonBlobListenerScopeId = "WebJobs.Internal.Blobs";
         private readonly IHostIdProvider _hostIdProvider;
-        private readonly QueuesOptions _queueOptions;
         private readonly BlobsOptions _blobsOptions;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
         private readonly IContextSetter<IBlobWrittenWatcher> _blobWrittenWatcherSetter;
@@ -40,7 +39,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
         private readonly IHostSingletonManager _singletonManager;
 
         public BlobListenerFactory(IHostIdProvider hostIdProvider,
-            QueuesOptions queueOptions,
             BlobsOptions blobsOptions,
             IWebJobsExceptionHandler exceptionHandler,
             IContextSetter<IBlobWrittenWatcher> blobWrittenWatcherSetter,
@@ -58,7 +56,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             IHostSingletonManager singletonManager)
         {
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
-            _queueOptions = queueOptions ?? throw new ArgumentNullException(nameof(queueOptions));
             _blobsOptions = blobsOptions ?? throw new ArgumentNullException(nameof(blobsOptions));
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _blobWrittenWatcherSetter = blobWrittenWatcherSetter ?? throw new ArgumentNullException(nameof(blobWrittenWatcherSetter));
@@ -106,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Listeners
             // notification queue and dispatch to the target job function.
             SharedBlobQueueListener sharedBlobQueueListener = _sharedContextProvider.GetOrCreateInstance<SharedBlobQueueListener>(
                 new SharedBlobQueueListenerFactory(_hostQueueServiceClient, sharedQueueWatcher, hostBlobTriggerQueue,
-                    _queueOptions, _exceptionHandler, _loggerFactory, sharedBlobListener.BlobWritterWatcher, _functionDescriptor));
+                    _blobsOptions, _exceptionHandler, _loggerFactory, sharedBlobListener.BlobWritterWatcher, _functionDescriptor));
             var queueListener = new BlobListener(sharedBlobQueueListener);
 
             // the client to use for the poison queue

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Triggers/BlobTriggerAttributeBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Triggers/BlobTriggerAttributeBindingProvider.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Triggers
         private readonly BlobServiceClientProvider _blobServiceClientProvider;
         private readonly QueueServiceClientProvider _queueServiceClientProvider;
         private readonly IHostIdProvider _hostIdProvider;
-        private readonly QueuesOptions _queueOptions;
         private readonly BlobsOptions _blobsOptions;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
         private readonly IContextSetter<IBlobWrittenWatcher> _blobWrittenWatcherSetter;
@@ -39,7 +38,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Triggers
             BlobServiceClientProvider blobServiceClientProvider,
             QueueServiceClientProvider queueServiceClientProvider,
             IHostIdProvider hostIdProvider,
-            IOptions<QueuesOptions> queueOptions,
             IOptions<BlobsOptions> blobsOptions,
             IWebJobsExceptionHandler exceptionHandler,
             IContextSetter<IBlobWrittenWatcher> blobWrittenWatcherSetter,
@@ -51,7 +49,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Triggers
             _blobServiceClientProvider = blobServiceClientProvider ?? throw new ArgumentNullException(nameof(blobServiceClientProvider));
             _queueServiceClientProvider = queueServiceClientProvider ?? throw new ArgumentNullException(nameof(queueServiceClientProvider));
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
-            _queueOptions = (queueOptions ?? throw new ArgumentNullException(nameof(queueOptions))).Value;
             _blobsOptions = (blobsOptions ?? throw new ArgumentNullException(nameof(blobsOptions))).Value;
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _blobWrittenWatcherSetter = blobWrittenWatcherSetter ?? throw new ArgumentNullException(nameof(blobWrittenWatcherSetter));
@@ -87,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Triggers
 
             ITriggerBinding binding = new BlobTriggerBinding(parameter, hostBlobServiceClient, hostQueueServiceClient,
                 dataBlobServiceClient, dataQueueServiceClient, path,
-                _hostIdProvider, _queueOptions, _blobsOptions, _exceptionHandler, _blobWrittenWatcherSetter,
+                _hostIdProvider, _blobsOptions, _exceptionHandler, _blobWrittenWatcherSetter,
                 _messageEnqueuedWatcherSetter, _sharedContextProvider, _singletonManager, _loggerFactory);
 
             return Task.FromResult(binding);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Triggers/BlobTriggerBinding.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Triggers/BlobTriggerBinding.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
 
             if (!conversionResult.Succeeded)
             {
-                throw new InvalidOperationException("Unable to convert trigger to IStorageBlob.");
+                throw new InvalidOperationException("Unable to convert trigger to BlobBaseClient.");
             }
 
             BlobBaseClient blobClient = conversionResult.Result;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Triggers/BlobTriggerBinding.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Triggers/BlobTriggerBinding.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
         private readonly string _accountName;
         private readonly IBlobPathSource _path;
         private readonly IHostIdProvider _hostIdProvider;
-        private readonly QueuesOptions _queueOptions;
         private readonly BlobsOptions _blobsOptions;
         private readonly IWebJobsExceptionHandler _exceptionHandler;
         private readonly IContextSetter<IBlobWrittenWatcher> _blobWrittenWatcherSetter;
@@ -53,7 +52,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             QueueServiceClient dataQueueServiceClient,
             IBlobPathSource path,
             IHostIdProvider hostIdProvider,
-            QueuesOptions queueOptions,
             BlobsOptions blobsOptions,
             IWebJobsExceptionHandler exceptionHandler,
             IContextSetter<IBlobWrittenWatcher> blobWrittenWatcherSetter,
@@ -71,7 +69,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
             _accountName = _dataBlobServiceClient.AccountName;
             _path = path ?? throw new ArgumentNullException(nameof(path));
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
-            _queueOptions = queueOptions ?? throw new ArgumentNullException(nameof(queueOptions));
             _blobsOptions = blobsOptions ?? throw new ArgumentNullException(nameof(blobsOptions));
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _blobWrittenWatcherSetter = blobWrittenWatcherSetter ?? throw new ArgumentNullException(nameof(blobWrittenWatcherSetter));
@@ -186,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Triggers
 
             var container = _dataBlobServiceClient.GetBlobContainerClient(_path.ContainerNamePattern);
 
-            var factory = new BlobListenerFactory(_hostIdProvider, _queueOptions, _blobsOptions, _exceptionHandler,
+            var factory = new BlobListenerFactory(_hostIdProvider, _blobsOptions, _exceptionHandler,
                 _blobWrittenWatcherSetter, _messageEnqueuedWatcherSetter, _sharedContextProvider, _loggerFactory,
                 context.Descriptor, _hostBlobServiceClient, _hostQueueServiceClient, _dataBlobServiceClient, _dataQueueServiceClient,
                 container, _path, context.Executor, _singletonManager);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/SharedBlobQueueListenerFactoryTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/SharedBlobQueueListenerFactoryTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.WebJobs.Host.Blobs.Listeners;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Host.UnitTests.Blobs.Listeners
+{
+    public class SharedBlobQueueListenerFactoryTests
+    {
+        [TestCase(100, 32, 68)]
+        [TestCase(64, 32, 32)]
+        [TestCase(63, 32, 31)]
+        [TestCase(62, 32, 30)]
+        [TestCase(16, 9, 7)]
+        [TestCase(3, 2, 1)]
+        [TestCase(2, 2, 0)]
+        [TestCase(1, 1, 0)]
+        public void ConvertsBlobOptionsToQueueOptionsCorrectly(int maxDegreeOfParallelism, int expectedBatchSize, int expectedNewBatchThreshold)
+        {
+            // Arrange
+            var blobOptions = new BlobsOptions()
+            {
+                MaxDegreeOfParallelism = maxDegreeOfParallelism,
+            };
+
+            // Act
+            var queueOptions = SharedBlobQueueListenerFactory.BlobsOptionsToQueuesOptions(blobOptions);
+
+            // Assert
+            Assert.AreEqual(expectedBatchSize, queueOptions.BatchSize);
+            Assert.AreEqual(expectedNewBatchThreshold, queueOptions.NewBatchThreshold);
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/StorageBlobsWebJobsBuilderExtensionsTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/StorageBlobsWebJobsBuilderExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.UnitTests.Queues
             string extensionPath = "AzureWebJobs:Extensions:Blobs";
             var values = new Dictionary<string, string>
             {
-                { $"{extensionPath}:CentralizedPoisonQueue", "true" },
+                { $"{extensionPath}:MaxDegreeOfParallelism", "2" },
             };
 
             BlobsOptions options = TestHelpers.GetConfiguredOptions<BlobsOptions>(b =>
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.UnitTests.Queues
                 b.AddAzureStorageBlobs();
             }, values);
 
-            Assert.True(options.CentralizedPoisonQueue);
+            Assert.AreEqual(2, options.MaxDegreeOfParallelism);
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Host
 
         // Azure Queues currently limits the number of messages retrieved to 32. We enforce this constraint here because
         // the runtime error message the user would receive from the SDK otherwise is not as helpful.
-        private const int MaxBatchSize = 32;
+        internal const int MaxBatchSize = 32;
 
         private int _batchSize = DefaultBatchSize;
         private int _newBatchThreshold;


### PR DESCRIPTION
In this PR:
- introduce MaxDegreeOfParallelism in BlobsOptions and translate that into QueueOptions used by QueueListener
- remove CentralizedPoisonQueue - that setting wasn't working before anyway and would be nice to not have it if we drop direct Queues SDK dependency in the future.