### PR TITLE
Disable code coverage

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -118,8 +118,6 @@ jobs:
         Windows_NetCoreApp:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1
-          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            CollectCoverage: true
         Windows_NetCoreApp_ProjectReferences:
           OSVmImage: "windows-2019"
           TestTargetFramework: netcoreapp2.1


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/15231


Azure.Core builds started failing after the code coverage change was merged. Considering there is, currently, no one who can look into coverage failing and the coverage is not useful because it doesn't display in devops I'm disabling it.
