### PR TITLE
feat(e2e): Adding E2E tests to test passing custom object serializer

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/E2eTestBase.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/E2eTestBase.cs
@@ -35,13 +35,18 @@ namespace Azure.DigitalTwins.Core.Tests
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
-        protected DigitalTwinsClient GetClient()
+        protected DigitalTwinsClient GetClient(DigitalTwinsClientOptions options = null)
         {
+            if (options == null)
+            {
+                options = new DigitalTwinsClientOptions();
+            }
+
             return InstrumentClient(
                 new DigitalTwinsClient(
                     new Uri(TestEnvironment.DigitalTwinHostname),
                     TestEnvironment.Credential,
-                    InstrumentClientOptions(new DigitalTwinsClientOptions())));
+                    InstrumentClientOptions(options)));
         }
 
         protected DigitalTwinsClient GetFakeClient()

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwinOperationsWithCustomObjectSerializer_Succeeds.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwinOperationsWithCustomObjectSerializer_Succeeds.json
@@ -1,0 +1,894 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin61537088?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4ba9cfa3602d07e1ee7124fe109970e4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "423",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:29 GMT",
+        "ETag": "W/\u00223a20023a-5bb7-4685-9f94-ebccfb90ae0f\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin61537088",
+        "$etag": "W/\u00223a20023a-5bb7-4685-9f94-ebccfb90ae0f\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;190129607",
+          "Temperature": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          },
+          "Humidity": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin916549295?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "2d55ce047e9f91d593e647fbe2232f2d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "424",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u002265f44121-95a0-400c-a66c-82f4a55b7305\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin916549295",
+        "$etag": "W/\u002265f44121-95a0-400c-a66c-82f4a55b7305\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;116902615",
+          "Temperature": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          },
+          "Humidity": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin901296073?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "09f8fd5fa68236861b475b2e23710bbc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022fca54902-cbe4-4f32-a63b-068c2505300e\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin901296073",
+        "$etag": "W/\u0022fca54902-cbe4-4f32-a63b-068c2505300e\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;134032790",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4250529Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4250529Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4250529Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4250529Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1770976668?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1226ec685103b9d39a799a0c0b4df4d0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022ea1a77c2-ad81-4b22-b6b3-3cc064550508\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1770976668",
+        "$etag": "W/\u0022ea1a77c2-ad81-4b22-b6b3-3cc064550508\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;114620686",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0529760Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0529760Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0529760Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0529760Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1950736454?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a6eb73392782f7ce8437796370743c3e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00223c87adce-ac77-4576-837e-2180534693b5\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1950736454",
+        "$etag": "W/\u00223c87adce-ac77-4576-837e-2180534693b5\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;118511369",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7110050Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7110050Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7110050Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7110050Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1690261573?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b70742bbab5c4f25e72cec290ff9665d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022ed43365c-91b9-42f2-bca4-8ca45fa3a83b\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1690261573",
+        "$etag": "W/\u0022ed43365c-91b9-42f2-bca4-8ca45fa3a83b\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;130862573",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6628875Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6628875Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6628875Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6628875Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin340327900?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f6d09838c4e61a577f1959552a045dcd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022fd8b6891-2fb7-49ff-9850-9687a802004d\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin340327900",
+        "$etag": "W/\u0022fd8b6891-2fb7-49ff-9850-9687a802004d\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;118546868",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6850454Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6850454Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6850454Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6850454Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1462068677?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8fc9b191c7dd56c69afbe2cd743d1305",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00220b565237-953e-4042-b18e-71d131e1e5a9\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1462068677",
+        "$etag": "W/\u00220b565237-953e-4042-b18e-71d131e1e5a9\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;144434410",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3420121Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3420121Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3420121Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3420121Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1851136915?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4f6da43c7ed59cafdc92cbfabd278e5c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00224a291fd3-8fa1-45bd-9308-b22645afa859\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1851136915",
+        "$etag": "W/\u00224a291fd3-8fa1-45bd-9308-b22645afa859\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;140049258",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9634263Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9634263Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9634263Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9634263Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin308625738?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4c94b467d05ba00a4bc9754d0bdb464f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00228a873131-171d-4173-918a-528321005f2c\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin308625738",
+        "$etag": "W/\u00228a873131-171d-4173-918a-528321005f2c\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;119737658",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:36:14.8105941Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:36:14.8105941Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:36:14.8105941Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:36:14.8105941Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1854686870?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7660b9c833bcf3190035fb5bddd35371",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022250796a1-8157-4f7c-b23a-5047a91fe957\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1854686870",
+        "$etag": "W/\u0022250796a1-8157-4f7c-b23a-5047a91fe957\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;136987051",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:38:41.6953408Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:38:41.6953408Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:38:41.6953408Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:38:41.6953408Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin444344106?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "47715ed5d3e1af6389b43a4ed1b684aa",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022e3be07b6-4f60-496f-b6e0-9f84f6b4b323\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin444344106",
+        "$etag": "W/\u0022e3be07b6-4f60-496f-b6e0-9f84f6b4b323\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;115290452",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:38:48.7941684Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:38:48.7941684Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:38:48.7941684Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:38:48.7941684Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin400492582?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d3fbd45f80aa587b5a9b0e446ef621db",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022c3c02e66-4ea9-4c4a-a0cb-1071007f0803\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin400492582",
+        "$etag": "W/\u0022c3c02e66-4ea9-4c4a-a0cb-1071007f0803\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;166321938",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5518135Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5518135Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5518135Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5518135Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1973765856?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4fdee705e6e7c7fc337fdfa42e7e76b0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1973765856. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Afloor%3B13698705?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "56757f73dd2aeef58638556a1abd1873",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:floor;13698705. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B115290452?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d6cc9cb1ee780cff77019cb32b1c9793",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "695",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:room;115290452",
+        "description": {
+          "en": "An enclosure inside a building."
+        },
+        "displayName": {
+          "en": "Room"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-29T17:38:48.6585849\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:room;115290452",
+          "@type": "Interface",
+          "displayName": "Room",
+          "description": "An enclosure inside a building.",
+          "contents": [
+            {
+              "@type": "Relationship",
+              "name": "containedIn",
+              "target": "dtmi:example:floor;14004925"
+            },
+            {
+              "@type": "Property",
+              "name": "Temperature",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "Humidity",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "IsOccupied",
+              "schema": "boolean"
+            },
+            {
+              "@type": "Property",
+              "name": "EmployeeId",
+              "schema": "string"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B166321938?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8a66a28209da60e860aea75c18c1c631",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "695",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:room;166321938",
+        "description": {
+          "en": "An enclosure inside a building."
+        },
+        "displayName": {
+          "en": "Room"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-29T17:47:24.4123537\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:room;166321938",
+          "@type": "Interface",
+          "displayName": "Room",
+          "description": "An enclosure inside a building.",
+          "contents": [
+            {
+              "@type": "Relationship",
+              "name": "containedIn",
+              "target": "dtmi:example:floor;11973765"
+            },
+            {
+              "@type": "Property",
+              "name": "Temperature",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "Humidity",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "IsOccupied",
+              "schema": "boolean"
+            },
+            {
+              "@type": "Property",
+              "name": "EmployeeId",
+              "schema": "string"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B118900767?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e0e4d9cd90fb4a75b3dc593b5a1bbdd7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:room;118900767. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "804",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "0c753b63d666e49376174058b05e3fd5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;118900767\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;13698705\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "192",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;118900767\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-29T17:47:30.939362\u002B00:00\u0022}]"
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1973765856?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "bd4fed81d6af1187f040272d8e250592",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;118900767"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00221aee8d2f-a4ae-425d-9fcc-5fe7b8076b25\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1973765856",
+        "$etag": "W/\u00221aee8d2f-a4ae-425d-9fcc-5fe7b8076b25\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;118900767",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1973765856?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "86b584e92550f7d746ff69e3501d9955",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
+        "ETag": "W/\u00221aee8d2f-a4ae-425d-9fcc-5fe7b8076b25\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1973765856",
+        "$etag": "W/\u00221aee8d2f-a4ae-425d-9fcc-5fe7b8076b25\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;118900767",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0700254Z"
+          }
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "DIGITALTWINS_URL": "https://fakeHost.api.wus2.digitaltwins.azure.net",
+    "RandomSeed": "354008543"
+  }
+}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwinOperationsWithCustomObjectSerializer_SucceedsAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwinOperationsWithCustomObjectSerializer_SucceedsAsync.json
@@ -1,0 +1,894 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1166423701?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7b07577e01ef5c763f85e7625c651d06",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "425",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:29 GMT",
+        "ETag": "W/\u0022cef519d6-559b-4bea-b25f-d4e18d704702\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1166423701",
+        "$etag": "W/\u0022cef519d6-559b-4bea-b25f-d4e18d704702\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;116018086",
+          "Temperature": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          },
+          "Humidity": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "10/29/2020 00:27:01"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1157156427?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "fa0e0ba08306e6175cd18bb5ce4af147",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "425",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022338bcf2c-397a-4220-8fe5-6ff133acdc6a\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1157156427",
+        "$etag": "W/\u0022338bcf2c-397a-4220-8fe5-6ff133acdc6a\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;110174774",
+          "Temperature": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          },
+          "Humidity": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "10/29/2020 03:02:31"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1601808632?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "02a1816fe1e9e92333889cbabd39b4b3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00226b51d30a-d8e7-4abd-a2ef-080a0c9cd6db\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1601808632",
+        "$etag": "W/\u00226b51d30a-d8e7-4abd-a2ef-080a0c9cd6db\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;138401929",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4342415Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4342415Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4342415Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:21:07.4342415Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin178446997?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9a7afc61d47895ef9230eba6703af51a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00226bbe615c-ab65-406d-8505-81fa632af5f0\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin178446997",
+        "$etag": "W/\u00226bbe615c-ab65-406d-8505-81fa632af5f0\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;163622943",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0636704Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0636704Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0636704Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:21:47.0636704Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1367671139?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "48649bf629b610ead2fa7b2b9f97d602",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022c199e93b-07cd-4f3d-afdf-92ac6a97a620\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1367671139",
+        "$etag": "W/\u0022c199e93b-07cd-4f3d-afdf-92ac6a97a620\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;121235454",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7069788Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7069788Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7069788Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:23:24.7069788Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1017477433?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5ecdf4e9adf66db156b13743c24ea69f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u002243d1ec4a-35e7-4cc8-ad67-78987b7b73c4\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1017477433",
+        "$etag": "W/\u002243d1ec4a-35e7-4cc8-ad67-78987b7b73c4\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;165961332",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6495319Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6495319Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6495319Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:25:42.6495319Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin384019290?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4c4e1843d2aa898fa5da7469f39814a4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00224b12a893-0ebe-4cea-93dc-6805d114bc0b\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin384019290",
+        "$etag": "W/\u00224b12a893-0ebe-4cea-93dc-6805d114bc0b\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;111270949",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6909987Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6909987Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6909987Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:28:15.6909987Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin636229431?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "054d0151edffdbb26078b2cd10acd48c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022c5e8aa03-1c20-4e9a-ab62-ca904e90cb97\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin636229431",
+        "$etag": "W/\u0022c5e8aa03-1c20-4e9a-ab62-ca904e90cb97\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;119751957",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3335767Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3335767Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3335767Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:29:47.3335767Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin2123545412?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "edb3be53213fd43d50d33d046318239e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u002200b155f7-4ccb-4894-a9e3-c21cf73d5e3e\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin2123545412",
+        "$etag": "W/\u002200b155f7-4ccb-4894-a9e3-c21cf73d5e3e\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;119106257",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9612464Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9612464Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9612464Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:36:06.9612464Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin659613323?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5452a5fc2a44719c495addbc952d9fdd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00222ce0dae0-2a5e-490a-bab4-6d67b784b9a5\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin659613323",
+        "$etag": "W/\u00222ce0dae0-2a5e-490a-bab4-6d67b784b9a5\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;115234165",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:36:15.0192586Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:36:15.0192586Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:36:15.0192586Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:36:15.0192586Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1127094958?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4af05645df12310fae1a74d7fc5f8f2e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022d157e7f8-7ee8-4f98-91e4-1f973bc0b248\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1127094958",
+        "$etag": "W/\u0022d157e7f8-7ee8-4f98-91e4-1f973bc0b248\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;116426340",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:38:41.7368094Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:38:41.7368094Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:38:41.7368094Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:38:41.7368094Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1975195780?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f0392fb0930f7c16f5c66018bba59d26",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u0022739a0a2d-9bb6-4bc8-b758-906f9de7606c\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1975195780",
+        "$etag": "W/\u0022739a0a2d-9bb6-4bc8-b758-906f9de7606c\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;111332883",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:38:48.8160761Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:38:48.8160761Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:38:48.8160761Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:38:48.8160761Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1910625716?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "41aeccd3c5e92343951028994dfb4e8d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u00226f64530e-ff62-4120-93c0-412301ccfae1\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1910625716",
+        "$etag": "W/\u00226f64530e-ff62-4120-93c0-412301ccfae1\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;111706874",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5583802Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5583802Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5583802Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:47:24.5583802Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1523416592?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "bea3707dc335ced91d18ae19f374d7b0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1523416592. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Afloor%3B11642634?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4380c28b69c6cdf67982eee2a7cb128a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:floor;11642634. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B111332883?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f6822d28099e73d4cbad9409a29c50e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "695",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:room;111332883",
+        "description": {
+          "en": "An enclosure inside a building."
+        },
+        "displayName": {
+          "en": "Room"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-29T17:38:48.6072756\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:room;111332883",
+          "@type": "Interface",
+          "displayName": "Room",
+          "description": "An enclosure inside a building.",
+          "contents": [
+            {
+              "@type": "Relationship",
+              "name": "containedIn",
+              "target": "dtmi:example:floor;11910625"
+            },
+            {
+              "@type": "Property",
+              "name": "Temperature",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "Humidity",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "IsOccupied",
+              "schema": "boolean"
+            },
+            {
+              "@type": "Property",
+              "name": "EmployeeId",
+              "schema": "string"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B111706874?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "cc0c8b7006b6f0adbb40eaeb764d9c8e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "694",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "id": "dtmi:example:room;111706874",
+        "description": {
+          "en": "An enclosure inside a building."
+        },
+        "displayName": {
+          "en": "Room"
+        },
+        "decommissioned": false,
+        "uploadTime": "2020-10-29T17:47:24.416178\u002B00:00",
+        "model": {
+          "@id": "dtmi:example:room;111706874",
+          "@type": "Interface",
+          "displayName": "Room",
+          "description": "An enclosure inside a building.",
+          "contents": [
+            {
+              "@type": "Relationship",
+              "name": "containedIn",
+              "target": "dtmi:example:floor;11523416"
+            },
+            {
+              "@type": "Property",
+              "name": "Temperature",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "Humidity",
+              "schema": "double"
+            },
+            {
+              "@type": "Property",
+              "name": "IsOccupied",
+              "schema": "boolean"
+            },
+            {
+              "@type": "Property",
+              "name": "EmployeeId",
+              "schema": "string"
+            }
+          ],
+          "@context": [
+            "dtmi:dtdl:context;2"
+          ]
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B118195018?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "502da94bb9edd0acfbbc62c3d7e69df8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:room;118195018. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "804",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7e865aa272ddd52705e2c8e987555ff7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;118195018\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;11642634\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "193",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;118195018\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-29T17:47:30.8874259\u002B00:00\u0022}]"
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1523416592?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a750597bb4bbd28260fcbb494a2de459",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;118195018"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u002232d5d5bb-0ed9-464f-8ad2-36a4d1af8bca\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1523416592",
+        "$etag": "W/\u002232d5d5bb-0ed9-464f-8ad2-36a4d1af8bca\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;118195018",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1523416592?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f2d3f24c1016d96b82574b0bf0c249a5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Thu, 29 Oct 2020 17:47:30 GMT",
+        "ETag": "W/\u002232d5d5bb-0ed9-464f-8ad2-36a4d1af8bca\u0022",
+        "Strict-Transport-Security": "max-age=2592000"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1523416592",
+        "$etag": "W/\u002232d5d5bb-0ed9-464f-8ad2-36a4d1af8bca\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;118195018",
+          "Temperature": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2020-10-29T17:47:31.0521338Z"
+          }
+        }
+      }
+    }
+  ],
+  "Variables": {
+    "DIGITALTWINS_URL": "https://fakeHost.api.wus2.digitaltwins.azure.net",
+    "RandomSeed": "428142243"
+  }
+}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_Lifecycle.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_Lifecycle.json
@@ -6,7 +6,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "f89a1358885c5a4d7e27bd45b3ae8b8a",
         "x-ms-return-client-request-id": "true"
       },
