### PR TITLE
[Storage][Webjobs] Bind to BlobClient

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -102,13 +102,13 @@ public static class BlobFunction_WriteStream
 
 ### Binding to Azure Storage Blob SDK types
 
-```C# Snippet:BlobFunction_BlobBaseClient
-public static class BlobFunction_BlobBaseClient
+```C# Snippet:BlobFunction_BlobClient
+public static class BlobFunction_BlobClient
 {
     [FunctionName("BlobFunction")]
     public static async Task Run(
-        [BlobTrigger("sample-container/sample-blob-1")] BlobBaseClient blobTriggerClient,
-        [Blob("sample-container/sample-blob-2")] BlobBaseClient blobClient,
+        [BlobTrigger("sample-container/sample-blob-1")] BlobClient blobTriggerClient,
+        [Blob("sample-container/sample-blob-2")] BlobClient blobClient,
         ILogger logger)
     {
         BlobProperties blobTriggerProperties = await blobTriggerClient.GetPropertiesAsync();

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Azure.WebJobs.Extensions.Storage.Common.Tests;
@@ -22,7 +23,7 @@ namespace Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
         [TestCase(typeof(BlobFunction_String))]
         [TestCase(typeof(BlobFunction_ReadStream))]
         [TestCase(typeof(BlobFunction_WriteStream))]
-        [TestCase(typeof(BlobFunction_BlobBaseClient))]
+        [TestCase(typeof(BlobFunction_BlobClient))]
         public async Task Run_BlobFunction(Type programType)
         {
             var containerClient = AzuriteNUnitFixture.Instance.GetBlobServiceClient().GetBlobContainerClient("sample-container");
@@ -96,13 +97,13 @@ namespace Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     }
     #endregion
 
-    #region Snippet:BlobFunction_BlobBaseClient
-    public static class BlobFunction_BlobBaseClient
+    #region Snippet:BlobFunction_BlobClient
+    public static class BlobFunction_BlobClient
     {
         [FunctionName("BlobFunction")]
         public static async Task Run(
-            [BlobTrigger("sample-container/sample-blob-1")] BlobBaseClient blobTriggerClient,
-            [Blob("sample-container/sample-blob-2")] BlobBaseClient blobClient,
+            [BlobTrigger("sample-container/sample-blob-1")] BlobClient blobTriggerClient,
+            [Blob("sample-container/sample-blob-2")] BlobClient blobClient,
             ILogger logger)
         {
             BlobProperties blobTriggerProperties = await blobTriggerClient.GetPropertiesAsync();

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Bindings/StorageBlobContainerExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Bindings/StorageBlobContainerExtensions.cs
@@ -16,7 +16,12 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
         public static Task<BlobBaseClient> GetBlobReferenceForArgumentTypeAsync(this BlobContainerClient container,
             string blobName, Type argumentType, CancellationToken cancellationToken)
         {
-            if (argumentType == typeof(BlockBlobClient))
+            if (argumentType == typeof(BlobClient))
+            {
+                BlobBaseClient blob = container.GetBlobClient(blobName);
+                return Task.FromResult(blob);
+            }
+            else if (argumentType == typeof(BlockBlobClient))
             {
                 BlobBaseClient blob = container.GetBlockBlobClient(blobName);
                 return Task.FromResult(blob);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobAttribute.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Azure.WebJobs.Description;
 
@@ -40,6 +41,7 @@ namespace Microsoft.Azure.WebJobs
     /// The parameter type can be CloudBlobContainer, CloudBlobDirectory or <see cref="IEnumerable{T}"/>
     /// of one of the following element types:
     /// <list type = "bullet" >
+    /// <item><description><see cref="BlobClient"/></description></item>
     /// <item><description><see cref="BlobBaseClient"/></description></item>
     /// <item><description><see cref="AppendBlobClient"/></description></item>
     /// <item><description><see cref="BlockBlobClient"/></description></item>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobTriggerAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobTriggerAttribute.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Azure.WebJobs.Description;
 
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.WebJobs
     /// <remarks>
     /// The method parameter type can be one of the following:
     /// <list type="bullet">
+    /// <item><description><see cref="BlobClient"/></description></item>
     /// <item><description><see cref="BlobBaseClient"/></description></item>
     /// <item><description><see cref="AppendBlobClient"/></description></item>
     /// <item><description><see cref="BlockBlobClient"/></description></item>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsExtensionConfigProvider.cs
@@ -163,7 +163,6 @@ namespace Microsoft.Azure.WebJobs.Host.Blobs.Bindings
             public BlobCollectionConverter(BlobsExtensionConfigProvider parent)
             {
                 IConverterManager cm = parent._converterManager;
-                var type = typeof(T);
                 _converter = cm.GetConverter<BlobBaseClient, T, BlobAttribute>();
                 if (_converter == null)
                 {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobTriggerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/BlobTriggerTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         {
             public static TaskCompletionSource<BlobBaseClient> TaskSource { get; set; }
 
-            public static void Run([BlobTrigger(BlobPath)] BlobBaseClient blob) // TODO (kasobol-msft how about binding to BlobClient??
+            public static void Run([BlobTrigger(BlobPath)] BlobBaseClient blob)
             {
                 TaskSource.TrySetResult(blob);
             }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/HostCallTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/HostCallTests.cs
@@ -123,6 +123,19 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
         }
 
         [Test]
+        public async Task Blob_IfBoundToBlobClient_CanCall()
+        {
+            // Arrange
+            var container = blobServiceClient.GetBlobContainerClient(ContainerName);
+            var inputBlob = container.GetBlockBlobClient(BlobName);
+            await container.CreateIfNotExistsAsync();
+            await inputBlob.UploadTextAsync("ignore");
+
+            // Act
+            await CallAsync(typeof(BlobProgram), "BindToBlobClient");
+        }
+
+        [Test]
         public async Task Blob_IfBoundToString_CanCall()
         {
             // Arrange
@@ -601,6 +614,12 @@ namespace Microsoft.Azure.WebJobs.Host.FunctionalTests
             }
 
             public static void BindToCloudBlockBlob([Blob(BlobPath)] BlockBlobClient blob)
+            {
+                Assert.NotNull(blob);
+                Assert.AreEqual(BlobName, blob.Name);
+            }
+
+            public static void BindToBlobClient([Blob(BlobPath)] BlobClient blob)
             {
                 Assert.NotNull(blob);
                 Assert.AreEqual(BlobName, blob.Name);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/BlobBindingEndToEndTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/BlobBindingEndToEndTests.cs
@@ -222,6 +222,14 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        public async Task BindToIEnumerableBlobClient()
+        {
+            await _fixture.JobHost.CallAsync(typeof(BlobBindingEndToEndTests).GetMethod("IEnumerableBlobClientBinding"));
+
+            Assert.AreEqual(6, _numBlobsRead);
+        }
+
+        [Test]
         public async Task BindToByteArray()
         {
             await _fixture.JobHost.CallAsync(typeof(BlobBindingEndToEndTests).GetMethod("ByteArrayBinding"));
@@ -501,6 +509,22 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         [NoAutomaticTrigger]
         public static async Task IEnumerableICloudBlobBinding(
             [Blob(ContainerName)] IEnumerable<BlobBaseClient> blobs)
+        {
+            foreach (var blob in blobs)
+            {
+                Stream stream = await blob.OpenReadAsync();
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    string content = reader.ReadToEnd();
+                    Assert.AreEqual(TestData, content);
+                }
+            }
+            _numBlobsRead = blobs.Count();
+        }
+
+        [NoAutomaticTrigger]
+        public static async Task IEnumerableBlobClientBinding(
+            [Blob(ContainerName)] IEnumerable<BlobClient> blobs)
         {
             foreach (var blob in blobs)
             {


### PR DESCRIPTION
This PR adds ability to bind to BlobClient. 

BlobClient is the simplest BlobClient the Storage SDK offers. It has all BlobBaseClient functionality as well as uploads that are backed by block blobs. Therefore it can be also seen as simplified version of BlockBlobClient.

The challenging part is that both BlobClient and BlockBlobClient are valid choices if blob exists and has blobType=Block, so there's ambiguity when reference is resolved with type check if blob exists. Additionally Blob And BlobTrigger attributes have somewhat different dataflow.
I ended up resolving to BlobClient if target type is known and adding converter to handle other cases.

Test coverage added:
- ability to bind [Blob] to BlobClient
- ability to bind [Blob] to IEnumerable<BlobClient>
- ability to bind [BlobTrigger] to BlobClient
