### PR TITLE
[Identity] Rename IncludeX5CClaimHeader to SendCertificateChain

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 1.3.0-beta.3 (Unreleased)
 
 ### Breaking Changes
+- Rename property `SendX5CClaimHeader` on `ClientCertificateCredentialOptions` to `SendCertificateChain`
 - Removing Application Authentication APIs for GA release. These will be reintroduced in 1.4.0-beta.1.
   - Removed class `AuthenticationRecord`
   - Removed class `AuthenticationRequiredException`

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 1.3.0-beta.3 (Unreleased)
 
 ### Breaking Changes
-- Rename property `SendX5CClaimHeader` on `ClientCertificateCredentialOptions` to `SendCertificateChain`
+- Rename property `IncludeX5CClaimHeader` on `ClientCertificateCredentialOptions` to `SendCertificateChain`
 - Removing Application Authentication APIs for GA release. These will be reintroduced in 1.4.0-beta.1.
   - Removed class `AuthenticationRecord`
   - Removed class `AuthenticationRequiredException`

--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -47,7 +47,7 @@ namespace Azure.Identity
     public partial class ClientCertificateCredentialOptions : Azure.Identity.TokenCredentialOptions
     {
         public ClientCertificateCredentialOptions() { }
-        public bool IncludeX5CClaimHeader { get { throw null; } set { } }
+        public bool SendCertificateChain { get { throw null; } set { } }
     }
     public partial class ClientSecretCredential : Azure.Core.TokenCredential
     {

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
@@ -133,7 +133,7 @@ namespace Azure.Identity
 
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
 
-            _client = client ?? new MsalConfidentialClient(_pipeline, tenantId, clientId, certificateProvider, (options as ClientCertificateCredentialOptions)?.IncludeX5CClaimHeader ?? false, options as ITokenCacheOptions);
+            _client = client ?? new MsalConfidentialClient(_pipeline, tenantId, clientId, certificateProvider, (options as ClientCertificateCredentialOptions)?.SendCertificateChain ?? false, options as ITokenCacheOptions);
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
@@ -22,7 +22,7 @@ namespace Azure.Identity
         /// <summary>
         /// Will include x5c header to enable subject name / issuer based authentication for the <see cref="ClientCertificateCredential"/>.
         /// </summary>
-        public bool IncludeX5CClaimHeader { get; set; }
+        public bool SendCertificateChain { get; set; }
 
         bool ITokenCacheOptions.EnablePersistentCache => EnablePersistentCache;
 

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredentialOptions.cs
@@ -20,7 +20,7 @@ namespace Azure.Identity
         internal bool AllowUnencryptedCache { get; set; }
 
         /// <summary>
-        /// Will include x5c header to enable subject name / issuer based authentication for the <see cref="ClientCertificateCredential"/>.
+        /// Will include x5c header in client claims when acquiring a token to enable subject name / issuer based authentication for the <see cref="ClientCertificateCredential"/>.
         /// </summary>
         public bool SendCertificateChain { get; set; }
 

--- a/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ClientCertificateCredentialLiveTests.cs
@@ -108,7 +108,7 @@ namespace Azure.Identity.Tests
             var clientId = TestEnvironment.ServicePrincipalClientId;
             var certPath = TestEnvironment.ServicePrincipalSniCertificatePath;
 
-            var options = InstrumentClientOptions(new ClientCertificateCredentialOptions { IncludeX5CClaimHeader = true });
+            var options = InstrumentClientOptions(new ClientCertificateCredentialOptions { SendCertificateChain = true });
 
             var credential = new ClientCertificateCredential(tenantId, clientId, certPath, options);
 


### PR DESCRIPTION
Based on architecture board feedback we are renaming  `IncludeX5CClaimHeader` to `SendCertificateChain` prior to the 1.3.0 GA release.