### PR TITLE
Fixing a bug in management client that is sending atom xml elements out of order

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/ManagementClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/ManagementClient.cs
@@ -984,20 +984,6 @@ namespace Microsoft.Azure.ServiceBus.Management
 
         #endregion
 
-        internal static XElement RemoveDuplicateChildElements(XElement source)
-        {
-            XElement copyElement = new XElement(source.Name);
-            foreach (var childElement in source.Elements())
-            {
-                if (copyElement.Element(childElement.Name) == null)
-                {
-                    copyElement.Add(childElement);
-                }
-            }
-
-            return copyElement;
-        }
-
         private static int GetPort(string endpoint)
         {
             // used for internal testing

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/ManagementClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/ManagementClient.cs
@@ -984,6 +984,20 @@ namespace Microsoft.Azure.ServiceBus.Management
 
         #endregion
 
+        internal static XElement RemoveDuplicateChildElements(XElement source)
+        {
+            XElement copyElement = new XElement(source.Name);
+            foreach (var childElement in source.Elements())
+            {
+                if (copyElement.Element(childElement.Name) == null)
+                {
+                    copyElement.Add(childElement);
+                }
+            }
+
+            return copyElement;
+        }
+
         private static int GetPort(string endpoint)
         {
             // used for internal testing

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescription.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescription.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.ServiceBus.Management
 {
     using System;
     using System.Collections.Generic;
+    using System.Xml.Linq;
     using Microsoft.Azure.ServiceBus.Primitives;
 
     /// <summary>
@@ -14,6 +15,7 @@ namespace Microsoft.Azure.ServiceBus.Management
     {
         internal TimeSpan duplicateDetectionHistoryTimeWindow = TimeSpan.FromMinutes(1);
         internal string path;
+        internal bool? internalSupportOrdering = null;
         TimeSpan lockDuration = TimeSpan.FromSeconds(60);
         TimeSpan defaultMessageTimeToLive = TimeSpan.MaxValue;
         TimeSpan autoDeleteOnIdle = TimeSpan.MaxValue;
@@ -273,11 +275,27 @@ namespace Microsoft.Azure.ServiceBus.Management
             }
         }
 
+        internal bool IsAnonymousAccessible { get; set; } = false;
+
+        internal bool SupportOrdering
+        { 
+            get
+            {
+                return this.internalSupportOrdering ?? !this.EnablePartitioning;
+            }
+            set
+            {
+                this.internalSupportOrdering = value;
+            }
+        }
+
+        internal bool EnableExpress { get; set; } = false;
+
         /// <summary>
         /// List of properties that were retrieved using GetQueue but are not understood by this version of client is stored here.
         /// The list will be sent back when an already retrieved QueueDescription will be used in UpdateQueue call.
         /// </summary>
-        internal List<object> UnknownProperties { get; set; }
+        internal List<XElement> UnknownProperties { get; set; }
 
         public override int GetHashCode()
         {
@@ -308,6 +326,9 @@ namespace Microsoft.Azure.ServiceBus.Management
                 && this.RequiresDuplicateDetection.Equals(other.RequiresDuplicateDetection)
                 && this.RequiresSession.Equals(other.RequiresSession)
                 && this.Status.Equals(other.Status)
+                && this.internalSupportOrdering.Equals(other.SupportOrdering)
+                && this.EnableExpress == other.EnableExpress
+                && this.IsAnonymousAccessible == other.IsAnonymousAccessible
                 && string.Equals(this.userMetadata, other.userMetadata, StringComparison.OrdinalIgnoreCase)
                 && (this.AuthorizationRules != null && other.AuthorizationRules != null
                     || this.AuthorizationRules == null && other.AuthorizationRules == null)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.ServiceBus.Management
     {
         public static XDocument Serialize(this QueueDescription description)
         {
-            var queueDescriptionElements = new List<object>()
+            var queueDescriptionElements = new List<XElement>()
             {
                 new XElement(XName.Get("LockDuration", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.LockDuration)),
                 new XElement(XName.Get("MaxSizeInMegabytes", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.MaxSizeInMB)),
@@ -26,14 +26,19 @@ namespace Microsoft.Azure.ServiceBus.Management
                 new XElement(XName.Get("MaxDeliveryCount", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.MaxDeliveryCount)),
                 new XElement(XName.Get("EnableBatchedOperations", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnableBatchedOperations)),
                 description.AuthorizationRules?.Serialize(),
+                new XElement(XName.Get("IsAnonymousAccessible", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.IsAnonymousAccessible)),
                 new XElement(XName.Get("Status", ManagementClientConstants.ServiceBusNamespace), description.Status.ToString()),
                 description.ForwardTo != null ? new XElement(XName.Get("ForwardTo", ManagementClientConstants.ServiceBusNamespace), description.ForwardTo) : null,
                 description.UserMetadata != null ? new XElement(XName.Get("UserMetadata", ManagementClientConstants.ServiceBusNamespace), description.UserMetadata) : null,
+                description.internalSupportOrdering.HasValue ? new XElement(XName.Get("SupportOrdering", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.internalSupportOrdering.Value)) : null,
                 description.AutoDeleteOnIdle != TimeSpan.MaxValue ? new XElement(XName.Get("AutoDeleteOnIdle", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.AutoDeleteOnIdle)) : null,
                 new XElement(XName.Get("EnablePartitioning", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnablePartitioning)),
-                description.ForwardDeadLetteredMessagesTo != null ? new XElement(XName.Get("ForwardDeadLetteredMessagesTo", ManagementClientConstants.ServiceBusNamespace), description.ForwardDeadLetteredMessagesTo) : null
+                description.ForwardDeadLetteredMessagesTo != null ? new XElement(XName.Get("ForwardDeadLetteredMessagesTo", ManagementClientConstants.ServiceBusNamespace), description.ForwardDeadLetteredMessagesTo) : null,
+                new XElement(XName.Get("EnableExpress", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnableExpress))
             };
 
+            // Insert unknown properties in the exact order they were in the received xml.
+            // Expectation is that servicebus will add any new elements only at the bottom of the xml tree.
             if (description.UnknownProperties != null)
             {
                 queueDescriptionElements.AddRange(description.UnknownProperties);
@@ -71,8 +76,6 @@ namespace Microsoft.Azure.ServiceBus.Management
         private static QueueDescription ParseFromEntryElement(XElement xEntry)
         {
             var name = xEntry.Element(XName.Get("title", ManagementClientConstants.AtomNamespace)).Value;
-            var qd = new QueueDescription(name);
-
             var qdXml = xEntry.Element(XName.Get("content", ManagementClientConstants.AtomNamespace))?
                 .Element(XName.Get("QueueDescription", ManagementClientConstants.ServiceBusNamespace));
 
@@ -81,10 +84,18 @@ namespace Microsoft.Azure.ServiceBus.Management
                 throw new MessagingEntityNotFoundException("Queue was not found");
             }
 
+            // Needed to deal with cases where this SDK caused many duplicate elements in the entry xml.
+            // One Get+Update combo from this SDK will remove those duplicate elements.
+            // This can be removed later when all duplicate entries are removed eventually.
+            qdXml = ManagementClient.RemoveDuplicateChildElements(qdXml);
+            var qd = new QueueDescription(name);
             foreach (var element in qdXml.Elements())
             {
                 switch (element.Name.LocalName)
                 {
+                    case "LockDuration":
+                        qd.LockDuration = XmlConvert.ToTimeSpan(element.Value);
+                        break;
                     case "MaxSizeInMegabytes":
                         qd.MaxSizeInMB = Int64.Parse(element.Value);
                         break;
@@ -94,17 +105,14 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "RequiresSession":
                         qd.RequiresSession = Boolean.Parse(element.Value);
                         break;
+                    case "DefaultMessageTimeToLive":
+                        qd.DefaultMessageTimeToLive = XmlConvert.ToTimeSpan(element.Value);
+                        break;
                     case "DeadLetteringOnMessageExpiration":
                         qd.EnableDeadLetteringOnMessageExpiration = Boolean.Parse(element.Value);
                         break;
                     case "DuplicateDetectionHistoryTimeWindow":
                         qd.duplicateDetectionHistoryTimeWindow = XmlConvert.ToTimeSpan(element.Value);
-                        break;
-                    case "LockDuration":
-                        qd.LockDuration = XmlConvert.ToTimeSpan(element.Value);
-                        break;
-                    case "DefaultMessageTimeToLive":
-                        qd.DefaultMessageTimeToLive = XmlConvert.ToTimeSpan(element.Value);
                         break;
                     case "MaxDeliveryCount":
                         qd.MaxDeliveryCount = Int32.Parse(element.Value);
@@ -112,17 +120,14 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "EnableBatchedOperations":
                         qd.EnableBatchedOperations = Boolean.Parse(element.Value);
                         break;
+                    case "AuthorizationRules":
+                        qd.AuthorizationRules = AuthorizationRules.ParseFromXElement(element);
+                        break;
+                    case "IsAnonymousAccessible":
+                        qd.IsAnonymousAccessible = Boolean.Parse(element.Value);
+                        break;
                     case "Status":
                         qd.Status = (EntityStatus)Enum.Parse(typeof(EntityStatus), element.Value);
-                        break;
-                    case "AutoDeleteOnIdle":
-                        qd.AutoDeleteOnIdle = XmlConvert.ToTimeSpan(element.Value);
-                        break;
-                    case "EnablePartitioning":
-                        qd.EnablePartitioning = bool.Parse(element.Value);
-                        break;
-                    case "UserMetadata":
-                        qd.UserMetadata = element.Value;
                         break;
                     case "ForwardTo":
                         if (!string.IsNullOrWhiteSpace(element.Value))
@@ -130,14 +135,26 @@ namespace Microsoft.Azure.ServiceBus.Management
                             qd.ForwardTo = element.Value;
                         }
                         break;
+                    case "UserMetadata":
+                        qd.UserMetadata = element.Value;
+                        break;
+                    case "SupportOrdering":
+                        qd.SupportOrdering = Boolean.Parse(element.Value);
+                        break;
+                    case "AutoDeleteOnIdle":
+                        qd.AutoDeleteOnIdle = XmlConvert.ToTimeSpan(element.Value);
+                        break;
+                    case "EnablePartitioning":
+                        qd.EnablePartitioning = bool.Parse(element.Value);
+                        break;
                     case "ForwardDeadLetteredMessagesTo":
                         if (!string.IsNullOrWhiteSpace(element.Value))
                         {
                             qd.ForwardDeadLetteredMessagesTo = element.Value;
                         }
                         break;
-                    case "AuthorizationRules":
-                        qd.AuthorizationRules = AuthorizationRules.ParseFromXElement(element);
+                    case "EnableExpress":
+                        qd.EnableExpress = bool.Parse(element.Value);
                         break;
                     case "AccessedAt":
                     case "CreatedAt":
@@ -152,7 +169,7 @@ namespace Microsoft.Azure.ServiceBus.Management
                         // For unknown properties, keep them as-is for forward proof.
                         if (qd.UnknownProperties == null)
                         {
-                            qd.UnknownProperties = new List<object>();
+                            qd.UnknownProperties = new List<XElement>();
                         }
 
                         qd.UnknownProperties.Add(element);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
@@ -84,10 +84,6 @@ namespace Microsoft.Azure.ServiceBus.Management
                 throw new MessagingEntityNotFoundException("Queue was not found");
             }
 
-            // Needed to deal with cases where this SDK caused many duplicate elements in the entry xml.
-            // One Get+Update combo from this SDK will remove those duplicate elements.
-            // This can be removed later when all duplicate entries are removed eventually.
-            qdXml = ManagementClient.RemoveDuplicateChildElements(qdXml);
             var qd = new QueueDescription(name);
             foreach (var element in qdXml.Elements())
             {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Azure.ServiceBus.Management
                     : null,
                 new XElement(XName.Get("MaxDeliveryCount", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.MaxDeliveryCount)),
                 new XElement(XName.Get("EnableBatchedOperations", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnableBatchedOperations)),
-                description.AuthorizationRules?.Serialize(),
                 new XElement(XName.Get("IsAnonymousAccessible", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.IsAnonymousAccessible)),
+                description.AuthorizationRules?.Serialize(),
                 new XElement(XName.Get("Status", ManagementClientConstants.ServiceBusNamespace), description.Status.ToString()),
                 description.ForwardTo != null ? new XElement(XName.Get("ForwardTo", ManagementClientConstants.ServiceBusNamespace), description.ForwardTo) : null,
                 description.UserMetadata != null ? new XElement(XName.Get("UserMetadata", ManagementClientConstants.ServiceBusNamespace), description.UserMetadata) : null,
@@ -116,11 +116,11 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "EnableBatchedOperations":
                         qd.EnableBatchedOperations = Boolean.Parse(element.Value);
                         break;
-                    case "AuthorizationRules":
-                        qd.AuthorizationRules = AuthorizationRules.ParseFromXElement(element);
-                        break;
                     case "IsAnonymousAccessible":
                         qd.IsAnonymousAccessible = Boolean.Parse(element.Value);
+                        break;
+                    case "AuthorizationRules":
+                        qd.AuthorizationRules = AuthorizationRules.ParseFromXElement(element);
                         break;
                     case "Status":
                         qd.Status = (EntityStatus)Enum.Parse(typeof(EntityStatus), element.Value);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescriptionExtensions.cs
@@ -105,8 +105,14 @@ namespace Microsoft.Azure.ServiceBus.Management
             {
                 switch (element.Name.LocalName)
                 {
+                    case "LockDuration":
+                        subscriptionDesc.LockDuration = XmlConvert.ToTimeSpan(element.Value);
+                        break;
                     case "RequiresSession":
                         subscriptionDesc.RequiresSession = bool.Parse(element.Value);
+                        break;
+                    case "DefaultMessageTimeToLive":
+                        subscriptionDesc.DefaultMessageTimeToLive = XmlConvert.ToTimeSpan(element.Value);
                         break;
                     case "DeadLetteringOnMessageExpiration":
                         subscriptionDesc.EnableDeadLetteringOnMessageExpiration = bool.Parse(element.Value);
@@ -114,26 +120,14 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "DeadLetteringOnFilterEvaluationExceptions":
                         subscriptionDesc.EnableDeadLetteringOnFilterEvaluationExceptions = bool.Parse(element.Value);
                         break;
-                    case "LockDuration":
-                        subscriptionDesc.LockDuration = XmlConvert.ToTimeSpan(element.Value);
-                        break;
-                    case "DefaultMessageTimeToLive":
-                        subscriptionDesc.DefaultMessageTimeToLive = XmlConvert.ToTimeSpan(element.Value);
-                        break;
                     case "MaxDeliveryCount":
                         subscriptionDesc.MaxDeliveryCount = int.Parse(element.Value);
-                        break;
-                    case "Status":
-                        subscriptionDesc.Status = (EntityStatus)Enum.Parse(typeof(EntityStatus), element.Value);
                         break;
                     case "EnableBatchedOperations":
                         subscriptionDesc.EnableBatchedOperations = bool.Parse(element.Value);
                         break;
-                    case "UserMetadata":
-                        subscriptionDesc.UserMetadata = element.Value;
-                        break;
-                    case "AutoDeleteOnIdle":
-                        subscriptionDesc.AutoDeleteOnIdle = XmlConvert.ToTimeSpan(element.Value);
+                    case "Status":
+                        subscriptionDesc.Status = (EntityStatus)Enum.Parse(typeof(EntityStatus), element.Value);
                         break;
                     case "ForwardTo":
                         if (!string.IsNullOrWhiteSpace(element.Value))
@@ -141,11 +135,17 @@ namespace Microsoft.Azure.ServiceBus.Management
                             subscriptionDesc.ForwardTo = element.Value;
                         }
                         break;
+                    case "UserMetadata":
+                        subscriptionDesc.UserMetadata = element.Value;
+                        break;
                     case "ForwardDeadLetteredMessagesTo":
                         if (!string.IsNullOrWhiteSpace(element.Value))
                         {
                             subscriptionDesc.ForwardDeadLetteredMessagesTo = element.Value;
                         }
+                        break;
+                    case "AutoDeleteOnIdle":
+                        subscriptionDesc.AutoDeleteOnIdle = XmlConvert.ToTimeSpan(element.Value);
                         break;
                     case "AccessedAt":
                     case "CreatedAt":
@@ -153,6 +153,7 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "SizeInBytes":
                     case "UpdatedAt":
                     case "CountDetails":
+                    case "DefaultRuleDescription":
                         // Ignore known properties
                         // Do nothing
                         break;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescription.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescription.cs
@@ -172,6 +172,16 @@ namespace Microsoft.Azure.ServiceBus.Management
             }
         }
 
+        internal bool IsAnonymousAccessible { get; set; } = false;
+
+        internal bool FilteringMessagesBeforePublishing { get; set; } = false;
+
+        internal string ForwardTo { get; set; } = null;
+
+        internal bool EnableExpress { get; set; } = false;
+
+        internal bool EnableSubscriptionPartitioning { get; set; } = false;
+
         /// <summary>
         /// List of properties that were retrieved using GetTopic but are not understood by this version of client is stored here.
         /// The list will be sent back when an already retrieved TopicDescription will be used in UpdateTopic call.
@@ -202,6 +212,11 @@ namespace Microsoft.Azure.ServiceBus.Management
                 && this.RequiresDuplicateDetection.Equals(other.RequiresDuplicateDetection)
                 && this.Status.Equals(other.Status)
                 && string.Equals(this.userMetadata, other.userMetadata, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(this.ForwardTo, other.ForwardTo, StringComparison.OrdinalIgnoreCase)
+                && this.EnableExpress == other.EnableExpress
+                && this.IsAnonymousAccessible == other.IsAnonymousAccessible
+                && this.FilteringMessagesBeforePublishing == other.FilteringMessagesBeforePublishing
+                && this.EnableSubscriptionPartitioning == other.EnableSubscriptionPartitioning
                 && (this.AuthorizationRules != null && other.AuthorizationRules != null
                     || this.AuthorizationRules == null && other.AuthorizationRules == null)
                 && (this.AuthorizationRules == null || this.AuthorizationRules.Equals(other.AuthorizationRules)))

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescriptionExtensions.cs
@@ -63,20 +63,26 @@ namespace Microsoft.Azure.ServiceBus.Management
         private static TopicDescription ParseFromEntryElement(XElement xEntry)
         {
             var name = xEntry.Element(XName.Get("title", ManagementClientConstants.AtomNamespace)).Value;
-            var topicDesc = new TopicDescription(name);
-
-            var qdXml = xEntry.Element(XName.Get("content", ManagementClientConstants.AtomNamespace))?
+            var tdXml = xEntry.Element(XName.Get("content", ManagementClientConstants.AtomNamespace))?
                 .Element(XName.Get("TopicDescription", ManagementClientConstants.ServiceBusNamespace));
 
-            if (qdXml == null)
+            if (tdXml == null)
             {
                 throw new MessagingEntityNotFoundException("Topic was not found");
             }
 
-            foreach (var element in qdXml.Elements())
+            // Needed to deal with cases where this SDK caused many duplicate elements in the entry xml.
+            // One Get+Update combo from this SDK will remove those duplicate elements.
+            // This can be removed later when all duplicate entries are removed eventually.
+            tdXml = ManagementClient.RemoveDuplicateChildElements(tdXml);
+            var topicDesc = new TopicDescription(name);
+            foreach (var element in tdXml.Elements())
             {
                 switch (element.Name.LocalName)
                 {
+                    case "DefaultMessageTimeToLive":
+                        topicDesc.DefaultMessageTimeToLive = XmlConvert.ToTimeSpan(element.Value);
+                        break;
                     case "MaxSizeInMegabytes":
                         topicDesc.MaxSizeInMB = long.Parse(element.Value);
                         break;
@@ -86,17 +92,32 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "DuplicateDetectionHistoryTimeWindow":
                         topicDesc.duplicateDetectionHistoryTimeWindow = XmlConvert.ToTimeSpan(element.Value);
                         break;
-                    case "DefaultMessageTimeToLive":
-                        topicDesc.DefaultMessageTimeToLive = XmlConvert.ToTimeSpan(element.Value);
-                        break;
                     case "EnableBatchedOperations":
                         topicDesc.EnableBatchedOperations = bool.Parse(element.Value);
+                        break;
+                    case "FilteringMessagesBeforePublishing":
+                        topicDesc.FilteringMessagesBeforePublishing = bool.Parse(element.Value);
+                        break;
+                    case "IsAnonymousAccessible":
+                        topicDesc.IsAnonymousAccessible = bool.Parse(element.Value);
+                        break;
+                    case "AuthorizationRules":
+                        topicDesc.AuthorizationRules = AuthorizationRules.ParseFromXElement(element);
                         break;
                     case "Status":
                         topicDesc.Status = (EntityStatus)Enum.Parse(typeof(EntityStatus), element.Value);
                         break;
+                    case "ForwardTo":
+                        if (!string.IsNullOrWhiteSpace(element.Value))
+                        {
+                            topicDesc.ForwardTo = element.Value;
+                        }
+                        break;
                     case "UserMetadata":
                         topicDesc.UserMetadata = element.Value;
+                        break;
+                    case "SupportOrdering":
+                        topicDesc.SupportOrdering = bool.Parse(element.Value);
                         break;
                     case "AutoDeleteOnIdle":
                         topicDesc.AutoDeleteOnIdle = XmlConvert.ToTimeSpan(element.Value);
@@ -104,11 +125,11 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "EnablePartitioning":
                         topicDesc.EnablePartitioning = bool.Parse(element.Value);
                         break;
-                    case "SupportOrdering":
-                        topicDesc.SupportOrdering = bool.Parse(element.Value);
+                    case "EnableSubscriptionPartitioning":
+                        topicDesc.EnableSubscriptionPartitioning = bool.Parse(element.Value);
                         break;
-                    case "AuthorizationRules":
-                        topicDesc.AuthorizationRules = AuthorizationRules.ParseFromXElement(element);
+                    case "EnableExpress":
+                        topicDesc.EnableExpress = bool.Parse(element.Value);
                         break;
                     case "AccessedAt":
                     case "CreatedAt":
@@ -146,14 +167,21 @@ namespace Microsoft.Azure.ServiceBus.Management
                     new XElement(XName.Get("DuplicateDetectionHistoryTimeWindow", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.DuplicateDetectionHistoryTimeWindow))
                     : null,
                 new XElement(XName.Get("EnableBatchedOperations", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnableBatchedOperations)),
+                new XElement(XName.Get("FilteringMessagesBeforePublishing", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.FilteringMessagesBeforePublishing)),
+                new XElement(XName.Get("IsAnonymousAccessible", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.IsAnonymousAccessible)),
                 description.AuthorizationRules?.Serialize(),
                 new XElement(XName.Get("Status", ManagementClientConstants.ServiceBusNamespace), description.Status.ToString()),
+                description.ForwardTo != null ? new XElement(XName.Get("ForwardTo", ManagementClientConstants.ServiceBusNamespace), description.ForwardTo) : null,
                 description.UserMetadata != null ? new XElement(XName.Get("UserMetadata", ManagementClientConstants.ServiceBusNamespace), description.UserMetadata) : null,
                 new XElement(XName.Get("SupportOrdering", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.SupportOrdering)),
                 description.AutoDeleteOnIdle != TimeSpan.MaxValue ? new XElement(XName.Get("AutoDeleteOnIdle", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.AutoDeleteOnIdle)) : null,
-                new XElement(XName.Get("EnablePartitioning", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnablePartitioning))
+                new XElement(XName.Get("EnablePartitioning", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnablePartitioning)),
+                new XElement(XName.Get("EnableSubscriptionPartitioning", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnableSubscriptionPartitioning)),
+                new XElement(XName.Get("EnableExpress", ManagementClientConstants.ServiceBusNamespace), XmlConvert.ToString(description.EnableExpress))
             };
 
+            // Insert unknown properties in the exact order they were in the received xml.
+            // Expectation is that servicebus will add any new elements only at the bottom of the xml tree.
             if (description.UnknownProperties != null)
             {
                 topicDescriptionElements.AddRange(description.UnknownProperties);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescriptionExtensions.cs
@@ -71,10 +71,6 @@ namespace Microsoft.Azure.ServiceBus.Management
                 throw new MessagingEntityNotFoundException("Topic was not found");
             }
 
-            // Needed to deal with cases where this SDK caused many duplicate elements in the entry xml.
-            // One Get+Update combo from this SDK will remove those duplicate elements.
-            // This can be removed later when all duplicate entries are removed eventually.
-            tdXml = ManagementClient.RemoveDuplicateChildElements(tdXml);
             var topicDesc = new TopicDescription(name);
             foreach (var element in tdXml.Elements())
             {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/QueueDescriptionTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/QueueDescriptionTests.cs
@@ -108,9 +108,9 @@ public class QueueDescriptionTests
             $"<DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration>" +
             $"<DuplicateDetectionHistoryTimeWindow>{XmlConvert.ToString(TimeSpan.FromMinutes(2))}</DuplicateDetectionHistoryTimeWindow>" +
             $"<MaxDeliveryCount>10</MaxDeliveryCount>" +
-            $"<EnableBatchedOperations>true</EnableBatchedOperations>" +
-            $"<AuthorizationRules />" +
+            $"<EnableBatchedOperations>true</EnableBatchedOperations>" +            
             $"<IsAnonymousAccessible>false</IsAnonymousAccessible>" +
+            $"<AuthorizationRules />" +
             $"<Status>Active</Status>" +
             $"<ForwardTo>fq1</ForwardTo>" +
             $"<UserMetadata></UserMetadata>" +

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/QueueDescriptionTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Management/QueueDescriptionTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
 using Microsoft.Azure.ServiceBus.Management;
 using Microsoft.Azure.ServiceBus.UnitTests;
 using Xunit;
@@ -88,5 +90,58 @@ public class QueueDescriptionTests
         var sub = new QueueDescription("Fake SubscriptionName");
         sub.Path = $"{baseUrl}{longName}";
         Assert.Equal($"{baseUrl}{longName}", sub.Path);
+    }
+
+    [Fact]
+    [DisplayTestMethodName]
+    public void UnknownElementsInAtomXmlHanldedRight()
+    {
+        string queueDescriptionXml = $@"<entry xmlns=""{ManagementClientConstants.AtomNamespace}"">" +
+            $@"<title xmlns=""{ManagementClientConstants.AtomNamespace}"">testqueue1</title>" +
+            $@"<content xmlns=""{ManagementClientConstants.AtomNamespace}"">" +
+            $@"<QueueDescription xmlns=""{ManagementClientConstants.ServiceBusNamespace}"">" +
+            $"<LockDuration>{XmlConvert.ToString(TimeSpan.FromMinutes(1))}</LockDuration>" +
+            $"<MaxSizeInMegabytes>1024</MaxSizeInMegabytes>" +
+            $"<RequiresDuplicateDetection>true</RequiresDuplicateDetection>" +
+            $"<RequiresSession>true</RequiresSession>" +
+            $"<DefaultMessageTimeToLive>{XmlConvert.ToString(TimeSpan.FromMinutes(60))}</DefaultMessageTimeToLive>" +
+            $"<DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration>" +
+            $"<DuplicateDetectionHistoryTimeWindow>{XmlConvert.ToString(TimeSpan.FromMinutes(2))}</DuplicateDetectionHistoryTimeWindow>" +
+            $"<MaxDeliveryCount>10</MaxDeliveryCount>" +
+            $"<EnableBatchedOperations>true</EnableBatchedOperations>" +
+            $"<AuthorizationRules />" +
+            $"<IsAnonymousAccessible>false</IsAnonymousAccessible>" +
+            $"<Status>Active</Status>" +
+            $"<ForwardTo>fq1</ForwardTo>" +
+            $"<UserMetadata></UserMetadata>" +
+            $"<SupportOrdering>true</SupportOrdering>" +
+            $"<AutoDeleteOnIdle>{XmlConvert.ToString(TimeSpan.FromMinutes(60))}</AutoDeleteOnIdle>" +
+            $"<EnablePartitioning>false</EnablePartitioning>" +
+            $"<EnableExpress>false</EnableExpress>" +
+            $"<UnknownElement1>prop1</UnknownElement1>" +
+            $"<UnknownElement2>prop2</UnknownElement2>" +
+            $"<UnknownElement3>prop3</UnknownElement3>" +
+            $"<UnknownElement4>prop4</UnknownElement4>" +
+            $"<UnknownElement5><PropertyValue>prop5</PropertyValue></UnknownElement5>" +
+            $"</QueueDescription>" +
+            $"</content>" +
+            $"</entry>";
+
+        QueueDescription queueDesc = QueueDescriptionExtensions.ParseFromContent(queueDescriptionXml);
+        Assert.NotNull(queueDesc.UnknownProperties);
+        XDocument doc = QueueDescriptionExtensions.Serialize(queueDesc);
+
+        XName queueDescriptionElementName = XName.Get("QueueDescription", ManagementClientConstants.ServiceBusNamespace);
+        XElement expectedQueueDecriptionElement = XElement.Parse(queueDescriptionXml).Descendants(queueDescriptionElementName).FirstOrDefault();
+        XElement serializedQueueDescritionElement = doc.Descendants(queueDescriptionElementName).FirstOrDefault();
+        XNode expectedChildNode = expectedQueueDecriptionElement.FirstNode;
+        XNode actualChildNode = serializedQueueDescritionElement.FirstNode;
+        while (expectedChildNode != null)
+        {
+            Assert.NotNull(actualChildNode);
+            Assert.True(XNode.DeepEquals(expectedChildNode, actualChildNode), $"QueueDescrition parsing and serialization combo didn't work as expected. {expectedChildNode.ToString()}");
+            expectedChildNode = expectedChildNode.NextNode;
+            actualChildNode = actualChildNode.NextNode;
+        }
     }
 }


### PR DESCRIPTION
Fixing a bug in management client that is sending atom xml elements in enity description
out of order in an update call. Because of this bug, deserializer on the service ignores
these out of order elements, and persists elements with default values in the righr order
resulting in these out of order elements getting duplicated in the resource xml.
This fix removes duplicate elements only if they are present from the xml, and sends
xml elements in the correct order in update call.