@@ -15,7 +15,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -31,7 +31,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "7091dd268409dfe995f799a112d9b79d",
         "x-ms-return-client-request-id": "true"
       },
@@ -40,7 +40,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -56,7 +56,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "4d548383587aa8ee0c7129c7e9837488",
         "x-ms-return-client-request-id": "true"
       },
@@ -65,7 +65,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -83,7 +83,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "804",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "65dcb4b44ff6b08f19c690b4b96b4e05",
         "x-ms-return-client-request-id": "true"
       },
@@ -92,10 +92,10 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;135050739\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-28T18:17:58.4079127\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;135050739\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-29T17:47:32.0973139\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin980686438?api-version=2020-10-31",
@@ -105,7 +105,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "082b2ea7f63584aba3c8fc13bf17ab74",
         "x-ms-return-client-request-id": "true"
       },
@@ -124,13 +124,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
-        "ETag": "W/\u00224453fa14-36d5-4402-a54a-bb672af816dd\u0022",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
+        "ETag": "W/\u002281ba0239-853c-4849-a19d-74e39e1eac7a\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin980686438",
-        "$etag": "W/\u00224453fa14-36d5-4402-a54a-bb672af816dd\u0022",
+        "$etag": "W/\u002281ba0239-853c-4849-a19d-74e39e1eac7a\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -138,16 +138,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;135050739",
           "Temperature": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           }
         }
       }
