### PR TITLE
Fix DigitalTwins QueryChargeHelper to take T rather than BasicDigitalTwin

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/api/Azure.DigitalTwins.Core.netstandard2.0.cs
@@ -187,7 +187,7 @@ namespace Azure.DigitalTwins.Core
     }
     public static partial class QueryChargeHelper
     {
-        public static bool TryGetQueryCharge(Azure.Page<Azure.DigitalTwins.Core.BasicDigitalTwin> page, out float queryCharge) { throw null; }
+        public static bool TryGetQueryCharge<T>(Azure.Page<T> page, out float queryCharge) { throw null; }
     }
     public partial class UpdateComponentOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Queries/QueryChargeHelper.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Queries/QueryChargeHelper.cs
@@ -51,7 +51,7 @@ namespace Azure.DigitalTwins.Core
         ///     }
         /// }
         /// </code>
-        public static bool TryGetQueryCharge(Page<BasicDigitalTwin> page, out float queryCharge)
+        public static bool TryGetQueryCharge<T>(Page<T> page, out float queryCharge)
         {
             Argument.AssertNotNull(page, nameof(page));
 


### PR DESCRIPTION
Users of our Query<T> API should be able to feed a page of their custom types into this helper and still have it work. There is no reason that we need this to be a page of BasicDigitalTwin

Java already has this change