### PR TITLE
Rename DigitalTwinsModelData displayName and description to DisplayNameLanguageMap and DescriptionLanguageMap

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -155,10 +155,10 @@ namespace Azure.DigitalTwins.Core
     {
         internal DigitalTwinsModelData() { }
         public bool? Decommissioned { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyDictionary<string, string> DescriptionLanguageDictionary { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyDictionary<string, string> DisplayNameLanguageDictionary { get { throw null; } }
         public string DtdlModel { get { throw null; } }
         public string Id { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> LanguageDescriptions { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> LanguageDisplayNames { get { throw null; } }
         public System.DateTimeOffset? UploadedOn { get { throw null; } }
     }
     public partial class GetModelsOptions

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -155,8 +155,8 @@ namespace Azure.DigitalTwins.Core
     {
         internal DigitalTwinsModelData() { }
         public bool? Decommissioned { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyDictionary<string, string> Description { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyDictionary<string, string> DisplayName { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> DescriptionLanguageDictionary { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> DisplayNameLanguageDictionary { get { throw null; } }
         public string DtdlModel { get { throw null; } }
         public string Id { get { throw null; } }
         public System.DateTimeOffset? UploadedOn { get { throw null; } }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
@@ -174,7 +174,7 @@ namespace Azure.DigitalTwins.Core.Samples
                 await foreach (DigitalTwinsModelData model in allModels)
                 {
                     Console.WriteLine($"Retrieved model '{model.Id}', " +
-                        $"display name '{model.DisplayName["en"]}', " +
+                        $"display name '{model.DisplayNameLanguageMap["en"]}', " +
                         $"uploaded on '{model.UploadedOn}', " +
                         $"and decommissioned '{model.Decommissioned}'");
                 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
@@ -174,7 +174,7 @@ namespace Azure.DigitalTwins.Core.Samples
                 await foreach (DigitalTwinsModelData model in allModels)
                 {
                     Console.WriteLine($"Retrieved model '{model.Id}', " +
-                        $"display name '{model.DisplayNameLanguageMap["en"]}', " +
+                        $"display name '{model.DisplayNameLanguageDictionary["en"]}', " +
                         $"uploaded on '{model.UploadedOn}', " +
                         $"and decommissioned '{model.Decommissioned}'");
                 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsLifecycleSamples.cs
@@ -174,7 +174,7 @@ namespace Azure.DigitalTwins.Core.Samples
                 await foreach (DigitalTwinsModelData model in allModels)
                 {
                     Console.WriteLine($"Retrieved model '{model.Id}', " +
-                        $"display name '{model.DisplayNameLanguageDictionary["en"]}', " +
+                        $"display name '{model.LanguageDisplayNames["en"]}', " +
                         $"uploaded on '{model.UploadedOn}', " +
                         $"and decommissioned '{model.Decommissioned}'");
                 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
@@ -69,7 +69,7 @@ AsyncPageable<DigitalTwinsModelData> allModels = client.GetModelsAsync();
 await foreach (DigitalTwinsModelData model in allModels)
 {
     Console.WriteLine($"Retrieved model '{model.Id}', " +
-        $"display name '{model.DisplayNameLanguageDictionary["en"]}', " +
+        $"display name '{model.LanguageDisplayNames["en"]}', " +
         $"uploaded on '{model.UploadedOn}', " +
         $"and decommissioned '{model.Decommissioned}'");
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/Readme.md
@@ -69,7 +69,7 @@ AsyncPageable<DigitalTwinsModelData> allModels = client.GetModelsAsync();
 await foreach (DigitalTwinsModelData model in allModels)
 {
     Console.WriteLine($"Retrieved model '{model.Id}', " +
-        $"display name '{model.DisplayName["en"]}', " +
+        $"display name '{model.DisplayNameLanguageDictionary["en"]}', " +
         $"uploaded on '{model.UploadedOn}', " +
         $"and decommissioned '{model.Decommissioned}'");
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
@@ -32,11 +32,11 @@ namespace Azure.DigitalTwins.Core
 
         /// <summary> A language dictionary that contains the localized display names as specified in the model definition. </summary>
         [CodeGenMember("DisplayName")]
-        public IReadOnlyDictionary<string, string> DisplayNameLanguageDictionary { get; }
+        public IReadOnlyDictionary<string, string> LanguageDisplayNames { get; }
 
         /// <summary> A language dictionary that contains the localized descriptions as specified in the model definition. </summary>
         [CodeGenMember("Description")]
-        public IReadOnlyDictionary<string, string> DescriptionLanguageDictionary { get; }
+        public IReadOnlyDictionary<string, string> LanguageDescriptions { get; }
 
         #region null overrides
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
@@ -30,11 +30,11 @@ namespace Azure.DigitalTwins.Core
         [CodeGenMember("UploadTime")]
         public DateTimeOffset? UploadedOn { get; }
 
-        /// <summary> A language map that contains the localized display names as specified in the model definition. </summary>
+        /// <summary> A language dictionary that contains the localized display names as specified in the model definition. </summary>
         [CodeGenMember("DisplayName")]
         public IReadOnlyDictionary<string, string> DisplayNameLanguageMap { get; }
 
-        /// <summary> A language map that contains the localized descriptions as specified in the model definition. </summary>
+        /// <summary> A language dictionary that contains the localized descriptions as specified in the model definition. </summary>
         [CodeGenMember("Description")]
         public IReadOnlyDictionary<string, string> DescriptionLanguageMap { get; }
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
@@ -32,11 +32,11 @@ namespace Azure.DigitalTwins.Core
 
         /// <summary> A language dictionary that contains the localized display names as specified in the model definition. </summary>
         [CodeGenMember("DisplayName")]
-        public IReadOnlyDictionary<string, string> DisplayNameLanguageMap { get; }
+        public IReadOnlyDictionary<string, string> DisplayNameLanguageDictionary { get; }
 
         /// <summary> A language dictionary that contains the localized descriptions as specified in the model definition. </summary>
         [CodeGenMember("Description")]
-        public IReadOnlyDictionary<string, string> DescriptionLanguageMap { get; }
+        public IReadOnlyDictionary<string, string> DescriptionLanguageDictionary { get; }
 
         #region null overrides
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
@@ -28,6 +29,14 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         [CodeGenMember("UploadTime")]
         public DateTimeOffset? UploadedOn { get; }
+
+        /// <summary> A language map that contains the localized display names as specified in the model definition. </summary>
+        [CodeGenMember("DisplayName")]
+        public IReadOnlyDictionary<string, string> DisplayNameLanguageMap { get; }
+
+        /// <summary> A language map that contains the localized descriptions as specified in the model definition. </summary>
+        [CodeGenMember("Description")]
+        public IReadOnlyDictionary<string, string> DescriptionLanguageMap { get; }
 
         #region null overrides
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1077,7 +1077,7 @@ namespace Azure.DigitalTwins.Core
         /// await foreach (DigitalTwinsModelData model in allModels)
         /// {
         ///     Console.WriteLine($&quot;Retrieved model &apos;{model.Id}&apos;, &quot; +
-        ///         $&quot;display name &apos;{model.DisplayNameLanguageDictionary[&quot;en&quot;]}&apos;, &quot; +
+        ///         $&quot;display name &apos;{model.LanguageDisplayNames[&quot;en&quot;]}&apos;, &quot; +
         ///         $&quot;uploaded on &apos;{model.UploadedOn}&apos;, &quot; +
         ///         $&quot;and decommissioned &apos;{model.Decommissioned}&apos;&quot;);
         /// }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1077,7 +1077,7 @@ namespace Azure.DigitalTwins.Core
         /// await foreach (DigitalTwinsModelData model in allModels)
         /// {
         ///     Console.WriteLine($&quot;Retrieved model &apos;{model.Id}&apos;, &quot; +
-        ///         $&quot;display name &apos;{model.DisplayName[&quot;en&quot;]}&apos;, &quot; +
+        ///         $&quot;display name &apos;{model.DisplayNameLanguageDictionary[&quot;en&quot;]}&apos;, &quot; +
         ///         $&quot;uploaded on &apos;{model.UploadedOn}&apos;, &quot; +
         ///         $&quot;and decommissioned &apos;{model.Decommissioned}&apos;&quot;);
         /// }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
@@ -16,16 +16,16 @@ namespace Azure.DigitalTwins.Core
     {
 
         /// <summary> Initializes a new instance of DigitalTwinsModelData. </summary>
-        /// <param name="displayNameLanguageDictionary"> A language map that contains the localized display names as specified in the model definition. </param>
-        /// <param name="descriptionLanguageDictionary"> A language map that contains the localized descriptions as specified in the model definition. </param>
+        /// <param name="languageDisplayNames"> A language map that contains the localized display names as specified in the model definition. </param>
+        /// <param name="languageDescriptions"> A language map that contains the localized descriptions as specified in the model definition. </param>
         /// <param name="id"> The id of the model as specified in the model definition. </param>
         /// <param name="uploadedOn"> The time the model was uploaded to the service. </param>
         /// <param name="decommissioned"> Indicates if the model is decommissioned. Decommissioned models cannot be referenced by newly created digital twins. </param>
         /// <param name="dtdlModel"> The model definition. </param>
-        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayNameLanguageDictionary, IReadOnlyDictionary<string, string> descriptionLanguageDictionary, string id, DateTimeOffset? uploadedOn, bool? decommissioned, string dtdlModel)
+        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> languageDisplayNames, IReadOnlyDictionary<string, string> languageDescriptions, string id, DateTimeOffset? uploadedOn, bool? decommissioned, string dtdlModel)
         {
-            LanguageDisplayNames = displayNameLanguageDictionary;
-            LanguageDescriptions = descriptionLanguageDictionary;
+            LanguageDisplayNames = languageDisplayNames;
+            LanguageDescriptions = languageDescriptions;
             Id = id;
             UploadedOn = uploadedOn;
             Decommissioned = decommissioned;

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
@@ -24,8 +24,8 @@ namespace Azure.DigitalTwins.Core
         /// <param name="dtdlModel"> The model definition. </param>
         internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayNameLanguageDictionary, IReadOnlyDictionary<string, string> descriptionLanguageDictionary, string id, DateTimeOffset? uploadedOn, bool? decommissioned, string dtdlModel)
         {
-            DisplayNameLanguageDictionary = displayNameLanguageDictionary;
-            DescriptionLanguageDictionary = descriptionLanguageDictionary;
+            LanguageDisplayNames = displayNameLanguageDictionary;
+            LanguageDescriptions = descriptionLanguageDictionary;
             Id = id;
             UploadedOn = uploadedOn;
             Decommissioned = decommissioned;

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
@@ -16,26 +16,21 @@ namespace Azure.DigitalTwins.Core
     {
 
         /// <summary> Initializes a new instance of DigitalTwinsModelData. </summary>
-        /// <param name="displayName"> A language map that contains the localized display names as specified in the model definition. </param>
-        /// <param name="description"> A language map that contains the localized descriptions as specified in the model definition. </param>
+        /// <param name="displayNameLanguageMap"> A language map that contains the localized display names as specified in the model definition. </param>
+        /// <param name="descriptionLanguageMap"> A language map that contains the localized descriptions as specified in the model definition. </param>
         /// <param name="id"> The id of the model as specified in the model definition. </param>
         /// <param name="uploadedOn"> The time the model was uploaded to the service. </param>
         /// <param name="decommissioned"> Indicates if the model is decommissioned. Decommissioned models cannot be referenced by newly created digital twins. </param>
         /// <param name="dtdlModel"> The model definition. </param>
-        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayName, IReadOnlyDictionary<string, string> description, string id, DateTimeOffset? uploadedOn, bool? decommissioned, string dtdlModel)
+        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayNameLanguageMap, IReadOnlyDictionary<string, string> descriptionLanguageMap, string id, DateTimeOffset? uploadedOn, bool? decommissioned, string dtdlModel)
         {
-            DisplayName = displayName;
-            Description = description;
+            DisplayNameLanguageMap = displayNameLanguageMap;
+            DescriptionLanguageMap = descriptionLanguageMap;
             Id = id;
             UploadedOn = uploadedOn;
             Decommissioned = decommissioned;
             DtdlModel = dtdlModel;
         }
-
-        /// <summary> A language map that contains the localized display names as specified in the model definition. </summary>
-        public IReadOnlyDictionary<string, string> DisplayName { get; }
-        /// <summary> A language map that contains the localized descriptions as specified in the model definition. </summary>
-        public IReadOnlyDictionary<string, string> Description { get; }
         /// <summary> The id of the model as specified in the model definition. </summary>
         public string Id { get; }
         /// <summary> Indicates if the model is decommissioned. Decommissioned models cannot be referenced by newly created digital twins. </summary>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Generated/Models/DigitalTwinsModelData.cs
@@ -16,16 +16,16 @@ namespace Azure.DigitalTwins.Core
     {
 
         /// <summary> Initializes a new instance of DigitalTwinsModelData. </summary>
-        /// <param name="displayNameLanguageMap"> A language map that contains the localized display names as specified in the model definition. </param>
-        /// <param name="descriptionLanguageMap"> A language map that contains the localized descriptions as specified in the model definition. </param>
+        /// <param name="displayNameLanguageDictionary"> A language map that contains the localized display names as specified in the model definition. </param>
+        /// <param name="descriptionLanguageDictionary"> A language map that contains the localized descriptions as specified in the model definition. </param>
         /// <param name="id"> The id of the model as specified in the model definition. </param>
         /// <param name="uploadedOn"> The time the model was uploaded to the service. </param>
         /// <param name="decommissioned"> Indicates if the model is decommissioned. Decommissioned models cannot be referenced by newly created digital twins. </param>
         /// <param name="dtdlModel"> The model definition. </param>
-        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayNameLanguageMap, IReadOnlyDictionary<string, string> descriptionLanguageMap, string id, DateTimeOffset? uploadedOn, bool? decommissioned, string dtdlModel)
+        internal DigitalTwinsModelData(IReadOnlyDictionary<string, string> displayNameLanguageDictionary, IReadOnlyDictionary<string, string> descriptionLanguageDictionary, string id, DateTimeOffset? uploadedOn, bool? decommissioned, string dtdlModel)
         {
-            DisplayNameLanguageMap = displayNameLanguageMap;
-            DescriptionLanguageMap = descriptionLanguageMap;
+            DisplayNameLanguageDictionary = displayNameLanguageDictionary;
+            DescriptionLanguageDictionary = descriptionLanguageDictionary;
             Id = id;
             UploadedOn = uploadedOn;
             Decommissioned = decommissioned;

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
@@ -98,8 +98,8 @@ namespace Azure.DigitalTwins.Core.Tests
 
             // assert
 
-            wardModel.Value.DisplayName.Count.Should().Be(1, "Should have 1 entry for display name");
-            wardModel.Value.DisplayName.Keys.First().Should().Be("en");
+            wardModel.Value.DisplayNameLanguageMap.Count.Should().Be(1, "Should have 1 entry for display name");
+            wardModel.Value.DisplayNameLanguageMap.Keys.First().Should().Be("en");
         }
 
         [Test]

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
@@ -98,8 +98,8 @@ namespace Azure.DigitalTwins.Core.Tests
 
             // assert
 
-            wardModel.Value.DisplayNameLanguageDictionary.Count.Should().Be(1, "Should have 1 entry for display name");
-            wardModel.Value.DisplayNameLanguageDictionary.Keys.First().Should().Be("en");
+            wardModel.Value.LanguageDisplayNames.Count.Should().Be(1, "Should have 1 entry for display name");
+            wardModel.Value.LanguageDisplayNames.Keys.First().Should().Be("en");
         }
 
         [Test]

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/ModelsTests.cs
@@ -98,8 +98,8 @@ namespace Azure.DigitalTwins.Core.Tests
 
             // assert
 
-            wardModel.Value.DisplayNameLanguageMap.Count.Should().Be(1, "Should have 1 entry for display name");
-            wardModel.Value.DisplayNameLanguageMap.Keys.First().Should().Be("en");
+            wardModel.Value.DisplayNameLanguageDictionary.Count.Should().Be(1, "Should have 1 entry for display name");
+            wardModel.Value.DisplayNameLanguageDictionary.Keys.First().Should().Be("en");
         }
 
         [Test]


### PR DESCRIPTION
For consistency with the Java library

We got feedback from the board about how "Description" and "DisplayName" would only make sense as names if they were tied to Strings. Since they are tied to Dictionary<String, String> instead, these names would make it a bit more clear as to what they are