### PR TITLE
ADT: Remove Azure.Core project reference to use shipped package

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/Azure.DigitalTwins.Core.sln
@@ -21,8 +21,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", "..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj", "{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\core\Azure.Core\src\Azure.Core.csproj", "{861E603A-6ADF-41C2-9364-C39499C08F25}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,10 +43,6 @@ Global
 		{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FC8A3EA-3C0D-4DDF-B710-A7091F2CEBB1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{861E603A-6ADF-41C2-9364-C39499C08F25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{861E603A-6ADF-41C2-9364-C39499C08F25}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{861E603A-6ADF-41C2-9364-C39499C08F25}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{861E603A-6ADF-41C2-9364-C39499C08F25}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <!--using the preview version of Azure.Identity to have access to KnownAuthorityHosts static class.-->
-    <PackageReference Include="Azure.Identity" Version="1.2.0-preview.2" />
+    <PackageReference Include="Azure.Identity" Version="1.2.1" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
 
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pavel already removed the project reference for us, but we can remove the .csproj from our solution.

https://github.com/Azure/azure-sdk-for-net/pull/16387/files