### PR TITLE
Validation fixes and allow unlimited unsettled messages

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -564,6 +564,12 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 // Create and open the AMQP session associated with the link.
 
                 var sessionSettings = new AmqpSessionSettings { Properties = new Fields() };
+
+                // This is the maximum number of unsettled transfers across all receive links on this session.
+                // This will allow the session to accept unlimited number of transfers, even if the recevier(s)
+                // are not settling any of the deliveries.
+                sessionSettings.IncomingWindow = uint.MaxValue;
+
                 session = connection.CreateSession(sessionSettings);
 
                 await OpenAmqpObjectAsync(session, timeout).ConfigureAwait(false);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -112,7 +112,8 @@ namespace Azure.Messaging.ServiceBus
 
             set
             {
-                ValidateMessageId(value);
+                Argument.AssertNotNullOrEmpty(value, nameof(MessageId));
+                Argument.AssertNotTooLong(value, Constants.MaxMessageIdLength, nameof(MessageId));
                 AmqpMessage.Properties.MessageId = value;
             }
         }
@@ -133,7 +134,7 @@ namespace Azure.Messaging.ServiceBus
             }
             set
             {
-                ValidatePartitionKey(value);
+                Argument.AssertNotTooLong(value, Constants.MaxPartitionKeyLength, nameof(PartitionKey));
                 AmqpMessage.MessageAnnotations[AmqpMessageConstants.PartitionKeyName] = value;
             }
         }
@@ -154,7 +155,7 @@ namespace Azure.Messaging.ServiceBus
             }
             set
             {
-                ValidatePartitionKey(value);
+                Argument.AssertNotTooLong(value, Constants.MaxPartitionKeyLength, nameof(TransactionPartitionKey));
                 AmqpMessage.MessageAnnotations[AmqpMessageConstants.ViaPartitionKeyName] = value;
             }
         }
@@ -174,7 +175,7 @@ namespace Azure.Messaging.ServiceBus
 
             set
             {
-                ValidateSessionId(value);
+                Argument.AssertNotTooLong(value, Constants.MaxSessionIdLength, nameof(SessionId));
                 AmqpMessage.Properties.GroupId = value;
             }
         }
@@ -192,7 +193,7 @@ namespace Azure.Messaging.ServiceBus
 
             set
             {
-                ValidateSessionId(value);
+                Argument.AssertNotTooLong(value, Constants.MaxSessionIdLength, nameof(ReplyToSessionId));
                 AmqpMessage.Properties.ReplyToGroupId = value;
             }
         }
@@ -370,31 +371,6 @@ namespace Azure.Messaging.ServiceBus
         public override string ToString()
         {
             return string.Format(CultureInfo.CurrentCulture, "{{MessageId:{0}}}", MessageId);
-        }
-
-        private static void ValidateMessageId(string messageId)
-        {
-            if (string.IsNullOrEmpty(messageId) ||
-                messageId.Length > Constants.MaxMessageIdLength)
-            {
-                throw new ArgumentException("MessageIdIsNullOrEmptyOrOverMaxValue");
-            }
-        }
-
-        private static void ValidateSessionId(string sessionId)
-        {
-            if (sessionId != null && sessionId.Length > Constants.MaxSessionIdLength)
-            {
-                throw new ArgumentException("SessionIdIsOverMaxValue");
-            }
-        }
-
-        private static void ValidatePartitionKey(string partitionKey)
-        {
-            if (partitionKey != null && partitionKey.Length > Constants.MaxPartitionKeyLength)
-            {
-                throw new ArgumentException("PropertyValueOverMaxValue");
-            }
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -112,8 +112,8 @@ namespace Azure.Messaging.ServiceBus
 
             set
             {
-                Argument.AssertNotNullOrEmpty(value, nameof(MessageId));
-                Argument.AssertNotTooLong(value, Constants.MaxMessageIdLength, nameof(MessageId));
+                Argument.AssertNotNullOrEmpty(value, nameof(value));
+                Argument.AssertNotTooLong(value, Constants.MaxMessageIdLength, nameof(value));
                 AmqpMessage.Properties.MessageId = value;
             }
         }
@@ -134,7 +134,11 @@ namespace Azure.Messaging.ServiceBus
             }
             set
             {
-                Argument.AssertNotTooLong(value, Constants.MaxPartitionKeyLength, nameof(PartitionKey));
+                Argument.AssertNotTooLong(value, Constants.MaxPartitionKeyLength, nameof(value));
+                if (SessionId != null && SessionId != value)
+                {
+                    throw new ArgumentOutOfRangeException($"PartitionKey:{value} cannot be set to a different value than SessionId:{SessionId}.");
+                }
                 AmqpMessage.MessageAnnotations[AmqpMessageConstants.PartitionKeyName] = value;
             }
         }
