### PR TITLE
[MetricsAdvisor] CreateDataFeed takes a whole DataFeed; DataSource property added to DataFeed

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## 1.0.0-beta.2 (Unreleased)
 
 ### Breaking Changes
+- In `MetricsAdvisorClient`, updated `CreateDataFeed` and `CreateDataFeedAsync` to take a whole `DataFeed` object as a parameter.
 - In `MetricsAdvisorClient`, changed return types of sync and async methods `GetIncidentRootCauses`, `GetMetricEnrichedSeriesData`, and `GetMetricSeriesData` to pageables.
 - In `MetricsAdvisorAdministrationClient`, changed return types of sync and async methods `GetAnomalyAlertConfigurations` and `GetMetricAnomalyDetectionConfigurations` to pageables.
 - In `MetricsAdvisorAdministrationClient`, renamed parameter `alertConfigurationId` to `detectionConfigurationId` in sync and async `GetAnomalyAlertConfigurations` methods.
+- Added a public constructor to `DataFeed`.
+- Added the `DataSource` property to `DataFeed`.
+- Added a public setter to `DataFeed.Options`.
 - In `MetricEnrichedSeriesData`, made elements of `ExpectedValues`, `Periods`, `IsAnomaly`, `LowerBoundaries` and `UpperBoundaries` nullables.
 - Renamed `MetricDimension` to `DataFeedDimension`.
 - Renamed `DataAnomaly` to `DataPointAnomaly`.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 ## 1.0.0-beta.2 (Unreleased)
 
+### New Features
+- Added a public constructor to `DataFeed`.
+- Added the `DataSource` property to `DataFeed`.
+- Added a public setter to `DataFeed.Options`.
+
 ### Breaking Changes
 - In `MetricsAdvisorClient`, updated `CreateDataFeed` and `CreateDataFeedAsync` to take a whole `DataFeed` object as a parameter.
 - In `MetricsAdvisorClient`, changed return types of sync and async methods `GetIncidentRootCauses`, `GetMetricEnrichedSeriesData`, and `GetMetricSeriesData` to pageables.
 - In `MetricsAdvisorAdministrationClient`, changed return types of sync and async methods `GetAnomalyAlertConfigurations` and `GetMetricAnomalyDetectionConfigurations` to pageables.
 - In `MetricsAdvisorAdministrationClient`, renamed parameter `alertConfigurationId` to `detectionConfigurationId` in sync and async `GetAnomalyAlertConfigurations` methods.
-- Added a public constructor to `DataFeed`.
-- Added the `DataSource` property to `DataFeed`.
-- Added a public setter to `DataFeed.Options`.
 - In `MetricEnrichedSeriesData`, made elements of `ExpectedValues`, `Periods`, `IsAnomaly`, `LowerBoundaries` and `UpperBoundaries` nullables.
 - Renamed `MetricDimension` to `DataFeedDimension`.
 - Renamed `DataAnomaly` to `DataPointAnomaly`.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
@@ -180,10 +180,11 @@ var dataFeedSchema = new DataFeedSchema(dataFeedMetrics)
 var ingestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
 var dataFeedIngestionSettings = new DataFeedIngestionSettings(ingestionStartTime);
 
-Response<DataFeed> response = await adminClient.CreateDataFeedAsync(dataFeedName, dataFeedSource,
-    dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings);
+var dataFeed = new DataFeed(dataFeedName, dataFeedSource, dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings);
 