@@ -158,7 +158,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "255e192538db348ff4a433b3c83aefa1",
         "x-ms-return-client-request-id": "true"
       },
@@ -167,13 +167,13 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
-        "ETag": "W/\u00224453fa14-36d5-4402-a54a-bb672af816dd\u0022",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
+        "ETag": "W/\u002281ba0239-853c-4849-a19d-74e39e1eac7a\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin980686438",
-        "$etag": "W/\u00224453fa14-36d5-4402-a54a-bb672af816dd\u0022",
+        "$etag": "W/\u002281ba0239-853c-4849-a19d-74e39e1eac7a\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -181,16 +181,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;135050739",
           "Temperature": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-28T18:17:58.4427720Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1771824Z"
           }
         }
       }
@@ -204,7 +204,7 @@
         "Content-Length": "131",
         "Content-Type": "application/json-patch\u002Bjson",
         "If-Match": "*",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "bb2024226b57be520857c22e527bf101",
         "x-ms-return-client-request-id": "true"
       },
@@ -212,8 +212,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
-        "ETag": "W/\u0022d6a1e544-7eb9-4ec0-afe2-bca371b5810a\u0022",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
+        "ETag": "W/\u00224c988862-ba3f-40ef-bb10-8829fe25ada9\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -224,7 +224,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "9f8e1c1b290d6e2a9ff71491c2f7bc68",
         "x-ms-return-client-request-id": "true"
       },
