### PR TITLE
Rename CorrelationRuleFilter.Properties and other admin fixes

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -492,10 +492,10 @@ namespace Azure.Messaging.ServiceBus.Administration
     {
         public CorrelationRuleFilter() { }
         public CorrelationRuleFilter(string correlationId) { }
+        public System.Collections.Generic.IDictionary<string, object> ApplicationProperties { get { throw null; } }
         public string ContentType { get { throw null; } set { } }
         public string CorrelationId { get { throw null; } set { } }
         public string MessageId { get { throw null; } set { } }
-        public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
         public string ReplyTo { get { throw null; } set { } }
         public string ReplyToSessionId { get { throw null; } set { } }
         public string SessionId { get { throw null; } set { } }
@@ -801,7 +801,7 @@ namespace Azure.Messaging.ServiceBus.Administration
     public sealed partial class SqlRuleAction : Azure.Messaging.ServiceBus.Administration.RuleAction
     {
         public SqlRuleAction(string sqlExpression) { }
-        public System.Collections.Generic.IDictionary<string, object> Parameters { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, object> Parameters { get { throw null; } }
         public string SqlExpression { get { throw null; } }
         public override bool Equals(Azure.Messaging.ServiceBus.Administration.RuleAction other) { throw null; }
         public override bool Equals(object obj) { throw null; }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilter.cs
@@ -61,7 +61,7 @@ namespace Azure.Messaging.ServiceBus.Administration
                 SessionId = SessionId,
                 ReplyToSessionId = ReplyToSessionId,
                 ContentType = ContentType,
-                Properties = (Properties as PropertyDictionary).Clone()
+                ApplicationProperties = (ApplicationProperties as PropertyDictionary).Clone()
             };
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Azure.Messaging.ServiceBus.Administration
         /// bool, Guid, string, Uri, DateTime, DateTimeOffset, TimeSpan, Stream, byte[],
         /// and IList / IDictionary of supported types
         /// </remarks>
-        public IDictionary<string, object> Properties { get; internal set; } = new PropertyDictionary();
+        public IDictionary<string, object> ApplicationProperties { get; internal set; } = new PropertyDictionary();
 
         /// <summary>
         /// Converts the value of the current instance to its equivalent string representation.
@@ -180,7 +180,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             AppendPropertyExpression(ref isFirstExpression, stringBuilder, "sys.ReplyToSessionId", ReplyToSessionId);
             AppendPropertyExpression(ref isFirstExpression, stringBuilder, "sys.ContentType", ContentType);
 
-            foreach (var pair in Properties)
+            foreach (var pair in ApplicationProperties)
             {
                 string propertyName = pair.Key;
                 object propertyValue = pair.Value;
@@ -243,14 +243,14 @@ namespace Azure.Messaging.ServiceBus.Administration
                     && string.Equals(ReplyToSessionId, correlationRuleFilter.ReplyToSessionId, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(ContentType, correlationRuleFilter.ContentType, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (Properties.Count != correlationRuleFilter.Properties.Count)
+                    if (ApplicationProperties.Count != correlationRuleFilter.ApplicationProperties.Count)
                     {
                         return false;
                     }
 
-                    foreach (var param in Properties)
+                    foreach (var param in ApplicationProperties)
                     {
-                        if (!correlationRuleFilter.Properties.TryGetValue(param.Key, out var otherParamValue) ||
+                        if (!correlationRuleFilter.ApplicationProperties.TryGetValue(param.Key, out var otherParamValue) ||
                             (param.Value == null ^ otherParamValue == null) ||
                             (param.Value != null && !param.Value.Equals(otherParamValue)))
                         {
@@ -265,12 +265,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return false;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator ==(CorrelationRuleFilter left, CorrelationRuleFilter right)
         {
             if (ReferenceEquals(left, right))
@@ -286,12 +281,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return left.Equals(right);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator !=(CorrelationRuleFilter left, CorrelationRuleFilter right)
         {
             return !(left == right);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilterExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CorrelationRuleFilterExtensions.cs
@@ -45,7 +45,7 @@ namespace Azure.Messaging.ServiceBus.Administration
                         {
                             var key = prop.Element(XName.Get("Key", AdministrationClientConstants.ServiceBusNamespace))?.Value;
                             var value = XmlObjectConvertor.ParseValueObject(prop.Element(XName.Get("Value", AdministrationClientConstants.ServiceBusNamespace)));
-                            correlationRuleFilter.Properties.Add(key, value);
+                            correlationRuleFilter.ApplicationProperties.Add(key, value);
                         }
                         break;
                     default:
@@ -66,7 +66,7 @@ namespace Azure.Messaging.ServiceBus.Administration
                     "Properties",
                     AdministrationClientConstants.ServiceBusNamespace));
 
-            foreach (KeyValuePair<string, object> param in filter.Properties)
+            foreach (KeyValuePair<string, object> param in filter.ApplicationProperties)
             {
                 parameterElement.Add(
                     new XElement(XName.Get("KeyValueOfstringanyType", AdministrationClientConstants.ServiceBusNamespace),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CreateRuleOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/CreateRuleOptions.cs
@@ -130,12 +130,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return false;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator ==(CreateRuleOptions left, CreateRuleOptions right)
         {
             if (ReferenceEquals(left, right))
@@ -151,12 +146,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return left.Equals(right);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator !=(CreateRuleOptions left, CreateRuleOptions right)
         {
             return !(left == right);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/FalseRuleFilter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/FalseRuleFilter.cs
@@ -46,12 +46,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return other is FalseRuleFilter;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator ==(FalseRuleFilter left, FalseRuleFilter right)
         {
             if (ReferenceEquals(left, right))
@@ -67,12 +62,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return left.Equals(right);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator !=(FalseRuleFilter left, FalseRuleFilter right)
         {
             return !(left == right);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/RuleDescriptionExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/RuleDescriptionExtensions.cs
@@ -56,10 +56,9 @@ namespace Azure.Messaging.ServiceBus.Administration
             }
             catch (Exception ex) when (!(ex is ServiceBusException))
             {
-                //throw new ServiceBusException(false, ex);
+                throw new ServiceBusException(isTransient: false, message: "An error occurred while attempting to parse the rule property.", innerException: ex);
             }
-            return null;
-            //throw new MessagingEntityNotFoundException("Rule was not found");
+            throw new ServiceBusException("Rule was not found", ServiceBusFailureReason.MessagingEntityNotFound);
         }
 
         public static List<RuleProperties> ParseCollectionFromContent(string xml)
@@ -85,10 +84,9 @@ namespace Azure.Messaging.ServiceBus.Administration
             }
             catch (Exception ex) when (!(ex is ServiceBusException))
             {
-                //throw new ServiceBusException(false, ex);
+                throw new ServiceBusException(isTransient: false, message: "An error occurred while attempting to parse the collection of rule properties.", innerException: ex);
             }
-            return null;
-            //throw new MessagingEntityNotFoundException("Rule was not found");
+            throw new ServiceBusException("Rule was not found", ServiceBusFailureReason.MessagingEntityNotFound);
         }
 
         private static RuleProperties ParseFromEntryElement(XElement xEntry)
@@ -101,7 +99,7 @@ namespace Azure.Messaging.ServiceBus.Administration
 
             if (rdXml == null)
             {
-                //throw new MessagingEntityNotFoundException("Rule was not found");
+                throw new ServiceBusException("Rule was not found", ServiceBusFailureReason.MessagingEntityNotFound);
             }
 
             foreach (var element in rdXml.Elements())

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/RuleProperties.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/RuleProperties.cs
@@ -121,12 +121,8 @@ namespace Azure.Messaging.ServiceBus.Administration
             return false;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
+
         public static bool operator ==(RuleProperties left, RuleProperties right)
         {
             if (ReferenceEquals(left, right))
@@ -142,12 +138,8 @@ namespace Azure.Messaging.ServiceBus.Administration
             return left.Equals(right);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
+
         public static bool operator !=(RuleProperties left, RuleProperties right)
         {
             return !(left == right);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/SqlRuleAction.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/SqlRuleAction.cs
@@ -41,10 +41,10 @@ namespace Azure.Messaging.ServiceBus.Administration
         public string SqlExpression { get; }
 
         /// <summary>
-        /// Sets the value of a rule action.
+        /// Gets the value of a rule action.
         /// </summary>
         /// <value>The value of a rule action.</value>
-        public IDictionary<string, object> Parameters { get; set; } = new PropertyDictionary();
+        public IDictionary<string, object> Parameters { get; internal set; } = new PropertyDictionary();
 
         /// <summary>
         /// Returns a string representation of <see cref="SqlRuleAction" />.
@@ -97,12 +97,8 @@ namespace Azure.Messaging.ServiceBus.Administration
             return false;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
+
         public static bool operator ==(SqlRuleAction left, SqlRuleAction right)
         {
             if (ReferenceEquals(left, right))
@@ -118,12 +114,8 @@ namespace Azure.Messaging.ServiceBus.Administration
             return left.Equals(right);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
+
         public static bool operator !=(SqlRuleAction left, SqlRuleAction right)
         {
             return !(left == right);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/SqlRuleFilter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/SqlRuleFilter.cs
@@ -105,12 +105,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return false;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator ==(SqlRuleFilter left, SqlRuleFilter right)
         {
             if (ReferenceEquals(left, right))
@@ -126,12 +121,7 @@ namespace Azure.Messaging.ServiceBus.Administration
             return left.Equals(right);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
         public static bool operator !=(SqlRuleFilter left, SqlRuleFilter right)
         {
             return !(left == right);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/TrueRuleFilter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/Rules/TrueRuleFilter.cs
@@ -48,12 +48,8 @@ namespace Azure.Messaging.ServiceBus.Administration
             return other is TrueRuleFilter;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
+
         public static bool operator ==(TrueRuleFilter left, TrueRuleFilter right)
         {
             if (ReferenceEquals(left, right))
@@ -69,12 +65,8 @@ namespace Azure.Messaging.ServiceBus.Administration
             return left.Equals(right);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
-        /// <returns></returns>
+        /// <inheritdoc/>
+
         public static bool operator !=(TrueRuleFilter left, TrueRuleFilter right)
         {
             return !(left == right);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageConverter.cs
@@ -427,7 +427,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                     foreach (var property in amqpCorrelationFilter.Properties)
                     {
-                        correlationFilter.Properties.Add(property.Key.Key.ToString(), property.Value);
+                        correlationFilter.ApplicationProperties.Add(property.Key.Key.ToString(), property.Value);
                     }
 
                     filter = correlationFilter;
@@ -678,7 +678,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             };
 
             var propertiesMap = new AmqpMap();
-            foreach (var property in correlationRuleFilter.Properties)
+            foreach (var property in correlationRuleFilter.ApplicationProperties)
             {
                 propertiesMap[new MapKey(property.Key)] = property.Value;
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Administration/ServiceBusManagementClientLiveTests.cs
@@ -326,7 +326,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
                 SessionId = "sessionId",
                 To = "to"
             };
-            correlationRuleFilter.Properties.Add("customKey", "customValue");
+            correlationRuleFilter.ApplicationProperties.Add("customKey", "customValue");
             var rule3 = new CreateRuleOptions()
             {
                 Name = "rule3",
@@ -758,15 +758,15 @@ namespace Azure.Messaging.ServiceBus.Tests.Management
             await client.CreateSubscriptionAsync(topicName, subscriptionName);
 
             var filter = new CorrelationRuleFilter();
-            filter.Properties.Add("stringKey", "stringVal");
-            filter.Properties.Add("intKey", 5);
-            filter.Properties.Add("dateTimeKey", Recording.Now.UtcDateTime);
+            filter.ApplicationProperties.Add("stringKey", "stringVal");
+            filter.ApplicationProperties.Add("intKey", 5);
+            filter.ApplicationProperties.Add("dateTimeKey", Recording.Now.UtcDateTime);
 
             RuleProperties rule = await client.CreateRuleAsync(
                 topicName,
                 subscriptionName,
                 new CreateRuleOptions("rule1", filter));
-            Assert.True(filter.Properties.Count == 3);
+            Assert.True(filter.ApplicationProperties.Count == 3);
             Assert.AreEqual(filter, rule.Filter);
 
             await client.DeleteTopicAsync(topicName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/RuleManager/RuleManagerLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/RuleManager/RuleManagerLiveTests.cs
@@ -40,7 +40,7 @@ namespace Azure.Messaging.ServiceBus.Tests.RuleManager
                         CorrelationId = "correlationId",
                         Subject = "label",
                         MessageId = "messageId",
-                        Properties =
+                        ApplicationProperties =
                             {
                                 {"key1", "value1"}
                             },
@@ -78,8 +78,8 @@ namespace Azure.Messaging.ServiceBus.Tests.RuleManager
                 Assert.AreEqual("replyToSessionId", correlationRuleFilter.ReplyToSessionId);
                 Assert.AreEqual("sessionId", correlationRuleFilter.SessionId);
                 Assert.AreEqual("to", correlationRuleFilter.To);
-                Assert.NotNull(correlationRuleFilter.Properties);
-                Assert.AreEqual("value1", correlationRuleFilter.Properties["key1"]);
+                Assert.NotNull(correlationRuleFilter.ApplicationProperties);
+                Assert.AreEqual("value1", correlationRuleFilter.ApplicationProperties["key1"]);
 
                 await ruleManager.RemoveRuleAsync(RuleProperties.DefaultRuleName);
                 await ruleManager.RemoveRuleAsync(sqlRuleName);
@@ -269,7 +269,7 @@ namespace Azure.Messaging.ServiceBus.Tests.RuleManager
 
                 await ruleManager.AddRuleAsync(new RuleProperties
                 {
-                    Filter = new CorrelationRuleFilter { Properties = { { "color", "red" } } },
+                    Filter = new CorrelationRuleFilter { ApplicationProperties = { { "color", "red" } } },
                     Name = "CorrelationUserPropertyRule"
                 });
 
@@ -305,7 +305,7 @@ namespace Azure.Messaging.ServiceBus.Tests.RuleManager
 
                 await ruleManager.AddRuleAsync(new RuleProperties
                 {
-                    Filter = new CorrelationRuleFilter { Properties = { { "Color", "blue" } } },
+                    Filter = new CorrelationRuleFilter { ApplicationProperties = { { "Color", "blue" } } },
                     Action = new SqlRuleAction("Set Priority = 'high'"),
                     Name = "CorrelationRuleWithAction"
                 });


### PR DESCRIPTION
- Fixes https://github.com/azure/azure-sdk-for-net/issues/16093
- Also now throwing exceptions in RuleDescriptionExtensions - this was commented out previously.
- Removing setter on SqlRuleAction.Parameters dictionary.