-DataFeed dataFeed = response.Value;
+Response<DataFeed> response = await adminClient.CreateDataFeedAsync(dataFeed);
+
+dataFeed = response.Value;
 
 Console.WriteLine($"Data feed ID: {dataFeed.Id}");
 ```

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -61,8 +61,8 @@ namespace Azure.AI.MetricsAdvisor.Administration
         public MetricsAdvisorAdministrationClient(System.Uri endpoint, Azure.AI.MetricsAdvisor.MetricsAdvisorKeyCredential credential, Azure.AI.MetricsAdvisor.MetricsAdvisorClientOptions options) { }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration> CreateAnomalyAlertConfiguration(Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration alertConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration>> CreateAnomalyAlertConfigurationAsync(Azure.AI.MetricsAdvisor.Models.AnomalyAlertConfiguration alertConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed> CreateDataFeed(string dataFeedName, Azure.AI.MetricsAdvisor.Models.DataFeedSource dataSource, Azure.AI.MetricsAdvisor.Models.DataFeedGranularity dataFeedGranularity, Azure.AI.MetricsAdvisor.Models.DataFeedSchema dataFeedSchema, Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings dataFeedIngestionSettings, Azure.AI.MetricsAdvisor.Models.DataFeedOptions dataFeedOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed>> CreateDataFeedAsync(string dataFeedName, Azure.AI.MetricsAdvisor.Models.DataFeedSource dataSource, Azure.AI.MetricsAdvisor.Models.DataFeedGranularity dataFeedGranularity, Azure.AI.MetricsAdvisor.Models.DataFeedSchema dataFeedSchema, Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings dataFeedIngestionSettings, Azure.AI.MetricsAdvisor.Models.DataFeedOptions dataFeedOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed> CreateDataFeed(Azure.AI.MetricsAdvisor.Models.DataFeed dataFeed, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.DataFeed>> CreateDataFeedAsync(Azure.AI.MetricsAdvisor.Models.DataFeed dataFeed, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook> CreateHook(Azure.AI.MetricsAdvisor.Models.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.AI.MetricsAdvisor.Models.NotificationHook>> CreateHookAsync(Azure.AI.MetricsAdvisor.Models.NotificationHook hook, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Response<Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration> CreateMetricAnomalyDetectionConfiguration(Azure.AI.MetricsAdvisor.Models.AnomalyDetectionConfiguration detectionConfiguration, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -344,16 +344,17 @@ namespace Azure.AI.MetricsAdvisor.Models
     }
     public partial class DataFeed
     {
-        internal DataFeed() { }
+        public DataFeed(string dataFeedName, Azure.AI.MetricsAdvisor.Models.DataFeedSource dataSource, Azure.AI.MetricsAdvisor.Models.DataFeedGranularity dataFeedGranularity, Azure.AI.MetricsAdvisor.Models.DataFeedSchema dataFeedSchema, Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings dataFeedIngestionSettings) { }
         public System.DateTimeOffset? CreatedTime { get { throw null; } }
         public string Creator { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.DataFeedSource DataSource { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedGranularity Granularity { get { throw null; } }
         public string Id { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings IngestionSettings { get { throw null; } }
         public bool? IsAdministrator { get { throw null; } }
         public System.Collections.Generic.IReadOnlyList<string> MetricIds { get { throw null; } }
         public string Name { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.DataFeedOptions Options { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.DataFeedOptions Options { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedSchema Schema { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedSourceType SourceType { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedStatus? Status { get { throw null; } }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -284,7 +284,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             scope.Start();
             try
             {
-                DataFeedDetail dataFeedDetail = dataFeed.BuildDataFeedDetail();
+                DataFeedDetail dataFeedDetail = dataFeed.GetDataFeedDetail();
                 ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = await _serviceRestClient.CreateDataFeedAsync(dataFeedDetail, cancellationToken).ConfigureAwait(false);
 
                 dataFeed.Id = ClientCommon.GetDataFeedId(response.Headers.Location);
@@ -315,7 +315,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             scope.Start();
             try
             {
-                DataFeedDetail dataFeedDetail = dataFeed.BuildDataFeedDetail();
+                DataFeedDetail dataFeedDetail = dataFeed.GetDataFeedDetail();
                 ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = _serviceRestClient.CreateDataFeed(dataFeedDetail, cancellationToken);
 
                 dataFeed.Id = ClientCommon.GetDataFeedId(response.Headers.Location);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -269,37 +269,26 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <summary>
         /// Creates a <see cref="DataFeed"/> and assigns it a unique ID.
         /// </summary>
-        /// <param name="dataFeedName">A custom name for the <see cref="DataFeed"/> to be displayed on the web portal.</param>
-        /// <param name="dataSource">The source from which data will be consumed.</param>
-        /// <param name="dataFeedGranularity">The frequency with which ingestion from the data source will happen.</param>
-        /// <param name="dataFeedSchema">Defines how this <see cref="DataFeed"/> structures the data ingested from the data source in terms of metrics and dimensions.</param>
-        /// <param name="dataFeedIngestionSettings">Configures how a <see cref="DataFeed"/> behaves during data ingestion from its data source.</param>
-        /// <param name="dataFeedOptions">An optional set of options configuring the behavior of the <see cref="DataFeed"/>.</param>
+        /// <param name="dataFeed">Specifies how the created <see cref="DataFeed"/> should be configured.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
         /// A <see cref="Response{T}"/> containing the result of the operation. The result is a <see cref="DataFeed"/> instance
         /// containing the ID of the newly created feed.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeedName"/>, <paramref name="dataSource"/>, <paramref name="dataFeedGranularity"/>, <paramref name="dataFeedSchema"/>, or <paramref name="dataFeedIngestionSettings"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="dataFeedName"/> is empty.</exception>
-        public virtual async Task<Response<DataFeed>> CreateDataFeedAsync(string dataFeedName, DataFeedSource dataSource, DataFeedGranularity dataFeedGranularity, DataFeedSchema dataFeedSchema, DataFeedIngestionSettings dataFeedIngestionSettings, DataFeedOptions dataFeedOptions = default, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/> is null.</exception>
+        public virtual async Task<Response<DataFeed>> CreateDataFeedAsync(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNullOrEmpty(dataFeedName, nameof(dataFeedName));
-            Argument.AssertNotNull(dataSource, nameof(dataSource));
-            Argument.AssertNotNull(dataFeedGranularity, nameof(dataFeedGranularity));
-            Argument.AssertNotNull(dataFeedSchema, nameof(dataFeedSchema));
-            Argument.AssertNotNull(dataFeedIngestionSettings, nameof(dataFeedIngestionSettings));
+            Argument.AssertNotNull(dataFeed, nameof(dataFeed));
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();
             try
             {
-                dataSource.SetDetail(dataFeedName, dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings, dataFeedOptions);
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = await _serviceRestClient.CreateDataFeedAsync(dataSource.DataFeedDetail, cancellationToken).ConfigureAwait(false);
+                DataFeedDetail dataFeedDetail = dataFeed.BuildDataFeedDetail();
+                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = await _serviceRestClient.CreateDataFeedAsync(dataFeedDetail, cancellationToken).ConfigureAwait(false);
 
-                string dataFeedId = ClientCommon.GetDataFeedId(response.Headers.Location);
-                var createdDataFeed = new DataFeed(dataSource.DataFeedDetail) { Id = dataFeedId };
-                return Response.FromValue(createdDataFeed, response.GetRawResponse());
+                dataFeed.Id = ClientCommon.GetDataFeedId(response.Headers.Location);
+                return Response.FromValue(dataFeed, response.GetRawResponse());
             }
             catch (Exception ex)
             {
@@ -311,37 +300,26 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <summary>
         /// Creates a <see cref="DataFeed"/> and assigns it a unique ID.
         /// </summary>
-        /// <param name="dataFeedName">A custom name for the <see cref="DataFeed"/> to be displayed on the web portal.</param>
-        /// <param name="dataSource">The source from which data will be consumed.</param>
-        /// <param name="dataFeedGranularity">The frequency with which ingestion from the data source will happen.</param>
-        /// <param name="dataFeedSchema">Defines how this <see cref="DataFeed"/> structures the data ingested from the data source in terms of metrics and dimensions.</param>
-        /// <param name="dataFeedIngestionSettings">Configures how a <see cref="DataFeed"/> behaves during data ingestion from its data source.</param>
-        /// <param name="dataFeedOptions">An optional set of options configuring the behavior of the <see cref="DataFeed"/>.</param>
+        /// <param name="dataFeed">Specifies how the created <see cref="DataFeed"/> should be configured.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         /// <returns>
         /// A <see cref="Response{T}"/> containing the result of the operation. The result is a <see cref="DataFeed"/> instance
         /// containing the ID of the newly created feed.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeedName"/>, <paramref name="dataSource"/>, <paramref name="dataFeedGranularity"/>, <paramref name="dataFeedSchema"/>, or <paramref name="dataFeedIngestionSettings"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="dataFeedName"/> is empty.</exception>
-        public virtual Response<DataFeed> CreateDataFeed(string dataFeedName, DataFeedSource dataSource, DataFeedGranularity dataFeedGranularity, DataFeedSchema dataFeedSchema, DataFeedIngestionSettings dataFeedIngestionSettings, DataFeedOptions dataFeedOptions = default, CancellationToken cancellationToken = default)
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/> is null.</exception>
+        public virtual Response<DataFeed> CreateDataFeed(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNullOrEmpty(dataFeedName, nameof(dataFeedName));
-            Argument.AssertNotNull(dataSource, nameof(dataSource));
-            Argument.AssertNotNull(dataFeedGranularity, nameof(dataFeedGranularity));
-            Argument.AssertNotNull(dataFeedSchema, nameof(dataFeedSchema));
-            Argument.AssertNotNull(dataFeedIngestionSettings, nameof(dataFeedIngestionSettings));
+            Argument.AssertNotNull(dataFeed, nameof(dataFeed));
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();
             try
             {
-                dataSource.SetDetail(dataFeedName, dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings, dataFeedOptions);
-                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = _serviceRestClient.CreateDataFeed(dataSource.DataFeedDetail, cancellationToken);
+                DataFeedDetail dataFeedDetail = dataFeed.BuildDataFeedDetail();
+                ResponseWithHeaders<AzureCognitiveServiceMetricsAdvisorRestAPIOpenAPIV2CreateDataFeedHeaders> response = _serviceRestClient.CreateDataFeed(dataFeedDetail, cancellationToken);
 
-                string dataFeedId = ClientCommon.GetDataFeedId(response.Headers.Location);
-                var createdDataFeed = new DataFeed(dataSource.DataFeedDetail) { Id = dataFeedId };
-                return Response.FromValue(createdDataFeed, response.GetRawResponse());
+                dataFeed.Id = ClientCommon.GetDataFeedId(response.Headers.Location);
+                return Response.FromValue(dataFeed, response.GetRawResponse());
             }
             catch (Exception ex)
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureApplicationInsightsDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureApplicationInsightsDataFeedSource.cs
@@ -30,5 +30,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new AzureApplicationInsightsParameter(azureCloud, applicationId, apiKey, query);
         }
+
+        internal AzureApplicationInsightsDataFeedSource(AzureApplicationInsightsParameter parameter)
+            : base(DataFeedSourceType.AzureApplicationInsights)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureBlobDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureBlobDataFeedSource.cs
@@ -52,5 +52,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new AzureBlobParameter(connectionString, container, blobTemplate);
         }
+
+        internal AzureBlobDataFeedSource(AzureBlobParameter parameter)
+            : base(DataFeedSourceType.AzureBlob)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureCosmosDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureCosmosDbDataFeedSource.cs
@@ -30,5 +30,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new AzureCosmosDBParameter(connectionString, sqlQuery, database, collectionId);
         }
+
+        internal AzureCosmosDbDataFeedSource(AzureCosmosDBParameter parameter)
+            : base(DataFeedSourceType.AzureCosmosDb)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureDataExplorerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureDataExplorerDataFeedSource.cs
@@ -26,5 +26,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new SqlSourceParameter(connectionString, query);
         }
+
+        internal AzureDataExplorerDataFeedSource(SqlSourceParameter parameter)
+            : base(DataFeedSourceType.AzureDataExplorer)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureDataLakeStorageGen2DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureDataLakeStorageGen2DataFeedSource.cs
@@ -56,5 +56,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new AzureDataLakeStorageGen2Parameter(accountName, accountKey, fileSystemName, directoryTemplate, fileTemplate);
         }
+
+        internal AzureDataLakeStorageGen2DataFeedSource(AzureDataLakeStorageGen2Parameter parameter)
+            : base(DataFeedSourceType.AzureDataLakeStorageGen2)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureTableDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/AzureTableDataFeedSource.cs
@@ -28,5 +28,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new AzureTableParameter(connectionString, table, query);
         }
+
+        internal AzureTableDataFeedSource(AzureTableParameter parameter)
+            : base(DataFeedSourceType.AzureTable)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -14,6 +14,32 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// </summary>
     public class DataFeed
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataFeed"/> class.
+        /// </summary>
+        /// <param name="dataFeedName">A custom name for the <see cref="DataFeed"/>.</param>
+        /// <param name="dataSource">The source from which data is consumed.</param>
+        /// <param name="dataFeedGranularity">The frequency with which ingestion from the data source occurs.</param>
+        /// <param name="dataFeedSchema">Defines how this <see cref="DataFeed"/> structures the data ingested from the data source in terms of metrics and dimensions.</param>
+        /// <param name="dataFeedIngestionSettings">Configures how a <see cref="DataFeed"/> behaves during data ingestion from its data source.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeedName"/>, <paramref name="dataSource"/>, <paramref name="dataFeedGranularity"/>, <paramref name="dataFeedSchema"/>, or <paramref name="dataFeedIngestionSettings"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="dataFeedName"/> is empty.</exception>
+        public DataFeed(string dataFeedName, DataFeedSource dataSource, DataFeedGranularity dataFeedGranularity, DataFeedSchema dataFeedSchema, DataFeedIngestionSettings dataFeedIngestionSettings)
+        {
+            Argument.AssertNotNullOrEmpty(dataFeedName, nameof(dataFeedName));
+            Argument.AssertNotNull(dataSource, nameof(dataSource));
+            Argument.AssertNotNull(dataFeedGranularity, nameof(dataFeedGranularity));
+            Argument.AssertNotNull(dataFeedSchema, nameof(dataFeedSchema));
+            Argument.AssertNotNull(dataFeedIngestionSettings, nameof(dataFeedIngestionSettings));
+
+            Name = dataFeedName;
+            DataSource = dataSource;
+            SourceType = dataSource.Type;
+            Granularity = dataFeedGranularity;
+            Schema = dataFeedSchema;
+            IngestionSettings = dataFeedIngestionSettings;
+        }
+
         internal DataFeed(DataFeedDetail dataFeedDetail)
         {
             Id = dataFeedDetail.DataFeedId;
@@ -23,6 +49,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             IsAdministrator = dataFeedDetail.IsAdmin;
             MetricIds = dataFeedDetail.Metrics.Select(metric => metric.MetricId).ToList();
             Name = dataFeedDetail.DataFeedName;
+            DataSource = DataFeedSource.CreateDataFeedSourceInstance(dataFeedDetail);
             SourceType = dataFeedDetail.DataSourceType;
             Schema = new DataFeedSchema(dataFeedDetail);
             Granularity = new DataFeedGranularity(dataFeedDetail);
@@ -68,6 +95,11 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Name { get; }
 
         /// <summary>
+        /// The source from which data is consumed.
+        /// </summary>
+        public DataFeedSource DataSource { get; }
+
+        /// <summary>
         /// The type of data source that ingests this <see cref="DataFeed"/> with data.
         /// </summary>
         public DataFeedSourceType SourceType { get; }
@@ -92,301 +124,103 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// A set of options configuring the behavior of this <see cref="DataFeed"/>. Options include administrators,
         /// roll-up settings, access mode, and others.
         /// </summary>
-        public DataFeedOptions Options { get; }
+        public DataFeedOptions Options { get; set; }
 
-        /// <summary> Converts a data source specific <see cref="DataFeed"/> into its equivalent data source specific <see cref="DataFeedDetailPatch"/>. </summary>
+        internal DataFeedDetail BuildDataFeedDetail()
+        {
+            DataFeedDetail detail = DataSource.InstantiateDataFeedDetail(Name, Granularity.GranularityType, Schema.MetricColumns, IngestionSettings.IngestionStartTime);
+
+            foreach (var column in Schema.DimensionColumns)
+            {
+                detail.Dimension.Add(column);
+            }
+            detail.TimestampColumn = Schema.TimestampColumn;
+
+            detail.GranularityAmount = Granularity.CustomGranularityValue;
+
+            detail.MaxConcurrency = IngestionSettings.DataSourceRequestConcurrency;
+            detail.MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds;
+            detail.StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds;
+            detail.StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds;
+
+            if (Options != null)
+            {
+                detail.DataFeedDescription = Options.Description;
+                detail.ActionLinkTemplate = Options.ActionLinkTemplate;
+                detail.ViewMode = Options.AccessMode;
+                if (Options.RollupSettings != null)
+                {
+                    detail.AllUpIdentification = Options.RollupSettings.AlreadyRollupIdentificationValue;
+                    detail.NeedRollup = Options.RollupSettings.RollupType;
+                    detail.RollUpMethod = Options.RollupSettings.RollupMethod;
+                    foreach (string columnName in Options.RollupSettings.AutoRollupGroupByColumnNames)
+                    {
+                        detail.RollUpColumns.Add(columnName);
+                    }
+                }
+                if (Options.MissingDataPointFillSettings != null)
+                {
+                    detail.FillMissingPointType = Options.MissingDataPointFillSettings.FillType;
+                    detail.FillMissingPointValue = Options.MissingDataPointFillSettings.CustomFillValue;
+                }
+                foreach (string admin in Options.Administrators)
+                {
+                    detail.Admins.Add(admin);
+                }
+                foreach (string viewer in Options.Viewers)
+                {
+                    detail.Admins.Add(viewer);
+                }
+            }
+
+            return detail;
+        }
+
+        /// <summary>
+        /// Converts a data source specific <see cref="DataFeed"/> into its equivalent data source specific <see cref="DataFeedDetailPatch"/>.
+        /// </summary>
         internal DataFeedDetailPatch GetPatchModel()
         {
-            return this switch
+            DataFeedDetailPatch patch = DataSource.InstantiateDataFeedDetailPatch();
+
+            patch.DataFeedName = Name;
+            // TODO
+            // Currently cannot be set. Fix it when a better Update design is in place.
+            patch.Status = Status.HasValue ? new DataFeedDetailPatchStatus(Status.ToString()) : default;
+
+            patch.TimestampColumn = Schema.TimestampColumn;
+
+            patch.DataStartFrom = IngestionSettings.IngestionStartTime;
+            patch.MaxConcurrency = IngestionSettings.DataSourceRequestConcurrency;
+            patch.MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds;
+            patch.StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds;
+            patch.StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds;
+
+            if (Options != null)
             {
-                DataFeed p when p.SourceType == DataFeedSourceType.AzureApplicationInsights => new AzureApplicationInsightsDataFeedPatch()
+                patch.DataFeedDescription = Options.Description;
+                patch.ActionLinkTemplate = Options.ActionLinkTemplate;
+                // TODO
+                patch.ViewMode = Options.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(Options.AccessMode.ToString()) : default;
+                if (Options.RollupSettings != null)
                 {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.AzureBlob => new AzureBlobDataFeedPatch()
+                    patch.AllUpIdentification = Options.RollupSettings.AlreadyRollupIdentificationValue;
+                    // TODO
+                    patch.NeedRollup = Options.RollupSettings.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(Options.RollupSettings.RollupType.ToString()) : default;
+                    patch.RollUpMethod = Options.RollupSettings.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(Options.RollupSettings.RollupMethod.ToString()) : default;
+                    patch.RollUpColumns = Options.RollupSettings.AutoRollupGroupByColumnNames;
+                }
+                if (Options.MissingDataPointFillSettings != null)
                 {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.AzureCosmosDb => new AzureCosmosDBDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.AzureDataLakeStorageGen2 => new AzureDataLakeStorageGen2DataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.AzureTable => new AzureTableDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.Elasticsearch => new ElasticsearchDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.HttpRequest => new HttpRequestDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.InfluxDb => new InfluxDBDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.AzureDataExplorer => new AzureDataExplorerDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.MySql => new MySqlDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.PostgreSql => new PostgreSqlDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.SqlServer => new SQLServerDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                DataFeed p when p.SourceType == DataFeedSourceType.MongoDb => new MongoDBDataFeedPatch()
-                {
-                    DataFeedName = p.Name,
-                    DataFeedDescription = p.Options?.Description,
-                    TimestampColumn = p.Schema.TimestampColumn,
-                    DataStartFrom = p.IngestionSettings.IngestionStartTime,
-                    StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds,
-                    MaxConcurrency = p.IngestionSettings.DataSourceRequestConcurrency,
-                    MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds,
-                    StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds,
-                    NeedRollup = p.Options?.RollupSettings?.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(p.Options.RollupSettings.RollupType.ToString()) : default,
-                    RollUpMethod = p.Options?.RollupSettings?.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(p.Options.RollupSettings.RollupMethod.ToString()) : default,
-                    RollUpColumns = p.Options?.RollupSettings?.AutoRollupGroupByColumnNames ?? new ChangeTrackingList<string>(),
-                    AllUpIdentification = p.Options?.RollupSettings?.AlreadyRollupIdentificationValue,
-                    FillMissingPointType = p.Options?.MissingDataPointFillSettings?.FillType.HasValue == true  ? new DataFeedDetailPatchFillMissingPointType(p.Options.MissingDataPointFillSettings.FillType.ToString()) : default,
-                    FillMissingPointValue = p.Options?.MissingDataPointFillSettings?.CustomFillValue,
-                    ViewMode = p.Options?.AccessMode.HasValue == true ? new DataFeedDetailPatchViewMode(p.Options.AccessMode.ToString()) : default,
-                    Admins = p.Options?.Administrators,
-                    Viewers = p.Options?.Viewers,
-                    ActionLinkTemplate = p.Options?.ActionLinkTemplate,
-                    Status = p.Status.HasValue ? new DataFeedDetailPatchStatus(p.Status.ToString()) : default,
-                },
-                _ => throw new InvalidOperationException("Invalid DataFeedDetail type")
-            };
+                    // TODO
+                    patch.FillMissingPointType = Options.MissingDataPointFillSettings.FillType.HasValue == true ? new DataFeedDetailPatchFillMissingPointType(Options.MissingDataPointFillSettings.FillType.ToString()) : default;
+                    patch.FillMissingPointValue = Options.MissingDataPointFillSettings.CustomFillValue;
+                }
+                patch.Admins = Options.Administrators;
+                patch.Viewers = Options.Viewers;
+            }
+
+            return patch;
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -202,13 +202,13 @@ namespace Azure.AI.MetricsAdvisor.Models
                 if (Options.RollupSettings != null)
                 {
                     patch.AllUpIdentification = Options.RollupSettings.AlreadyRollupIdentificationValue;
-                    patch.NeedRollup = Options.RollupSettings.RollupType.HasValue == true ? new DataFeedDetailPatchNeedRollup(Options.RollupSettings.RollupType.ToString()) : default;
-                    patch.RollUpMethod = Options.RollupSettings.RollupMethod.HasValue == true ? new DataFeedDetailPatchRollUpMethod(Options.RollupSettings.RollupMethod.ToString()) : default;
+                    patch.NeedRollup = Options.RollupSettings.RollupType.HasValue ? new DataFeedDetailPatchNeedRollup(Options.RollupSettings.RollupType.ToString()) : default;
+                    patch.RollUpMethod = Options.RollupSettings.RollupMethod.HasValue ? new DataFeedDetailPatchRollUpMethod(Options.RollupSettings.RollupMethod.ToString()) : default;
                     patch.RollUpColumns = Options.RollupSettings.AutoRollupGroupByColumnNames;
                 }
                 if (Options.MissingDataPointFillSettings != null)
                 {
-                    patch.FillMissingPointType = Options.MissingDataPointFillSettings.FillType.HasValue == true ? new DataFeedDetailPatchFillMissingPointType(Options.MissingDataPointFillSettings.FillType.ToString()) : default;
+                    patch.FillMissingPointType = Options.MissingDataPointFillSettings.FillType.HasValue ? new DataFeedDetailPatchFillMissingPointType(Options.MissingDataPointFillSettings.FillType.ToString()) : default;
                     patch.FillMissingPointValue = Options.MissingDataPointFillSettings.CustomFillValue;
                 }
                 patch.Admins = Options.Administrators;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
@@ -38,7 +38,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The starting point in time from which data will be ingested from the data source. Subsequent
         /// ingestions happen periodically according to the data feed's granularity.
         /// </summary>
-        public DateTimeOffset IngestionStartTime { get; internal set; }
+        public DateTimeOffset IngestionStartTime { get; }
 
         /// <summary>
         /// If the specified data source supports limited concurrency, this can be set to specify the

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using Azure.Core;
+using System.Collections.Generic;
 
 namespace Azure.AI.MetricsAdvisor.Models
 {
@@ -11,91 +11,83 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// </summary>
     public abstract class DataFeedSource
     {
-        internal DataFeedDetail DataFeedDetail { get; set; }
+        internal DataFeedSourceType Type { get; }
 
         internal object Parameter { get; set; }
 
-        private DataFeedSourceType DataFeedSourceType { get; }
-
         internal DataFeedSource(DataFeedSourceType dataFeedSourceType)
         {
-            DataFeedSourceType = dataFeedSourceType;
+            Type = dataFeedSourceType;
         }
 
-        internal DataFeedSource(DataFeedDetail detail)
-        {
-            Argument.AssertNotNull(detail, nameof(detail));
-
-            DataFeedSourceType = detail.DataSourceType;
-            DataFeedDetail = detail;
-        }
-
-        /// <summary> Initializes a new instance of a data source specific DataFeedDetail. </summary>
-        /// <param name="dataFeedName"> data feed name. </param>
-        /// <param name="dataFeedGranularity"></param>
-        /// <param name="dataFeedSchema"></param>
-        /// <param name="dataFeedIngestionSettings"></param>
-        /// <param name="dataFeedOptions"></param>
-        internal void SetDetail(string dataFeedName, DataFeedGranularity dataFeedGranularity, DataFeedSchema dataFeedSchema, DataFeedIngestionSettings dataFeedIngestionSettings, DataFeedOptions dataFeedOptions)
-        {
-            dataFeedIngestionSettings.IngestionStartTime = ClientCommon.NormalizeDateTimeOffset(dataFeedIngestionSettings.IngestionStartTime);
-
-            DataFeedDetail = Parameter switch
+        internal static DataFeedSource CreateDataFeedSourceInstance(DataFeedDetail dataFeedDetail) =>
+            dataFeedDetail switch
             {
-                AzureApplicationInsightsParameter p => new AzureApplicationInsightsDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                AzureBlobParameter p => new AzureBlobDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                AzureCosmosDBParameter p => new AzureCosmosDBDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                AzureDataLakeStorageGen2Parameter p => new AzureDataLakeStorageGen2DataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                AzureTableParameter p => new AzureTableDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                ElasticsearchParameter p => new ElasticsearchDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                HttpRequestParameter p => new HttpRequestDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                InfluxDBParameter p => new InfluxDBDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                SqlSourceParameter p when DataFeedSourceType == DataFeedSourceType.AzureDataExplorer => new AzureDataExplorerDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                SqlSourceParameter p when DataFeedSourceType == DataFeedSourceType.MySql => new MySqlDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                SqlSourceParameter p when DataFeedSourceType == DataFeedSourceType.PostgreSql => new PostgreSqlDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                SqlSourceParameter p when DataFeedSourceType == DataFeedSourceType.SqlServer => new SQLServerDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
-                MongoDBParameter p => new MongoDBDataFeed(dataFeedName, dataFeedGranularity.GranularityType, dataFeedSchema.MetricColumns, dataFeedIngestionSettings.IngestionStartTime, p),
+                AzureApplicationInsightsDataFeed d => new AzureApplicationInsightsDataFeedSource(d.DataSourceParameter),
+                AzureBlobDataFeed d => new AzureBlobDataFeedSource(d.DataSourceParameter),
+                AzureCosmosDBDataFeed d => new AzureCosmosDbDataFeedSource(d.DataSourceParameter),
+                AzureDataLakeStorageGen2DataFeed d => new AzureDataLakeStorageGen2DataFeedSource(d.DataSourceParameter),
+                AzureTableDataFeed d => new AzureTableDataFeedSource(d.DataSourceParameter),
+                ElasticsearchDataFeed d => new ElasticsearchDataFeedSource(d.DataSourceParameter),
+                HttpRequestDataFeed d => new HttpRequestDataFeedSource(d.DataSourceParameter),
+                InfluxDBDataFeed d => new InfluxDbDataFeedSource(d.DataSourceParameter),
+                AzureDataExplorerDataFeed d => new AzureDataExplorerDataFeedSource(d.DataSourceParameter),
+                MySqlDataFeed d => new MySqlDataFeedSource(d.DataSourceParameter),
+                PostgreSqlDataFeed d => new PostgreSqlDataFeedSource(d.DataSourceParameter),
+                SQLServerDataFeed d => new SqlServerDataFeedSource(d.DataSourceParameter),
+                MongoDBDataFeed d => new MongoDbDataFeedSource(d.DataSourceParameter),
                 _ => throw new InvalidOperationException("Invalid DataFeedDetail type")
             };
 
-            DataFeedDetail.GranularityAmount = dataFeedGranularity.CustomGranularityValue;
-            foreach (var column in dataFeedSchema.DimensionColumns)
+        /// <summary>
+        /// Initializes a new instance of a data source specific DataFeedDetail.
+        /// </summary>
+        internal DataFeedDetail InstantiateDataFeedDetail(string name, DataFeedGranularityType granularityType, IList<DataFeedMetric> metricColumns, DateTimeOffset ingestionStartTime)
+        {
+            // TODO: do we do the same for patch?
+            ingestionStartTime = ClientCommon.NormalizeDateTimeOffset(ingestionStartTime);
+
+            return Parameter switch
             {
-                DataFeedDetail.Dimension.Add(column);
-            }
-            DataFeedDetail.TimestampColumn = dataFeedSchema.TimestampColumn;
-            DataFeedDetail.MaxConcurrency = dataFeedIngestionSettings.DataSourceRequestConcurrency;
-            DataFeedDetail.MinRetryIntervalInSeconds = (long?)dataFeedIngestionSettings.IngestionRetryDelay?.TotalSeconds;
-            DataFeedDetail.StartOffsetInSeconds = (long?)dataFeedIngestionSettings.IngestionStartOffset?.TotalSeconds;
-            DataFeedDetail.StopRetryAfterInSeconds = (long?)dataFeedIngestionSettings.StopRetryAfter?.TotalSeconds;
-            if (dataFeedOptions != null)
+                AzureApplicationInsightsParameter p => new AzureApplicationInsightsDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                AzureBlobParameter p => new AzureBlobDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                AzureCosmosDBParameter p => new AzureCosmosDBDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                AzureDataLakeStorageGen2Parameter p => new AzureDataLakeStorageGen2DataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                AzureTableParameter p => new AzureTableDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                ElasticsearchParameter p => new ElasticsearchDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                HttpRequestParameter p => new HttpRequestDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                InfluxDBParameter p => new InfluxDBDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                SqlSourceParameter p when Type == DataFeedSourceType.AzureDataExplorer => new AzureDataExplorerDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                SqlSourceParameter p when Type == DataFeedSourceType.MySql => new MySqlDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                SqlSourceParameter p when Type == DataFeedSourceType.PostgreSql => new PostgreSqlDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                SqlSourceParameter p when Type == DataFeedSourceType.SqlServer => new SQLServerDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                MongoDBParameter p => new MongoDBDataFeed(name, granularityType, metricColumns, ingestionStartTime, p),
+                _ => throw new InvalidOperationException("Invalid DataFeedDetail type")
+            };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of a data source specific DataFeedDetailPatch.
+        /// </summary>
+        internal DataFeedDetailPatch InstantiateDataFeedDetailPatch()
+        {
+            return Parameter switch
             {
-                foreach (var admin in dataFeedOptions.Administrators)
-                {
-                    DataFeedDetail.Admins.Add(admin);
-                }
-                foreach (var viewer in dataFeedOptions.Viewers)
-                {
-                    DataFeedDetail.Viewers.Add(viewer);
-                }
-                DataFeedDetail.DataFeedDescription = dataFeedOptions.Description;
-                DataFeedDetail.ViewMode = dataFeedOptions.AccessMode;
-                if (dataFeedOptions.RollupSettings != null)
-                {
-                    foreach (var columnName in dataFeedOptions.RollupSettings.AutoRollupGroupByColumnNames)
-                    {
-                        DataFeedDetail.RollUpColumns.Add(columnName);
-                    }
-                    DataFeedDetail.RollUpMethod = dataFeedOptions.RollupSettings.RollupMethod;
-                    DataFeedDetail.NeedRollup = dataFeedOptions.RollupSettings.RollupType;
-                }
-                if (dataFeedOptions.MissingDataPointFillSettings != null)
-                {
-                    DataFeedDetail.FillMissingPointType = dataFeedOptions.MissingDataPointFillSettings.FillType;
-                    DataFeedDetail.FillMissingPointValue = dataFeedOptions.MissingDataPointFillSettings.CustomFillValue;
-                }
-                DataFeedDetail.ActionLinkTemplate = dataFeedOptions.ActionLinkTemplate;
-            }
+                AzureApplicationInsightsParameter p => new AzureApplicationInsightsDataFeedPatch() { DataSourceParameter = p },
+                AzureBlobParameter p => new AzureBlobDataFeedPatch() { DataSourceParameter = p },
+                AzureCosmosDBParameter p => new AzureCosmosDBDataFeedPatch() { DataSourceParameter = p },
+                AzureDataLakeStorageGen2Parameter p => new AzureDataLakeStorageGen2DataFeedPatch() { DataSourceParameter = p },
+                AzureTableParameter p => new AzureTableDataFeedPatch() { DataSourceParameter = p },
+                ElasticsearchParameter p => new ElasticsearchDataFeedPatch() { DataSourceParameter = p },
+                HttpRequestParameter p => new HttpRequestDataFeedPatch() { DataSourceParameter = p },
+                InfluxDBParameter p => new InfluxDBDataFeedPatch() { DataSourceParameter = p },
+                SqlSourceParameter p when Type == DataFeedSourceType.AzureDataExplorer => new AzureDataExplorerDataFeedPatch() { DataSourceParameter = p },
+                SqlSourceParameter p when Type == DataFeedSourceType.MySql => new MySqlDataFeedPatch() { DataSourceParameter = p },
+                SqlSourceParameter p when Type == DataFeedSourceType.PostgreSql => new PostgreSqlDataFeedPatch() { DataSourceParameter = p },
+                SqlSourceParameter p when Type == DataFeedSourceType.SqlServer => new SQLServerDataFeedPatch() { DataSourceParameter = p },
+                MongoDBParameter p => new MongoDBDataFeedPatch() { DataSourceParameter = p },
+                _ => throw new InvalidOperationException("Invalid DataFeedDetailPatch type")
+            };
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSource.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             Type = dataFeedSourceType;
         }
 
-        internal static DataFeedSource CreateDataFeedSourceInstance(DataFeedDetail dataFeedDetail) =>
+        internal static DataFeedSource GetDataFeedSource(DataFeedDetail dataFeedDetail) =>
             dataFeedDetail switch
             {
                 AzureApplicationInsightsDataFeed d => new AzureApplicationInsightsDataFeedSource(d.DataSourceParameter),
@@ -44,7 +44,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// </summary>
         internal DataFeedDetail InstantiateDataFeedDetail(string name, DataFeedGranularityType granularityType, IList<DataFeedMetric> metricColumns, DateTimeOffset ingestionStartTime)
         {
-            // TODO: do we do the same for patch?
             ingestionStartTime = ClientCommon.NormalizeDateTimeOffset(ingestionStartTime);
 
             return Parameter switch

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/ElasticsearchDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/ElasticsearchDataFeedSource.cs
@@ -30,5 +30,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new ElasticsearchParameter(host, port, authHeader, query);
         }
+        internal ElasticsearchDataFeedSource(ElasticsearchParameter parameter)
+            : base(DataFeedSourceType.Elasticsearch)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
+
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/HttpRequestDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/HttpRequestDataFeedSource.cs
@@ -30,5 +30,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new HttpRequestParameter(url.AbsoluteUri, httpHeader, httpMethod, payload);
         }
+
+        internal HttpRequestDataFeedSource(HttpRequestParameter parameter)
+            : base(DataFeedSourceType.HttpRequest)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/InfluxDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/InfluxDbDataFeedSource.cs
@@ -32,5 +32,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new InfluxDBParameter(connectionString, database, username, password, query);
         }
+
+        internal InfluxDbDataFeedSource(InfluxDBParameter parameter)
+            : base(DataFeedSourceType.InfluxDb)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/MongoDbDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/MongoDbDataFeedSource.cs
@@ -28,5 +28,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new MongoDBParameter(connectionString, database, command);
         }
+        internal MongoDbDataFeedSource(MongoDBParameter parameter)
+            : base(DataFeedSourceType.MongoDb)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
+
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/MySqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/MySqlDataFeedSource.cs
@@ -26,5 +26,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new SqlSourceParameter(connectionString, query);
         }
+
+        internal MySqlDataFeedSource(SqlSourceParameter parameter)
+            : base(DataFeedSourceType.MySql)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/PostgreSqlDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/PostgreSqlDataFeedSource.cs
@@ -26,5 +26,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new SqlSourceParameter(connectionString, query);
         }
+
+        internal PostgreSqlDataFeedSource(SqlSourceParameter parameter)
+            : base(DataFeedSourceType.PostgreSql)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/SqlServerDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/SqlServerDataFeedSource.cs
@@ -26,5 +26,13 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = new SqlSourceParameter(connectionString, query);
         }
+
+        internal SqlServerDataFeedSource(SqlSourceParameter parameter)
+            : base(DataFeedSourceType.SqlServer)
+        {
+            Argument.AssertNotNull(parameter, nameof(parameter));
+
+            Parameter = parameter;
+        }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClientLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClientLiveTests.cs
@@ -113,11 +113,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(dataFeed.Id, Is.Not.Null);
 
-            dataFeed.Options.Description = Recording.GenerateAlphaNumericId("desc");
+            dataFeed.Options = new DataFeedOptions()
+            {
+                Description = Recording.GenerateAlphaNumericId("desc")
+            };
+
             await adminClient.UpdateDataFeedAsync(dataFeed.Id, dataFeed).ConfigureAwait(false);
 
             await adminClient.DeleteDataFeedAsync(dataFeed.Id).ConfigureAwait(false);
-            ;
         }
 
         [RecordedTest]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClientLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClientLiveTests.cs
@@ -60,14 +60,19 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var adminClient = GetMetricsAdvisorAdministrationClient();
             InitDataFeedSources();
 
-            DataFeed createdDataFeed = await adminClient.CreateDataFeedAsync(_blobFeedName, _blobSource, _dailyGranularity, _dataFeedSchema, _dataFeedIngestionSettings, _dataFeedOptions).ConfigureAwait(false);
+            DataFeed dataFeed = new DataFeed(_blobFeedName, _blobSource, _dailyGranularity, _dataFeedSchema, _dataFeedIngestionSettings)
+            {
+                Options = _dataFeedOptions
+            };
 
-            Assert.That(createdDataFeed.Id, Is.Not.Null);
+            dataFeed = await adminClient.CreateDataFeedAsync(dataFeed).ConfigureAwait(false);
 
-            createdDataFeed.Options.Description = Recording.GenerateAlphaNumericId("desc");
-            await adminClient.UpdateDataFeedAsync(createdDataFeed.Id, createdDataFeed).ConfigureAwait(false);
+            Assert.That(dataFeed.Id, Is.Not.Null);
 
-            await adminClient.DeleteDataFeedAsync(createdDataFeed.Id);
+            dataFeed.Options.Description = Recording.GenerateAlphaNumericId("desc");
+            await adminClient.UpdateDataFeedAsync(dataFeed.Id, dataFeed).ConfigureAwait(false);
+
+            await adminClient.DeleteDataFeedAsync(dataFeed.Id);
         }
 
         [RecordedTest]
@@ -76,11 +81,16 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var adminClient = GetMetricsAdvisorAdministrationClient();
             InitDataFeedSources();
 
-            DataFeed createdDataFeed = await adminClient.CreateDataFeedAsync(_blobFeedName, _blobSource, _dailyGranularity, _dataFeedSchema, _dataFeedIngestionSettings, _dataFeedOptions).ConfigureAwait(false);
+            DataFeed dataFeed = new DataFeed(_blobFeedName, _blobSource, _dailyGranularity, _dataFeedSchema, _dataFeedIngestionSettings)
+            {
+                Options = _dataFeedOptions
+            };
 
-            Assert.That(createdDataFeed.Id, Is.Not.Null);
+            dataFeed = await adminClient.CreateDataFeedAsync(dataFeed).ConfigureAwait(false);
 
-            DataFeed getDataFeed = await adminClient.GetDataFeedAsync(createdDataFeed.Id);
+            Assert.That(dataFeed.Id, Is.Not.Null);
+
+            DataFeed getDataFeed = await adminClient.GetDataFeedAsync(dataFeed.Id);
 
             getDataFeed.Options.Description = Recording.GenerateAlphaNumericId("desc");
             getDataFeed.Options.MissingDataPointFillSettings.CustomFillValue = 42;
@@ -88,7 +98,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await adminClient.UpdateDataFeedAsync(getDataFeed.Id, getDataFeed).ConfigureAwait(false);
 
-            await adminClient.DeleteDataFeedAsync(createdDataFeed.Id);
+            await adminClient.DeleteDataFeedAsync(dataFeed.Id);
         }
 
         [RecordedTest]
@@ -97,14 +107,16 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var adminClient = GetMetricsAdvisorAdministrationClient();
             InitDataFeedSources();
 
-            DataFeed createdDataFeed = await adminClient.CreateDataFeedAsync(_blobFeedName, _blobSource, _dailyGranularity, _dataFeedSchema, _dataFeedIngestionSettings, dataFeedOptions: null).ConfigureAwait(false);
+            DataFeed dataFeed = new DataFeed(_blobFeedName, _blobSource, _dailyGranularity, _dataFeedSchema, _dataFeedIngestionSettings);
 
-            Assert.That(createdDataFeed.Id, Is.Not.Null);
+            dataFeed = await adminClient.CreateDataFeedAsync(dataFeed).ConfigureAwait(false);
 
-            createdDataFeed.Options.Description = Recording.GenerateAlphaNumericId("desc");
-            await adminClient.UpdateDataFeedAsync(createdDataFeed.Id, createdDataFeed).ConfigureAwait(false);
+            Assert.That(dataFeed.Id, Is.Not.Null);
 
-            await adminClient.DeleteDataFeedAsync(createdDataFeed.Id).ConfigureAwait(false);
+            dataFeed.Options.Description = Recording.GenerateAlphaNumericId("desc");
+            await adminClient.UpdateDataFeedAsync(dataFeed.Id, dataFeed).ConfigureAwait(false);
+
+            await adminClient.DeleteDataFeedAsync(dataFeed.Id).ConfigureAwait(false);
             ;
         }
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
@@ -54,10 +54,11 @@ namespace Azure.AI.MetricsAdvisor.Samples
             var ingestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
             var dataFeedIngestionSettings = new DataFeedIngestionSettings(ingestionStartTime);
 
-            Response<DataFeed> response = await adminClient.CreateDataFeedAsync(dataFeedName, dataFeedSource,
-                dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings);
+            var dataFeed = new DataFeed(dataFeedName, dataFeedSource, dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings);
 
-            DataFeed dataFeed = response.Value;
+            Response<DataFeed> response = await adminClient.CreateDataFeedAsync(dataFeed);
+
+            dataFeed = response.Value;
 
             Console.WriteLine($"Data feed ID: {dataFeed.Id}");
             #endregion

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeed.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeed.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "394",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-248a040fb6c58f4ba776dd93b799a577-a53832ec13da8749-00",
+        "traceparent": "00-e198ae3b121b91459395b5e2f8cff6fb-a77badd88d12804c-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200930.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a29f66d6509a5f22400d06ca187f5c3c",
@@ -34,71 +34,73 @@
             "metricDescription": "someDescription"
           }
         ],
-        "dataStartFrom": "2020-09-30T00:00:00Z"
+        "dataStartFrom": "2020-10-28T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "15ef62bb-d988-4b9e-90fb-989914a8230a",
+        "apim-request-id": "49389c51-7cf4-466d-9531-0d26a43931d3",
         "Content-Length": "0",
-        "Date": "Wed, 30 Sep 2020 22:46:35 GMT",
-        "Location": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc40d277-0848-45d2-a4d1-7433f674e6e8",
+        "Date": "Wed, 28 Oct 2020 18:40:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2ef373e3-5aba-421f-8aff-7bd4cd55fd9d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10529",
-        "X-Request-ID": "15ef62bb-d988-4b9e-90fb-989914a8230a"
+        "x-envoy-upstream-service-time": "5535",
+        "X-Request-ID": "49389c51-7cf4-466d-9531-0d26a43931d3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc40d277-0848-45d2-a4d1-7433f674e6e8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2ef373e3-5aba-421f-8aff-7bd4cd55fd9d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "232",
+        "Content-Length": "265",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-db04d9dac32d404c90001525c41239bf-f705907ad209f24c-00",
+        "traceparent": "00-f5d0cfe04b251346b3e17101a1493849-811e84b336957e4e-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200930.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "05bf8e871ebca6814f4822e1aabb4f61",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "foo",
+          "blobTemplate": "template"
+        },
         "dataSourceType": "AzureBlob",
         "dataFeedName": "testBUIyQFO5",
         "dataFeedDescription": "descU17vAWN9",
-        "dataStartFrom": "2020-09-30T00:00:00Z",
-        "needRollup": null,
-        "rollUpMethod": null,
-        "fillMissingPointType": null,
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "viewMode": null,
         "status": null
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "10f16227-40cf-440d-b88d-c3b1e154f4a6",
+        "apim-request-id": "c646c7b8-027a-492c-aa35-b14c864fbf40",
         "Content-Length": "0",
-        "Date": "Wed, 30 Sep 2020 22:46:46 GMT",
+        "Date": "Wed, 28 Oct 2020 18:40:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "10681",
-        "X-Request-ID": "10f16227-40cf-440d-b88d-c3b1e154f4a6"
+        "x-envoy-upstream-service-time": "675",
+        "X-Request-ID": "c646c7b8-027a-492c-aa35-b14c864fbf40"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc40d277-0848-45d2-a4d1-7433f674e6e8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2ef373e3-5aba-421f-8aff-7bd4cd55fd9d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8c0ddc350f658f41ba13cafdc877cc55-d91e9d7a8f4c184b-00",
+        "traceparent": "00-a3f0c5577c07a34ba120f9a80d2717e5-3ebe342404855945-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200930.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "29fd742fd7baa09a52330651fa20044d",
@@ -107,20 +109,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "abbc3fe5-3fc0-4cd8-82a5-11e2e52ff3b2",
+        "apim-request-id": "54877892-f15c-47ce-8b5e-69eff9db3985",
         "Content-Length": "0",
-        "Date": "Wed, 30 Sep 2020 22:46:51 GMT",
+        "Date": "Wed, 28 Oct 2020 18:40:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5418",
-        "X-Request-ID": "abbc3fe5-3fc0-4cd8-82a5-11e2e52ff3b2"
+        "x-envoy-upstream-service-time": "5332",
+        "X-Request-ID": "54877892-f15c-47ce-8b5e-69eff9db3985"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-09-30T17:46:24.6471525-05:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-10-28T11:40:18.2937184-07:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "394",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-061dc0976ce6eb448707fb29034880bd-e58a61053e267d41-00",
+        "traceparent": "00-258cd2c0885386499cd55f31fb63fad3-3847f826a79d2540-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200930.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a6259961edb6409a07ef3275c87c77fa",
@@ -34,71 +34,73 @@
             "metricDescription": "someDescription"
           }
         ],
-        "dataStartFrom": "2020-09-30T00:00:00Z"
+        "dataStartFrom": "2020-10-28T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "670a9bf8-a106-4b48-8e87-bb4b8cd13290",
+        "apim-request-id": "a7a894d4-3ea9-4913-a687-10723f0072ac",
         "Content-Length": "0",
-        "Date": "Wed, 30 Sep 2020 22:46:52 GMT",
-        "Location": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55ea897b-6a78-4798-b568-22e953655a5f",
+        "Date": "Wed, 28 Oct 2020 18:41:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ffb2ee37-4c8d-4060-bbf8-7e8ad7fa8337",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "359",
-        "X-Request-ID": "670a9bf8-a106-4b48-8e87-bb4b8cd13290"
+        "x-envoy-upstream-service-time": "644",
+        "X-Request-ID": "a7a894d4-3ea9-4913-a687-10723f0072ac"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55ea897b-6a78-4798-b568-22e953655a5f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ffb2ee37-4c8d-4060-bbf8-7e8ad7fa8337",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "232",
+        "Content-Length": "265",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-786a06854e064348be64d51b79635d45-6728592564173d41-00",
+        "traceparent": "00-6403de9ec9a112429612f54d9dfb1ef2-2349b99abf64014c-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200930.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1cec035913bb358eb8c746cb12695bcd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "foo",
+          "blobTemplate": "template"
+        },
         "dataSourceType": "AzureBlob",
         "dataFeedName": "testcDESulVE",
         "dataFeedDescription": "descozI95qqA",
-        "dataStartFrom": "2020-09-30T00:00:00Z",
-        "needRollup": null,
-        "rollUpMethod": null,
-        "fillMissingPointType": null,
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "viewMode": null,
         "status": null
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d557576c-86b7-4460-9f8b-34b0570f2282",
+        "apim-request-id": "ee0ed1d9-3ea3-45d8-bc01-902d17294144",
         "Content-Length": "0",
-        "Date": "Wed, 30 Sep 2020 22:46:53 GMT",
+        "Date": "Wed, 28 Oct 2020 18:41:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "463",
-        "X-Request-ID": "d557576c-86b7-4460-9f8b-34b0570f2282"
+        "x-envoy-upstream-service-time": "615",
+        "X-Request-ID": "ee0ed1d9-3ea3-45d8-bc01-902d17294144"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55ea897b-6a78-4798-b568-22e953655a5f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ffb2ee37-4c8d-4060-bbf8-7e8ad7fa8337",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1c27ea0d5f91ab48bb3e131cc0aeaa9b-51223175dbc0b540-00",
+        "traceparent": "00-69bb62a47a3068429e3f0ce0607b5444-c3722848e7bdc549-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200930.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ef1486f477a7854057ce4ee1313f6896",
@@ -107,20 +109,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "22c3ed6b-4c03-436a-8787-23f7b3875796",
+        "apim-request-id": "ac1add46-9121-44d5-a3f9-015aa2162892",
         "Content-Length": "0",
-        "Date": "Wed, 30 Sep 2020 22:46:53 GMT",
+        "Date": "Wed, 28 Oct 2020 18:41:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "300",
-        "X-Request-ID": "22c3ed6b-4c03-436a-8787-23f7b3875796"
+        "x-envoy-upstream-service-time": "227",
+        "X-Request-ID": "ac1add46-9121-44d5-a3f9-015aa2162892"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-09-30T17:46:52.8612125-05:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-10-28T11:41:06.0650732-07:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedFromGet.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedFromGet.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "394",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-91ebc6726d8b3d40a1119c3df132d068-03b12ab2a523ff4f-00",
+        "traceparent": "00-891d4e333b209e4abb14f9eb6bc0c22d-edb98540f2bdbe45-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "96dc954a6befadbf546cef4b33280818",
@@ -34,31 +34,31 @@
             "metricDescription": "someDescription"
           }
         ],
-        "dataStartFrom": "2020-10-07T00:00:00Z"
+        "dataStartFrom": "2020-10-28T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "93c17ca2-28d7-4f7b-9a0f-fb7014c0c17c",
+        "apim-request-id": "85dbe73c-49d7-4d7e-9ae8-9cfc189cc90a",
         "Content-Length": "0",
-        "Date": "Wed, 07 Oct 2020 14:14:10 GMT",
-        "Location": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b65f4cbc-2ffc-4e95-aac5-95f6990fc517",
+        "Date": "Wed, 28 Oct 2020 18:40:49 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/95ffb635-5ba3-4396-974f-a91f65962ee9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "5684",
-        "X-Request-ID": "93c17ca2-28d7-4f7b-9a0f-fb7014c0c17c"
+        "x-envoy-upstream-service-time": "310",
+        "X-Request-ID": "85dbe73c-49d7-4d7e-9ae8-9cfc189cc90a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b65f4cbc-2ffc-4e95-aac5-95f6990fc517",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/95ffb635-5ba3-4396-974f-a91f65962ee9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4a1487c8c4e9894a89ac9b2ecc10527e-3cda393458fb9a4c-00",
+        "traceparent": "00-5049b30cd806da4fa1e85667438369c6-6f68d9189e6aec41-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4a88ae85f892fce5fbfd8aec04a22869",
@@ -67,28 +67,28 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f1dc3e5-711a-4f20-b417-a554d179e305",
+        "apim-request-id": "37aa3555-ba44-4afe-a1de-7f415bd6da87",
         "Content-Length": "1031",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 07 Oct 2020 14:14:28 GMT",
+        "Date": "Wed, 28 Oct 2020 18:40:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "17898",
-        "X-Request-ID": "6f1dc3e5-711a-4f20-b417-a554d179e305"
+        "x-envoy-upstream-service-time": "146",
+        "X-Request-ID": "37aa3555-ba44-4afe-a1de-7f415bd6da87"
       },
       "ResponseBody": {
-        "dataFeedId": "b65f4cbc-2ffc-4e95-aac5-95f6990fc517",
+        "dataFeedId": "95ffb635-5ba3-4396-974f-a91f65962ee9",
         "dataFeedName": "testP9GzRcqT",
         "metrics": [
           {
-            "metricId": "f5c3f6ca-5544-41c9-867a-2e7832fe5021",
+            "metricId": "4ae89cdf-bef7-4853-bdf1-35ff1453065f",
             "metricName": "someMetricName",
             "metricDisplayName": "someMetricDisplayName",
             "metricDescription": "someDescription"
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-10-07T00:00:00Z",
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "",
         "startOffsetInSeconds": 0,
@@ -112,7 +112,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-10-07T14:14:10Z",
+        "createdTime": "2020-10-28T18:40:49Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -123,28 +123,33 @@
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b65f4cbc-2ffc-4e95-aac5-95f6990fc517",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/95ffb635-5ba3-4396-974f-a91f65962ee9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "496",
+        "Content-Length": "595",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cd4c694928aa9341b9fbb6642220cfca-5a424c079a72f541-00",
+        "traceparent": "00-7fdf232a8be231489565a70e7277b494-955d58aadc8e874f-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "898ec986729c5069f99b94f66acda252",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "foo",
+          "blobTemplate": "template"
+        },
         "dataSourceType": "AzureBlob",
         "dataFeedName": "testP9GzRcqT",
         "dataFeedDescription": "descy8eoKjh5",
         "timestampColumn": "",
-        "dataStartFrom": "2020-10-07T00:00:00Z",
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "startOffsetInSeconds": 0,
         "maxConcurrency": -1,
         "minRetryIntervalInSeconds": -1,
@@ -164,26 +169,26 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4ffbbfd7-4451-49aa-9ce8-4a57b4324dad",
+        "apim-request-id": "362c5481-3c6e-4191-ba03-f6e8be99cdf5",
         "Content-Length": "0",
-        "Date": "Wed, 07 Oct 2020 14:14:36 GMT",
+        "Date": "Wed, 28 Oct 2020 18:40:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "8415",
-        "X-Request-ID": "4ffbbfd7-4451-49aa-9ce8-4a57b4324dad"
+        "x-envoy-upstream-service-time": "654",
+        "X-Request-ID": "362c5481-3c6e-4191-ba03-f6e8be99cdf5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b65f4cbc-2ffc-4e95-aac5-95f6990fc517",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/95ffb635-5ba3-4396-974f-a91f65962ee9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4b1cf3caf9480c4d93a74be900ee8cb2-8e0756fae93f1e43-00",
+        "traceparent": "00-87b53bfe4f60b24eb470912ec36ac69f-dcaafa40a9803141-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f29ae0afd3e0b1a94386d46bbeed9229",
@@ -192,20 +197,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6cf34a80-cd77-449f-a504-3e15a5d3aadb",
+        "apim-request-id": "3e1eea90-7b49-4565-a58c-a8fed86fb91d",
         "Content-Length": "0",
-        "Date": "Wed, 07 Oct 2020 14:14:37 GMT",
+        "Date": "Wed, 28 Oct 2020 18:40:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "259",
-        "X-Request-ID": "6cf34a80-cd77-449f-a504-3e15a5d3aadb"
+        "x-envoy-upstream-service-time": "229",
+        "X-Request-ID": "3e1eea90-7b49-4565-a58c-a8fed86fb91d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-10-07T07:14:03.6768669-07:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-10-28T11:40:48.4830960-07:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedFromGetAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedFromGetAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "394",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-803828c61ab3ff48b84c6264cdcdb20f-c5ea4a3ad8a2ba42-00",
+        "traceparent": "00-d2fd7f889f580a488085927302589bdd-e2339c1a1be9fa4d-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "486faeaa13f9878faaf9f9aad989a23c",
@@ -34,31 +34,31 @@
             "metricDescription": "someDescription"
           }
         ],
-        "dataStartFrom": "2020-10-07T00:00:00Z"
+        "dataStartFrom": "2020-10-28T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "edf61ade-2589-4538-852f-e3195e79812c",
+        "apim-request-id": "ac449482-957a-48d5-babd-0deb0cdde5d1",
         "Content-Length": "0",
-        "Date": "Wed, 07 Oct 2020 14:14:38 GMT",
-        "Location": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0bc0d1-f4fd-4438-a603-ee7eb2490721",
+        "Date": "Wed, 28 Oct 2020 18:41:07 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ff454466-6ff7-4cd0-9df1-3c3e2f939580",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "508",
-        "X-Request-ID": "edf61ade-2589-4538-852f-e3195e79812c"
+        "x-envoy-upstream-service-time": "445",
+        "X-Request-ID": "ac449482-957a-48d5-babd-0deb0cdde5d1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0bc0d1-f4fd-4438-a603-ee7eb2490721",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ff454466-6ff7-4cd0-9df1-3c3e2f939580",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9695137ca4010147a7dc6f081af5fbb6-cc9a4ec5acf4e94e-00",
+        "traceparent": "00-60d98702b78a444d9acc5a3532530732-a9496cd74b1db246-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ca06a26b26f3b60b33a6ea44e2d5a54a",
@@ -67,28 +67,28 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "92e92337-35d5-49a0-9e58-42b5ab0ad08a",
+        "apim-request-id": "58b2a999-5a3b-4e9f-a6fe-2e84ea4508be",
         "Content-Length": "1031",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 07 Oct 2020 14:14:38 GMT",
+        "Date": "Wed, 28 Oct 2020 18:41:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "X-Request-ID": "92e92337-35d5-49a0-9e58-42b5ab0ad08a"
+        "x-envoy-upstream-service-time": "113",
+        "X-Request-ID": "58b2a999-5a3b-4e9f-a6fe-2e84ea4508be"
       },
       "ResponseBody": {
-        "dataFeedId": "4d0bc0d1-f4fd-4438-a603-ee7eb2490721",
+        "dataFeedId": "ff454466-6ff7-4cd0-9df1-3c3e2f939580",
         "dataFeedName": "testXb9Olo8m",
         "metrics": [
           {
-            "metricId": "5f615202-2739-4f8c-ac8e-dac86992cd59",
+            "metricId": "0481bd34-ee87-4970-abf4-542b6af0f356",
             "metricName": "someMetricName",
             "metricDisplayName": "someMetricDisplayName",
             "metricDescription": "someDescription"
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-10-07T00:00:00Z",
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "",
         "startOffsetInSeconds": 0,
@@ -112,7 +112,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-10-07T14:14:38Z",
+        "createdTime": "2020-10-28T18:41:08Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -123,28 +123,33 @@
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0bc0d1-f4fd-4438-a603-ee7eb2490721",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ff454466-6ff7-4cd0-9df1-3c3e2f939580",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "496",
+        "Content-Length": "595",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d7794b243946d43b97d27bbf00e39e3-2c0e9dfa1056a945-00",
+        "traceparent": "00-bc43fc59df87644ba3fe8a4639d84297-1887a6c44e7fa34b-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c01e0541c178fe13545851b9c15a4483",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "foo",
+          "blobTemplate": "template"
+        },
         "dataSourceType": "AzureBlob",
         "dataFeedName": "testXb9Olo8m",
         "dataFeedDescription": "descnVzy8c9y",
         "timestampColumn": "",
-        "dataStartFrom": "2020-10-07T00:00:00Z",
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "startOffsetInSeconds": 0,
         "maxConcurrency": -1,
         "minRetryIntervalInSeconds": -1,
@@ -164,26 +169,26 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "07e2d476-c2d4-423b-99f9-23e3b46af498",
+        "apim-request-id": "0ac43662-ec4b-44cb-928c-23baebe8594c",
         "Content-Length": "0",
-        "Date": "Wed, 07 Oct 2020 14:14:39 GMT",
+        "Date": "Wed, 28 Oct 2020 18:41:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "527",
-        "X-Request-ID": "07e2d476-c2d4-423b-99f9-23e3b46af498"
+        "x-envoy-upstream-service-time": "615",
+        "X-Request-ID": "0ac43662-ec4b-44cb-928c-23baebe8594c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0bc0d1-f4fd-4438-a603-ee7eb2490721",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ff454466-6ff7-4cd0-9df1-3c3e2f939580",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3de884bf2fff844c9a3cce41f911e7c6-32b4317b84b12041-00",
+        "traceparent": "00-6cdd91de0d9cdc48850a9e31ff9e0431-c7fc8c7fecebe34a-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201007.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.19041 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5214b8a24a28d5a454ae57f7580fc53b",
@@ -192,20 +197,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "70b5d360-30c3-4626-94e5-71dc2f255a1f",
+        "apim-request-id": "f73c5adc-9140-4ad1-8418-bf3af998ae2b",
         "Content-Length": "0",
-        "Date": "Wed, 07 Oct 2020 14:14:39 GMT",
+        "Date": "Wed, 28 Oct 2020 18:41:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "335",
-        "X-Request-ID": "70b5d360-30c3-4626-94e5-71dc2f255a1f"
+        "x-envoy-upstream-service-time": "245",
+        "X-Request-ID": "f73c5adc-9140-4ad1-8418-bf3af998ae2b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-10-07T07:14:37.9054348-07:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-10-28T11:41:08.1483879-07:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedNullOptions.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedNullOptions.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "350",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2593b1c6dd21cc4f968f3fdee2b9bf77-9b56cb6a14fda641-00",
+        "traceparent": "00-1237825e0f5500478f546ed2270f69e0-0345b94919bf6e4c-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201005.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "da34050857241c1b63f966e943fd3db1",
@@ -33,71 +33,73 @@
             "metricDescription": "someDescription"
           }
         ],
-        "dataStartFrom": "2020-10-05T00:00:00Z"
+        "dataStartFrom": "2020-10-28T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5b6964e2-e59d-49d7-95ab-c4030406dd1d",
+        "apim-request-id": "068866ba-a231-4e4a-aaef-07196e276549",
         "Content-Length": "0",
-        "Date": "Mon, 05 Oct 2020 15:20:44 GMT",
-        "Location": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3088da1a-4256-4240-a034-c5b9a978dd70",
+        "Date": "Wed, 28 Oct 2020 18:46:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/92fef93f-054e-4e6e-b125-47d03d8cfe63",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "307",
-        "X-Request-ID": "5b6964e2-e59d-49d7-95ab-c4030406dd1d"
+        "x-envoy-upstream-service-time": "441",
+        "X-Request-ID": "068866ba-a231-4e4a-aaef-07196e276549"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3088da1a-4256-4240-a034-c5b9a978dd70",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/92fef93f-054e-4e6e-b125-47d03d8cfe63",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "232",
+        "Content-Length": "265",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21e91ac2571f9f488ef5e64f70bf5b7f-cd239e47eee6ad4e-00",
+        "traceparent": "00-fd8905eb7440a847b615beee1fbbe93e-244fc68d9e5beb45-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201005.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7d6b60ee925b3d52aced9156cc883f68",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "foo",
+          "blobTemplate": "template"
+        },
         "dataSourceType": "AzureBlob",
         "dataFeedName": "testgaFwl7u0",
         "dataFeedDescription": "descGVciX0cR",
-        "dataStartFrom": "2020-10-05T00:00:00Z",
-        "needRollup": null,
-        "rollUpMethod": null,
-        "fillMissingPointType": null,
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "viewMode": null,
         "status": null
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "eb1b0c04-a066-46b0-8711-6399512f4f65",
+        "apim-request-id": "e0bd9d32-300f-443b-92d6-61d50bc5efa3",
         "Content-Length": "0",
-        "Date": "Mon, 05 Oct 2020 15:20:45 GMT",
+        "Date": "Wed, 28 Oct 2020 18:46:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "454",
-        "X-Request-ID": "eb1b0c04-a066-46b0-8711-6399512f4f65"
+        "x-envoy-upstream-service-time": "589",
+        "X-Request-ID": "e0bd9d32-300f-443b-92d6-61d50bc5efa3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3088da1a-4256-4240-a034-c5b9a978dd70",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/92fef93f-054e-4e6e-b125-47d03d8cfe63",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c5516f8bdec6f844909d4cf26717ec0b-2d1a99351963b048-00",
+        "traceparent": "00-c767b612a22a994a97797204da46672f-b99f068c5365b846-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201005.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "52cbaed28098609b4215d311fdae7c6b",
@@ -106,20 +108,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "23287323-bc20-4d2c-8353-f5c3a2f3a87a",
+        "apim-request-id": "81e79916-ad8b-44a0-81c1-7ddebe4ceef2",
         "Content-Length": "0",
-        "Date": "Mon, 05 Oct 2020 15:20:45 GMT",
+        "Date": "Wed, 28 Oct 2020 18:46:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "257",
-        "X-Request-ID": "23287323-bc20-4d2c-8353-f5c3a2f3a87a"
+        "x-envoy-upstream-service-time": "279",
+        "X-Request-ID": "81e79916-ad8b-44a0-81c1-7ddebe4ceef2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-10-05T10:20:45.5757822-05:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-10-28T11:46:18.2422249-07:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedNullOptionsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorAdministrationClientLiveTests/CreateAndUpdateBlobDataFeedNullOptionsAsync.json
@@ -1,17 +1,17 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "350",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2ca2853872d18e4095cf0950775dcc72-b9a9478d4b35e048-00",
+        "traceparent": "00-8637617f0cabb24d86af2b853d50f4fb-43865f1d5ada3d49-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201005.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "86de1e049ffe3049bbbde30edec00852",
@@ -33,71 +33,73 @@
             "metricDescription": "someDescription"
           }
         ],
-        "dataStartFrom": "2020-10-05T00:00:00Z"
+        "dataStartFrom": "2020-10-28T00:00:00Z"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "08a15992-dd70-4997-9ef3-44b7e3201915",
+        "apim-request-id": "a86ed3ee-8acb-4e0b-871c-c6dde88332a9",
         "Content-Length": "0",
-        "Date": "Mon, 05 Oct 2020 15:20:52 GMT",
-        "Location": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/721a87b9-c538-4cc1-a503-9041562b7876",
+        "Date": "Wed, 28 Oct 2020 18:45:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7df4acd6-369d-4528-9520-a8b300162957",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "294",
-        "X-Request-ID": "08a15992-dd70-4997-9ef3-44b7e3201915"
+        "x-envoy-upstream-service-time": "729",
+        "X-Request-ID": "a86ed3ee-8acb-4e0b-871c-c6dde88332a9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/721a87b9-c538-4cc1-a503-9041562b7876",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7df4acd6-369d-4528-9520-a8b300162957",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "232",
+        "Content-Length": "265",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e4bc1f072296854ab6a21d006b68492d-0331daaa3581d940-00",
+        "traceparent": "00-4b127b3ffb24ef4282c524e37d7dce5d-e671bd3976bfed49-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201005.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "eed18a881bdc931e56056a89e786667b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "foo",
+          "blobTemplate": "template"
+        },
         "dataSourceType": "AzureBlob",
         "dataFeedName": "testEm4Bzhht",
         "dataFeedDescription": "descCUE8itQq",
-        "dataStartFrom": "2020-10-05T00:00:00Z",
-        "needRollup": null,
-        "rollUpMethod": null,
-        "fillMissingPointType": null,
+        "dataStartFrom": "2020-10-28T00:00:00Z",
         "viewMode": null,
         "status": null
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "167acc86-c8ce-4701-863d-b5302224e1e1",
+        "apim-request-id": "2bf0ab5f-de38-4774-8049-24434d84e4f9",
         "Content-Length": "0",
-        "Date": "Mon, 05 Oct 2020 15:20:52 GMT",
+        "Date": "Wed, 28 Oct 2020 18:45:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "453",
-        "X-Request-ID": "167acc86-c8ce-4701-863d-b5302224e1e1"
+        "x-envoy-upstream-service-time": "757",
+        "X-Request-ID": "2bf0ab5f-de38-4774-8049-24434d84e4f9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/721a87b9-c538-4cc1-a503-9041562b7876",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7df4acd6-369d-4528-9520-a8b300162957",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-34a3110cb05fa2448afdac891d2f6704-97cc5b765a868d4d-00",
+        "traceparent": "00-236751f359c52a45bb134f4a5f3838e4-45ea7179b376b447-00",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201005.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201028.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d1e22e512e341b4e81243c5d03680332",
@@ -106,20 +108,20 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "42c78968-1bf7-459b-a843-ae6e6ae6b89f",
+        "apim-request-id": "32cee884-133d-4b9a-85e5-f3d6a8549e9d",
         "Content-Length": "0",
-        "Date": "Mon, 05 Oct 2020 15:20:53 GMT",
+        "Date": "Wed, 28 Oct 2020 18:46:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "237",
-        "X-Request-ID": "42c78968-1bf7-459b-a843-ae6e6ae6b89f"
+        "x-envoy-upstream-service-time": "5414",
+        "X-Request-ID": "32cee884-133d-4b9a-85e5-f3d6a8549e9d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-10-05T10:20:52.7202771-05:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-10-28T11:45:54.3245326-07:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_PRIMARY_STORAGE_ACCOUNT_KEY": "Kg==",


### PR DESCRIPTION
Adding a `DataSource` property to `DataFeed` made some restructuring necessary. We are not keeping an internal `DataFeedDetail` instance anymore. Instead, a new `DataFeedDetail` is built right before we serialize the model and send it to the service.

These three possible scenarios are being covered:
- User has a `DataFeed` object and calls `CreateDataFeed`. `DataFeed.GetDataFeedDetail` is called to build a `DataFeedDetail` from scratch. It goes as follows:
  - Firstly, a call to `DataFeedSource.InstantiateDataFeedDetail` is made to get the right `DataFeedDetail` derived class to build (`AzureBlobDataFeed`, for instance).
  - Finally, all properties of the created instance are assigned based on the properties of the `DataFeed`.
</br>

- User has a `DataFeed` object and calls `UpdateDataFeed`. `DataFeed.GetPatchModel` is called to build a `DataFeedDetailPatch` from scratch. It goes as follows:
  - Firstly, a call to `DataFeedSource.InstantiateDataFeedDetailPatch` is made to get the right `DataFeedDetailPatch` derived class to build (`AzureBlobDataFeedPatch`, for instance).
  - Finally, all properties of the created instance are assigned based on the properties of the `DataFeed`.
</br>

- User calls `GetDataFeed` and a new `DataFeed` object must be built from `DataFeedDetail`. There are no major changes in the behavior, but we now need to be able to build a `DataFeedSource` from the `DataFeedDetail` returned by the service. The static method `DataFeedSource.GetDataFeedSource` was created for this purpose.

Fixes https://github.com/azure/azure-sdk-for-net/issues/16170.
Fixes https://github.com/azure/azure-sdk-for-net/issues/16313.