@@ -232,7 +232,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -243,7 +243,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "9af05bd8f0f7ba1cc6a01c837560e178",
         "x-ms-return-client-request-id": "true"
       },
@@ -252,7 +252,7 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -268,7 +268,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "ab9832b24facf993f9b11c6056c1fc10",
         "x-ms-return-client-request-id": "true"
       },
@@ -276,7 +276,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_LifecycleAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/DigitalTwinTests/DigitalTwins_LifecycleAsync.json
@@ -6,7 +6,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "aa56202560de16f9e34b92d3bca4d016",
         "x-ms-return-client-request-id": "true"
       },
@@ -15,7 +15,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -31,7 +31,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "34f951b847bb5b40494fb417c22f2fa7",
         "x-ms-return-client-request-id": "true"
       },
@@ -40,7 +40,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -56,7 +56,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "87d26a9f8786f17dcebf040ba36e7307",
         "x-ms-return-client-request-id": "true"
       },
@@ -65,7 +65,7 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -83,7 +83,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "804",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "d1b900236ab715d84f941045fe201b62",
         "x-ms-return-client-request-id": "true"
       },
@@ -92,10 +92,10 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:31 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;124539051\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-28T18:17:58.3295996\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;124539051\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222020-10-29T17:47:32.0323724\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1765057771?api-version=2020-10-31",
@@ -105,7 +105,7 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "6605112bf944ca317b42ec873c50a5e1",
         "x-ms-return-client-request-id": "true"
       },
