### PR TITLE
[MetricsAdvisor] Bug fix: CreateDataFeed sample fails to ingest data

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
@@ -159,7 +159,7 @@ string sqlServerConnectionString = "<connectionString>";
 string sqlServerQuery = "<query>";
 
 var dataFeedName = "Sample data feed";
-var dataFeedSource = new MySqlDataFeedSource(sqlServerConnectionString, sqlServerQuery);
+var dataFeedSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
 var dataFeedGranularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
 
 var dataFeedMetrics = new List<DataFeedMetric>()

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
@@ -33,7 +33,7 @@ namespace Azure.AI.MetricsAdvisor.Samples
             //@@ string sqlServerQuery = "<query>";
 
             var dataFeedName = "Sample data feed";
-            var dataFeedSource = new MySqlDataFeedSource(sqlServerConnectionString, sqlServerQuery);
+            var dataFeedSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
             var dataFeedGranularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
 
             var dataFeedMetrics = new List<DataFeedMetric>()


### PR DESCRIPTION
Amazingly short fix. We were using the wrong data feed source for the credentials provided. It was a sample bug. SDK works just fine.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/16473.