### PR TITLE
[Identity] Remove app service identity 2019-08-01 support

### DIFF
--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -68,8 +68,7 @@ namespace Azure.Identity
                 return asyncLock.Value;
             }
 
-            IManagedIdentitySource identitySource = AppServiceV2019ManagedIdentitySource.TryCreate(_pipeline.HttpPipeline, ClientId) ??
-                                                    AppServiceV2017ManagedIdentitySource.TryCreate(_pipeline.HttpPipeline, ClientId) ??
+            IManagedIdentitySource identitySource = AppServiceV2017ManagedIdentitySource.TryCreate(_pipeline.HttpPipeline, ClientId) ??
                                                     CloudShellManagedIdentitySource.TryCreate(_pipeline.HttpPipeline, ClientId) ??
                                                     await ImdsManagedIdentitySource.TryCreateAsync(_pipeline.HttpPipeline, ClientId, async, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
IDENTITY_ENDPOINT and IDENTITY_HEADER are set in Functions apps on Linux Consumption hosting plans. However, the endpoint returns an error for version 2019-08-01, for example: "(UnsupportedApiVersion) The HTTP resource that matches the request URI 'http://localhost:8081/msi/token?api-version=2019-08-01&resource=https://vault.azure.net' does not support the API version '2019-08-01'"

Lacking a way to tell whether it's in an affected environment, this PR updates `ManagedIdentityCredential` to use *only* the prior API version, 2017-09-01, and its associated environment variables MSI_ENDPOINT and MSI_SECRET.

Fixes #16278 