@@ -124,13 +124,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
-        "ETag": "W/\u0022becb7999-89a2-417e-8fc9-fd6d9b65d4aa\u0022",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
+        "ETag": "W/\u002239e4c181-5c30-4d91-8cc8-27441cbfe00c\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1765057771",
-        "$etag": "W/\u0022becb7999-89a2-417e-8fc9-fd6d9b65d4aa\u0022",
+        "$etag": "W/\u002239e4c181-5c30-4d91-8cc8-27441cbfe00c\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -138,16 +138,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;124539051",
           "Temperature": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           }
         }
       }
@@ -158,7 +158,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "2f9e0f40d57634f391bc38f17738f2ad",
         "x-ms-return-client-request-id": "true"
       },
@@ -167,13 +167,13 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
-        "ETag": "W/\u0022becb7999-89a2-417e-8fc9-fd6d9b65d4aa\u0022",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
+        "ETag": "W/\u002239e4c181-5c30-4d91-8cc8-27441cbfe00c\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1765057771",
-        "$etag": "W/\u0022becb7999-89a2-417e-8fc9-fd6d9b65d4aa\u0022",
+        "$etag": "W/\u002239e4c181-5c30-4d91-8cc8-27441cbfe00c\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -181,16 +181,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;124539051",
           "Temperature": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2020-10-28T18:17:58.3602696Z"
