### PR TITLE
Mark GetDigitalTwinsEventRouteOptions page size internal

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -170,7 +170,6 @@ namespace Azure.DigitalTwins.Core
     public partial class GetDigitalTwinsEventRoutesOptions
     {
         public GetDigitalTwinsEventRoutesOptions() { }
-        public int? MaxItemsPerPage { get { throw null; } set { } }
     }
     public partial class GetModelsOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -103,8 +103,8 @@ namespace Azure.DigitalTwins.Core
         public virtual Azure.Response<T> GetDigitalTwin<T>(string digitalTwinId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoute(string eventRouteId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsEventRoute>> GetEventRouteAsync(string eventRouteId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Pageable<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoutes(Azure.DigitalTwins.Core.GetDigitalTwinsEventRoutesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.AsyncPageable<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoutesAsync(Azure.DigitalTwins.Core.GetDigitalTwinsEventRoutesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoutes(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.DigitalTwins.Core.DigitalTwinsEventRoute> GetEventRoutesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.DigitalTwins.Core.IncomingRelationship> GetIncomingRelationships(string digitalTwinId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.DigitalTwins.Core.IncomingRelationship> GetIncomingRelationshipsAsync(string digitalTwinId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.DigitalTwins.Core.DigitalTwinsModelData> GetModel(string modelId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -166,10 +166,6 @@ namespace Azure.DigitalTwins.Core
         public string DtdlModel { get { throw null; } }
         public string Id { get { throw null; } }
         public System.DateTimeOffset? UploadedOn { get { throw null; } }
-    }
-    public partial class GetDigitalTwinsEventRoutesOptions
-    {
-        public GetDigitalTwinsEventRoutesOptions() { }
     }
     public partial class GetModelsOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
@@ -21,5 +21,7 @@ namespace Azure.DigitalTwins.Core
         /// <summary> Provides vendor-specific trace identification information and is a companion to TraceParent. </summary>
         [CodeGenMember("Tracestate")]
         internal string TraceState { get; set; }
+
+        internal int? MaxItemsPerPage { get; set; }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
@@ -7,7 +7,7 @@ namespace Azure.DigitalTwins.Core
 {
     /// <inheritdoc />
     [CodeGenModel("EventRoutesListOptions")]
-    public partial class GetDigitalTwinsEventRoutesOptions
+    internal partial class GetDigitalTwinsEventRoutesOptions
     {
         // This class declaration changes the namespace, class name and property visibility; do not remove.
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1618,7 +1618,6 @@ namespace Azure.DigitalTwins.Core
         /// <summary>.
         /// Lists the event routes in a digital twins instance by iterating through a collection asynchronously.
         /// </summary>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="AsyncPageable{T}"/> of application/json event routes and the http response.</returns>
         /// <remarks>
@@ -1636,7 +1635,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// </code>
         /// </example>
-        public virtual AsyncPageable<DigitalTwinsEventRoute> GetEventRoutesAsync(GetDigitalTwinsEventRoutesOptions options = null, CancellationToken cancellationToken = default)
+        public virtual AsyncPageable<DigitalTwinsEventRoute> GetEventRoutesAsync(CancellationToken cancellationToken = default)
         {
             async Task<Page<DigitalTwinsEventRoute>> FirstPageFunc(int? pageSizeHint)
             {
@@ -1644,10 +1643,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    if (options == null)
-                    {
-                        options = new GetDigitalTwinsEventRoutesOptions();
-                    }
+                    var options = new GetDigitalTwinsEventRoutesOptions();
 
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
                     options.MaxItemsPerPage = pageSizeHint;
@@ -1668,10 +1664,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    if (options == null)
-                    {
-                        options = new GetDigitalTwinsEventRoutesOptions();
-                    }
+                    var options = new GetDigitalTwinsEventRoutesOptions();
 
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
                     options.MaxItemsPerPage = pageSizeHint;
@@ -1692,7 +1685,6 @@ namespace Azure.DigitalTwins.Core
         /// <summary>.
         /// Lists the event routes in a digital twins instance by iterating through a collection synchronously.
         /// </summary>
-        /// <param name="options">The optional parameters for this request. If null, the default option values will be used.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The pageable list <see cref="Pageable{T}"/> of application/json event routes and the http response.</returns>
         /// <remarks>
@@ -1701,10 +1693,10 @@ namespace Azure.DigitalTwins.Core
         /// <exception cref="RequestFailedException">
         /// The exception that captures the errors from the service. Check the <see cref="RequestFailedException.ErrorCode"/> and <see cref="RequestFailedException.Status"/> properties for more details.
         /// </exception>
-        /// <seealso cref="GetEventRoutesAsync(GetDigitalTwinsEventRoutesOptions, CancellationToken)">
+        /// <seealso cref="GetEventRoutesAsync(CancellationToken)">
         /// See the asynchronous version of this method for examples.
         /// </seealso>
-        public virtual Pageable<DigitalTwinsEventRoute> GetEventRoutes(GetDigitalTwinsEventRoutesOptions options = null, CancellationToken cancellationToken = default)
+        public virtual Pageable<DigitalTwinsEventRoute> GetEventRoutes(CancellationToken cancellationToken = default)
         {
             Page<DigitalTwinsEventRoute> FirstPageFunc(int? pageSizeHint)
             {
@@ -1712,10 +1704,7 @@ namespace Azure.DigitalTwins.Core
                 scope.Start();
                 try
                 {
-                    if (options == null)
-                    {
-                        options = new GetDigitalTwinsEventRoutesOptions();
-                    }
+                    var options = new GetDigitalTwinsEventRoutesOptions();
 
                     // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
                     options.MaxItemsPerPage = pageSizeHint;
@@ -1735,10 +1724,7 @@ namespace Azure.DigitalTwins.Core
                 using DiagnosticScope scope = _clientDiagnostics.CreateScope("EventRoutesClient.List");
                 scope.Start();
 
-                if (options == null)
-                {
-                    options = new GetDigitalTwinsEventRoutesOptions();
-                }
+                var options = new GetDigitalTwinsEventRoutesOptions();
 
                 // Page size hint is only specified by AsPages() methods, so we add it here manually since the user can't set it on the options object directly
                 options.MaxItemsPerPage = pageSizeHint;

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinsEventRoutesOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinsEventRoutesOptions.cs
@@ -8,7 +8,7 @@
 namespace Azure.DigitalTwins.Core
 {
     /// <summary> Parameter group. </summary>
-    public partial class GetDigitalTwinsEventRoutesOptions
+    internal partial class GetDigitalTwinsEventRoutesOptions
     {
         /// <summary> Initializes a new instance of GetDigitalTwinsEventRoutesOptions. </summary>
         public GetDigitalTwinsEventRoutesOptions()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinsEventRoutesOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/GetDigitalTwinsEventRoutesOptions.cs
@@ -14,7 +14,5 @@ namespace Azure.DigitalTwins.Core
         public GetDigitalTwinsEventRoutesOptions()
         {
         }
-        /// <summary> The maximum number of items to retrieve per request. The server may choose to return less than the requested number. </summary>
-        public int? MaxItemsPerPage { get; set; }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/EventRouteTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/EventRouteTests.cs
@@ -45,8 +45,7 @@ namespace Azure.DigitalTwins.Core.Tests
             eventRouteId.Should().Be(getEventRouteResult.Id);
 
             // Test GetEventRoutes
-            var eventRoutesListOptions = new GetDigitalTwinsEventRoutesOptions();
-            AsyncPageable<DigitalTwinsEventRoute> eventRouteList = client.GetEventRoutesAsync(eventRoutesListOptions);
+            AsyncPageable<DigitalTwinsEventRoute> eventRouteList = client.GetEventRoutesAsync();
             bool eventRouteFoundInList = false;
             await foreach (DigitalTwinsEventRoute eventRouteListEntry in eventRouteList)
             {


### PR DESCRIPTION
Users are expected to specify the page size in the pageable's .AsPages() method instead

#16329 got closed, and couldn't be re-opened, so I created this new PR instead