### PR TITLE
Update Options to hide traceparent and tracestate

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -26,63 +26,25 @@ namespace Azure.DigitalTwins.Core
         [System.Text.Json.Serialization.JsonPropertyNameAttribute("$targetId")]
         public string TargetId { get { throw null; } set { } }
     }
-    public partial class CreateModelsOptions
-    {
-        public CreateModelsOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
     public partial class CreateOrReplaceDigitalTwinOptions
     {
         public CreateOrReplaceDigitalTwinOptions() { }
         public string IfNoneMatch { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class CreateOrReplaceEventRouteOptions
-    {
-        public CreateOrReplaceEventRouteOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class CreateOrReplaceRelationshipOptions
     {
         public CreateOrReplaceRelationshipOptions() { }
         public string IfNoneMatch { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class DecomissionModelOptions
-    {
-        public DecomissionModelOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class DeleteDigitalTwinOptions
     {
         public DeleteDigitalTwinOptions() { }
         public string IfMatch { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class DeleteEventRouteOptions
-    {
-        public DeleteEventRouteOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class DeleteModelOptions
-    {
-        public DeleteModelOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class DeleteRelationshipOptions
     {
         public DeleteRelationshipOptions() { }
         public string IfMatch { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class DigitalTwinComponent
     {
@@ -103,48 +65,48 @@ namespace Azure.DigitalTwins.Core
         protected DigitalTwinsClient() { }
         public DigitalTwinsClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
         public DigitalTwinsClient(System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.DigitalTwins.Core.DigitalTwinsClientOptions options) { }
-        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]> CreateModels(System.Collections.Generic.IEnumerable<string> dtdlModels, Azure.DigitalTwins.Core.CreateModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]>> CreateModelsAsync(System.Collections.Generic.IEnumerable<string> dtdlModels, Azure.DigitalTwins.Core.CreateModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]> CreateModels(System.Collections.Generic.IEnumerable<string> dtdlModels, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData[]>> CreateModelsAsync(System.Collections.Generic.IEnumerable<string> dtdlModels, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<T>> CreateOrReplaceDigitalTwinAsync<T>(string digitalTwinId, T digitalTwin, Azure.DigitalTwins.Core.CreateOrReplaceDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<T> CreateOrReplaceDigitalTwin<T>(string digitalTwinId, T digitalTwin, Azure.DigitalTwins.Core.CreateOrReplaceDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response CreateOrReplaceEventRoute(string eventRouteId, Azure.DigitalTwins.Core.DigitalTwinsEventRoute eventRoute, Azure.DigitalTwins.Core.CreateOrReplaceEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response> CreateOrReplaceEventRouteAsync(string eventRouteId, Azure.DigitalTwins.Core.DigitalTwinsEventRoute eventRoute, Azure.DigitalTwins.Core.CreateOrReplaceEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response CreateOrReplaceEventRoute(string eventRouteId, Azure.DigitalTwins.Core.DigitalTwinsEventRoute eventRoute, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> CreateOrReplaceEventRouteAsync(string eventRouteId, Azure.DigitalTwins.Core.DigitalTwinsEventRoute eventRoute, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<T>> CreateOrReplaceRelationshipAsync<T>(string digitalTwinId, string relationshipId, T relationship, Azure.DigitalTwins.Core.CreateOrReplaceRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<T> CreateOrReplaceRelationship<T>(string digitalTwinId, string relationshipId, T relationship, Azure.DigitalTwins.Core.CreateOrReplaceRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response DecommissionModel(string modelId, Azure.DigitalTwins.Core.DecomissionModelOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response> DecommissionModelAsync(string modelId, Azure.DigitalTwins.Core.DecomissionModelOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response DecommissionModel(string modelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> DecommissionModelAsync(string modelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response DeleteDigitalTwin(string digitalTwinId, Azure.DigitalTwins.Core.DeleteDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> DeleteDigitalTwinAsync(string digitalTwinId, Azure.DigitalTwins.Core.DeleteDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response DeleteEventRoute(string eventRouteId, Azure.DigitalTwins.Core.DeleteEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response> DeleteEventRouteAsync(string eventRouteId, Azure.DigitalTwins.Core.DeleteEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response DeleteModel(string modelId, Azure.DigitalTwins.Core.DeleteModelOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response> DeleteModelAsync(string modelId, Azure.DigitalTwins.Core.DeleteModelOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response DeleteEventRoute(string eventRouteId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> DeleteEventRouteAsync(string eventRouteId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response DeleteModel(string modelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response> DeleteModelAsync(string modelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response DeleteRelationship(string digitalTwinId, string relationshipId, Azure.DigitalTwins.Core.DeleteRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> DeleteRelationshipAsync(string digitalTwinId, string relationshipId, Azure.DigitalTwins.Core.DeleteRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetComponentAsync<T>(string digitalTwinId, string componentName, Azure.DigitalTwins.Core.GetComponentOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<T> GetComponent<T>(string digitalTwinId, string componentName, Azure.DigitalTwins.Core.GetComponentOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetDigitalTwinAsync<T>(string digitalTwinId, Azure.DigitalTwins.Core.GetDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<T> GetDigitalTwin<T>(string digitalTwinId, Azure.DigitalTwins.Core.GetDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoute(string eventRouteId, Azure.DigitalTwins.Core.GetDigitalTwinsEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsEventRoute>> GetEventRouteAsync(string eventRouteId, Azure.DigitalTwins.Core.GetDigitalTwinsEventRouteOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetComponentAsync<T>(string digitalTwinId, string componentName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<T> GetComponent<T>(string digitalTwinId, string componentName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetDigitalTwinAsync<T>(string digitalTwinId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<T> GetDigitalTwin<T>(string digitalTwinId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoute(string eventRouteId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsEventRoute>> GetEventRouteAsync(string eventRouteId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoutes(Azure.DigitalTwins.Core.GetDigitalTwinsEventRoutesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoutesAsync(Azure.DigitalTwins.Core.GetDigitalTwinsEventRoutesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.DigitalTwins.Core.IncomingRelationship> GetIncomingRelationships(string digitalTwinId, Azure.DigitalTwins.Core.GetIncomingRelationshipsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.DigitalTwins.Core.IncomingRelationship> GetIncomingRelationshipsAsync(string digitalTwinId, Azure.DigitalTwins.Core.GetIncomingRelationshipsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData> GetModel(string modelId, Azure.DigitalTwins.Core.GetModelOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData>> GetModelAsync(string modelId, Azure.DigitalTwins.Core.GetModelOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.DigitalTwins.Core.IncomingRelationship> GetIncomingRelationships(string digitalTwinId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.DigitalTwins.Core.IncomingRelationship> GetIncomingRelationshipsAsync(string digitalTwinId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData> GetModel(string modelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData>> GetModelAsync(string modelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.DigitalTwins.Core.DigitalTwinsModelData> GetModels(Azure.DigitalTwins.Core.GetModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.DigitalTwins.Core.DigitalTwinsModelData> GetModelsAsync(Azure.DigitalTwins.Core.GetModelsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetRelationshipAsync<T>(string digitalTwinId, string relationshipId, Azure.DigitalTwins.Core.GetRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<string> GetRelationships(string digitalTwinId, string relationshipName = null, Azure.DigitalTwins.Core.GetRelationshipsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<string> GetRelationshipsAsync(string digitalTwinId, string relationshipName = null, Azure.DigitalTwins.Core.GetRelationshipsOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<T> GetRelationship<T>(string digitalTwinId, string relationshipId, Azure.DigitalTwins.Core.GetRelationshipOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<T>> GetRelationshipAsync<T>(string digitalTwinId, string relationshipId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<string> GetRelationships(string digitalTwinId, string relationshipName = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<string> GetRelationshipsAsync(string digitalTwinId, string relationshipName = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<T> GetRelationship<T>(string digitalTwinId, string relationshipId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response PublishComponentTelemetry(string digitalTwinId, string componentName, string messageId, string payload, Azure.DigitalTwins.Core.PublishComponentTelemetryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> PublishComponentTelemetryAsync(string digitalTwinId, string componentName, string messageId, string payload, Azure.DigitalTwins.Core.PublishComponentTelemetryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response PublishTelemetry(string digitalTwinId, string messageId, string payload, Azure.DigitalTwins.Core.PublishTelemetryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> PublishTelemetryAsync(string digitalTwinId, string messageId, string payload, Azure.DigitalTwins.Core.PublishTelemetryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<string> Query(string query, Azure.DigitalTwins.Core.QueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<string> QueryAsync(string query, Azure.DigitalTwins.Core.QueryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<string> Query(string query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<string> QueryAsync(string query, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response UpdateComponent(string digitalTwinId, string componentName, Azure.JsonPatchDocument jsonPatchDocument, Azure.DigitalTwins.Core.UpdateComponentOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response> UpdateComponentAsync(string digitalTwinId, string componentName, Azure.JsonPatchDocument jsonPatchDocument, Azure.DigitalTwins.Core.UpdateComponentOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response UpdateDigitalTwin(string digitalTwinId, Azure.JsonPatchDocument jsonPatchDocument, Azure.DigitalTwins.Core.UpdateDigitalTwinOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -190,62 +152,16 @@ namespace Azure.DigitalTwins.Core
         public string Id { get { throw null; } }
         public System.DateTimeOffset? UploadedOn { get { throw null; } }
     }
-    public partial class GetComponentOptions
-    {
-        public GetComponentOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class GetDigitalTwinOptions
-    {
-        public GetDigitalTwinOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class GetDigitalTwinsEventRouteOptions
-    {
-        public GetDigitalTwinsEventRouteOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
     public partial class GetDigitalTwinsEventRoutesOptions
     {
         public GetDigitalTwinsEventRoutesOptions() { }
         public int? MaxItemsPerPage { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class GetIncomingRelationshipsOptions
-    {
-        public GetIncomingRelationshipsOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class GetModelOptions
-    {
-        public GetModelOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class GetModelsOptions
     {
         public GetModelsOptions() { }
         public System.Collections.Generic.IEnumerable<string> DependenciesFor { get { throw null; } set { } }
         public bool IncludeModelDefinition { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class GetRelationshipOptions
-    {
-        public GetRelationshipOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
-    public partial class GetRelationshipsOptions
-    {
-        public GetRelationshipsOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class IncomingRelationship
     {
@@ -259,45 +175,29 @@ namespace Azure.DigitalTwins.Core
     {
         public PublishComponentTelemetryOptions() { }
         public System.DateTimeOffset TimeStamp { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class PublishTelemetryOptions
     {
         public PublishTelemetryOptions() { }
         public System.DateTimeOffset TimeStamp { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public static partial class QueryChargeHelper
     {
         public static bool TryGetQueryCharge(Azure.Page<string> page, out float queryCharge) { throw null; }
     }
-    public partial class QueryOptions
-    {
-        public QueryOptions() { }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
-    }
     public partial class UpdateComponentOptions
     {
         public UpdateComponentOptions() { }
         public string IfMatch { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class UpdateDigitalTwinOptions
     {
         public UpdateDigitalTwinOptions() { }
         public string IfMatch { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
     public partial class UpdateRelationshipOptions
     {
         public UpdateRelationshipOptions() { }
         public string IfMatch { get { throw null; } set { } }
-        public string TraceParent { get { throw null; } set { } }
-        public string TraceState { get { throw null; } set { } }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateModelsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateModelsOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateModelsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateModelsOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsAddOptions")]
-    public partial class CreateModelsOptions
+    internal partial class CreateModelsOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
@@ -23,7 +23,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -32,7 +31,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
@@ -9,15 +9,7 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsAddOptions")]
     public partial class CreateOrReplaceDigitalTwinOptions
     {
-        // This class declaration changes the namespace; do not remove.
-
-        /// <summary> Identifies the request in a distributed tracing system. </summary>
-        [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
-
-        /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
-        [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
 
         /// <summary>
         /// If-Non-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
@@ -28,5 +20,19 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         [CodeGenMember("IfNoneMatch")]
         public string IfNoneMatch { get; set; }
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
+
+        /// <summary> Identifies the request in a distributed tracing system. </summary>
+        [CodeGenMember("Traceparent")]
+        internal string TraceParent { get; set; }
+
+        /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
+        [CodeGenMember("Tracestate")]
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceEventRouteOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("EventRoutesAddOptions")]
-    public partial class CreateOrReplaceEventRouteOptions
+    internal partial class CreateOrReplaceEventRouteOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceEventRouteOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
@@ -9,15 +9,7 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsAddRelationshipOptions")]
     public partial class CreateOrReplaceRelationshipOptions
     {
-        // This class declaration changes the namespace; do not remove.
-
-        /// <summary> Identifies the request in a distributed tracing system. </summary>
-        [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
-
-        /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
-        [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
 
         /// <summary>
         /// If-Non-Match header that makes the request method conditional on a recipient cache or origin server either not having any current representation of the target resource.
@@ -28,5 +20,19 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         [CodeGenMember("IfNoneMatch")]
         public string IfNoneMatch { get; set; }
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
+
+        /// <summary> Identifies the request in a distributed tracing system. </summary>
+        [CodeGenMember("Traceparent")]
+        internal string TraceParent { get; set; }
+
+        /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
+        [CodeGenMember("Tracestate")]
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
@@ -23,7 +23,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -32,7 +31,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DecomissionModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DecomissionModelOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsUpdateOptions")]
-    public partial class DecomissionModelOptions
+    internal partial class DecomissionModelOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DecomissionModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DecomissionModelOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteDigitalTwinOptions.cs
@@ -9,14 +9,20 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsDeleteOptions")]
     public partial class DeleteDigitalTwinOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteDigitalTwinOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteEventRouteOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteEventRouteOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("EventRoutesDeleteOptions")]
-    public partial class DeleteEventRouteOptions
+    internal partial class DeleteEventRouteOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteModelOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsDeleteOptions")]
-    public partial class DeleteModelOptions
+    internal partial class DeleteModelOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteModelOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteRelationshipOptions.cs
@@ -9,14 +9,20 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsDeleteRelationshipOptions")]
     public partial class DeleteRelationshipOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteRelationshipOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetComponentOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetComponentOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinsGetComponentOptions")]
-    public partial class GetComponentOptions
+    internal partial class GetComponentOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetComponentOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetComponentOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinsGetByIdOptions")]
-    public partial class GetDigitalTwinOptions
+    internal partial class GetDigitalTwinOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRouteOptions.cs
@@ -7,19 +7,27 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("EventRoutesGetByIdOptions")]
-    public partial class GetDigitalTwinsEventRouteOptions
+    internal partial class GetDigitalTwinsEventRouteOptions
     {
-        // This class declaration changes the namespace and the class name; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState, MaxItemsPerPage) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
 
         // This is internal because users should not set page size here. It should be set on the pageable instances's .AsPages() method.
         internal int? MaxItemsPerPage { get; set; }
+
+        #endregion internalProperties
+
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRouteOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState, MaxItemsPerPage) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -26,8 +25,5 @@ namespace Azure.DigitalTwins.Core
 
         // This is internal because users should not set page size here. It should be set on the pageable instances's .AsPages() method.
         internal int? MaxItemsPerPage { get; set; }
-
-        #endregion internalProperties
-
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
@@ -9,14 +9,20 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("EventRoutesListOptions")]
     public partial class GetDigitalTwinsEventRoutesOptions
     {
-        // This class declaration changes the namespace and the class name; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetIncomingRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetIncomingRelationshipsOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinsListIncomingRelationshipsOptions")]
-    public partial class GetIncomingRelationshipsOptions
+    internal partial class GetIncomingRelationshipsOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetIncomingRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetIncomingRelationshipsOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsGetByIdOptions")]
-    public partial class GetModelOptions
+    internal partial class GetModelOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelsOptions.cs
@@ -27,7 +27,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState, MaxItemsPerPage) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -39,6 +38,5 @@ namespace Azure.DigitalTwins.Core
 
         // This is internal because users should not set page size here. It should be set on the pageable instances's .AsPages() method.
         internal int? MaxItemsPerPage { get; set; }
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelsOptions.cs
@@ -25,15 +25,20 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         public bool IncludeModelDefinition { get; set; } = false;
 
+        // This class contains two properties (TraceParent ,TraceState, MaxItemsPerPage) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
+
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
 
         // This is internal because users should not set page size here. It should be set on the pageable instances's .AsPages() method.
         internal int? MaxItemsPerPage { get; set; }
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinsGetRelationshipByIdOptions")]
-    public partial class GetRelationshipOptions
+    internal partial class GetRelationshipOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipsOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipsOptions.cs
@@ -7,16 +7,22 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("DigitalTwinsListRelationshipsOptions")]
-    public partial class GetRelationshipsOptions
+    internal partial class GetRelationshipsOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishComponentTelemetryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishComponentTelemetryOptions.cs
@@ -17,12 +17,18 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         public DateTimeOffset TimeStamp { get; set; } = DateTimeOffset.UtcNow;
 
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
+
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishComponentTelemetryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishComponentTelemetryOptions.cs
@@ -19,7 +19,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -28,7 +27,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishTelemetryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishTelemetryOptions.cs
@@ -17,12 +17,18 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         public DateTimeOffset TimeStamp { get; set; } = DateTimeOffset.UtcNow;
 
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
+
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishTelemetryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishTelemetryOptions.cs
@@ -19,7 +19,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -28,7 +27,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/QueryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/QueryOptions.cs
@@ -7,19 +7,25 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("QueryTwinsOptions")]
-    public partial class QueryOptions
+    internal partial class QueryOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState, MaxItemsPerPage) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
 
         // This is internal because users should not set page size here. It should be set on the pageable instances's .AsPages() method.
         internal int? MaxItemsPerPage { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/QueryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/QueryOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState, MaxItemsPerPage) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -25,7 +24,5 @@ namespace Azure.DigitalTwins.Core
 
         // This is internal because users should not set page size here. It should be set on the pageable instances's .AsPages() method.
         internal int? MaxItemsPerPage { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateComponentOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateComponentOptions.cs
@@ -11,7 +11,6 @@ namespace Azure.DigitalTwins.Core
     {
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -20,7 +19,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateComponentOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateComponentOptions.cs
@@ -9,14 +9,18 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsUpdateComponentOptions")]
     public partial class UpdateComponentOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateDigitalTwinOptions.cs
@@ -9,14 +9,20 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsUpdateOptions")]
     public partial class UpdateDigitalTwinOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateDigitalTwinOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateRelationshipOptions.cs
@@ -9,14 +9,20 @@ namespace Azure.DigitalTwins.Core
     [CodeGenModel("DigitalTwinsUpdateRelationshipOptions")]
     public partial class UpdateRelationshipOptions
     {
-        // This class declaration changes the namespace; do not remove.
+        // This class declaration changes the namespace, class name and property visibility; do not remove.
+
+        // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
+        // Marking these properties as internal.
+        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
-        public string TraceParent { get; set; }
+        internal string TraceParent { get; set; }
 
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
-        public string TraceState { get; set; }
+        internal string TraceState { get; set; }
+
+        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateRelationshipOptions.cs
@@ -13,7 +13,6 @@ namespace Azure.DigitalTwins.Core
 
         // This class contains two properties (TraceParent ,TraceState) that are not intended to be used by the Track 2 SDKs.
         // Marking these properties as internal.
-        #region internalProperties
 
         /// <summary> Identifies the request in a distributed tracing system. </summary>
         [CodeGenMember("Traceparent")]
@@ -22,7 +21,5 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
-
-        #endregion internalProperties
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -119,7 +119,6 @@ namespace Azure.DigitalTwins.Core
         /// </para>
         /// </remarks>
         /// <param name="digitalTwinId">The Id of the digital twin.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized application/json digital twin and the http response <see cref="Response{T}"/>.</returns>
         /// <typeparam name="T">The type to deserialize the digital twin to.</typeparam>
@@ -143,10 +142,10 @@ namespace Azure.DigitalTwins.Core
         ///     $&quot;ComponentProp2: {customDt.Component1.ComponentProp2}&quot;);
         /// </code>
         /// </example>
-        public virtual async Task<Response<T>> GetDigitalTwinAsync<T>(string digitalTwinId, GetDigitalTwinOptions options = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<T>> GetDigitalTwinAsync<T>(string digitalTwinId, CancellationToken cancellationToken = default)
         {
             // Get the digital twin as a stream object
-            Response<Stream> digitalTwinStream = await _dtRestClient.GetByIdAsync(digitalTwinId, options, cancellationToken).ConfigureAwait(false);
+            Response<Stream> digitalTwinStream = await _dtRestClient.GetByIdAsync(digitalTwinId, null, cancellationToken).ConfigureAwait(false);
 
             // Deserialize the stream into the specified type
             T deserializedDigitalTwin = (T)await _objectSerializer.DeserializeAsync(digitalTwinStream, typeof(T), cancellationToken).ConfigureAwait(false);
@@ -170,7 +169,6 @@ namespace Azure.DigitalTwins.Core
         /// </remarks>
         /// <param name="digitalTwinId">The Id of the digital twin.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <returns>The deserialized application/json digital twin and the http response <see cref="Response{T}"/>.</returns>
         /// <typeparam name="T">The type to deserialize the digital twin to.</typeparam>
         /// <exception cref="RequestFailedException">
@@ -179,10 +177,10 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="digitalTwinId"/> is <c>null</c>.
         /// </exception>
-        public virtual Response<T> GetDigitalTwin<T>(string digitalTwinId, GetDigitalTwinOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response<T> GetDigitalTwin<T>(string digitalTwinId, CancellationToken cancellationToken = default)
         {
             // Get the digital twin as a stream object
-            Response<Stream> digitalTwinStream = _dtRestClient.GetById(digitalTwinId, options, cancellationToken);
+            Response<Stream> digitalTwinStream = _dtRestClient.GetById(digitalTwinId, null, cancellationToken);
 
             // Deserialize the stream into the specified type
             T deserializedDigitalTwin = (T)_objectSerializer.Deserialize(digitalTwinStream, typeof(T), cancellationToken);
@@ -392,7 +390,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="digitalTwinId">The Id of the digital twin.</param>
         /// <param name="componentName">The component being retrieved.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized object representation of the component corresponding to the provided componentName and the HTTP response <see cref="Response{T}"/>.</returns>
         /// <typeparam name="T">The type to deserialize the component to.</typeparam>
@@ -411,10 +408,10 @@ namespace Azure.DigitalTwins.Core
         /// Console.WriteLine($&quot;Retrieved component for digital twin &apos;{basicDtId}&apos;.&quot;);
         /// </code>
         /// </example>
-        public virtual async Task<Response<T>> GetComponentAsync<T>(string digitalTwinId, string componentName, GetComponentOptions options = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<T>> GetComponentAsync<T>(string digitalTwinId, string componentName, CancellationToken cancellationToken = default)
         {
             // Get the component as a stream object
-            Response<Stream> componentStream = await _dtRestClient.GetComponentAsync(digitalTwinId, componentName, options, cancellationToken).ConfigureAwait(false);
+            Response<Stream> componentStream = await _dtRestClient.GetComponentAsync(digitalTwinId, componentName, null, cancellationToken).ConfigureAwait(false);
 
             // Deserialize the stream into the specified type
             T deserializedComponent = (T)await _objectSerializer.DeserializeAsync(componentStream, typeof(T), cancellationToken).ConfigureAwait(false);
@@ -427,7 +424,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="digitalTwinId">The Id of the digital twin.</param>
         /// <param name="componentName">The component being retrieved.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized object representation of the component corresponding to the provided componentName and the HTTP response <see cref="Response{T}"/>.</returns>
         /// <typeparam name="T">The type to deserialize the component to.</typeparam>
@@ -440,13 +436,13 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="componentName"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="GetComponentAsync(string, string, GetComponentOptions, CancellationToken)">
+        /// <seealso cref="GetComponentAsync(string, string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response<T> GetComponent<T>(string digitalTwinId, string componentName, GetComponentOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response<T> GetComponent<T>(string digitalTwinId, string componentName, CancellationToken cancellationToken = default)
         {
             // Get the component as a stream object
-            Response<Stream> componentStream = _dtRestClient.GetComponent(digitalTwinId, componentName, options, cancellationToken);
+            Response<Stream> componentStream = _dtRestClient.GetComponent(digitalTwinId, componentName, null, cancellationToken);
 
             // Deserialize the stream into the specified type
             T deserializedComponent = (T)_objectSerializer.Deserialize(componentStream, typeof(T), cancellationToken);
@@ -520,7 +516,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="digitalTwinId">The Id of the source digital twin.</param>
         /// <param name="relationshipName">The name of a relationship to filter to. If null, all relationships for the digital twin will be returned.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="AsyncPageable{T}"/> of application/json relationships belonging to the specified digital twin and the http response.</returns>
         /// <remarks>
@@ -552,7 +547,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// </code>
         /// </example>
-        public virtual AsyncPageable<string> GetRelationshipsAsync(string digitalTwinId, string relationshipName = null, GetRelationshipsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<string> GetRelationshipsAsync(string digitalTwinId, string relationshipName = null, CancellationToken cancellationToken = default)
         {
             if (digitalTwinId == null)
             {
@@ -565,7 +560,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<RelationshipCollection> response = await _dtRestClient.ListRelationshipsAsync(digitalTwinId, relationshipName, options, cancellationToken).ConfigureAwait(false);
+                    Response<RelationshipCollection> response = await _dtRestClient.ListRelationshipsAsync(digitalTwinId, relationshipName, null, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception ex)
@@ -581,7 +576,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<RelationshipCollection> response = await _dtRestClient.ListRelationshipsNextPageAsync(nextLink, digitalTwinId, relationshipName, options, cancellationToken).ConfigureAwait(false);
+                    Response<RelationshipCollection> response = await _dtRestClient.ListRelationshipsNextPageAsync(nextLink, digitalTwinId, relationshipName, null, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception ex)
@@ -599,7 +594,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="digitalTwinId">The Id of the source digital twin.</param>
         /// <param name="relationshipName">The name of a relationship to filter to. If null, all relationships for the digital twin will be returned.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="Pageable{T}"/> of application/json relationships belonging to the specified digital twin and the http response.</returns>
         /// <remarks>
@@ -611,10 +605,10 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="digitalTwinId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="GetRelationshipsAsync(string, string, GetRelationshipsOptions, CancellationToken)">
+        /// <seealso cref="GetRelationshipsAsync(string, string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Pageable<string> GetRelationships(string digitalTwinId, string relationshipName = null, GetRelationshipsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Pageable<string> GetRelationships(string digitalTwinId, string relationshipName = null, CancellationToken cancellationToken = default)
         {
             if (digitalTwinId == null)
             {
@@ -627,7 +621,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<RelationshipCollection> response = _dtRestClient.ListRelationships(digitalTwinId, relationshipName, options, cancellationToken);
+                    Response<RelationshipCollection> response = _dtRestClient.ListRelationships(digitalTwinId, relationshipName, null, cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception ex)
@@ -643,7 +637,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<RelationshipCollection> response = _dtRestClient.ListRelationshipsNextPage(nextLink, digitalTwinId, relationshipName, options, cancellationToken);
+                    Response<RelationshipCollection> response = _dtRestClient.ListRelationshipsNextPage(nextLink, digitalTwinId, relationshipName, null, cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception ex)
@@ -660,7 +654,6 @@ namespace Azure.DigitalTwins.Core
         /// Gets all the relationships referencing a digital twin as a target by iterating through a collection asynchronously.
         /// </summary>
         /// <param name="digitalTwinId">The Id of the target digital twin.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="AsyncPageable{T}"/> of application/json relationships directed towards the specified digital twin and the http response.</returns>
         /// <remarks>
@@ -682,7 +675,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// </code>
         /// </example>
-        public virtual AsyncPageable<IncomingRelationship> GetIncomingRelationshipsAsync(string digitalTwinId, GetIncomingRelationshipsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<IncomingRelationship> GetIncomingRelationshipsAsync(string digitalTwinId, CancellationToken cancellationToken = default)
         {
             async Task<Page<IncomingRelationship>> FirstPageFunc(int? pageSizeHint)
             {
@@ -690,7 +683,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<IncomingRelationshipCollection> response = await _dtRestClient.ListIncomingRelationshipsAsync(digitalTwinId, options, cancellationToken).ConfigureAwait(false);
+                    Response<IncomingRelationshipCollection> response = await _dtRestClient.ListIncomingRelationshipsAsync(digitalTwinId, null, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception ex)
@@ -706,7 +699,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<IncomingRelationshipCollection> response = await _dtRestClient.ListIncomingRelationshipsNextPageAsync(nextLink, digitalTwinId, options, cancellationToken).ConfigureAwait(false);
+                    Response<IncomingRelationshipCollection> response = await _dtRestClient.ListIncomingRelationshipsNextPageAsync(nextLink, digitalTwinId, null, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception ex)
@@ -723,7 +716,6 @@ namespace Azure.DigitalTwins.Core
         /// Gets all the relationships referencing a digital twin as a target by iterating through a collection synchronously.
         /// </summary>
         /// <param name="digitalTwinId">The Id of the target digital twin.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="Pageable{T}"/> of application/json relationships directed towards the specified digital twin and the http response.</returns>
         /// <remarks>
@@ -735,10 +727,10 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="digitalTwinId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="GetIncomingRelationshipsAsync(string, GetIncomingRelationshipsOptions, CancellationToken)">
+        /// <seealso cref="GetIncomingRelationshipsAsync(string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Pageable<IncomingRelationship> GetIncomingRelationships(string digitalTwinId, GetIncomingRelationshipsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Pageable<IncomingRelationship> GetIncomingRelationships(string digitalTwinId, CancellationToken cancellationToken = default)
         {
             Page<IncomingRelationship> FirstPageFunc(int? pageSizeHint)
             {
@@ -746,7 +738,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<IncomingRelationshipCollection> response = _dtRestClient.ListIncomingRelationships(digitalTwinId, options, cancellationToken);
+                    Response<IncomingRelationshipCollection> response = _dtRestClient.ListIncomingRelationships(digitalTwinId, null, cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)
@@ -762,7 +754,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    Response<IncomingRelationshipCollection> response = _dtRestClient.ListIncomingRelationshipsNextPage(nextLink, digitalTwinId, options, cancellationToken);
+                    Response<IncomingRelationshipCollection> response = _dtRestClient.ListIncomingRelationshipsNextPage(nextLink, digitalTwinId, null, cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.NextLink, response.GetRawResponse());
                 }
                 catch (Exception e)
@@ -780,7 +772,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="digitalTwinId">The Id of the source digital twin.</param>
         /// <param name="relationshipId">The Id of the relationship to retrieve.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized application/json relationship corresponding to the provided relationshipId and the http response <see cref="Response{T}"/>.</returns>
         /// <typeparam name="T">The type to deserialize the relationship to.</typeparam>
@@ -810,11 +801,10 @@ namespace Azure.DigitalTwins.Core
         public virtual async Task<Response<T>> GetRelationshipAsync<T>(
             string digitalTwinId,
             string relationshipId,
-            GetRelationshipOptions options = null,
             CancellationToken cancellationToken = default)
         {
             // Get the relationship as a stream object
-            Response<Stream> relationshipStream = await _dtRestClient.GetRelationshipByIdAsync(digitalTwinId, relationshipId, options, cancellationToken).ConfigureAwait(false);
+            Response<Stream> relationshipStream = await _dtRestClient.GetRelationshipByIdAsync(digitalTwinId, relationshipId, null, cancellationToken).ConfigureAwait(false);
 
             // Deserialize the stream into the specified type
             T deserializedRelationship = (T)await _objectSerializer.DeserializeAsync(relationshipStream, typeof(T), cancellationToken).ConfigureAwait(false);
@@ -827,7 +817,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="digitalTwinId">The Id of the source digital twin.</param>
         /// <param name="relationshipId">The Id of the relationship to retrieve.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The deserialized application/json relationship corresponding to the provided relationshipId and the http response <see cref="Response{T}"/>.</returns>
         /// <typeparam name="T">The type to deserialize the relationship to.</typeparam>
@@ -840,17 +829,16 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="digitalTwinId"/> or <paramref name="relationshipId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="GetRelationshipAsync(string, string, GetRelationshipOptions, CancellationToken)">
+        /// <seealso cref="GetRelationshipAsync(string, string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
         public virtual Response<T> GetRelationship<T>(
             string digitalTwinId,
             string relationshipId,
-            GetRelationshipOptions options = null,
             CancellationToken cancellationToken = default)
         {
             // Get the relationship as a stream object
-            Response<Stream> relationshipStream = _dtRestClient.GetRelationshipById(digitalTwinId, relationshipId, options, cancellationToken);
+            Response<Stream> relationshipStream = _dtRestClient.GetRelationshipById(digitalTwinId, relationshipId, null, cancellationToken);
 
             // Deserialize the stream into the specified type
             T deserializedRelationship = (T)_objectSerializer.Deserialize(relationshipStream, typeof(T), cancellationToken);
@@ -1197,7 +1185,6 @@ namespace Azure.DigitalTwins.Core
         /// Gets a model, including the model metadata and the model definition asynchronously.
         /// </summary>
         /// <param name="modelId">The Id of the model.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The application/json model and the http response <see cref="Response{T}"/>.</returns>
         /// <remarks>
@@ -1215,17 +1202,16 @@ namespace Azure.DigitalTwins.Core
         /// Console.WriteLine($&quot;Retrieved model &apos;{sampleModelResponse.Value.Id}&apos;.&quot;);
         /// </code>
         /// </example>
-        public virtual Task<Response<DigitalTwinsModelData>> GetModelAsync(string modelId, GetModelOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Task<Response<DigitalTwinsModelData>> GetModelAsync(string modelId, CancellationToken cancellationToken = default)
         {
             // The GetModel API will include the model definition in its response by default.
-            return _dtModelsRestClient.GetByIdAsync(modelId, IncludeModelDefinition, options, cancellationToken);
+            return _dtModelsRestClient.GetByIdAsync(modelId, IncludeModelDefinition, null, cancellationToken);
         }
 
         /// <summary>
         /// Gets a model, including the model metadata and the model definition synchronously.
         /// </summary>
         /// <param name="modelId">The Id of the model.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The application/json model and the http response <see cref="Response{T}"/>.</returns>
         /// <remarks>
@@ -1237,20 +1223,19 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="modelId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="GetModelAsync(string, GetModelOptions, CancellationToken)">
+        /// <seealso cref="GetModelAsync(string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response<DigitalTwinsModelData> GetModel(string modelId, GetModelOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response<DigitalTwinsModelData> GetModel(string modelId, CancellationToken cancellationToken = default)
         {
             // The GetModel API will include the model definition in its response by default.
-            return _dtModelsRestClient.GetById(modelId, IncludeModelDefinition, options, cancellationToken);
+            return _dtModelsRestClient.GetById(modelId, IncludeModelDefinition, null, cancellationToken);
         }
 
         /// <summary>
         /// Decommissions a model asynchronously.
         /// </summary>
         /// <param name="modelId">The Id of the model to decommission.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1282,16 +1267,15 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// </code>
         /// </example>
-        public virtual Task<Response> DecommissionModelAsync(string modelId, DecomissionModelOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Task<Response> DecommissionModelAsync(string modelId, CancellationToken cancellationToken = default)
         {
-            return _dtModelsRestClient.UpdateAsync(modelId, ModelsConstants.DecommissionModelOperationList, options, cancellationToken);
+            return _dtModelsRestClient.UpdateAsync(modelId, ModelsConstants.DecommissionModelOperationList, null, cancellationToken);
         }
 
         /// <summary>
         /// Decommissions a model synchronously.
         /// </summary>
         /// <param name="modelId">The Id of the model to decommission.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1310,19 +1294,18 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="modelId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="DecommissionModelAsync(string, DecomissionModelOptions, CancellationToken)">
+        /// <seealso cref="DecommissionModelAsync(string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response DecommissionModel(string modelId, DecomissionModelOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response DecommissionModel(string modelId, CancellationToken cancellationToken = default)
         {
-            return _dtModelsRestClient.Update(modelId, ModelsConstants.DecommissionModelOperationList, options, cancellationToken);
+            return _dtModelsRestClient.Update(modelId, ModelsConstants.DecommissionModelOperationList, null, cancellationToken);
         }
 
         /// <summary>
         /// Creates one or many models asynchronously.
         /// </summary>
         /// <param name="dtdlModels">The set of models conforming to Digital Twins Definition Language (DTDL) v2 to create. Each string corresponds to exactly one model.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The created models and the http response <see cref="Response{T}"/>.</returns>
         /// <exception cref="RequestFailedException">
@@ -1346,9 +1329,9 @@ namespace Azure.DigitalTwins.Core
         /// Console.WriteLine($&quot;Created models &apos;{componentModelId}&apos; and &apos;{sampleModelId}&apos;.&quot;);
         /// </code>
         /// </example>
-        public virtual async Task<Response<DigitalTwinsModelData[]>> CreateModelsAsync(IEnumerable<string> dtdlModels, CreateModelsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual async Task<Response<DigitalTwinsModelData[]>> CreateModelsAsync(IEnumerable<string> dtdlModels, CancellationToken cancellationToken = default)
         {
-            Response<IReadOnlyList<DigitalTwinsModelData>> response = await _dtModelsRestClient.AddAsync(dtdlModels, options, cancellationToken).ConfigureAwait(false);
+            Response<IReadOnlyList<DigitalTwinsModelData>> response = await _dtModelsRestClient.AddAsync(dtdlModels, null, cancellationToken).ConfigureAwait(false);
             return Response.FromValue(response.Value.ToArray(), response.GetRawResponse());
         }
 
@@ -1356,7 +1339,6 @@ namespace Azure.DigitalTwins.Core
         /// Creates one or many models synchronously.
         /// </summary>
         /// <param name="dtdlModels">The set of models conforming to Digital Twins Definition Language (DTDL) v2 to create. Each string corresponds to exactly one model.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The created models and the http response <see cref="Response{T}"/>.</returns>
         /// <remarks>
@@ -1374,12 +1356,12 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="RequestFailedException">
         /// The exception that captures the errors from the service. Check the <see cref="RequestFailedException.ErrorCode"/> and <see cref="RequestFailedException.Status"/> properties for more details.
         /// </exception>
-        /// <seealso cref="CreateModelsAsync(IEnumerable{string}, CreateModelsOptions, CancellationToken)">
+        /// <seealso cref="CreateModelsAsync(IEnumerable{string}, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response<DigitalTwinsModelData[]> CreateModels(IEnumerable<string> dtdlModels, CreateModelsOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response<DigitalTwinsModelData[]> CreateModels(IEnumerable<string> dtdlModels, CancellationToken cancellationToken = default)
         {
-            Response<IReadOnlyList<DigitalTwinsModelData>> response = _dtModelsRestClient.Add(dtdlModels, options, cancellationToken);
+            Response<IReadOnlyList<DigitalTwinsModelData>> response = _dtModelsRestClient.Add(dtdlModels, null, cancellationToken);
             return Response.FromValue(response.Value.ToArray(), response.GetRawResponse());
         }
 
@@ -1387,7 +1369,6 @@ namespace Azure.DigitalTwins.Core
         /// Deletes a model asynchronously.
         /// </summary>
         /// <param name="modelId"> The id for the model. The id is globally unique and case sensitive. </param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1422,16 +1403,15 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// </code>
         /// </example>
-        public virtual Task<Response> DeleteModelAsync(string modelId, DeleteModelOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Task<Response> DeleteModelAsync(string modelId, CancellationToken cancellationToken = default)
         {
-            return _dtModelsRestClient.DeleteAsync(modelId, options, cancellationToken);
+            return _dtModelsRestClient.DeleteAsync(modelId, null, cancellationToken);
         }
 
         /// <summary>
         /// Deletes a model synchronously.
         /// </summary>
         /// <param name="modelId"> The id for the model. The id is globally unique and case sensitive. </param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1453,19 +1433,18 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="modelId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="DeleteModelAsync(string, DeleteModelOptions, CancellationToken)">
+        /// <seealso cref="DeleteModelAsync(string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response DeleteModel(string modelId, DeleteModelOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response DeleteModel(string modelId, CancellationToken cancellationToken = default)
         {
-            return _dtModelsRestClient.Delete(modelId, options, cancellationToken);
+            return _dtModelsRestClient.Delete(modelId, null, cancellationToken);
         }
 
         /// <summary>
         /// Queries for digital twins by iterating through a collection asynchronously.
         /// </summary>
         /// <param name="query">The query string, in SQL-like syntax.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="AsyncPageable{T}"/> of query results.</returns>
         /// <remarks>
@@ -1493,7 +1472,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// </code>
         /// </example>
-        public virtual AsyncPageable<string> QueryAsync(string query, QueryOptions options = null, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<string> QueryAsync(string query, CancellationToken cancellationToken = default)
         {
             // Note: pageSizeHint is not supported as a parameter in the service for query API, so ignoring it.
             // Cannot remove the parameter as the function signature in Azure.Core helper needs it.
@@ -1508,13 +1487,11 @@ namespace Azure.DigitalTwins.Core
                         Query = query
                     };
 
-                    if (options == null)
-                    {
-                        options = new QueryOptions();
-                    }
-
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    options.MaxItemsPerPage = pageSizeHint;
+                    QueryOptions options = new QueryOptions
+                    {
+                        MaxItemsPerPage = pageSizeHint
+                    };
 
                     Response<QueryResult> response = await _queryClient.QueryTwinsAsync(querySpecification, options, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
@@ -1537,13 +1514,11 @@ namespace Azure.DigitalTwins.Core
                         ContinuationToken = nextLink
                     };
 
-                    if (options == null)
-                    {
-                        options = new QueryOptions();
-                    }
-
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    options.MaxItemsPerPage = pageSizeHint;
+                    QueryOptions options = new QueryOptions
+                    {
+                        MaxItemsPerPage = pageSizeHint
+                    };
 
                     Response<QueryResult> response = await _queryClient.QueryTwinsAsync(querySpecification, options, cancellationToken).ConfigureAwait(false);
                     return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
@@ -1562,7 +1537,6 @@ namespace Azure.DigitalTwins.Core
         /// Queries for digital twins by iterating through a collection synchronously.
         /// </summary>
         /// <param name="query">The query string, in SQL-like syntax.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="Pageable{T}"/> of query results.</returns>
         /// <remarks>
@@ -1577,10 +1551,10 @@ namespace Azure.DigitalTwins.Core
         /// <example>
         /// A basic query for all digital twins: SELECT * FROM digitalTwins.
         /// </example>
-        /// <seealso cref="QueryAsync(string, QueryOptions, CancellationToken)">
+        /// <seealso cref="QueryAsync(string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Pageable<string> Query(string query, QueryOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Pageable<string> Query(string query, CancellationToken cancellationToken = default)
         {
             // Note: pageSizeHint is not supported as a parameter in the service for query API, so ignoring it.
             // Cannot remove the parameter as the function signature in Azure.Core helper needs it.
@@ -1595,13 +1569,11 @@ namespace Azure.DigitalTwins.Core
                         Query = query
                     };
 
-                    if (options == null)
-                    {
-                        options = new QueryOptions();
-                    }
-
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    options.MaxItemsPerPage = pageSizeHint;
+                    QueryOptions options = new QueryOptions
+                    {
+                        MaxItemsPerPage = pageSizeHint
+                    };
 
                     Response<QueryResult> response = _queryClient.QueryTwins(querySpecification, options, cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
@@ -1624,13 +1596,11 @@ namespace Azure.DigitalTwins.Core
                         ContinuationToken = nextLink
                     };
 
-                    if (options == null)
-                    {
-                        options = new QueryOptions();
-                    }
-
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    options.MaxItemsPerPage = pageSizeHint;
+                    QueryOptions options = new QueryOptions
+                    {
+                        MaxItemsPerPage = pageSizeHint
+                    };
 
                     Response<QueryResult> response = _queryClient.QueryTwins(querySpecification, options, cancellationToken);
                     return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
@@ -1792,7 +1762,6 @@ namespace Azure.DigitalTwins.Core
         /// Gets an event route by Id asynchronously.
         /// </summary>
         /// <param name="eventRouteId">The Id of the event route.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The application/json event routes and the http response <see cref="Response{T}"/>.</returns>
         /// <remarks>
@@ -1804,16 +1773,15 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="eventRouteId"/> is <c>null</c>.
         /// </exception>
-        public virtual Task<Response<DigitalTwinsEventRoute>> GetEventRouteAsync(string eventRouteId, GetDigitalTwinsEventRouteOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Task<Response<DigitalTwinsEventRoute>> GetEventRouteAsync(string eventRouteId, CancellationToken cancellationToken = default)
         {
-            return _eventRoutesRestClient.GetByIdAsync(eventRouteId, options, cancellationToken);
+            return _eventRoutesRestClient.GetByIdAsync(eventRouteId, null, cancellationToken);
         }
 
         /// <summary>
         /// Gets an event route by Id synchronously.
         /// </summary>
         /// <param name="eventRouteId">The Id of the event route.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The application/json event routes and the http response <see cref="Response{T}"/>.</returns>
         /// <remarks>
@@ -1825,12 +1793,12 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="eventRouteId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="GetEventRouteAsync(string, GetDigitalTwinsEventRouteOptions, CancellationToken)">
+        /// <seealso cref="GetEventRouteAsync(string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response<DigitalTwinsEventRoute> GetEventRoute(string eventRouteId, GetDigitalTwinsEventRouteOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response<DigitalTwinsEventRoute> GetEventRoute(string eventRouteId, CancellationToken cancellationToken = default)
         {
-            return _eventRoutesRestClient.GetById(eventRouteId, options, cancellationToken);
+            return _eventRoutesRestClient.GetById(eventRouteId, null, cancellationToken);
         }
 
         /// <summary>
@@ -1839,7 +1807,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="eventRouteId">The Id of the event route to create.</param>
         /// <param name="eventRoute">The event route data containing the endpoint and optional filter.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1860,9 +1827,9 @@ namespace Azure.DigitalTwins.Core
         /// Console.WriteLine($&quot;Created event route &apos;{_eventRouteId}&apos;.&quot;);
         /// </code>
         /// </example>
-        public virtual Task<Response> CreateOrReplaceEventRouteAsync(string eventRouteId, DigitalTwinsEventRoute eventRoute, CreateOrReplaceEventRouteOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Task<Response> CreateOrReplaceEventRouteAsync(string eventRouteId, DigitalTwinsEventRoute eventRoute, CancellationToken cancellationToken = default)
         {
-            return _eventRoutesRestClient.AddAsync(eventRouteId, eventRoute, options, cancellationToken);
+            return _eventRoutesRestClient.AddAsync(eventRouteId, eventRoute, null, cancellationToken);
         }
 
         /// <summary>
@@ -1871,7 +1838,6 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="eventRouteId">The Id of the event route to create.</param>
         /// <param name="eventRoute">The event route data containing the endpoint and optional filter.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1883,19 +1849,18 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="eventRouteId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="CreateOrReplaceEventRouteAsync(string, DigitalTwinsEventRoute, CreateOrReplaceEventRouteOptions, CancellationToken)">
+        /// <seealso cref="CreateOrReplaceEventRouteAsync(string, DigitalTwinsEventRoute, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response CreateOrReplaceEventRoute(string eventRouteId, DigitalTwinsEventRoute eventRoute, CreateOrReplaceEventRouteOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response CreateOrReplaceEventRoute(string eventRouteId, DigitalTwinsEventRoute eventRoute, CancellationToken cancellationToken = default)
         {
-            return _eventRoutesRestClient.Add(eventRouteId, eventRoute, options, cancellationToken);
+            return _eventRoutesRestClient.Add(eventRouteId, eventRoute, null, cancellationToken);
         }
 
         /// <summary>
         /// Deletes an event route asynchronously.
         /// </summary>
         /// <param name="eventRouteId">The Id of the event route to delete.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1913,16 +1878,15 @@ namespace Azure.DigitalTwins.Core
         /// Console.WriteLine($&quot;Deleted event route &apos;{_eventRouteId}&apos;.&quot;);
         /// </code>
         /// </example>
-        public virtual Task<Response> DeleteEventRouteAsync(string eventRouteId, DeleteEventRouteOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Task<Response> DeleteEventRouteAsync(string eventRouteId, CancellationToken cancellationToken = default)
         {
-            return _eventRoutesRestClient.DeleteAsync(eventRouteId, options, cancellationToken);
+            return _eventRoutesRestClient.DeleteAsync(eventRouteId, null, cancellationToken);
         }
 
         /// <summary>
         /// Deletes an event route synchronously.
         /// </summary>
         /// <param name="eventRouteId">The Id of the event route to delete.</param>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The http response <see cref="Response"/>.</returns>
         /// <remarks>
@@ -1934,12 +1898,12 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="ArgumentNullException">
         /// The exception is thrown when <paramref name="eventRouteId"/> is <c>null</c>.
         /// </exception>
-        /// <seealso cref="DeleteEventRouteAsync(string, DeleteEventRouteOptions, CancellationToken)">
+        /// <seealso cref="DeleteEventRouteAsync(string, CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Response DeleteEventRoute(string eventRouteId, DeleteEventRouteOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Response DeleteEventRoute(string eventRouteId, CancellationToken cancellationToken = default)
         {
-            return _eventRoutesRestClient.Delete(eventRouteId, options, cancellationToken);
+            return _eventRoutesRestClient.Delete(eventRouteId, null, cancellationToken);
         }
 
         /// <summary>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1263,7 +1263,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// catch (RequestFailedException ex)
         /// {
-        ///     FatalError($&quot;Failed to decommission model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
+        ///     FatalError($&quot;Failed to decommision model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
         /// }
         /// </code>
         /// </example>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1263,7 +1263,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// catch (RequestFailedException ex)
         /// {
-        ///     FatalError($&quot;Failed to decommision model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
+        ///     FatalError($&quot;Failed to decommission model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
         /// }
         /// </code>
         /// </example>
@@ -1488,7 +1488,7 @@ namespace Azure.DigitalTwins.Core
                     };
 
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    QueryOptions options = new QueryOptions
+                    var options = new QueryOptions
                     {
                         MaxItemsPerPage = pageSizeHint
                     };
@@ -1515,7 +1515,7 @@ namespace Azure.DigitalTwins.Core
                     };
 
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    QueryOptions options = new QueryOptions
+                    var options = new QueryOptions
                     {
                         MaxItemsPerPage = pageSizeHint
                     };
@@ -1570,7 +1570,7 @@ namespace Azure.DigitalTwins.Core
                     };
 
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    QueryOptions options = new QueryOptions
+                    var options = new QueryOptions
                     {
                         MaxItemsPerPage = pageSizeHint
                     };
@@ -1597,7 +1597,7 @@ namespace Azure.DigitalTwins.Core
                     };
 
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
-                    QueryOptions options = new QueryOptions
+                    var options = new QueryOptions
                     {
                         MaxItemsPerPage = pageSizeHint
                     };

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/CreateModelsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/CreateModelsOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class CreateModelsOptions
+    internal partial class CreateModelsOptions
     {
         /// <summary> Initializes a new instance of CreateModelsOptions. </summary>
         public CreateModelsOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/CreateOrReplaceEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/CreateOrReplaceEventRouteOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class CreateOrReplaceEventRouteOptions
+    internal partial class CreateOrReplaceEventRouteOptions
     {
         /// <summary> Initializes a new instance of CreateOrReplaceEventRouteOptions. </summary>
         public CreateOrReplaceEventRouteOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DecomissionModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DecomissionModelOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class DecomissionModelOptions
+    internal partial class DecomissionModelOptions
     {
         /// <summary> Initializes a new instance of DecomissionModelOptions. </summary>
         public DecomissionModelOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DeleteEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DeleteEventRouteOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class DeleteEventRouteOptions
+    internal partial class DeleteEventRouteOptions
     {
         /// <summary> Initializes a new instance of DeleteEventRouteOptions. </summary>
         public DeleteEventRouteOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DeleteModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DeleteModelOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class DeleteModelOptions
+    internal partial class DeleteModelOptions
     {
         /// <summary> Initializes a new instance of DeleteModelOptions. </summary>
         public DeleteModelOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetComponentOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetComponentOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetComponentOptions
+    internal partial class GetComponentOptions
     {
         /// <summary> Initializes a new instance of GetComponentOptions. </summary>
         public GetComponentOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetDigitalTwinOptions
+    internal partial class GetDigitalTwinOptions
     {
         /// <summary> Initializes a new instance of GetDigitalTwinOptions. </summary>
         public GetDigitalTwinOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinsEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinsEventRouteOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetDigitalTwinsEventRouteOptions
+    internal partial class GetDigitalTwinsEventRouteOptions
     {
         /// <summary> Initializes a new instance of GetDigitalTwinsEventRouteOptions. </summary>
         public GetDigitalTwinsEventRouteOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetIncomingRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetIncomingRelationshipsOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetIncomingRelationshipsOptions
+    internal partial class GetIncomingRelationshipsOptions
     {
         /// <summary> Initializes a new instance of GetIncomingRelationshipsOptions. </summary>
         public GetIncomingRelationshipsOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetModelOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetModelOptions
+    internal partial class GetModelOptions
     {
         /// <summary> Initializes a new instance of GetModelOptions. </summary>
         public GetModelOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetRelationshipOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetRelationshipOptions
+    internal partial class GetRelationshipOptions
     {
         /// <summary> Initializes a new instance of GetRelationshipOptions. </summary>
         public GetRelationshipOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetRelationshipsOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetRelationshipsOptions
+    internal partial class GetRelationshipsOptions
     {
         /// <summary> Initializes a new instance of GetRelationshipsOptions. </summary>
         public GetRelationshipsOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/QueryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/QueryOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class QueryOptions
+    internal partial class QueryOptions
     {
         /// <summary> Initializes a new instance of QueryOptions. </summary>
         public QueryOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/QueryTests.cs
@@ -105,7 +105,7 @@ namespace Azure.DigitalTwins.Core.Tests
                         throw new AssertionException($"Timed out waiting for at least {pageSize + 1} twins to be queryable");
                     }
 
-                    AsyncPageable<string> asyncPageableResponse = client.QueryAsync(queryString, null, queryTimeoutCancellationToken.Token);
+                    AsyncPageable<string> asyncPageableResponse = client.QueryAsync(queryString, queryTimeoutCancellationToken.Token);
                     int count = 0;
                     await foreach (Page<string> queriedTwinPage in asyncPageableResponse.AsPages(pageSizeHint: pageSize))
                     {


### PR DESCRIPTION
This change will render certain options look empty to users so we are removing them from the API signatures.

We have the option to just mark some of the options internal and do not implement any overrides in customized classes, but that will result in TraceParent and TraceState have the incorrect naming format : Tracestate, Traceparent