### PR TITLE
Ignoring two more properties in entity update.

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/QueueDescriptionExtensions.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "SizeInBytes":
                     case "UpdatedAt":
                     case "CountDetails":
+                    case "EntityAvailabilityStatus":
+                    case "SkippedUpdate":
                         // Ignore known properties
                         // Do nothing
                         break;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/SubscriptionDescriptionExtensions.cs
@@ -154,6 +154,8 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "UpdatedAt":
                     case "CountDetails":
                     case "DefaultRuleDescription":
+                    case "EntityAvailabilityStatus":
+                    case "SkippedUpdate":
                         // Ignore known properties
                         // Do nothing
                         break;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescriptionExtensions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Management/TopicDescriptionExtensions.cs
@@ -134,6 +134,8 @@ namespace Microsoft.Azure.ServiceBus.Management
                     case "UpdatedAt":
                     case "CountDetails":
                     case "SubscriptionCount":
+                    case "EntityAvailabilityStatus":
+                    case "SkippedUpdate":
                         // Ignore known properties
                         // Do nothing
                         break;


### PR DESCRIPTION
SkippedUpdate is emitted by debug code, which is used for our internal testing.
EntityAvailabilityStatus needs to be ignored in update request.