+            "lastUpdateTime": "2020-10-29T17:47:32.1266333Z"
           }
         }
       }
@@ -204,7 +204,7 @@
         "Content-Length": "131",
         "Content-Type": "application/json-patch\u002Bjson",
         "If-Match": "*",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "91dfa1a40d692ac3ceef55747d51d9ff",
         "x-ms-return-client-request-id": "true"
       },
@@ -212,8 +212,8 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 28 Oct 2020 18:17:57 GMT",
-        "ETag": "W/\u00228492a209-f6b9-418f-a62b-0247f6a56ea2\u0022",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
+        "ETag": "W/\u00226c0548e4-cd38-4f56-a9f5-4db4d93e9895\u0022",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -224,7 +224,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "ee042fefec8255ec1ed0d487c13f5243",
         "x-ms-return-client-request-id": "true"
       },
@@ -232,7 +232,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []
@@ -243,7 +243,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "9ae33e50137033774c7460877f7eb740",
         "x-ms-return-client-request-id": "true"
       },
@@ -252,7 +252,7 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": {
@@ -268,7 +268,7 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201028.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "User-Agent": "azsdk-net-DigitalTwins.Core/1.0.0-alpha.20201029.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "470238e30334b72bb58a7398383c688e",
         "x-ms-return-client-request-id": "true"
       },
@@ -276,7 +276,7 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 28 Oct 2020 18:17:58 GMT",
+        "Date": "Thu, 29 Oct 2020 17:47:32 GMT",
         "Strict-Transport-Security": "max-age=2592000"
       },
       "ResponseBody": []

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/TestObjectSerializer.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/TestObjectSerializer.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Serialization;
+
+namespace Azure.DigitalTwins.Core.Tests
+{
+    /// <summary>
+    /// Custom serializer to pass to the DigitalTwins client.
+    /// </summary>
+    public class TestObjectSerializer : ObjectSerializer
+    {
+        private static JsonObjectSerializer _serializer = new JsonObjectSerializer();
+
+        // This field is used by the tests to confirm the function was called.
+        public bool WasDeserializeCalled { get; set; }
+
+        // This field is used by the tests to confirm the function was called.
+        public bool WasSerializeCalled { get; set; }
+
+        public override object Deserialize(Stream stream, Type returnType, CancellationToken cancellationToken)
+        {
+            WasDeserializeCalled = true;
+            return _serializer.Deserialize(stream, returnType, cancellationToken);
+        }
+
+        public async override ValueTask<object> DeserializeAsync(Stream stream, Type returnType, CancellationToken cancellationToken)
+        {
+            WasDeserializeCalled = true;
+            return await _serializer.DeserializeAsync(stream, returnType, cancellationToken);
+        }
+
+        public override void Serialize(Stream stream, object value, Type inputType, CancellationToken cancellationToken)
+        {
+            WasSerializeCalled = true;
+            _serializer.Serialize(stream, value, inputType, cancellationToken);
+        }
+
+        public async override ValueTask SerializeAsync(Stream stream, object value, Type inputType, CancellationToken cancellationToken)
+        {
+            WasSerializeCalled = true;
+            await _serializer.SerializeAsync(stream, value, inputType, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Adding E2E test to ensure we can pass a custom Object Serializer. This should be the same for any ADT API call so I have only added one test that calls the serialize and deseriazlize of custom Serializer.