@@ -155,7 +159,7 @@ namespace Azure.Messaging.ServiceBus
             }
             set
             {
-                Argument.AssertNotTooLong(value, Constants.MaxPartitionKeyLength, nameof(TransactionPartitionKey));
+                Argument.AssertNotTooLong(value, Constants.MaxPartitionKeyLength, nameof(value));
                 AmqpMessage.MessageAnnotations[AmqpMessageConstants.ViaPartitionKeyName] = value;
             }
         }
@@ -175,7 +179,11 @@ namespace Azure.Messaging.ServiceBus
 
             set
             {
-                Argument.AssertNotTooLong(value, Constants.MaxSessionIdLength, nameof(SessionId));
+                Argument.AssertNotTooLong(value, Constants.MaxSessionIdLength, nameof(value));
+                if (PartitionKey != null && PartitionKey != value)
+                {
+                    throw new ArgumentOutOfRangeException($"SessionId:{value} cannot be set to a different value than PartitionKey:{PartitionKey}.");
+                }
                 AmqpMessage.Properties.GroupId = value;
             }
         }
@@ -193,7 +201,7 @@ namespace Azure.Messaging.ServiceBus
 
             set
             {
-                Argument.AssertNotTooLong(value, Constants.MaxSessionIdLength, nameof(ReplyToSessionId));
+                Argument.AssertNotTooLong(value, Constants.MaxSessionIdLength, nameof(value));
                 AmqpMessage.Properties.ReplyToGroupId = value;
             }
         }
@@ -217,7 +225,7 @@ namespace Azure.Messaging.ServiceBus
             }
             set
             {
-                Argument.AssertPositive(value, nameof(TimeToLive));
+                Argument.AssertPositive(value, nameof(value));
                 AmqpMessage.Header.TimeToLive = value;
             }
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -137,7 +137,7 @@ namespace Azure.Messaging.ServiceBus
                 Argument.AssertNotTooLong(value, Constants.MaxPartitionKeyLength, nameof(value));
                 if (SessionId != null && SessionId != value)
                 {
-                    throw new ArgumentOutOfRangeException($"PartitionKey:{value} cannot be set to a different value than SessionId:{SessionId}.");
+                    throw new ArgumentOutOfRangeException(nameof(value), $"PartitionKey:{value} cannot be set to a different value than SessionId:{SessionId}.");
                 }
                 AmqpMessage.MessageAnnotations[AmqpMessageConstants.PartitionKeyName] = value;
             }
