### PR TITLE
ADT: Add basic component metadata type

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -18,13 +18,27 @@ namespace Azure.DigitalTwins.Core
         [System.Text.Json.Serialization.JsonExtensionDataAttribute]
         public System.Collections.Generic.IDictionary<string, object> Contents { get { throw null; } }
         [System.Text.Json.Serialization.JsonPropertyNameAttribute("$metadata")]
-        public object Metadata { get { throw null; } set { } }
+        public Azure.DigitalTwins.Core.BasicDigitalTwinComponentMetadata Metadata { get { throw null; } set { } }
+    }
+    public partial class BasicDigitalTwinComponentMetadata
+    {
+        public BasicDigitalTwinComponentMetadata() { }
+        [System.Text.Json.Serialization.JsonExtensionDataAttribute]
+        public System.Collections.Generic.IDictionary<string, object> PropertyMetadata { get { throw null; } set { } }
     }
     public partial class BasicDigitalTwinMetadata
     {
         public BasicDigitalTwinMetadata() { }
         [System.Text.Json.Serialization.JsonPropertyNameAttribute("$model")]
         public string ModelId { get { throw null; } set { } }
+        [System.Text.Json.Serialization.JsonExtensionDataAttribute]
+        public System.Collections.Generic.IDictionary<string, object> PropertyMetadata { get { throw null; } set { } }
+    }
+    public partial class BasicDigitalTwinPropertyMetadata
+    {
+        public BasicDigitalTwinPropertyMetadata() { }
+        [System.Text.Json.Serialization.JsonPropertyNameAttribute("lastUpdateTime")]
+        public System.DateTimeOffset LastUpdatedOn { get { throw null; } set { } }
     }
     public partial class BasicRelationship
     {
@@ -175,6 +189,7 @@ namespace Azure.DigitalTwins.Core
         public const string DigitalTwinId = "$dtId";
         public const string DigitalTwinMetadata = "$metadata";
         public const string MetadataModel = "$model";
+        public const string MetadataPropertyLastUpdateTime = "lastUpdateTime";
         public const string RelationshipId = "$relationshipId";
         public const string RelationshipName = "$relationshipName";
         public const string RelationshipSourceId = "$sourceId";

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/ComponentSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/ComponentSamples.cs
@@ -97,7 +97,8 @@ namespace Azure.DigitalTwins.Core.Samples
                     $"ETag: {basicDt.ETag}\n\t" +
                     $"Prop1: {basicDt.Contents["Prop1"]}\n\t" +
                     $"Prop2: {basicDt.Contents["Prop2"]}\n\t" +
-                    $"ComponentProp1: {component1["ComponentProp1"]}\n\t" +
+                    $"Component1 metadata: {component1[DigitalTwinsJsonPropertyNames.DigitalTwinMetadata]}\n\t" +
+                    $"Component1.Prop1: {component1["ComponentProp1"]}\n\t" +
                     $"ComponentProp2: {component1["ComponentProp2"]}");
             }
 
@@ -139,7 +140,7 @@ namespace Azure.DigitalTwins.Core.Samples
                 $"ETag: {customDt.ETag}\n\t" +
                 $"Prop1: {customDt.Prop1}\n\t" +
                 $"Prop2: {customDt.Prop2}\n\t" +
-                $"ComponentProp1: {customDt.Component1.ComponentProp1}\n\t" +
+                $"ComponentProp1: {customDt.Component1.ComponentProp1} last updated {customDt.Component1.Metadata["ComponentProp1"].LastUpdatedOn}\n\t" +
                 $"ComponentProp2: {customDt.Component1.ComponentProp2}");
 
             #endregion Snippet:DigitalTwinsSampleGetCustomDigitalTwin

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/CustomDigitalTwin.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/CustomDigitalTwin.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Azure.DigitalTwins.Core.Samples
@@ -36,7 +37,7 @@ namespace Azure.DigitalTwins.Core.Samples
         /// A component must have a property named $metadata with no properties to be distinguished from other properties as a component.
         /// </summary>
         [JsonPropertyName(DigitalTwinsJsonPropertyNames.DigitalTwinMetadata)]
