### PR TITLE
Fixed the bug of throwing 404 if no version exists.

### DIFF
--- a/doc/ApiDocGeneration/templates/matthews/styles/main.js
+++ b/doc/ApiDocGeneration/templates/matthews/styles/main.js
@@ -91,7 +91,7 @@ function httpGetAsync(targetUrl, callback) {
     xmlHttp.send(null);
 }
 
-function httpGetAsyncOnSuccessAndFailed(targetUrl, successCallback, failureCallback) {
+function httpGetAsyncFallbackOnFail(targetUrl, successCallback, failureCallback) {
     var xmlHttp = new XMLHttpRequest();
     xmlHttp.onreadystatechange = function () {
         if (xmlHttp.readyState == 4) {
@@ -137,7 +137,7 @@ function populateOptions(selector, packageName) {
             url = WINDOW_CONTENTS.slice()
             url[6] = targetVersion
             var targetUrl = url.join('/')
-            httpGetAsyncOnSuccessAndFailed(targetUrl, (unused) => window.location.href = url.join('/'),
+            httpGetAsyncFallbackOnFail(targetUrl, (unused) => window.location.href = url.join('/'),
                 (failureStatus) => window.location.href = getPackageUrl(SELECTED_LANGUAGE, packageName, targetVersion))
         });
 

--- a/doc/ApiDocGeneration/templates/matthews/styles/main.js
+++ b/doc/ApiDocGeneration/templates/matthews/styles/main.js
@@ -91,6 +91,21 @@ function httpGetAsync(targetUrl, callback) {
     xmlHttp.send(null);
 }
 
+function httpGetAsyncOnSuccessAndFailed(targetUrl, successCallback, failureCallback) {
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.onreadystatechange = function () {
+        if (xmlHttp.readyState == 4) {
+            if (xmlHttp.status == 200) {
+                successCallback(xmlHttp.responseText);
+            } else {
+                failureCallback(xmlHttp.status)
+            }
+        }
+    }
+    xmlHttp.open("GET", targetUrl, true); // true for asynchronous 
+    xmlHttp.send(null);
+}
+
 function populateOptions(selector, packageName) {
     var versionRequestUrl = BLOB_URI_PREFIX + packageName + "/versioning/versions"
 
@@ -118,9 +133,12 @@ function populateOptions(selector, packageName) {
 
         $(versionselector).change(function () {
             targetVersion = $(this).val()
+            original
             url = WINDOW_CONTENTS.slice()
             url[6] = targetVersion
-            window.location.href = url.join('/')
+            var targetUrl = url.join('/')
+            httpGetAsyncOnSuccessAndFailed(targetUrl, (unused) => window.location.href = url.join('/'),
+                (failureStatus) => window.location.href = getPackageUrl(SELECTED_LANGUAGE, packageName, targetVersion))
         });
 
     })

--- a/doc/ApiDocGeneration/templates/matthews/styles/main.js
+++ b/doc/ApiDocGeneration/templates/matthews/styles/main.js
@@ -133,7 +133,6 @@ function populateOptions(selector, packageName) {
 
         $(versionselector).change(function () {
             targetVersion = $(this).val()
-            original
             url = WINDOW_CONTENTS.slice()
             url[6] = targetVersion
             var targetUrl = url.join('/')


### PR DESCRIPTION
Fixed issue: https://github.com/Azure/azure-sdk/issues/1668

Currently solution: if the open page is not 200, jump to the sdk api/index.html page.