@@ -182,7 +182,7 @@ namespace Azure.Messaging.ServiceBus
                 Argument.AssertNotTooLong(value, Constants.MaxSessionIdLength, nameof(value));
                 if (PartitionKey != null && PartitionKey != value)
                 {
-                    throw new ArgumentOutOfRangeException($"SessionId:{value} cannot be set to a different value than PartitionKey:{PartitionKey}.");
+                    throw new ArgumentOutOfRangeException(nameof(value), $"SessionId:{value} cannot be set to a different value than PartitionKey:{PartitionKey}.");
                 }
                 AmqpMessage.Properties.GroupId = value;
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -352,6 +352,11 @@ namespace Azure.Messaging.ServiceBus
         {
             Argument.AssertNotNull(messageBatch, nameof(messageBatch));
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusSender));
+            if (messageBatch.Count == 0)
+            {
+                return;
+            }
+
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.SendMessageStart(Identifier, messageBatch.Count);
             using DiagnosticScope scope = CreateDiagnosticScope(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpConverterTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             var messageId = Guid.NewGuid().ToString();
             var partitionKey = Guid.NewGuid().ToString();
             var viaPartitionKey = Guid.NewGuid().ToString();
-            var sessionId = Guid.NewGuid().ToString();
+            var sessionId = partitionKey;
             var correlationId = Guid.NewGuid().ToString();
             var label = Guid.NewGuid().ToString();
             var to = Guid.NewGuid().ToString();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Azure.Core;
 using NUnit.Framework;
@@ -38,6 +39,61 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
         {
             var message = new ServiceBusMessage();
             Assert.That(() => message.MessageId = "", Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public void SettingLongMessageIdThrows()
+        {
+            var message = new ServiceBusMessage();
+            Assert.That(() => message.MessageId = string.Concat(Enumerable.Repeat("a", 130)), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public void SettingNullSessionDoesNotThrow()
+        {
+            var message = new ServiceBusMessage
+            {
+                SessionId = null
+            };
+        }
+
+        [Test]
+        public void SettingLongSessionIdThrows()
+        {
+            var message = new ServiceBusMessage();
+            Assert.That(() => message.SessionId = string.Concat(Enumerable.Repeat("a", 130)), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public void SettingNullReplyToSessionDoesNotThrow()
+        {
+            var message = new ServiceBusMessage
+            {
+                ReplyToSessionId = null
+            };
+        }
+
+        [Test]
+        public void SettingLongReplyToSessionIdThrows()
+        {
+            var message = new ServiceBusMessage();
+            Assert.That(() => message.ReplyToSessionId = string.Concat(Enumerable.Repeat("a", 130)), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public void SettingNullPartitionKeyDoesNotThrow()
+        {
+            var message = new ServiceBusMessage
+            {
+                PartitionKey = null
+            };
+        }
+
+        [Test]
+        public void SettingLongPartitionKeyThrows()
+        {
+            var message = new ServiceBusMessage();
+            Assert.That(() => message.PartitionKey = string.Concat(Enumerable.Repeat("a", 130)), Throws.InstanceOf<ArgumentException>());
         }
 
         [Test]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageTests.cs
@@ -97,6 +97,66 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
         }
 
         [Test]
+        public void PartitionKeyMustMatchSessionIdIfBothSet()
+        {
+            var message = new ServiceBusMessage
+            {
+                SessionId = "session"
+            };
+            Assert.That(
+                () => message.PartitionKey = "partition",
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            message = new ServiceBusMessage
+            {
+                PartitionKey = "partition"
+            };
+            Assert.That(
+                () => message.SessionId = "session",
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            message = new ServiceBusMessage
+            {
+                SessionId = "session"
+            };
+            Assert.That(
+                () => message.PartitionKey = null,
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            message = new ServiceBusMessage
+            {
+                PartitionKey = "partition"
+            };
+            Assert.That(
+                () => message.SessionId = null,
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+
+            message = new ServiceBusMessage
+            {
+                PartitionKey = null,
+                SessionId = "session"
+            };
+
+            message = new ServiceBusMessage
+            {
+                SessionId = null,
+                PartitionKey = "partition"
+            };
+
+            message = new ServiceBusMessage
+            {
+                SessionId = "partition",
+                PartitionKey = "partition"
+            };
+
+            message = new ServiceBusMessage
+            {
+                PartitionKey = "partition",
+                SessionId = "partition"
+            };
+        }
+
+        [Test]
         public void SetMessageBodyToString()
         {
             var messageBody = "some message";
@@ -173,8 +233,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
             Assert.AreEqual(new DateTimeOffset(fixedDate, TimeSpan.FromHours(2)).UtcDateTime, receivedMessage.ScheduledEnqueueTime.UtcDateTime);
             Assert.IsNotNull(receivedMessage.ApplicationProperties);
             Assert.IsNotEmpty(receivedMessage.ApplicationProperties);
-            Assert.AreEqual(new[]{ "42", "properties0864"}, receivedMessage.ApplicationProperties.Keys);
-            Assert.AreEqual(new object[]{ 6420, "testValue"}, receivedMessage.ApplicationProperties.Values);
+            Assert.AreEqual(new[] { "42", "properties0864" }, receivedMessage.ApplicationProperties.Keys);
+            Assert.AreEqual(new object[] { 6420, "testValue" }, receivedMessage.ApplicationProperties.Values);
             Assert.AreEqual("f5ae57c7-963b-4864-ae19-32b12451e5d8", receivedMessage.LockTokenGuid.ToString());
             Assert.AreEqual(4321, receivedMessage.DeliveryCount);
             Assert.AreEqual(new DateTimeOffset(fixedDate, TimeSpan.FromMinutes(18)).UtcDateTime, receivedMessage.LockedUntil.UtcDateTime);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -106,6 +106,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         }
 
         [Test]
+        public async Task SendingEmptyBatchDoesNotThrow()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
+                await sender.SendMessagesAsync(batch);
+            }
+        }
+
+        [Test]
         public async Task CanSendAnEmptyBodyMessageBatch()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -228,6 +228,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 .Setup(transport => transport.TryAddMessage(It.IsAny<ServiceBusMessage>()))
                 .Returns(true);
 
+            mockTransportBatch
+                .Setup(transport => transport.Count)
+                .Returns(1);
+
             mockTransportSender
                 .Setup(transport => transport.SendBatchAsync(It.IsAny<ServiceBusMessageBatch>(), It.IsAny<CancellationToken>()))
                 .Returns(async () => await Task.WhenAny(completionSource.Task, Task.Delay(Timeout.Infinite, cancellationSource.Token)));


### PR DESCRIPTION
- Fixes https://github.com/Azure/azure-sdk-for-net/issues/16182
- Adds validation for partitionKey/sessionId
- Fixes issue where empty message batch would throw a nullref