-        public object Metadata { get; set; } = new object();
+        public Dictionary<string, BasicDigitalTwinPropertyMetadata> Metadata { get; set; } = new Dictionary<string, BasicDigitalTwinPropertyMetadata>();
 
         [JsonPropertyName("ComponentProp1")]
         public string ComponentProp1 { get; set; }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
@@ -197,7 +197,8 @@ if (getBasicDtResponse.GetRawResponse().Status == (int)HttpStatusCode.OK)
         $"ETag: {basicDt.ETag}\n\t" +
         $"Prop1: {basicDt.Contents["Prop1"]}\n\t" +
         $"Prop2: {basicDt.Contents["Prop2"]}\n\t" +
-        $"ComponentProp1: {component1["ComponentProp1"]}\n\t" +
+        $"Component1 metadata: {component1[DigitalTwinsJsonPropertyNames.DigitalTwinMetadata]}\n\t" +
+        $"Component1.Prop1: {component1["ComponentProp1"]}\n\t" +
         $"ComponentProp2: {component1["ComponentProp2"]}");
 }
 ```
@@ -212,7 +213,7 @@ Console.WriteLine($"Retrieved and deserialized digital twin {customDt.Id}:\n\t" 
     $"ETag: {customDt.ETag}\n\t" +
     $"Prop1: {customDt.Prop1}\n\t" +
     $"Prop2: {customDt.Prop2}\n\t" +
-    $"ComponentProp1: {customDt.Component1.ComponentProp1}\n\t" +
+    $"ComponentProp1: {customDt.Component1.ComponentProp1} last updated {customDt.Component1.Metadata["ComponentProp1"].LastUpdatedOn}\n\t" +
     $"ComponentProp2: {customDt.Component1.ComponentProp2}");
 ```
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -139,7 +139,7 @@ namespace Azure.DigitalTwins.Core
         ///     $&quot;ETag: {customDt.ETag}\n\t&quot; +
         ///     $&quot;Prop1: {customDt.Prop1}\n\t&quot; +
         ///     $&quot;Prop2: {customDt.Prop2}\n\t&quot; +
-        ///     $&quot;ComponentProp1: {customDt.Component1.ComponentProp1}\n\t&quot; +
+        ///     $&quot;ComponentProp1: {customDt.Component1.ComponentProp1} last updated {customDt.Component1.Metadata[&quot;ComponentProp1&quot;].LastUpdatedOn}\n\t&quot; +
         ///     $&quot;ComponentProp2: {customDt.Component1.ComponentProp2}&quot;);
         /// </code>
         /// </example>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwin.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwin.cs
@@ -68,7 +68,8 @@ namespace Azure.DigitalTwins.Core
     ///         $&quot;ETag: {basicDt.ETag}\n\t&quot; +
     ///         $&quot;Prop1: {basicDt.Contents[&quot;Prop1&quot;]}\n\t&quot; +
     ///         $&quot;Prop2: {basicDt.Contents[&quot;Prop2&quot;]}\n\t&quot; +
-    ///         $&quot;ComponentProp1: {component1[&quot;ComponentProp1&quot;]}\n\t&quot; +
+    ///         $&quot;Component1 metadata: {component1[DigitalTwinsJsonPropertyNames.DigitalTwinMetadata]}\n\t&quot; +
+    ///         $&quot;Component1.Prop1: {component1[&quot;ComponentProp1&quot;]}\n\t&quot; +
     ///         $&quot;ComponentProp2: {component1[&quot;ComponentProp2&quot;]}&quot;);
     /// }
     /// </code>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwinComponent.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwinComponent.cs
@@ -22,7 +22,7 @@ namespace Azure.DigitalTwins.Core
         /// The metadata property, required on a component to identify as one.
         /// </summary>
         [JsonPropertyName(DigitalTwinsJsonPropertyNames.DigitalTwinMetadata)]
-        public object Metadata { get; set; } = new object();
+        public BasicDigitalTwinComponentMetadata Metadata { get; set; } = new BasicDigitalTwinComponentMetadata();
 
         /// <summary>
         /// This field will contain properties and components as defined in the contents section of the DTDL definition of the twin.

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwinComponentMetadata.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwinComponentMetadata.cs
@@ -7,22 +7,16 @@ using System.Text.Json.Serialization;
 namespace Azure.DigitalTwins.Core
 {
     /// <summary>
-    /// An optional, helper class for deserializing a digital twin.
-    /// The $metadata class on a <see cref="BasicDigitalTwin"/>.
+    /// An optional, helper class for deserializing a digital twin component metadata object.
+    /// The $metadata object on a <see cref="BasicDigitalTwinComponent"/>.
     /// </summary>
     /// <remarks>
     /// For more samples, see <see href="https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/digitaltwins/Azure.DigitalTwins.Core/samples">our repo samples</see>.
     /// </remarks>
-    public class BasicDigitalTwinMetadata
+    public class BasicDigitalTwinComponentMetadata
     {
         /// <summary>
-        /// The Id of the model that the digital twin or component is modeled by.
-        /// </summary>
-        [JsonPropertyName(DigitalTwinsJsonPropertyNames.MetadataModel)]
-        public string ModelId { get; set; }
-
-        /// <summary>
-        /// This field will contain metadata about changes on properties on the digital twin.
+        /// This field will contain metadata about changes on properties on a component.
         /// For your convenience, the value can be deserialized into <see cref="BasicDigitalTwinPropertyMetadata"/>.
         /// </summary>
         [JsonExtensionData]

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwinPropertyMetadata.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwinPropertyMetadata.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Azure.DigitalTwins.Core
+{
+    /// <summary>
+    /// Contain metadata about changes on properties on a digital twin or component.
+    /// </summary>
+    public class BasicDigitalTwinPropertyMetadata
+    {
+        /// <summary>
+        /// The date and time the property was last updated.
+        /// </summary>
+        [JsonPropertyName(DigitalTwinsJsonPropertyNames.MetadataPropertyLastUpdateTime)]
+        public DateTimeOffset LastUpdatedOn { get; set; }
+    }
+}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/DigitalTwinsJsonPropertyNames.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/DigitalTwinsJsonPropertyNames.cs
@@ -29,6 +29,12 @@ namespace Azure.DigitalTwins.Core
         public const string MetadataModel = "$model";
 
         /// <summary>
+        /// The last update time of a digital twin property, used in the $metadata object
+        /// on a digital twin or component about their properties.
+        /// </summary>
+        public const string MetadataPropertyLastUpdateTime = "lastUpdateTime";
+
+        /// <summary>
         /// The JSON property name for the Id field on a relationship.
         /// </summary>
         public const string RelationshipId = "$relationshipId";


### PR DESCRIPTION
Component sample output:
```
===COMPONENT SAMPLE===

Created models dtmi:com:samples:ComponentModel;1810 and dtmi:com:samples:TempModel;9396.
Created digital twin 'sampleTwin1835'.
Retrieved and deserialized digital twin sampleTwin1835:
        ETag: W/"fde79216-1481-4f8e-a6b7-c4f577ff1561"
        Prop1: Value1
        Prop2: 987
        Component1 metadata: {"ComponentProp1":{"lastUpdateTime":"2020-10-27T20:28:34.0563558Z"},"ComponentProp2":{"lastUpdateTime":"2020-10-27T20:28:34.0563558Z"}}
        Component1.Prop1: Component value 1
        ComponentProp2: 123
Created digital twin 'sampleTwin4104'.
Retrieved and deserialized digital twin sampleTwin4104:
        ETag: W/"43b005f6-43ff-4942-b584-efada0c2d933"
        Prop1: Prop1 val
        Prop2: 987
        ComponentProp1: Component prop1 val last updated 10/27/2020 8:28:34 PM +00:00
        ComponentProp2: 123
Updated component for digital twin 'sampleTwin1835'.
Retrieved component for digital twin 'sampleTwin1835'.
```