### PR TITLE
Remove V2020-02-02-Preview ShortTermRetentionPolicy in new SDK. 

### DIFF
--- a/eng/mgmt/mgmtmetadata/sql_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/sql_resource-manager.txt
@@ -4,11 +4,11 @@ Commencing code generation
 Generating CSharp code
 Executing AutoRest command
 cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/sql/resource-manager/readme.md --csharp --version=v2 --reflect-api-versions --csharp-sdks-folder=.
-2020-09-05 01:00:06 UTC
+2020-11-03 03:12:13 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      ff06cd382011e3f255a602a813289609eb930ef3
+Commit:      f89a6707f26d612eceb8402f073932e6c72eff85
 AutoRest information
 Requested version: v2
 Bootstrapper version:    autorest@2.0.4413

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/BackupShortTermRetentionPoliciesOperations.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/BackupShortTermRetentionPoliciesOperations.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Management.Sql
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
             string policyName = "default";
-            string apiVersion = "2020-02-02-preview";
+            string apiVersion = "2017-10-01-preview";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Management.Sql
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
-            string apiVersion = "2020-02-02-preview";
+            string apiVersion = "2017-10-01-preview";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -579,7 +579,7 @@ namespace Microsoft.Azure.Management.Sql
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
             string policyName = "default";
-            string apiVersion = "2020-02-02-preview";
+            string apiVersion = "2017-10-01-preview";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
@@ -800,7 +800,7 @@ namespace Microsoft.Azure.Management.Sql
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");
             }
             string policyName = "default";
-            string apiVersion = "2020-02-02-preview";
+            string apiVersion = "2017-10-01-preview";
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/BackupShortTermRetentionPolicy.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Generated/Models/BackupShortTermRetentionPolicy.cs
@@ -40,15 +40,10 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// <param name="retentionDays">The backup retention period in days.
         /// This is how many days Point-in-Time Restore will be
         /// supported.</param>
-        /// <param name="diffBackupIntervalInHours">The differential backup
-        /// interval in hours. This is how many interval hours between each
-        /// differential backup will be supported. This is only applicable to
-        /// live databases but not dropped databases.</param>
-        public BackupShortTermRetentionPolicy(string id = default(string), string name = default(string), string type = default(string), int? retentionDays = default(int?), int? diffBackupIntervalInHours = default(int?))
+        public BackupShortTermRetentionPolicy(string id = default(string), string name = default(string), string type = default(string), int? retentionDays = default(int?))
             : base(id, name, type)
         {
             RetentionDays = retentionDays;
-            DiffBackupIntervalInHours = diffBackupIntervalInHours;
             CustomInit();
         }
 
@@ -63,15 +58,6 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.retentionDays")]
         public int? RetentionDays { get; set; }
-
-        /// <summary>
-        /// Gets or sets the differential backup interval in hours. This is how
-        /// many interval hours between each differential backup will be
-        /// supported. This is only applicable to live databases but not
-        /// dropped databases.
-        /// </summary>
-        [JsonProperty(PropertyName = "properties.diffBackupIntervalInHours")]
-        public int? DiffBackupIntervalInHours { get; set; }
 
     }
 }

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Microsoft.Azure.Management.Sql.csproj
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Microsoft.Azure.Management.Sql.csproj
@@ -7,12 +7,12 @@
 		<PackageId>Microsoft.Azure.Management.Sql</PackageId>
 		<Description>Azure SQL Management SDK library</Description>
 		<AssemblyName>Microsoft.Azure.Management.Sql</AssemblyName>
-		<Version>1.46.0-preview</Version>
+		<Version>1.47.0-preview</Version>
 		<PackageTags>Microsoft Azure SQL Management;SQL;SQL Management;</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
 New features:
-- Added SQL DB Short Term Retention APIs(2020-02-02-preview)
+- Disable feature SQL DB Short Term Retention APIs(2020-02-02-preview)
       ]]>
 		</PackageReleaseNotes>
 	</PropertyGroup>

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Properties/AssemblyInfo.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure SQL Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure SQL.")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.46.0.0")]
+[assembly: AssemblyFileVersion("1.47.0.0")]
 

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnBasic.json
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnBasic.json
@@ -1,28 +1,28 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourcegroups/sqlcrudtest-1024?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQ/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-9356?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTkzNTY/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"southeast asia\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-1024\": \"2020-10-06 05:16:23Z\"\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-9356\": \"2020-11-03 04:18:09Z\"\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "54ec776a-0a5d-4969-98e2-bbd4ad9e585f"
+          "24106792-6bc8-484c-aa10-05df12139b57"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "103"
+          "95"
         ]
       },
       "ResponseHeaders": {
@@ -36,13 +36,13 @@
           "1199"
         ],
         "x-ms-request-id": [
-          "6d29d15b-7c5a-4497-a6f5-ec37add6dd8c"
+          "c06f0520-3ab3-413f-a777-4cbce58527a4"
         ],
         "x-ms-correlation-request-id": [
-          "6d29d15b-7c5a-4497-a6f5-ec37add6dd8c"
+          "c06f0520-3ab3-413f-a777-4cbce58527a4"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051626Z:6d29d15b-7c5a-4497-a6f5-ec37add6dd8c"
+          "WESTUS:20201103T041811Z:c06f0520-3ab3-413f-a777-4cbce58527a4"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -51,10 +51,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:16:25 GMT"
+          "Tue, 03 Nov 2020 04:18:10 GMT"
         ],
         "Content-Length": [
-          "243"
+          "236"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -63,32 +63,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024\",\r\n  \"name\": \"sqlcrudtest-1024\",\r\n  \"location\": \"southeastasia\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-1024\": \"2020-10-06 05:16:23Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356\",\r\n  \"name\": \"sqlcrudtest-9356\",\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-9356\": \"2020-11-03 04:18:09Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"location\": \"southeast asia\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "808738ca-aadc-44ef-8134-f4692d56dd34"
+          "09415e61-fa13-4ff1-b99a-5ec34dd66713"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "188"
+          "180"
         ]
       },
       "ResponseHeaders": {
@@ -99,16 +99,16 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverOperationResults/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/serverOperationResults/d2cec09b-b44d-41db-bce8-26cf3355927d?api-version=2019-06-01-preview"
         ],
         "Retry-After": [
           "1"
         ],
         "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/d2cec09b-b44d-41db-bce8-26cf3355927d?api-version=2019-06-01-preview"
         ],
         "x-ms-request-id": [
-          "035d5d78-3077-4d03-ae1d-e944085a2b39"
+          "d2cec09b-b44d-41db-bce8-26cf3355927d"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -117,10 +117,10 @@
           "1199"
         ],
         "x-ms-correlation-request-id": [
-          "1b664637-d0fa-4a43-9161-0115a5e34d96"
+          "adc13a8f-5f3d-4821-8855-a1c30afe763d"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051629Z:1b664637-d0fa-4a43-9161-0115a5e34d96"
+          "WESTUS:20201103T041816Z:adc13a8f-5f3d-4821-8855-a1c30afe763d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -129,10 +129,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:16:29 GMT"
+          "Tue, 03 Nov 2020 04:18:15 GMT"
         ],
         "Content-Length": [
-          "73"
+          "74"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -141,20 +141,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2020-10-06T05:16:29.62Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2020-11-03T04:18:13.993Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMzVkNWQ3OC0zMDc3LTRkMDMtYWUxZC1lOTQ0MDg1YTJiMzk/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/d2cec09b-b44d-41db-bce8-26cf3355927d?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2QyY2VjMDliLWI0NGQtNDFkYi1iY2U4LTI2Y2YzMzU1OTI3ZD9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -168,19 +168,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "72732d61-3fcb-4bb1-b7d8-8921b852afd4"
+          "14a01ffb-8eb0-4e19-8359-00a0a32940d0"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14999"
+          "11999"
         ],
         "x-ms-correlation-request-id": [
-          "42327f6b-45bf-4260-90d8-f8d5f25dbbd3"
+          "d4a2f34e-4a7f-40ba-8765-969e84b2f97d"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051631Z:42327f6b-45bf-4260-90d8-f8d5f25dbbd3"
+          "WESTUS:20201103T041817Z:d4a2f34e-4a7f-40ba-8765-969e84b2f97d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -189,10 +189,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:16:30 GMT"
+          "Tue, 03 Nov 2020 04:18:16 GMT"
         ],
         "Content-Length": [
-          "107"
+          "108"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -201,20 +201,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"035d5d78-3077-4d03-ae1d-e944085a2b39\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:16:29.62Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"d2cec09b-b44d-41db-bce8-26cf3355927d\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:18:13.993Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMzVkNWQ3OC0zMDc3LTRkMDMtYWUxZC1lOTQ0MDg1YTJiMzk/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/d2cec09b-b44d-41db-bce8-26cf3355927d?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2QyY2VjMDliLWI0NGQtNDFkYi1iY2U4LTI2Y2YzMzU1OTI3ZD9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -228,19 +228,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "25c2f7f1-23d6-40a5-8223-a30b9bf100b1"
+          "97765cfa-eb4a-4339-a347-0f31363af2bb"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14998"
+          "11998"
         ],
         "x-ms-correlation-request-id": [
-          "cbac6f4a-1150-44a4-b3dd-bca61762a128"
+          "b7a624a6-4109-48fa-8493-5860186c8b47"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051632Z:cbac6f4a-1150-44a4-b3dd-bca61762a128"
+          "WESTUS:20201103T041818Z:b7a624a6-4109-48fa-8493-5860186c8b47"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -249,10 +249,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:16:31 GMT"
+          "Tue, 03 Nov 2020 04:18:17 GMT"
         ],
         "Content-Length": [
-          "107"
+          "108"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -261,80 +261,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"035d5d78-3077-4d03-ae1d-e944085a2b39\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:16:29.62Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"d2cec09b-b44d-41db-bce8-26cf3355927d\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:18:13.993Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMzVkNWQ3OC0zMDc3LTRkMDMtYWUxZC1lOTQ0MDg1YTJiMzk/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/d2cec09b-b44d-41db-bce8-26cf3355927d?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2QyY2VjMDliLWI0NGQtNDFkYi1iY2U4LTI2Y2YzMzU1OTI3ZD9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "1"
-        ],
-        "x-ms-request-id": [
-          "28b57f29-83e1-464f-a545-e54cf2a507ae"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
-        ],
-        "x-ms-correlation-request-id": [
-          "f19ed54a-9364-4232-9842-60347d2b262d"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051633Z:f19ed54a-9364-4232-9842-60347d2b262d"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:16:32 GMT"
-        ],
-        "Content-Length": [
-          "107"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"035d5d78-3077-4d03-ae1d-e944085a2b39\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:16:29.62Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMzVkNWQ3OC0zMDc3LTRkMDMtYWUxZC1lOTQ0MDg1YTJiMzk/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -348,19 +288,19 @@
           "20"
         ],
         "x-ms-request-id": [
-          "7e9d01e8-1662-4918-acef-85f3d199075f"
+          "7cbd0b88-5383-4b0a-b3f8-c688141eae81"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "11997"
         ],
         "x-ms-correlation-request-id": [
-          "e7fd9a3d-bde8-43a4-bb0d-58e5b93322dc"
+          "867a8e21-b7e4-4863-99c8-166139139bdd"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051635Z:e7fd9a3d-bde8-43a4-bb0d-58e5b93322dc"
+          "WESTUS:20201103T041819Z:867a8e21-b7e4-4863-99c8-166139139bdd"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -369,10 +309,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:16:35 GMT"
+          "Tue, 03 Nov 2020 04:18:18 GMT"
         ],
         "Content-Length": [
-          "107"
+          "108"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -381,20 +321,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"035d5d78-3077-4d03-ae1d-e944085a2b39\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:16:29.62Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"d2cec09b-b44d-41db-bce8-26cf3355927d\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:18:13.993Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMzVkNWQ3OC0zMDc3LTRkMDMtYWUxZC1lOTQ0MDg1YTJiMzk/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/d2cec09b-b44d-41db-bce8-26cf3355927d?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2QyY2VjMDliLWI0NGQtNDFkYi1iY2U4LTI2Y2YzMzU1OTI3ZD9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -408,19 +348,19 @@
           "20"
         ],
         "x-ms-request-id": [
-          "c54fc968-f502-431e-b1f3-7d1f8e6bbc11"
+          "f15271b4-3da1-49fd-91d8-e3851357de27"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "11996"
         ],
         "x-ms-correlation-request-id": [
-          "d7420339-ac69-447d-9be9-faf5d6c007ef"
+          "b868e60e-b0b4-47f6-a91e-fa8dff551cd7"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051655Z:d7420339-ac69-447d-9be9-faf5d6c007ef"
+          "WESTUS:20201103T041839Z:b868e60e-b0b4-47f6-a91e-fa8dff551cd7"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -429,10 +369,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:16:55 GMT"
+          "Tue, 03 Nov 2020 04:18:38 GMT"
         ],
         "Content-Length": [
-          "107"
+          "108"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -441,20 +381,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"035d5d78-3077-4d03-ae1d-e944085a2b39\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:16:29.62Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"d2cec09b-b44d-41db-bce8-26cf3355927d\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:18:13.993Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/035d5d78-3077-4d03-ae1d-e944085a2b39?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8wMzVkNWQ3OC0zMDc3LTRkMDMtYWUxZC1lOTQ0MDg1YTJiMzk/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/d2cec09b-b44d-41db-bce8-26cf3355927d?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2QyY2VjMDliLWI0NGQtNDFkYi1iY2U4LTI2Y2YzMzU1OTI3ZD9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -468,19 +408,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "4cd86f35-3d9f-462f-9f63-723b8b0905c9"
+          "0c4c5e9c-e9cf-47ec-aa2a-d6908d222f25"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
+          "11995"
         ],
         "x-ms-correlation-request-id": [
-          "784a97b4-023c-4f7d-8224-411c0d8895b0"
+          "175c78c9-032e-4c7b-ac46-3bdb5771f216"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051715Z:784a97b4-023c-4f7d-8224-411c0d8895b0"
+          "WESTUS:20201103T041859Z:175c78c9-032e-4c7b-ac46-3bdb5771f216"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -489,10 +429,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:17:15 GMT"
+          "Tue, 03 Nov 2020 04:18:58 GMT"
         ],
         "Content-Length": [
-          "106"
+          "107"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -501,20 +441,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"035d5d78-3077-4d03-ae1d-e944085a2b39\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-10-06T05:16:29.62Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"d2cec09b-b44d-41db-bce8-26cf3355927d\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T04:18:13.993Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -525,19 +465,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "99cda191-bb4a-426c-b9fc-831f65f1f291"
+          "bcb9d743-14ac-4518-b7af-cad4cdecd939"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
+          "11994"
         ],
         "x-ms-correlation-request-id": [
-          "b03b7df7-ab11-4024-9380-ad9fed2b8ebd"
+          "447d7af8-db8b-4532-a2c3-0a783e9757e3"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051716Z:b03b7df7-ab11-4024-9380-ad9fed2b8ebd"
+          "WESTUS:20201103T041859Z:447d7af8-db8b-4532-a2c3-0a783e9757e3"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -546,10 +486,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:17:15 GMT"
+          "Tue, 03 Nov 2020 04:18:58 GMT"
         ],
         "Content-Length": [
-          "464"
+          "456"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -558,32 +498,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-1245.sqltest-eg1.mscds.com\",\r\n    \"privateEndpointConnections\": [],\r\n    \"publicNetworkAccess\": \"Enabled\"\r\n  },\r\n  \"location\": \"southeastasia\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245\",\r\n  \"name\": \"sqlcrudtest-1245\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
+      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-7558.database.windows.net\",\r\n    \"privateEndpointConnections\": [],\r\n    \"publicNetworkAccess\": \"Enabled\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558\",\r\n  \"name\": \"sqlcrudtest-7558\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04ODQ4P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"location\": \"southeastasia\"\r\n}",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"location\": \"eastus\"\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f7bce765-7624-4016-b107-7f70d98286e3"
+          "0f498315-62c5-410a-8b1c-776365ab385d"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "74"
+          "67"
         ]
       },
       "ResponseHeaders": {
@@ -594,16 +534,16 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/databaseOperationResults/a6f799ca-4991-4ca4-a6ab-44578cc77ba9?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/databaseOperationResults/b82b1a1b-8a31-480a-b1da-eeb0008cbb57?api-version=2020-08-01-preview"
         ],
         "Retry-After": [
           "15"
         ],
         "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/a6f799ca-4991-4ca4-a6ab-44578cc77ba9?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/b82b1a1b-8a31-480a-b1da-eeb0008cbb57?api-version=2020-08-01-preview"
         ],
         "x-ms-request-id": [
-          "a6f799ca-4991-4ca4-a6ab-44578cc77ba9"
+          "b82b1a1b-8a31-480a-b1da-eeb0008cbb57"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -612,10 +552,10 @@
           "1198"
         ],
         "x-ms-correlation-request-id": [
-          "575f43ae-75e5-4b08-ab49-74ff6f8c4acd"
+          "cb141ca4-81b0-4e75-a7a8-7f90ec34e2aa"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051718Z:575f43ae-75e5-4b08-ab49-74ff6f8c4acd"
+          "WESTUS:20201103T041901Z:cb141ca4-81b0-4e75-a7a8-7f90ec34e2aa"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -624,10 +564,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:17:17 GMT"
+          "Tue, 03 Nov 2020 04:19:00 GMT"
         ],
         "Content-Length": [
-          "75"
+          "74"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -636,20 +576,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-06T05:17:17.93Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T04:19:01.4Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/a6f799ca-4991-4ca4-a6ab-44578cc77ba9?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2E2Zjc5OWNhLTQ5OTEtNGNhNC1hNmFiLTQ0NTc4Y2M3N2JhOT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/b82b1a1b-8a31-480a-b1da-eeb0008cbb57?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vYjgyYjFhMWItOGEzMS00ODBhLWIxZGEtZWViMDAwOGNiYjU3P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -663,19 +603,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "7f3d365a-509b-4a78-aa3d-73c45db72170"
+          "cc3604ae-5057-41a1-a343-f35154471652"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
+          "11993"
         ],
         "x-ms-correlation-request-id": [
-          "ca7f04a0-a529-4154-912d-130a34cca3ba"
+          "470fea30-eed5-4140-8b0e-19ed96170cff"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051733Z:ca7f04a0-a529-4154-912d-130a34cca3ba"
+          "WESTUS:20201103T041917Z:470fea30-eed5-4140-8b0e-19ed96170cff"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -684,187 +624,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:17:33 GMT"
-        ],
-        "Content-Length": [
-          "107"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"a6f799ca-4991-4ca4-a6ab-44578cc77ba9\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:17:17.93Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/a6f799ca-4991-4ca4-a6ab-44578cc77ba9?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2E2Zjc5OWNhLTQ5OTEtNGNhNC1hNmFiLTQ0NTc4Y2M3N2JhOT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "769f0cfc-60d2-4f94-a9ba-7c71b03e4ee9"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
-        ],
-        "x-ms-correlation-request-id": [
-          "a8b2789b-136c-4f91-b792-ecd65d9a324b"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051748Z:a8b2789b-136c-4f91-b792-ecd65d9a324b"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:17:48 GMT"
-        ],
-        "Content-Length": [
-          "107"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"a6f799ca-4991-4ca4-a6ab-44578cc77ba9\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:17:17.93Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/a6f799ca-4991-4ca4-a6ab-44578cc77ba9?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2E2Zjc5OWNhLTQ5OTEtNGNhNC1hNmFiLTQ0NTc4Y2M3N2JhOT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "26bbe48a-5bf0-4a83-b52a-64d859d2d8f3"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14990"
-        ],
-        "x-ms-correlation-request-id": [
-          "6d55f5ac-0bb1-4c5c-9508-a343fd2a5166"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051804Z:6d55f5ac-0bb1-4c5c-9508-a343fd2a5166"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:18:03 GMT"
-        ],
-        "Content-Length": [
-          "107"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"a6f799ca-4991-4ca4-a6ab-44578cc77ba9\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T05:17:17.93Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/a6f799ca-4991-4ca4-a6ab-44578cc77ba9?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2E2Zjc5OWNhLTQ5OTEtNGNhNC1hNmFiLTQ0NTc4Y2M3N2JhOT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "fd1a0da6-e230-40f6-96b2-f19fde3ee629"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14989"
-        ],
-        "x-ms-correlation-request-id": [
-          "1ac7d9d2-6aa3-42a2-8656-f86d6c265472"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051819Z:1ac7d9d2-6aa3-42a2-8656-f86d6c265472"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:18:18 GMT"
+          "Tue, 03 Nov 2020 04:19:16 GMT"
         ],
         "Content-Length": [
           "106"
@@ -876,20 +636,140 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"a6f799ca-4991-4ca4-a6ab-44578cc77ba9\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-10-06T05:17:17.93Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"b82b1a1b-8a31-480a-b1da-eeb0008cbb57\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:19:01.4Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/b82b1a1b-8a31-480a-b1da-eeb0008cbb57?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vYjgyYjFhMWItOGEzMS00ODBhLWIxZGEtZWViMDAwOGNiYjU3P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "130cd0d0-1a41-4f0c-97bc-198d9383ea65"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11992"
+        ],
+        "x-ms-correlation-request-id": [
+          "2d4fc7af-5dab-4566-a3a4-92e48486b779"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T041932Z:2d4fc7af-5dab-4566-a3a4-92e48486b779"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:19:32 GMT"
+        ],
+        "Content-Length": [
+          "106"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"b82b1a1b-8a31-480a-b1da-eeb0008cbb57\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:19:01.4Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/b82b1a1b-8a31-480a-b1da-eeb0008cbb57?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vYjgyYjFhMWItOGEzMS00ODBhLWIxZGEtZWViMDAwOGNiYjU3P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "59ecdaec-fab6-483f-9bc7-19c4d85e943c"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11991"
+        ],
+        "x-ms-correlation-request-id": [
+          "e2eb2bac-38d4-466e-b47b-f92fe82fe18c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T041947Z:e2eb2bac-38d4-466e-b47b-f92fe82fe18c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:19:47 GMT"
+        ],
+        "Content-Length": [
+          "105"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"b82b1a1b-8a31-480a-b1da-eeb0008cbb57\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T04:19:01.4Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04ODQ4P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -900,19 +780,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "99a17d3d-73be-49f0-8020-21a94934c7a9"
+          "755256b4-deca-4541-a35c-d82ee0880670"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14988"
+          "11990"
         ],
         "x-ms-correlation-request-id": [
-          "2366fd79-5976-48a2-a4bf-13ef09147e7a"
+          "813e0402-32b1-4143-93f1-02a3528fdecc"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051819Z:2366fd79-5976-48a2-a4bf-13ef09147e7a"
+          "WESTUS:20201103T041947Z:813e0402-32b1-4143-93f1-02a3528fdecc"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -921,10 +801,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:18:19 GMT"
+          "Tue, 03 Nov 2020 04:19:47 GMT"
         ],
         "Content-Length": [
-          "898"
+          "865"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -933,26 +813,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Basic\",\r\n    \"capacity\": 5\r\n  },\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": 2147483648,\r\n    \"status\": \"Online\",\r\n    \"databaseId\": \"4c16a847-151e-4a68-a052-7afea023f6d5\",\r\n    \"creationDate\": \"2020-10-06T05:18:17.613Z\",\r\n    \"currentServiceObjectiveName\": \"Basic\",\r\n    \"requestedServiceObjectiveName\": \"Basic\",\r\n    \"defaultSecondaryLocation\": \"northeurope\",\r\n    \"catalogCollation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"zoneRedundant\": false,\r\n    \"earliestRestoreDate\": \"2020-10-06T05:48:17.613Z\",\r\n    \"readScale\": \"Disabled\",\r\n    \"readReplicaCount\": 0,\r\n    \"currentSku\": {\r\n      \"name\": \"Basic\",\r\n      \"tier\": \"Basic\",\r\n      \"capacity\": 5\r\n    },\r\n    \"storageAccountType\": \"GRS\"\r\n  },\r\n  \"location\": \"southeastasia\",\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850\",\r\n  \"name\": \"sqlcrudtest-5850\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\"\r\n}",
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Basic\",\r\n    \"capacity\": 5\r\n  },\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": 2147483648,\r\n    \"status\": \"Online\",\r\n    \"databaseId\": \"99631717-355f-4b16-b8dd-3d2ff6640279\",\r\n    \"creationDate\": \"2020-11-03T04:19:38.557Z\",\r\n    \"currentServiceObjectiveName\": \"Basic\",\r\n    \"requestedServiceObjectiveName\": \"Basic\",\r\n    \"defaultSecondaryLocation\": \"westus\",\r\n    \"catalogCollation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"zoneRedundant\": false,\r\n    \"earliestRestoreDate\": \"2020-11-03T04:49:38.557Z\",\r\n    \"readScale\": \"Disabled\",\r\n    \"currentSku\": {\r\n      \"name\": \"Basic\",\r\n      \"tier\": \"Basic\",\r\n      \"capacity\": 5\r\n    },\r\n    \"storageAccountType\": \"GRS\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848\",\r\n  \"name\": \"sqlcrudtest-8848\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04ODQ4L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "a526516d-537d-4d7a-aadb-5af6974b73f0"
+          "5cf3587f-e93b-44f4-8b64-91b689a39be9"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -963,19 +843,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "7f7d8465-ec08-4de1-ac5b-db97f6f3104a"
+          "8bf11962-7a49-471e-9f33-d0b26d9040db"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14987"
+          "11989"
         ],
         "x-ms-correlation-request-id": [
-          "01e07162-0787-4a0d-8824-b86d5491e65b"
+          "9b4443ba-0cb8-40ee-b021-ad6dda6a2e58"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051820Z:01e07162-0787-4a0d-8824-b86d5491e65b"
+          "WESTUS:20201103T041947Z:9b4443ba-0cb8-40ee-b021-ad6dda6a2e58"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -984,10 +864,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:18:19 GMT"
+          "Tue, 03 Nov 2020 04:19:47 GMT"
         ],
         "Content-Length": [
-          "364"
+          "333"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -996,26 +876,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04ODQ4L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "24b025f1-b7ca-4642-8dbc-98450e9c3eb9"
+          "12b43294-374c-479b-bd9f-c3412683f848"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1026,19 +906,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "e302a8d9-ca26-4437-b617-d9b1f28b412b"
+          "9549e86b-e445-491f-b733-085a7edcb28d"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14986"
+          "11988"
         ],
         "x-ms-correlation-request-id": [
-          "c4d53f4c-a264-4fbe-974e-0f7c985b3416"
+          "169a6a25-52f1-451a-bc0a-abc8a57503d5"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051823Z:c4d53f4c-a264-4fbe-974e-0f7c985b3416"
+          "WESTUS:20201103T041950Z:169a6a25-52f1-451a-bc0a-abc8a57503d5"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1047,10 +927,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:18:22 GMT"
+          "Tue, 03 Nov 2020 04:19:50 GMT"
         ],
         "Content-Length": [
-          "364"
+          "333"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1059,26 +939,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04ODQ4L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "1be4bb95-f6e6-4cd9-bdc4-e66d40790087"
+          "01ccf8e6-4cdc-4d2f-bb3f-45e061e66c8b"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1089,19 +969,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "a95e0c3f-a9de-4486-a10b-14afb3cffc7d"
+          "8334b548-f1dc-468e-b0e9-569fdfd6c8d0"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14985"
+          "11987"
         ],
         "x-ms-correlation-request-id": [
-          "43ca40bb-ad88-46dd-9339-e3fa94d3f870"
+          "2b235a43-7c91-4aba-9990-bf8aef5c8b90"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051826Z:43ca40bb-ad88-46dd-9339-e3fa94d3f870"
+          "WESTUS:20201103T041953Z:2b235a43-7c91-4aba-9990-bf8aef5c8b90"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1110,10 +990,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:18:26 GMT"
+          "Tue, 03 Nov 2020 04:19:53 GMT"
         ],
         "Content-Length": [
-          "364"
+          "333"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1122,158 +1002,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 6\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "db9ab640-11e1-4657-b5cf-e9e9e7b33a64"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "35de6622-9c09-4f7a-aea9-690e04b6db41"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14984"
-        ],
-        "x-ms-correlation-request-id": [
-          "5dba5bd8-14ef-43ae-a186-e3634cdce998"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051830Z:5dba5bd8-14ef-43ae-a186-e3634cdce998"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:18:30 GMT"
-        ],
-        "Content-Length": [
-          "364"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 6,\r\n    \"diffBackupIntervalInHours\": 24\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "57d4ef26-1d66-4594-8910-b57a0eb31c0f"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "0ba386ae-23b7-40f0-b834-179b34a94ba1"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14983"
-        ],
-        "x-ms-correlation-request-id": [
-          "e35025df-0785-41eb-ad99-7eeea8356287"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051833Z:e35025df-0785-41eb-ad99-7eeea8356287"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:18:33 GMT"
-        ],
-        "Content-Length": [
-          "364"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 6,\r\n    \"diffBackupIntervalInHours\": 24\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04ODQ4L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 8,\r\n    \"diffBackupIntervalInHours\": 12\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 8\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "3153a338-0ded-4b8e-808b-bf623c99a5c1"
+          "f36e483d-1f8d-4491-9b1e-deede0190cec"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "90"
+          "52"
         ]
       },
       "ResponseHeaders": {
@@ -1284,7 +1038,7 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "a7bfc8a2-6c17-40e7-a20c-bbd564a858c9"
+          "fd5efa67-e964-4168-909e-ed8d1142c712"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -1293,10 +1047,10 @@
           "1197"
         ],
         "x-ms-correlation-request-id": [
-          "8b594334-346a-4849-9a6e-3a816cb792e2"
+          "67e83e2b-514c-4750-8f45-70506ed917dd"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051820Z:8b594334-346a-4849-9a6e-3a816cb792e2"
+          "WESTUS:20201103T041947Z:67e83e2b-514c-4750-8f45-70506ed917dd"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1305,7 +1059,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:18:20 GMT"
+          "Tue, 03 Nov 2020 04:19:47 GMT"
         ],
         "Content-Length": [
           "170"
@@ -1321,28 +1075,28 @@
       "StatusCode": 400
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/servers/sqlcrudtest-7558/databases/sqlcrudtest-8848/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTkzNTYvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03NTU4L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04ODQ4L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 6,\r\n    \"diffBackupIntervalInHours\": 6\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 6\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "9dd0f246-20d3-4008-b999-ef0479b4f4b8"
+          "a316de34-cb10-4a7a-9238-329061f76782"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "89"
+          "52"
         ]
       },
       "ResponseHeaders": {
@@ -1352,8 +1106,17 @@
         "Pragma": [
           "no-cache"
         ],
+        "Location": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyOperationResults/6425d7f1-50ea-4ada-bac4-bf4c0c781f97?api-version=2017-10-01-preview"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-9356/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/6425d7f1-50ea-4ada-bac4-bf4c0c781f97?api-version=2017-10-01-preview"
+        ],
         "x-ms-request-id": [
-          "22a2a83a-0ae6-4aaa-8b72-7b767c560f35"
+          "6425d7f1-50ea-4ada-bac4-bf4c0c781f97"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -1362,10 +1125,10 @@
           "1196"
         ],
         "x-ms-correlation-request-id": [
-          "b279b4a6-d68e-42eb-9e7a-22c601046103"
+          "1123128c-3f5c-4f4d-9f8e-ebe762642172"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051824Z:b279b4a6-d68e-42eb-9e7a-22c601046103"
+          "WESTUS:20201103T041951Z:1123128c-3f5c-4f4d-9f8e-ebe762642172"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1374,85 +1137,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:18:24 GMT"
-        ],
-        "Content-Length": [
-          "204"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidDiffBackupIntervalHours\",\r\n    \"message\": \"The differential backup interval hours of 6 is not a valid configuration. Valid differential backup interval must be 0.08 or 12 or 24 hours.\"\r\n  }\r\n}",
-      "StatusCode": 400
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 6,\r\n    \"diffBackupIntervalInHours\": 24\r\n  }\r\n}",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "d4543e15-30df-4e99-a0a1-50d29f8b7655"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "90"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyOperationResults/d19568a0-3d28-485a-b709-32b9113901be?api-version=2020-02-02-preview"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyAzureAsyncOperation/d19568a0-3d28-485a-b709-32b9113901be?api-version=2020-02-02-preview"
-        ],
-        "x-ms-request-id": [
-          "d19568a0-3d28-485a-b709-32b9113901be"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
-        ],
-        "x-ms-correlation-request-id": [
-          "70dc13b9-604f-48f3-9bee-6019c86adbf7"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051827Z:70dc13b9-604f-48f3-9bee-6019c86adbf7"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:18:26 GMT"
+          "Tue, 03 Nov 2020 04:19:50 GMT"
         ],
         "Content-Length": [
           "76"
@@ -1464,103 +1149,25 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-06T05:18:27.303Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T04:19:50.853Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/servers/sqlcrudtest-1245/databases/sqlcrudtest-5850/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0xMjQ1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01ODUwL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 6,\r\n    \"diffBackupIntervalInHours\": 24\r\n  }\r\n}",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "6104eee0-7a38-4996-939c-d8c096e98c2d"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "90"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyOperationResults/18c1aeb2-06a3-47d7-815f-0b0ccdb6b7b8?api-version=2020-02-02-preview"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-1024/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyAzureAsyncOperation/18c1aeb2-06a3-47d7-815f-0b0ccdb6b7b8?api-version=2020-02-02-preview"
-        ],
-        "x-ms-request-id": [
-          "18c1aeb2-06a3-47d7-815f-0b0ccdb6b7b8"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
-        ],
-        "x-ms-correlation-request-id": [
-          "f36eccad-412a-4446-bcc8-380f759bb308"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051830Z:f36eccad-412a-4446-bcc8-380f759bb308"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 05:18:30 GMT"
-        ],
-        "Content-Length": [
-          "76"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-06T05:18:30.633Z\"\r\n}",
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourcegroups/sqlcrudtest-1024?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTEwMjQ/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-9356?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTkzNTY/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "0ca8666b-abb2-4c5e-83df-528181d9383b"
+          "f9a351dc-0393-4eae-9767-13059b071b9a"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
@@ -1572,7 +1179,7 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDEwMjQtU09VVEhFQVNUQVNJQSIsImpvYkxvY2F0aW9uIjoic291dGhlYXN0YXNpYSJ9?api-version=2017-05-10"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDkzNTYtRUFTVFVTIiwiam9iTG9jYXRpb24iOiJlYXN0dXMifQ?api-version=2017-05-10"
         ],
         "Retry-After": [
           "15"
@@ -1581,13 +1188,13 @@
           "14999"
         ],
         "x-ms-request-id": [
-          "7a043443-360c-4ebd-880b-e679e7ba9107"
+          "24c05de6-35ab-444d-a3c4-b5d7ffbc96de"
         ],
         "x-ms-correlation-request-id": [
-          "7a043443-360c-4ebd-880b-e679e7ba9107"
+          "24c05de6-35ab-444d-a3c4-b5d7ffbc96de"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T051835Z:7a043443-360c-4ebd-880b-e679e7ba9107"
+          "WESTUS:20201103T041954Z:24c05de6-35ab-444d-a3c4-b5d7ffbc96de"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1596,7 +1203,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 05:18:35 GMT"
+          "Tue, 03 Nov 2020 04:19:54 GMT"
         ],
         "Expires": [
           "-1"
@@ -1611,17 +1218,17 @@
   ],
   "Names": {
     "CreateResourceGroup": [
-      "sqlcrudtest-1024"
+      "sqlcrudtest-9356"
     ],
     "CreateServer": [
-      "sqlcrudtest-1245"
+      "sqlcrudtest-7558"
     ],
     "TestShortTermRetentionPolicyOnBasic": [
-      "sqlcrudtest-5850"
+      "sqlcrudtest-8848"
     ]
   },
   "Variables": {
-    "SubscriptionId": "4b6aaaf2-6fd8-418b-a06d-6ede39a32270",
-    "DefaultLocation": "southeast asia"
+    "SubscriptionId": "dc1789a8-0762-4dfb-8901-4c0da08b83d3",
+    "DefaultLocation": "eastus"
   }
 }

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnGeneralPurpose.json
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnGeneralPurpose.json
@@ -1,28 +1,28 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourcegroups/sqlcrudtest-3755?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTM3NTU/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-87?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTg3P2FwaS12ZXJzaW9uPTIwMTctMDUtMTA=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"southeast asia\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-3755\": \"2020-10-08 02:02:20Z\"\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-87\": \"2020-11-03 04:25:11Z\"\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "c37ac0f6-0204-43b0-80e2-f669e3f21092"
+          "2671b99c-7c9a-435d-827b-4f736882be4b"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "103"
+          "93"
         ]
       },
       "ResponseHeaders": {
@@ -33,16 +33,16 @@
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1199"
+          "1195"
         ],
         "x-ms-request-id": [
-          "eab07e36-5a5c-40f6-a23a-6918a373be10"
+          "8429b796-c700-4cdf-bd0d-c1d03ecc0427"
         ],
         "x-ms-correlation-request-id": [
-          "eab07e36-5a5c-40f6-a23a-6918a373be10"
+          "8429b796-c700-4cdf-bd0d-c1d03ecc0427"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020222Z:eab07e36-5a5c-40f6-a23a-6918a373be10"
+          "WESTUS:20201103T042513Z:8429b796-c700-4cdf-bd0d-c1d03ecc0427"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -51,10 +51,10 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:02:22 GMT"
+          "Tue, 03 Nov 2020 04:25:13 GMT"
         ],
         "Content-Length": [
-          "243"
+          "230"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -63,32 +63,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755\",\r\n  \"name\": \"sqlcrudtest-3755\",\r\n  \"location\": \"southeastasia\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-3755\": \"2020-10-08 02:02:20Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87\",\r\n  \"name\": \"sqlcrudtest-87\",\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-87\": \"2020-11-03 04:25:11Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"location\": \"southeast asia\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "b5c59926-0087-4568-af8d-de93870ef5cc"
+          "33fba39e-013d-460d-8f84-98dc3e080146"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "188"
+          "180"
         ]
       },
       "ResponseHeaders": {
@@ -99,16 +99,16 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverOperationResults/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverOperationResults/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview"
         ],
         "Retry-After": [
           "1"
         ],
         "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview"
         ],
         "x-ms-request-id": [
-          "490317e9-546b-4132-a0c2-12b71dca4471"
+          "218ad0a1-b418-415e-8f99-afb5f9cefdb8"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -117,10 +117,10 @@
           "1199"
         ],
         "x-ms-correlation-request-id": [
-          "d503a959-24b1-40da-96ee-ed60bf4d9cb3"
+          "aef3600d-4891-4ed3-988f-c7a7dc5496b9"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020225Z:d503a959-24b1-40da-96ee-ed60bf4d9cb3"
+          "WESTUS:20201103T042516Z:aef3600d-4891-4ed3-988f-c7a7dc5496b9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -129,7 +129,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:02:25 GMT"
+          "Tue, 03 Nov 2020 04:25:16 GMT"
         ],
         "Content-Length": [
           "74"
@@ -141,20 +141,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2020-10-08T02:02:25.623Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi80OTAzMTdlOS01NDZiLTQxMzItYTBjMi0xMmI3MWRjYTQ0NzE/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8yMThhZDBhMS1iNDE4LTQxNWUtOGY5OS1hZmI1ZjljZWZkYjg/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -168,19 +168,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "68c1d62e-2e02-4330-9614-4b74fec8bea4"
+          "349eed17-b581-4deb-9f16-a55f9f96fa13"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14999"
+          "11999"
         ],
         "x-ms-correlation-request-id": [
-          "313c4800-227b-4e38-8efc-3b97bb267eb2"
+          "9c3c6403-0b98-4123-a8df-fa861429efa2"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020227Z:313c4800-227b-4e38-8efc-3b97bb267eb2"
+          "WESTUS:20201103T042517Z:9c3c6403-0b98-4123-a8df-fa861429efa2"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -189,7 +189,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:02:26 GMT"
+          "Tue, 03 Nov 2020 04:25:17 GMT"
         ],
         "Content-Length": [
           "108"
@@ -201,20 +201,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"490317e9-546b-4132-a0c2-12b71dca4471\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:02:25.623Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"218ad0a1-b418-415e-8f99-afb5f9cefdb8\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi80OTAzMTdlOS01NDZiLTQxMzItYTBjMi0xMmI3MWRjYTQ0NzE/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8yMThhZDBhMS1iNDE4LTQxNWUtOGY5OS1hZmI1ZjljZWZkYjg/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -228,19 +228,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "1076c503-522a-4585-a365-4fe7b1ed496b"
+          "cb864fb2-5d92-44c2-8fbd-9771bbfe5c4a"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14998"
+          "11998"
         ],
         "x-ms-correlation-request-id": [
-          "c3e663f2-696b-4dd3-a1d8-871dc1c0fd3e"
+          "b765e0a9-d315-4c1a-883a-5580f86a643e"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020228Z:c3e663f2-696b-4dd3-a1d8-871dc1c0fd3e"
+          "WESTUS:20201103T042519Z:b765e0a9-d315-4c1a-883a-5580f86a643e"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -249,7 +249,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:02:28 GMT"
+          "Tue, 03 Nov 2020 04:25:18 GMT"
         ],
         "Content-Length": [
           "108"
@@ -261,20 +261,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"490317e9-546b-4132-a0c2-12b71dca4471\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:02:25.623Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"218ad0a1-b418-415e-8f99-afb5f9cefdb8\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi80OTAzMTdlOS01NDZiLTQxMzItYTBjMi0xMmI3MWRjYTQ0NzE/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8yMThhZDBhMS1iNDE4LTQxNWUtOGY5OS1hZmI1ZjljZWZkYjg/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -288,19 +288,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "b2510b41-09b0-4213-9653-c39c86f88aca"
+          "8a706919-cdf2-497c-9c11-462234193f0e"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
+          "11997"
         ],
         "x-ms-correlation-request-id": [
-          "c3905092-d003-444d-bb54-a3ee8c730659"
+          "3959b50c-9b5b-47a3-87ee-4d721e435372"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020229Z:c3905092-d003-444d-bb54-a3ee8c730659"
+          "WESTUS:20201103T042520Z:3959b50c-9b5b-47a3-87ee-4d721e435372"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -309,7 +309,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:02:29 GMT"
+          "Tue, 03 Nov 2020 04:25:19 GMT"
         ],
         "Content-Length": [
           "108"
@@ -321,20 +321,80 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"490317e9-546b-4132-a0c2-12b71dca4471\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:02:25.623Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"218ad0a1-b418-415e-8f99-afb5f9cefdb8\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi80OTAzMTdlOS01NDZiLTQxMzItYTBjMi0xMmI3MWRjYTQ0NzE/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8yMThhZDBhMS1iNDE4LTQxNWUtOGY5OS1hZmI1ZjljZWZkYjg/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "1"
+        ],
+        "x-ms-request-id": [
+          "82fe1537-4527-411e-a7e5-f6ffc50e8bfa"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "x-ms-correlation-request-id": [
+          "c2a1140b-f194-45f6-9c3a-bb9ea254b766"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T042521Z:c2a1140b-f194-45f6-9c3a-bb9ea254b766"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:25:20 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"218ad0a1-b418-415e-8f99-afb5f9cefdb8\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8yMThhZDBhMS1iNDE4LTQxNWUtOGY5OS1hZmI1ZjljZWZkYjg/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -348,19 +408,19 @@
           "20"
         ],
         "x-ms-request-id": [
-          "3f498a97-f092-4336-8f69-cfddcd0d821d"
+          "72456653-03f6-4106-9924-27ba9c8de778"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "11995"
         ],
         "x-ms-correlation-request-id": [
-          "0d06343f-616b-4306-8e1f-5dc6c72e77e8"
+          "72aab936-b5d8-42ba-b415-97d85e3f780c"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020231Z:0d06343f-616b-4306-8e1f-5dc6c72e77e8"
+          "WESTUS:20201103T042522Z:72aab936-b5d8-42ba-b415-97d85e3f780c"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -369,7 +429,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:02:31 GMT"
+          "Tue, 03 Nov 2020 04:25:22 GMT"
         ],
         "Content-Length": [
           "108"
@@ -381,20 +441,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"490317e9-546b-4132-a0c2-12b71dca4471\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:02:25.623Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"218ad0a1-b418-415e-8f99-afb5f9cefdb8\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi80OTAzMTdlOS01NDZiLTQxMzItYTBjMi0xMmI3MWRjYTQ0NzE/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8yMThhZDBhMS1iNDE4LTQxNWUtOGY5OS1hZmI1ZjljZWZkYjg/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -408,19 +468,19 @@
           "20"
         ],
         "x-ms-request-id": [
-          "11670592-4d7a-4c4f-822c-f31e74cd5681"
+          "46c909a3-612a-47ed-9394-5a5e0f0ce095"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "11994"
         ],
         "x-ms-correlation-request-id": [
-          "08b8f77d-b3d1-428c-8bcf-e7dcb49a5ac6"
+          "bfe8327e-b777-4d01-b734-c83e2678630e"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020251Z:08b8f77d-b3d1-428c-8bcf-e7dcb49a5ac6"
+          "WESTUS:20201103T042542Z:bfe8327e-b777-4d01-b734-c83e2678630e"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -429,7 +489,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:02:51 GMT"
+          "Tue, 03 Nov 2020 04:25:42 GMT"
         ],
         "Content-Length": [
           "108"
@@ -441,20 +501,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"490317e9-546b-4132-a0c2-12b71dca4471\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:02:25.623Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"218ad0a1-b418-415e-8f99-afb5f9cefdb8\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/490317e9-546b-4132-a0c2-12b71dca4471?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi80OTAzMTdlOS01NDZiLTQxMzItYTBjMi0xMmI3MWRjYTQ0NzE/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/218ad0a1-b418-415e-8f99-afb5f9cefdb8?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi8yMThhZDBhMS1iNDE4LTQxNWUtOGY5OS1hZmI1ZjljZWZkYjg/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -468,19 +528,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "b3caa946-1676-4986-8e99-c67b6f09fc96"
+          "f4ec3e2a-7c61-4cf2-a646-c368dc53ccae"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
+          "11993"
         ],
         "x-ms-correlation-request-id": [
-          "fb80ee0b-4237-4794-a167-935a7f8dc0f8"
+          "34c2c2f8-8062-4f29-b6ac-f7cbbd94d518"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020311Z:fb80ee0b-4237-4794-a167-935a7f8dc0f8"
+          "WESTUS:20201103T042602Z:34c2c2f8-8062-4f29-b6ac-f7cbbd94d518"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -489,7 +549,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:03:11 GMT"
+          "Tue, 03 Nov 2020 04:26:02 GMT"
         ],
         "Content-Length": [
           "107"
@@ -501,20 +561,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"490317e9-546b-4132-a0c2-12b71dca4471\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-10-08T02:02:25.623Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"218ad0a1-b418-415e-8f99-afb5f9cefdb8\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T04:25:16.403Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -525,19 +585,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "f806f6fc-11df-4daa-af8c-7af3959215c8"
+          "c3a5313d-c3ed-477e-8f3f-007848f0c827"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
+          "11992"
         ],
         "x-ms-correlation-request-id": [
-          "4f2ae6d0-dd22-44c9-9011-9785a203401f"
+          "61aad3f5-78e1-49e7-bb65-42605d2c40d1"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020312Z:4f2ae6d0-dd22-44c9-9011-9785a203401f"
+          "WESTUS:20201103T042602Z:61aad3f5-78e1-49e7-bb65-42605d2c40d1"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -546,10 +606,10 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:03:11 GMT"
+          "Tue, 03 Nov 2020 04:26:02 GMT"
         ],
         "Content-Length": [
-          "464"
+          "454"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -558,32 +618,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-4113.sqltest-eg1.mscds.com\",\r\n    \"privateEndpointConnections\": [],\r\n    \"publicNetworkAccess\": \"Enabled\"\r\n  },\r\n  \"location\": \"southeastasia\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113\",\r\n  \"name\": \"sqlcrudtest-4113\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
+      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-1159.database.windows.net\",\r\n    \"privateEndpointConnections\": [],\r\n    \"publicNetworkAccess\": \"Enabled\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159\",\r\n  \"name\": \"sqlcrudtest-1159\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OS9kYXRhYmFzZXMvc3FsY3J1ZHRlc3QtNjc0OT9hcGktdmVyc2lvbj0yMDIwLTA4LTAxLXByZXZpZXc=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"P1\"\r\n  },\r\n  \"location\": \"southeastasia\"\r\n}",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"P1\"\r\n  },\r\n  \"location\": \"eastus\"\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "7223cbce-1657-40b7-913b-529d69500953"
+          "cc17585b-cd6f-408a-9648-c3d4cc4a520b"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "71"
+          "64"
         ]
       },
       "ResponseHeaders": {
@@ -594,16 +654,16 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseOperationResults/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/databaseOperationResults/df2fe6b7-22ce-4225-81a2-a8d11a546fff?api-version=2020-08-01-preview"
         ],
         "Retry-After": [
           "15"
         ],
         "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/df2fe6b7-22ce-4225-81a2-a8d11a546fff?api-version=2020-08-01-preview"
         ],
         "x-ms-request-id": [
-          "be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2"
+          "df2fe6b7-22ce-4225-81a2-a8d11a546fff"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -612,10 +672,10 @@
           "1198"
         ],
         "x-ms-correlation-request-id": [
-          "b70147d2-871b-47ce-96ed-d432642bc231"
+          "82b7f820-d63c-4a06-a557-9737bddc6bd8"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020313Z:b70147d2-871b-47ce-96ed-d432642bc231"
+          "WESTUS:20201103T042604Z:82b7f820-d63c-4a06-a557-9737bddc6bd8"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -624,7 +684,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:03:13 GMT"
+          "Tue, 03 Nov 2020 04:26:03 GMT"
         ],
         "Content-Length": [
           "76"
@@ -636,20 +696,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-08T02:03:13.587Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T04:26:03.863Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2JlOGNhN2RjLTNhYzItNDdkNy1iMmFiLWIzMzc3NGY5NWVlMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/df2fe6b7-22ce-4225-81a2-a8d11a546fff?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2RmMmZlNmI3LTIyY2UtNDIyNS04MWEyLWE4ZDExYTU0NmZmZj9hcGktdmVyc2lvbj0yMDIwLTA4LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -663,19 +723,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "adbb38f9-99a3-4675-80be-84319c348cbb"
+          "2b58e403-62ca-4fa4-b230-87a8a8324272"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
+          "11991"
         ],
         "x-ms-correlation-request-id": [
-          "f91b9270-e34e-4342-937f-e9d9b66dd3dd"
+          "0c1c7f8f-ef59-4608-b4c5-b8e757906b67"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020329Z:f91b9270-e34e-4342-937f-e9d9b66dd3dd"
+          "WESTUS:20201103T042619Z:0c1c7f8f-ef59-4608-b4c5-b8e757906b67"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -684,7 +744,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:03:29 GMT"
+          "Tue, 03 Nov 2020 04:26:18 GMT"
         ],
         "Content-Length": [
           "108"
@@ -696,20 +756,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:03:13.587Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"df2fe6b7-22ce-4225-81a2-a8d11a546fff\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:26:03.863Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2JlOGNhN2RjLTNhYzItNDdkNy1iMmFiLWIzMzc3NGY5NWVlMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/df2fe6b7-22ce-4225-81a2-a8d11a546fff?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2RmMmZlNmI3LTIyY2UtNDIyNS04MWEyLWE4ZDExYTU0NmZmZj9hcGktdmVyc2lvbj0yMDIwLTA4LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -723,19 +783,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "7b3a6067-1ab9-4218-8259-cf4be58abab6"
+          "fc0e23b8-7616-4322-8c0f-43a451861736"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
+          "11990"
         ],
         "x-ms-correlation-request-id": [
-          "7c0736a1-37ec-4210-b772-28bd98d77f12"
+          "0203a061-96cb-4488-90e6-3f9c75557c18"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020344Z:7c0736a1-37ec-4210-b772-28bd98d77f12"
+          "WESTUS:20201103T042634Z:0203a061-96cb-4488-90e6-3f9c75557c18"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -744,7 +804,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:03:43 GMT"
+          "Tue, 03 Nov 2020 04:26:33 GMT"
         ],
         "Content-Length": [
           "108"
@@ -756,20 +816,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:03:13.587Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"df2fe6b7-22ce-4225-81a2-a8d11a546fff\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:26:03.863Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2JlOGNhN2RjLTNhYzItNDdkNy1iMmFiLWIzMzc3NGY5NWVlMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/df2fe6b7-22ce-4225-81a2-a8d11a546fff?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2RmMmZlNmI3LTIyY2UtNDIyNS04MWEyLWE4ZDExYTU0NmZmZj9hcGktdmVyc2lvbj0yMDIwLTA4LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -783,19 +843,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "d097f3ba-4582-4e9d-89af-fbfec6033603"
+          "6d872c2d-2211-4aca-9c4f-bbeb5ea60f87"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14990"
+          "11989"
         ],
         "x-ms-correlation-request-id": [
-          "69cfd400-14a8-47e4-bb5e-b7b3cf5540a2"
+          "097182f0-1133-4731-8214-89ecf6081ab9"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020359Z:69cfd400-14a8-47e4-bb5e-b7b3cf5540a2"
+          "WESTUS:20201103T042649Z:097182f0-1133-4731-8214-89ecf6081ab9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -804,7 +864,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:03:59 GMT"
+          "Tue, 03 Nov 2020 04:26:48 GMT"
         ],
         "Content-Length": [
           "108"
@@ -816,20 +876,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:03:13.587Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"df2fe6b7-22ce-4225-81a2-a8d11a546fff\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:26:03.863Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2JlOGNhN2RjLTNhYzItNDdkNy1iMmFiLWIzMzc3NGY5NWVlMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/df2fe6b7-22ce-4225-81a2-a8d11a546fff?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2RmMmZlNmI3LTIyY2UtNDIyNS04MWEyLWE4ZDExYTU0NmZmZj9hcGktdmVyc2lvbj0yMDIwLTA4LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -843,19 +903,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "b30af13c-7fe6-4dae-b288-3448927ffae1"
+          "c5286212-64b2-4515-a166-e18ddd2dd07d"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14989"
+          "11988"
         ],
         "x-ms-correlation-request-id": [
-          "236bb6b8-6b6b-433b-9749-618fcc187163"
+          "d217af4c-da79-47f1-b9e0-f48bda709d78"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020415Z:236bb6b8-6b6b-433b-9749-618fcc187163"
+          "WESTUS:20201103T042704Z:d217af4c-da79-47f1-b9e0-f48bda709d78"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -864,7 +924,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:14 GMT"
+          "Tue, 03 Nov 2020 04:27:03 GMT"
         ],
         "Content-Length": [
           "108"
@@ -876,20 +936,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:03:13.587Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"df2fe6b7-22ce-4225-81a2-a8d11a546fff\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:26:03.863Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2JlOGNhN2RjLTNhYzItNDdkNy1iMmFiLWIzMzc3NGY5NWVlMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/df2fe6b7-22ce-4225-81a2-a8d11a546fff?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL2xvY2F0aW9ucy9lYXN0dXMvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2RmMmZlNmI3LTIyY2UtNDIyNS04MWEyLWE4ZDExYTU0NmZmZj9hcGktdmVyc2lvbj0yMDIwLTA4LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -903,19 +963,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "80542530-5547-483d-be1f-c92e7e3a9906"
+          "187c4da1-1ad4-47af-a864-964626e9d924"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14988"
+          "11987"
         ],
         "x-ms-correlation-request-id": [
-          "257fdf27-581a-4fa7-b101-ef56971df4bc"
+          "1428aba2-8368-4a04-86dc-6ae1449c1a35"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020430Z:257fdf27-581a-4fa7-b101-ef56971df4bc"
+          "WESTUS:20201103T042719Z:1428aba2-8368-4a04-86dc-6ae1449c1a35"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -924,67 +984,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:30 GMT"
-        ],
-        "Content-Length": [
-          "108"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-08T02:03:13.587Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2JlOGNhN2RjLTNhYzItNDdkNy1iMmFiLWIzMzc3NGY5NWVlMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "967065c4-d85a-4979-86fd-5079629f2dcc"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14987"
-        ],
-        "x-ms-correlation-request-id": [
-          "c6136196-285e-46a9-8ae4-d7e3f9afa547"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020445Z:c6136196-285e-46a9-8ae4-d7e3f9afa547"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Thu, 08 Oct 2020 02:04:45 GMT"
+          "Tue, 03 Nov 2020 04:27:18 GMT"
         ],
         "Content-Length": [
           "107"
@@ -996,20 +996,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"be8ca7dc-3ac2-47d7-b2ab-b33774f95ee2\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-10-08T02:03:13.587Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"df2fe6b7-22ce-4225-81a2-a8d11a546fff\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T04:26:03.863Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OS9kYXRhYmFzZXMvc3FsY3J1ZHRlc3QtNjc0OT9hcGktdmVyc2lvbj0yMDIwLTA4LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1020,19 +1020,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "3fdb02d5-9cf4-4c4a-9374-12ba877407e9"
+          "a65fad72-8218-43e5-b278-7e1e1b802ff8"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14986"
+          "11986"
         ],
         "x-ms-correlation-request-id": [
-          "3e70dd11-977d-43d0-b732-f9358ada91e3"
+          "ccda5aae-ec43-4932-9ad6-952626fe1d6d"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020446Z:3e70dd11-977d-43d0-b732-f9358ada91e3"
+          "WESTUS:20201103T042719Z:ccda5aae-ec43-4932-9ad6-952626fe1d6d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1041,10 +1041,10 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:45 GMT"
+          "Tue, 03 Nov 2020 04:27:19 GMT"
         ],
         "Content-Length": [
-          "903"
+          "870"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1053,26 +1053,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Premium\",\r\n    \"tier\": \"Premium\",\r\n    \"capacity\": 125\r\n  },\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": 536870912000,\r\n    \"status\": \"Online\",\r\n    \"databaseId\": \"98095015-cb1d-4f7f-b7d8-60d2bac99faa\",\r\n    \"creationDate\": \"2020-10-08T02:04:31.42Z\",\r\n    \"currentServiceObjectiveName\": \"P1\",\r\n    \"requestedServiceObjectiveName\": \"P1\",\r\n    \"defaultSecondaryLocation\": \"northeurope\",\r\n    \"catalogCollation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"zoneRedundant\": false,\r\n    \"earliestRestoreDate\": \"2020-10-08T02:34:31.42Z\",\r\n    \"readScale\": \"Enabled\",\r\n    \"readReplicaCount\": 1,\r\n    \"currentSku\": {\r\n      \"name\": \"Premium\",\r\n      \"tier\": \"Premium\",\r\n      \"capacity\": 125\r\n    },\r\n    \"storageAccountType\": \"GRS\"\r\n  },\r\n  \"location\": \"southeastasia\",\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091\",\r\n  \"name\": \"sqlcrudtest-9091\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\"\r\n}",
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Premium\",\r\n    \"tier\": \"Premium\",\r\n    \"capacity\": 125\r\n  },\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": 536870912000,\r\n    \"status\": \"Online\",\r\n    \"databaseId\": \"ff8eaf40-edf7-47dd-908f-cae699603043\",\r\n    \"creationDate\": \"2020-11-03T04:27:06.457Z\",\r\n    \"currentServiceObjectiveName\": \"P1\",\r\n    \"requestedServiceObjectiveName\": \"P1\",\r\n    \"defaultSecondaryLocation\": \"westus\",\r\n    \"catalogCollation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"zoneRedundant\": false,\r\n    \"earliestRestoreDate\": \"2020-11-03T04:57:06.457Z\",\r\n    \"readScale\": \"Enabled\",\r\n    \"currentSku\": {\r\n      \"name\": \"Premium\",\r\n      \"tier\": \"Premium\",\r\n      \"capacity\": 125\r\n    },\r\n    \"storageAccountType\": \"GRS\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749\",\r\n  \"name\": \"sqlcrudtest-6749\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OS9kYXRhYmFzZXMvc3FsY3J1ZHRlc3QtNjc0OS9iYWNrdXBTaG9ydFRlcm1SZXRlbnRpb25Qb2xpY2llcy9kZWZhdWx0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "d53f8b7c-b058-4b77-815a-0f3378b9f67b"
+          "a253aa6d-d3b2-4888-8e5f-bce7780ac0db"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1083,19 +1083,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "d897bab6-afd1-43e0-bd9e-4772ec7556a0"
+          "2cd34aa7-595c-486f-981a-bff31002cd12"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14985"
+          "11985"
         ],
         "x-ms-correlation-request-id": [
-          "c5512584-7f26-4281-be67-bb9e26e652c2"
+          "6b30dcc7-18b8-44e2-afde-1c2e284414ec"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020446Z:c5512584-7f26-4281-be67-bb9e26e652c2"
+          "WESTUS:20201103T042720Z:6b30dcc7-18b8-44e2-afde-1c2e284414ec"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1104,10 +1104,10 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:46 GMT"
+          "Tue, 03 Nov 2020 04:27:19 GMT"
         ],
         "Content-Length": [
-          "364"
+          "331"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1116,26 +1116,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OS9kYXRhYmFzZXMvc3FsY3J1ZHRlc3QtNjc0OS9iYWNrdXBTaG9ydFRlcm1SZXRlbnRpb25Qb2xpY2llcy9kZWZhdWx0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "131a4cc8-54ba-4c59-88e3-742c96e91f84"
+          "fa73c737-63fc-4ff4-8b0f-fd10bbe2f169"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1146,19 +1146,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "14e49f45-f39e-4d7a-a3eb-be3e2ff53fdb"
+          "aaf352db-cefa-4ebc-a9ad-1cc90c61913d"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14984"
+          "11984"
         ],
         "x-ms-correlation-request-id": [
-          "4ccafe30-41c7-44e6-b61f-74ce08d3b8ae"
+          "03fdef8e-ec24-4f50-9dd4-0058d652eb2d"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020450Z:4ccafe30-41c7-44e6-b61f-74ce08d3b8ae"
+          "WESTUS:20201103T042723Z:03fdef8e-ec24-4f50-9dd4-0058d652eb2d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1167,10 +1167,10 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:49 GMT"
+          "Tue, 03 Nov 2020 04:27:22 GMT"
         ],
         "Content-Length": [
-          "364"
+          "331"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1179,26 +1179,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OS9kYXRhYmFzZXMvc3FsY3J1ZHRlc3QtNjc0OS9iYWNrdXBTaG9ydFRlcm1SZXRlbnRpb25Qb2xpY2llcy9kZWZhdWx0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "48a97b94-454e-42a0-bd67-a5c801a0c3b2"
+          "a281e7a1-a39a-42d3-a3bb-cb6d7973f91a"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1209,19 +1209,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "10ebfe59-5578-42de-940d-c7c0d4532030"
+          "c2b655d2-7bcc-4362-a35f-7071df812995"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14983"
+          "11983"
         ],
         "x-ms-correlation-request-id": [
-          "367c49c2-0f5f-4699-ae53-d7769e1bccf8"
+          "5a23a57a-375e-4b02-9feb-0599b50addb1"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020453Z:367c49c2-0f5f-4699-ae53-d7769e1bccf8"
+          "WESTUS:20201103T042726Z:5a23a57a-375e-4b02-9feb-0599b50addb1"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1230,10 +1230,10 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:53 GMT"
+          "Tue, 03 Nov 2020 04:27:25 GMT"
         ],
         "Content-Length": [
-          "364"
+          "332"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1242,158 +1242,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "5ae22fb5-fad7-4afa-a99f-b156f5a05298"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "18030db0-5b41-468c-b9a0-28c311ca0909"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14982"
-        ],
-        "x-ms-correlation-request-id": [
-          "19a13c20-662a-4b31-bbf8-37a18b0d2c71"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020456Z:19a13c20-662a-4b31-bbf8-37a18b0d2c71"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Thu, 08 Oct 2020 02:04:56 GMT"
-        ],
-        "Content-Length": [
-          "365"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35,\r\n    \"diffBackupIntervalInHours\": 24\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "9b5ecaa2-2a36-42a3-b422-44b093edaaa0"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "b4480a7e-c4d6-4b61-a3c3-f8b7d8a7ecf8"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14981"
-        ],
-        "x-ms-correlation-request-id": [
-          "4618b5bd-ceda-4811-a1ec-8db57deded87"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020500Z:4618b5bd-ceda-4811-a1ec-8db57deded87"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Thu, 08 Oct 2020 02:04:59 GMT"
-        ],
-        "Content-Length": [
-          "364"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OS9kYXRhYmFzZXMvc3FsY3J1ZHRlc3QtNjc0OS9iYWNrdXBTaG9ydFRlcm1SZXRlbnRpb25Qb2xpY2llcy9kZWZhdWx0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 36,\r\n    \"diffBackupIntervalInHours\": 24\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 36\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "ef21c30c-64a6-4498-b2c1-ef5bb8f32960"
+          "b4483d74-f0bc-4058-ae1e-984e06a78b4f"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "91"
+          "53"
         ]
       },
       "ResponseHeaders": {
@@ -1404,7 +1278,7 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "895d00a5-ae49-4301-8bd0-baed1f8a222a"
+          "c18b3651-93cf-4201-9515-31180d13d3b7"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -1413,10 +1287,10 @@
           "1197"
         ],
         "x-ms-correlation-request-id": [
-          "3451f18b-b370-40e6-b6cb-aa1b02e38f9d"
+          "74efecf8-ab8c-4775-b2b1-772a58219143"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020447Z:3451f18b-b370-40e6-b6cb-aa1b02e38f9d"
+          "WESTUS:20201103T042720Z:74efecf8-ab8c-4775-b2b1-772a58219143"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1425,7 +1299,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:46 GMT"
+          "Tue, 03 Nov 2020 04:27:19 GMT"
         ],
         "Content-Length": [
           "172"
@@ -1441,28 +1315,28 @@
       "StatusCode": 400
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/servers/sqlcrudtest-1159/databases/sqlcrudtest-6749/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTg3L3Byb3ZpZGVycy9NaWNyb3NvZnQuU3FsL3NlcnZlcnMvc3FsY3J1ZHRlc3QtMTE1OS9kYXRhYmFzZXMvc3FsY3J1ZHRlc3QtNjc0OS9iYWNrdXBTaG9ydFRlcm1SZXRlbnRpb25Qb2xpY2llcy9kZWZhdWx0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35,\r\n    \"diffBackupIntervalInHours\": 25\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "d2efd324-d71f-4049-9f0d-7708108287b8"
+          "5770d31f-2ad8-424b-8f03-d26ac6425c44"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "91"
+          "53"
         ]
       },
       "ResponseHeaders": {
@@ -1472,8 +1346,17 @@
         "Pragma": [
           "no-cache"
         ],
+        "Location": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyOperationResults/574180ae-446a-44fc-904e-889a1c4203e6?api-version=2017-10-01-preview"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-87/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/574180ae-446a-44fc-904e-889a1c4203e6?api-version=2017-10-01-preview"
+        ],
         "x-ms-request-id": [
-          "f03f7ce0-87a9-46e1-a8d1-ba376d606293"
+          "574180ae-446a-44fc-904e-889a1c4203e6"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -1482,10 +1365,10 @@
           "1196"
         ],
         "x-ms-correlation-request-id": [
-          "1a04437a-1a94-4352-9fdf-206f91edcb98"
+          "caeac368-3fd0-4eb4-a376-de4dee9e71d9"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020450Z:1a04437a-1a94-4352-9fdf-206f91edcb98"
+          "WESTUS:20201103T042723Z:caeac368-3fd0-4eb4-a376-de4dee9e71d9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1494,85 +1377,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:04:49 GMT"
-        ],
-        "Content-Length": [
-          "205"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidDiffBackupIntervalHours\",\r\n    \"message\": \"The differential backup interval hours of 25 is not a valid configuration. Valid differential backup interval must be 0.08 or 12 or 24 hours.\"\r\n  }\r\n}",
-      "StatusCode": 400
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35,\r\n    \"diffBackupIntervalInHours\": 24\r\n  }\r\n}",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "45f4362b-05d0-46f8-b881-f566e6287f3b"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "91"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyOperationResults/5d5f2575-6384-4408-9fd7-25bd081e382e?api-version=2020-02-02-preview"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyAzureAsyncOperation/5d5f2575-6384-4408-9fd7-25bd081e382e?api-version=2020-02-02-preview"
-        ],
-        "x-ms-request-id": [
-          "5d5f2575-6384-4408-9fd7-25bd081e382e"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
-        ],
-        "x-ms-correlation-request-id": [
-          "a1a135bc-afcb-425f-b97e-fdf72263bcc8"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020453Z:a1a135bc-afcb-425f-b97e-fdf72263bcc8"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Thu, 08 Oct 2020 02:04:53 GMT"
+          "Tue, 03 Nov 2020 04:27:22 GMT"
         ],
         "Content-Length": [
           "76"
@@ -1584,103 +1389,25 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-08T02:04:53.753Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T04:27:23.427Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/servers/sqlcrudtest-4113/databases/sqlcrudtest-9091/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTM3NTUvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC00MTEzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC05MDkxL2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  }\r\n}",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "1abdd452-ee06-4b0b-8fd6-e3306eccbb67"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "90"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyOperationResults/fdc8923f-ca4f-4479-b53a-33e70408b3d1?api-version=2020-02-02-preview"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-3755/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyAzureAsyncOperation/fdc8923f-ca4f-4479-b53a-33e70408b3d1?api-version=2020-02-02-preview"
-        ],
-        "x-ms-request-id": [
-          "fdc8923f-ca4f-4479-b53a-33e70408b3d1"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
-        ],
-        "x-ms-correlation-request-id": [
-          "9f67ca17-eb90-4779-b561-820ffbe609de"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020457Z:9f67ca17-eb90-4779-b561-820ffbe609de"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Thu, 08 Oct 2020 02:04:56 GMT"
-        ],
-        "Content-Length": [
-          "76"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-08T02:04:57.083Z\"\r\n}",
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourcegroups/sqlcrudtest-3755?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTM3NTU/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-87?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTg3P2FwaS12ZXJzaW9uPTIwMTctMDUtMTA=",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "0acba78e-05be-4eb3-9c2f-723081e7aa00"
+          "8ae36c16-4069-4cb3-b7ab-ba6eea1cf668"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
@@ -1692,7 +1419,7 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDM3NTUtU09VVEhFQVNUQVNJQSIsImpvYkxvY2F0aW9uIjoic291dGhlYXN0YXNpYSJ9?api-version=2017-05-10"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDg3LUVBU1RVUyIsImpvYkxvY2F0aW9uIjoiZWFzdHVzIn0?api-version=2017-05-10"
         ],
         "Retry-After": [
           "15"
@@ -1701,13 +1428,13 @@
           "14999"
         ],
         "x-ms-request-id": [
-          "f6f753ea-90cc-4e59-8ac3-fb5ab7808e10"
+          "e2c2777e-74ba-45c0-8fea-3a0a27cd9fb7"
         ],
         "x-ms-correlation-request-id": [
-          "f6f753ea-90cc-4e59-8ac3-fb5ab7808e10"
+          "e2c2777e-74ba-45c0-8fea-3a0a27cd9fb7"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201008T020502Z:f6f753ea-90cc-4e59-8ac3-fb5ab7808e10"
+          "WESTUS:20201103T042727Z:e2c2777e-74ba-45c0-8fea-3a0a27cd9fb7"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1716,7 +1443,7 @@
           "nosniff"
         ],
         "Date": [
-          "Thu, 08 Oct 2020 02:05:01 GMT"
+          "Tue, 03 Nov 2020 04:27:26 GMT"
         ],
         "Expires": [
           "-1"
@@ -1731,17 +1458,17 @@
   ],
   "Names": {
     "CreateResourceGroup": [
-      "sqlcrudtest-3755"
+      "sqlcrudtest-87"
     ],
     "CreateServer": [
-      "sqlcrudtest-4113"
+      "sqlcrudtest-1159"
     ],
     "TestShortTermRetentionPolicyOnGeneralPurpose": [
-      "sqlcrudtest-9091"
+      "sqlcrudtest-6749"
     ]
   },
   "Variables": {
-    "SubscriptionId": "4b6aaaf2-6fd8-418b-a06d-6ede39a32270",
-    "DefaultLocation": "southeast asia"
+    "SubscriptionId": "dc1789a8-0762-4dfb-8901-4c0da08b83d3",
+    "DefaultLocation": "eastus"
   }
 }

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnGeneralPurposeScriptUse.json
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnGeneralPurposeScriptUse.json
@@ -1,0 +1,1819 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-8273?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTgyNzM/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-8273\": \"2020-11-03 05:11:40Z\"\r\n  }\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "fb2954bd-a357-45be-8369-a3e91f200f22"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "95"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-request-id": [
+          "71bf3044-7c32-4394-bfbd-2988074fe98c"
+        ],
+        "x-ms-correlation-request-id": [
+          "71bf3044-7c32-4394-bfbd-2988074fe98c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051142Z:71bf3044-7c32-4394-bfbd-2988074fe98c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:11:41 GMT"
+        ],
+        "Content-Length": [
+          "236"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273\",\r\n  \"name\": \"sqlcrudtest-8273\",\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-8273\": \"2020-11-03 05:11:40Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC01ODQ5P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {}\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "820bd515-86f2-4bac-bfea-6043d2710934"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "180"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverOperationResults/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview"
+        ],
+        "Retry-After": [
+          "1"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview"
+        ],
+        "x-ms-request-id": [
+          "e2b7bc65-1162-479d-85c2-bba945af2cf2"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-correlation-request-id": [
+          "daa7d917-ed56-49ec-aada-887e5301e7cd"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051144Z:daa7d917-ed56-49ec-aada-887e5301e7cd"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:11:44 GMT"
+        ],
+        "Content-Length": [
+          "73"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "1"
+        ],
+        "x-ms-request-id": [
+          "44d389d7-42a6-47e7-9ee4-45d9edf70626"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11999"
+        ],
+        "x-ms-correlation-request-id": [
+          "84da3548-5aaf-47c8-8e35-bfbcc6a89678"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051145Z:84da3548-5aaf-47c8-8e35-bfbcc6a89678"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:11:45 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "1"
+        ],
+        "x-ms-request-id": [
+          "45f4d3f9-0b61-4724-9355-2500c252462c"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11998"
+        ],
+        "x-ms-correlation-request-id": [
+          "6fc12aa8-9d28-4cf4-a7af-dda3d772fd35"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051147Z:6fc12aa8-9d28-4cf4-a7af-dda3d772fd35"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:11:46 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "1"
+        ],
+        "x-ms-request-id": [
+          "b7716733-491c-4ce2-b2bb-5cc21146a51a"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11997"
+        ],
+        "x-ms-correlation-request-id": [
+          "69381f26-cfe1-4879-bb32-668de80d254c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051148Z:69381f26-cfe1-4879-bb32-668de80d254c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:11:48 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "1"
+        ],
+        "x-ms-request-id": [
+          "38cb53a6-b453-42b2-b6e1-9e8deca7a3eb"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "x-ms-correlation-request-id": [
+          "3eb207fa-127f-4be8-a368-0dbb2342e3b8"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051149Z:3eb207fa-127f-4be8-a368-0dbb2342e3b8"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:11:49 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "20"
+        ],
+        "x-ms-request-id": [
+          "b5d6378c-219e-40f9-bbae-d90c8b0d0773"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11995"
+        ],
+        "x-ms-correlation-request-id": [
+          "74eb237f-1cec-4431-960b-2865bf41d198"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051150Z:74eb237f-1cec-4431-960b-2865bf41d198"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:11:50 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "20"
+        ],
+        "x-ms-request-id": [
+          "05dc2aa7-a751-4247-bca8-66eaaf809edf"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11994"
+        ],
+        "x-ms-correlation-request-id": [
+          "1b2c26bd-5dfe-4a33-8166-7febf17553a9"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051210Z:1b2c26bd-5dfe-4a33-8166-7febf17553a9"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:12:10 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "20"
+        ],
+        "x-ms-request-id": [
+          "550ab524-bdfb-4c84-8eac-00d01b12b0c9"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11993"
+        ],
+        "x-ms-correlation-request-id": [
+          "adab5b94-f464-456d-bd3f-94e08087c280"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051232Z:adab5b94-f464-456d-bd3f-94e08087c280"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:12:32 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/e2b7bc65-1162-479d-85c2-bba945af2cf2?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uL2UyYjdiYzY1LTExNjItNDc5ZC04NWMyLWJiYTk0NWFmMmNmMj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "cd394c2c-54c3-459a-8ea0-43a492262d62"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11992"
+        ],
+        "x-ms-correlation-request-id": [
+          "b26bfd91-f446-4da2-a999-c9c9d207bc5a"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051253Z:b26bfd91-f446-4da2-a999-c9c9d207bc5a"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:12:53 GMT"
+        ],
+        "Content-Length": [
+          "106"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"e2b7bc65-1162-479d-85c2-bba945af2cf2\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T05:11:44.43Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC01ODQ5P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "31955c9b-6788-4463-a586-03f36293bf5e"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11991"
+        ],
+        "x-ms-correlation-request-id": [
+          "1be1f4b6-7cb9-448f-bef0-34bc03f8b074"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051253Z:1be1f4b6-7cb9-448f-bef0-34bc03f8b074"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:12:53 GMT"
+        ],
+        "Content-Length": [
+          "456"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-5849.database.windows.net\",\r\n    \"privateEndpointConnections\": [],\r\n    \"publicNetworkAccess\": \"Enabled\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849\",\r\n  \"name\": \"sqlcrudtest-5849\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849/databases/sqlcrudtest-576?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC01ODQ5L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NzY/YXBpLXZlcnNpb249MjAyMC0wOC0wMS1wcmV2aWV3",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"P1\"\r\n  },\r\n  \"location\": \"eastus\"\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "ca7ab652-a2ee-4ead-8ce3-217c07aadab5"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "64"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseOperationResults/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview"
+        ],
+        "x-ms-request-id": [
+          "f44b8b24-4d88-4674-80bf-448be1ebc40c"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
+        ],
+        "x-ms-correlation-request-id": [
+          "84ededae-978d-4ced-92aa-f99671f894ea"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051258Z:84ededae-978d-4ced-92aa-f99671f894ea"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:12:58 GMT"
+        ],
+        "Content-Length": [
+          "76"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "2c0fd1f5-fe0b-4980-a529-0c293672c21c"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11990"
+        ],
+        "x-ms-correlation-request-id": [
+          "7fb18fa4-9b84-43ef-80f9-d1cfbe0da17f"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051313Z:7fb18fa4-9b84-43ef-80f9-d1cfbe0da17f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:13:13 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "aae03a63-9ec2-49d1-8aab-5145bf9b6715"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11989"
+        ],
+        "x-ms-correlation-request-id": [
+          "57ef44d3-faf4-4dfd-b05c-2199b7d53329"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051328Z:57ef44d3-faf4-4dfd-b05c-2199b7d53329"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:13:28 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "f7037026-9556-4318-86bb-901ed7586bd0"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11988"
+        ],
+        "x-ms-correlation-request-id": [
+          "d068abc1-1aaa-4112-8199-742004b137b1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051344Z:d068abc1-1aaa-4112-8199-742004b137b1"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:13:43 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "cb9752a9-a95d-4620-bc73-afe0f0601d60"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11987"
+        ],
+        "x-ms-correlation-request-id": [
+          "8802784b-76a2-4149-b30b-12d2032c9e5c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051400Z:8802784b-76a2-4149-b30b-12d2032c9e5c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:13:59 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "ccb6ddfb-bda1-4519-9d83-56e565447149"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11986"
+        ],
+        "x-ms-correlation-request-id": [
+          "181a12d9-538d-4138-a43f-bbcec23daec2"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051415Z:181a12d9-538d-4138-a43f-bbcec23daec2"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:14:15 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "082d295b-a42a-411b-ac56-b898836c3972"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11985"
+        ],
+        "x-ms-correlation-request-id": [
+          "54e5fab8-f241-4b2a-a637-087f49226c4c"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051430Z:54e5fab8-f241-4b2a-a637-087f49226c4c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:14:30 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "27b5bf45-706b-4b23-83ff-bbb792d7391c"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11984"
+        ],
+        "x-ms-correlation-request-id": [
+          "5619123a-a04e-4846-8754-cfe740c4a223"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051445Z:5619123a-a04e-4846-8754-cfe740c4a223"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:14:45 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "8302baa5-e9b5-4ee6-976c-bb100a9cdba8"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11983"
+        ],
+        "x-ms-correlation-request-id": [
+          "2e84b9e8-d930-433d-9d9e-64a6ec1129cc"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051502Z:2e84b9e8-d930-433d-9d9e-64a6ec1129cc"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:15:02 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "619cfa61-ec98-4605-afce-314ba6d0f33e"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11982"
+        ],
+        "x-ms-correlation-request-id": [
+          "3ece7b07-9f72-465d-997d-6e3f914468d5"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051517Z:3ece7b07-9f72-465d-997d-6e3f914468d5"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:15:17 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "a32e7785-aef2-4f55-9378-f13b9b285842"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11981"
+        ],
+        "x-ms-correlation-request-id": [
+          "0504c175-b2de-456a-b2c9-b909a80c0f3e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051534Z:0504c175-b2de-456a-b2c9-b909a80c0f3e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:15:33 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "2a8b205f-9288-4fc5-85dc-f07a270d0dbb"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11980"
+        ],
+        "x-ms-correlation-request-id": [
+          "37f171a5-c691-4f21-a4d1-81eef62c583a"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051549Z:37f171a5-c691-4f21-a4d1-81eef62c583a"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:15:48 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "f27942d8-f083-40a0-956c-a825d5b7d840"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11979"
+        ],
+        "x-ms-correlation-request-id": [
+          "57bc8bee-4810-4120-80a5-9cd5674061a1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051604Z:57bc8bee-4810-4120-80a5-9cd5674061a1"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:16:03 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/f44b8b24-4d88-4674-80bf-448be1ebc40c?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vZjQ0YjhiMjQtNGQ4OC00Njc0LTgwYmYtNDQ4YmUxZWJjNDBjP2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "cbe9a6d3-7a4a-449b-b7f4-2b8f5ad420d0"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11978"
+        ],
+        "x-ms-correlation-request-id": [
+          "f42647dd-3f89-4827-8800-6c3c6b30aedd"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051619Z:f42647dd-3f89-4827-8800-6c3c6b30aedd"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:16:19 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"f44b8b24-4d88-4674-80bf-448be1ebc40c\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T05:12:55.823Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849/databases/sqlcrudtest-576?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC01ODQ5L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NzY/YXBpLXZlcnNpb249MjAyMC0wOC0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "381d6879-7f57-4ee7-ba6f-ce9ad8ed1e79"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11977"
+        ],
+        "x-ms-correlation-request-id": [
+          "7401f4ea-19f8-47e7-8e95-12048ebb1428"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051619Z:7401f4ea-19f8-47e7-8e95-12048ebb1428"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:16:19 GMT"
+        ],
+        "Content-Length": [
+          "868"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Premium\",\r\n    \"tier\": \"Premium\",\r\n    \"capacity\": 125\r\n  },\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": 536870912000,\r\n    \"status\": \"Online\",\r\n    \"databaseId\": \"39ce02a2-67f4-43c9-beca-fe850008a755\",\r\n    \"creationDate\": \"2020-11-03T05:16:08.78Z\",\r\n    \"currentServiceObjectiveName\": \"P1\",\r\n    \"requestedServiceObjectiveName\": \"P1\",\r\n    \"defaultSecondaryLocation\": \"westus\",\r\n    \"catalogCollation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"zoneRedundant\": false,\r\n    \"earliestRestoreDate\": \"2020-11-03T05:46:08.78Z\",\r\n    \"readScale\": \"Enabled\",\r\n    \"currentSku\": {\r\n      \"name\": \"Premium\",\r\n      \"tier\": \"Premium\",\r\n      \"capacity\": 125\r\n    },\r\n    \"storageAccountType\": \"GRS\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849/databases/sqlcrudtest-576\",\r\n  \"name\": \"sqlcrudtest-576\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849/databases/sqlcrudtest-576/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC01ODQ5L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NzYvYmFja3VwU2hvcnRUZXJtUmV0ZW50aW9uUG9saWNpZXMvZGVmYXVsdD9hcGktdmVyc2lvbj0yMDE3LTEwLTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "62f9c8cc-69fc-4825-8a38-ff0bf7e99b68"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "4eee979f-803f-41b4-8a5c-b0ea3a77945d"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11976"
+        ],
+        "x-ms-correlation-request-id": [
+          "9fdd48bc-2f40-41d3-ac5d-e632a536c0c4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051620Z:9fdd48bc-2f40-41d3-ac5d-e632a536c0c4"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:16:19 GMT"
+        ],
+        "Content-Length": [
+          "332"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849/databases/sqlcrudtest-576/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/servers/sqlcrudtest-5849/databases/sqlcrudtest-576/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTgyNzMvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC01ODQ5L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC01NzYvYmFja3VwU2hvcnRUZXJtUmV0ZW50aW9uUG9saWNpZXMvZGVmYXVsdD9hcGktdmVyc2lvbj0yMDE3LTEwLTAxLXByZXZpZXc=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 28\r\n  }\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "396a97cc-6e8f-476d-9a01-9dae89b14afc"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "53"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyOperationResults/9c456bea-2bff-470a-ab48-41d085e38533?api-version=2017-10-01-preview"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-8273/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/9c456bea-2bff-470a-ab48-41d085e38533?api-version=2017-10-01-preview"
+        ],
+        "x-ms-request-id": [
+          "9c456bea-2bff-470a-ab48-41d085e38533"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1197"
+        ],
+        "x-ms-correlation-request-id": [
+          "cc405d65-e605-4908-9c57-450b2272f074"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051620Z:cc405d65-e605-4908-9c57-450b2272f074"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:16:19 GMT"
+        ],
+        "Content-Length": [
+          "76"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T05:16:20.303Z\"\r\n}",
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-8273?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTgyNzM/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "07352629-ecee-4b15-bc2c-d06d97fdb6e2"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDgyNzMtRUFTVFVTIiwiam9iTG9jYXRpb24iOiJlYXN0dXMifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-deletes": [
+          "14999"
+        ],
+        "x-ms-request-id": [
+          "6e86644b-0458-454f-b841-dffa77d6b4d4"
+        ],
+        "x-ms-correlation-request-id": [
+          "6e86644b-0458-454f-b841-dffa77d6b4d4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T051622Z:6e86644b-0458-454f-b841-dffa77d6b4d4"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 05:16:22 GMT"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Content-Length": [
+          "0"
+        ]
+      },
+      "ResponseBody": "",
+      "StatusCode": 202
+    }
+  ],
+  "Names": {
+    "CreateResourceGroup": [
+      "sqlcrudtest-8273"
+    ],
+    "CreateServer": [
+      "sqlcrudtest-5849"
+    ],
+    "TestShortTermRetentionPolicyOnGeneralPurposeScriptUse": [
+      "sqlcrudtest-576"
+    ]
+  },
+  "Variables": {
+    "SubscriptionId": "dc1789a8-0762-4dfb-8901-4c0da08b83d3",
+    "DefaultLocation": "eastus"
+  }
+}

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnPremium.json
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/SessionRecords/ShortTermRetentionTests/TestShortTermRetentionPolicyOnPremium.json
@@ -1,28 +1,28 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourcegroups/sqlcrudtest-4857?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTc/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-4257?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTQyNTc/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"southeast asia\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-4857\": \"2020-10-06 18:35:25Z\"\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-4257\": \"2020-11-03 04:27:46Z\"\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "e88d483e-cb85-4d31-a65b-f51a1a0ef2f2"
+          "284e2201-ad06-4e53-a952-00a1a3e27851"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "103"
+          "95"
         ]
       },
       "ResponseHeaders": {
@@ -36,13 +36,13 @@
           "1199"
         ],
         "x-ms-request-id": [
-          "be6a4e81-9502-434a-aa53-e0a544f38315"
+          "979f3c99-82e4-4138-b92e-6652e002b768"
         ],
         "x-ms-correlation-request-id": [
-          "be6a4e81-9502-434a-aa53-e0a544f38315"
+          "979f3c99-82e4-4138-b92e-6652e002b768"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183527Z:be6a4e81-9502-434a-aa53-e0a544f38315"
+          "WESTUS:20201103T042748Z:979f3c99-82e4-4138-b92e-6652e002b768"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -51,10 +51,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:35:27 GMT"
+          "Tue, 03 Nov 2020 04:27:47 GMT"
         ],
         "Content-Length": [
-          "243"
+          "236"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -63,32 +63,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857\",\r\n  \"name\": \"sqlcrudtest-4857\",\r\n  \"location\": \"southeastasia\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-4857\": \"2020-10-06 18:35:25Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257\",\r\n  \"name\": \"sqlcrudtest-4257\",\r\n  \"location\": \"eastus\",\r\n  \"tags\": {\r\n    \"sqlcrudtest-4257\": \"2020-11-03 04:27:46Z\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"location\": \"southeast asia\",\r\n  \"tags\": {}\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"administratorLoginPassword\": \"Un53cuRE!\",\r\n    \"version\": \"12.0\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {}\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "9c033a85-b8de-4b84-a53e-077d4558a760"
+          "e8d5bfe1-3cc8-464c-90a3-ca6824f05227"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "188"
+          "180"
         ]
       },
       "ResponseHeaders": {
@@ -99,16 +99,16 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverOperationResults/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverOperationResults/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview"
         ],
         "Retry-After": [
           "1"
         ],
         "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview"
         ],
         "x-ms-request-id": [
-          "55ff8589-57ce-4d8b-8f90-9c3d28025c77"
+          "2a50715d-56d9-44c7-9040-18285e64d27f"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -117,10 +117,10 @@
           "1199"
         ],
         "x-ms-correlation-request-id": [
-          "9772fd62-4717-40ea-a602-86efe31bcc4a"
+          "911ad0d5-15a4-4c1e-9fc5-2a3a052286fa"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183531Z:9772fd62-4717-40ea-a602-86efe31bcc4a"
+          "WESTUS:20201103T042750Z:911ad0d5-15a4-4c1e-9fc5-2a3a052286fa"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -129,7 +129,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:35:31 GMT"
+          "Tue, 03 Nov 2020 04:27:49 GMT"
         ],
         "Content-Length": [
           "74"
@@ -141,20 +141,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2020-10-06T18:35:31.297Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpsertLogicalServer\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi81NWZmODU4OS01N2NlLTRkOGItOGY5MC05YzNkMjgwMjVjNzc/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uLzJhNTA3MTVkLTU2ZDktNDRjNy05MDQwLTE4Mjg1ZTY0ZDI3Zj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -168,19 +168,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "4648a574-8f2d-404b-ab89-5ca5ce4af926"
+          "5c74cbac-496a-4367-911a-71f0dadd376b"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14999"
+          "11999"
         ],
         "x-ms-correlation-request-id": [
-          "d9f77856-aafc-44c4-87cb-219a7cde9f18"
+          "09e247c5-468e-4a3c-8d25-aa3e4052b446"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183532Z:d9f77856-aafc-44c4-87cb-219a7cde9f18"
+          "WESTUS:20201103T042751Z:09e247c5-468e-4a3c-8d25-aa3e4052b446"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -189,7 +189,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:35:32 GMT"
+          "Tue, 03 Nov 2020 04:27:50 GMT"
         ],
         "Content-Length": [
           "108"
@@ -201,20 +201,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"55ff8589-57ce-4d8b-8f90-9c3d28025c77\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:35:31.297Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"2a50715d-56d9-44c7-9040-18285e64d27f\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi81NWZmODU4OS01N2NlLTRkOGItOGY5MC05YzNkMjgwMjVjNzc/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uLzJhNTA3MTVkLTU2ZDktNDRjNy05MDQwLTE4Mjg1ZTY0ZDI3Zj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -228,19 +228,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "77a2e6ce-0505-44ec-9deb-3b89f483862b"
+          "8fbb69ec-4cec-4f58-aa89-016b224b17c9"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14998"
+          "11998"
         ],
         "x-ms-correlation-request-id": [
-          "9cd7b244-f622-4f32-9a94-5295614998fa"
+          "475bc7f9-2e70-4a06-99da-0b0cc9e718f3"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183534Z:9cd7b244-f622-4f32-9a94-5295614998fa"
+          "WESTUS:20201103T042753Z:475bc7f9-2e70-4a06-99da-0b0cc9e718f3"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -249,7 +249,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:35:34 GMT"
+          "Tue, 03 Nov 2020 04:27:52 GMT"
         ],
         "Content-Length": [
           "108"
@@ -261,20 +261,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"55ff8589-57ce-4d8b-8f90-9c3d28025c77\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:35:31.297Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"2a50715d-56d9-44c7-9040-18285e64d27f\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi81NWZmODU4OS01N2NlLTRkOGItOGY5MC05YzNkMjgwMjVjNzc/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uLzJhNTA3MTVkLTU2ZDktNDRjNy05MDQwLTE4Mjg1ZTY0ZDI3Zj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -288,19 +288,19 @@
           "1"
         ],
         "x-ms-request-id": [
-          "62cd1105-002d-419a-96af-2a43082a3dc8"
+          "dd2370b7-ec9a-468b-972a-a6a562d97122"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
+          "11997"
         ],
         "x-ms-correlation-request-id": [
-          "64fe79a1-b7d0-4166-84f5-d26638effa5c"
+          "e51400e9-b1b1-4fc6-9994-4f24e6109f81"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183535Z:64fe79a1-b7d0-4166-84f5-d26638effa5c"
+          "WESTUS:20201103T042754Z:e51400e9-b1b1-4fc6-9994-4f24e6109f81"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -309,7 +309,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:35:35 GMT"
+          "Tue, 03 Nov 2020 04:27:53 GMT"
         ],
         "Content-Length": [
           "108"
@@ -321,20 +321,80 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"55ff8589-57ce-4d8b-8f90-9c3d28025c77\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:35:31.297Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"2a50715d-56d9-44c7-9040-18285e64d27f\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi81NWZmODU4OS01N2NlLTRkOGItOGY5MC05YzNkMjgwMjVjNzc/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uLzJhNTA3MTVkLTU2ZDktNDRjNy05MDQwLTE4Mjg1ZTY0ZDI3Zj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "1"
+        ],
+        "x-ms-request-id": [
+          "8408f5d9-23a2-4e75-97b7-cfbd0aff25cc"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "x-ms-correlation-request-id": [
+          "1db720b1-62ab-4298-b04b-3ccb6915c9a0"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T042755Z:1db720b1-62ab-4298-b04b-3ccb6915c9a0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:27:54 GMT"
+        ],
+        "Content-Length": [
+          "108"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"2a50715d-56d9-44c7-9040-18285e64d27f\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uLzJhNTA3MTVkLTU2ZDktNDRjNy05MDQwLTE4Mjg1ZTY0ZDI3Zj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -348,19 +408,19 @@
           "20"
         ],
         "x-ms-request-id": [
-          "e80dd84a-e20a-46c0-af8f-78f9fdd037ba"
+          "403cd38b-f4c1-4af5-a853-ec1892433676"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "11995"
         ],
         "x-ms-correlation-request-id": [
-          "9f8bc0c3-b382-4636-8357-5576c0d9cdf7"
+          "9bb4a967-ef22-45e9-846c-a603f28fd970"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183536Z:9f8bc0c3-b382-4636-8357-5576c0d9cdf7"
+          "WESTUS:20201103T042756Z:9bb4a967-ef22-45e9-846c-a603f28fd970"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -369,7 +429,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:35:36 GMT"
+          "Tue, 03 Nov 2020 04:27:55 GMT"
         ],
         "Content-Length": [
           "108"
@@ -381,20 +441,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"55ff8589-57ce-4d8b-8f90-9c3d28025c77\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:35:31.297Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"2a50715d-56d9-44c7-9040-18285e64d27f\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi81NWZmODU4OS01N2NlLTRkOGItOGY5MC05YzNkMjgwMjVjNzc/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uLzJhNTA3MTVkLTU2ZDktNDRjNy05MDQwLTE4Mjg1ZTY0ZDI3Zj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -408,19 +468,19 @@
           "20"
         ],
         "x-ms-request-id": [
-          "aca33b69-a6fa-4cde-9310-90a911147f4e"
+          "5ce243ae-af0c-4d04-9257-9d2f458d2710"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "11994"
         ],
         "x-ms-correlation-request-id": [
-          "e7a5a130-2f18-4e76-8cc4-6d945d97f2ea"
+          "4581345c-26ed-4fd4-91d0-02d7b4fa4a41"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183557Z:e7a5a130-2f18-4e76-8cc4-6d945d97f2ea"
+          "WESTUS:20201103T042816Z:4581345c-26ed-4fd4-91d0-02d7b4fa4a41"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -429,7 +489,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:35:56 GMT"
+          "Tue, 03 Nov 2020 04:28:16 GMT"
         ],
         "Content-Length": [
           "108"
@@ -441,20 +501,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"55ff8589-57ce-4d8b-8f90-9c3d28025c77\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:35:31.297Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"2a50715d-56d9-44c7-9040-18285e64d27f\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/serverAzureAsyncOperation/55ff8589-57ce-4d8b-8f90-9c3d28025c77?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvc2VydmVyQXp1cmVBc3luY09wZXJhdGlvbi81NWZmODU4OS01N2NlLTRkOGItOGY5MC05YzNkMjgwMjVjNzc/YXBpLXZlcnNpb249MjAxOS0wNi0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/serverAzureAsyncOperation/2a50715d-56d9-44c7-9040-18285e64d27f?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9zZXJ2ZXJBenVyZUFzeW5jT3BlcmF0aW9uLzJhNTA3MTVkLTU2ZDktNDRjNy05MDQwLTE4Mjg1ZTY0ZDI3Zj9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -468,19 +528,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "227a2220-9baa-46b4-957d-dba3f2007ca2"
+          "8e0b736c-b96e-49d9-abc7-19380cc13894"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
+          "11993"
         ],
         "x-ms-correlation-request-id": [
-          "9cc730e6-d9ca-4a43-9764-666288714ad7"
+          "2efc1a7a-7a88-484e-a1a5-d8e1074d74f6"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183617Z:9cc730e6-d9ca-4a43-9764-666288714ad7"
+          "WESTUS:20201103T042836Z:2efc1a7a-7a88-484e-a1a5-d8e1074d74f6"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -489,7 +549,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:36:17 GMT"
+          "Tue, 03 Nov 2020 04:28:36 GMT"
         ],
         "Content-Length": [
           "107"
@@ -501,20 +561,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"55ff8589-57ce-4d8b-8f90-9c3d28025c77\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-10-06T18:35:31.297Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"2a50715d-56d9-44c7-9040-18285e64d27f\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T04:27:50.493Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893?api-version=2019-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzP2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -525,19 +585,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "c9ac4528-e7e4-408f-adbb-d3fb1da046d9"
+          "1265303e-5b47-484a-813a-82514a9e0358"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14993"
+          "11992"
         ],
         "x-ms-correlation-request-id": [
-          "65cc8ba1-0a5d-4b53-857a-d42fe116c506"
+          "520c5c36-85b5-4b50-8b47-f8e86228d8af"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183617Z:65cc8ba1-0a5d-4b53-857a-d42fe116c506"
+          "WESTUS:20201103T042836Z:520c5c36-85b5-4b50-8b47-f8e86228d8af"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -546,10 +606,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:36:17 GMT"
+          "Tue, 03 Nov 2020 04:28:36 GMT"
         ],
         "Content-Length": [
-          "464"
+          "456"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -558,32 +618,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-3505.sqltest-eg1.mscds.com\",\r\n    \"privateEndpointConnections\": [],\r\n    \"publicNetworkAccess\": \"Enabled\"\r\n  },\r\n  \"location\": \"southeastasia\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505\",\r\n  \"name\": \"sqlcrudtest-3505\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
+      "ResponseBody": "{\r\n  \"kind\": \"v12.0\",\r\n  \"properties\": {\r\n    \"administratorLogin\": \"dummylogin\",\r\n    \"version\": \"12.0\",\r\n    \"state\": \"Ready\",\r\n    \"fullyQualifiedDomainName\": \"sqlcrudtest-7893.database.windows.net\",\r\n    \"privateEndpointConnections\": [],\r\n    \"publicNetworkAccess\": \"Enabled\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"tags\": {},\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893\",\r\n  \"name\": \"sqlcrudtest-7893\",\r\n  \"type\": \"Microsoft.Sql/servers\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC03NzU3P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"P1\"\r\n  },\r\n  \"location\": \"southeastasia\"\r\n}",
+      "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"P1\"\r\n  },\r\n  \"location\": \"eastus\"\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "5b6db1fb-2e6f-41b7-9a78-a56877306a50"
+          "e01e4a38-87c3-4508-9533-b05cf34beeb7"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "71"
+          "64"
         ]
       },
       "ResponseHeaders": {
@@ -594,16 +654,16 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/databaseOperationResults/efc446c9-55a8-4aad-b0f4-df3f7fcab75a?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/databaseOperationResults/693b00ef-e6f3-4942-be2f-80a030e2e7c6?api-version=2020-08-01-preview"
         ],
         "Retry-After": [
           "15"
         ],
         "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/efc446c9-55a8-4aad-b0f4-df3f7fcab75a?api-version=2019-06-01-preview"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/693b00ef-e6f3-4942-be2f-80a030e2e7c6?api-version=2020-08-01-preview"
         ],
         "x-ms-request-id": [
-          "efc446c9-55a8-4aad-b0f4-df3f7fcab75a"
+          "693b00ef-e6f3-4942-be2f-80a030e2e7c6"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -612,10 +672,10 @@
           "1198"
         ],
         "x-ms-correlation-request-id": [
-          "8c119ca6-ce95-49c8-9119-76c908f16395"
+          "7d5551db-476c-4f01-964f-660c405a56c6"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183619Z:8c119ca6-ce95-49c8-9119-76c908f16395"
+          "WESTUS:20201103T042838Z:7d5551db-476c-4f01-964f-660c405a56c6"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -624,10 +684,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:36:19 GMT"
+          "Tue, 03 Nov 2020 04:28:37 GMT"
         ],
         "Content-Length": [
-          "76"
+          "75"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -636,20 +696,20 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-06T18:36:19.663Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"CreateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T04:28:37.79Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/efc446c9-55a8-4aad-b0f4-df3f7fcab75a?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2VmYzQ0NmM5LTU1YTgtNGFhZC1iMGY0LWRmM2Y3ZmNhYjc1YT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/693b00ef-e6f3-4942-be2f-80a030e2e7c6?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vNjkzYjAwZWYtZTZmMy00OTQyLWJlMmYtODBhMDMwZTJlN2M2P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -663,19 +723,19 @@
           "15"
         ],
         "x-ms-request-id": [
-          "120d5c0f-ba1a-4935-bf19-5c0118f031fe"
+          "2d6d5926-17a3-4ddd-bdd9-6bf801cf2180"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
+          "11991"
         ],
         "x-ms-correlation-request-id": [
-          "d37a0771-5d0d-4520-8a5b-05a02305e709"
+          "fb3446b6-3fe9-4745-95b3-d9c40e68856f"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183635Z:d37a0771-5d0d-4520-8a5b-05a02305e709"
+          "WESTUS:20201103T042853Z:fb3446b6-3fe9-4745-95b3-d9c40e68856f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -684,247 +744,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:36:34 GMT"
-        ],
-        "Content-Length": [
-          "108"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"efc446c9-55a8-4aad-b0f4-df3f7fcab75a\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:36:19.663Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/efc446c9-55a8-4aad-b0f4-df3f7fcab75a?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2VmYzQ0NmM5LTU1YTgtNGFhZC1iMGY0LWRmM2Y3ZmNhYjc1YT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "c4658ccd-22a2-4443-866a-b442c862f823"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
-        ],
-        "x-ms-correlation-request-id": [
-          "dbbef3a5-2339-468a-9920-03efe4eb0ab6"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183650Z:dbbef3a5-2339-468a-9920-03efe4eb0ab6"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:36:49 GMT"
-        ],
-        "Content-Length": [
-          "108"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"efc446c9-55a8-4aad-b0f4-df3f7fcab75a\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:36:19.663Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/efc446c9-55a8-4aad-b0f4-df3f7fcab75a?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2VmYzQ0NmM5LTU1YTgtNGFhZC1iMGY0LWRmM2Y3ZmNhYjc1YT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "910a56f5-7084-4344-8b0f-6758f9bcae26"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14990"
-        ],
-        "x-ms-correlation-request-id": [
-          "0cc1b2f1-5925-4a23-8a0d-32f7481bf999"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183705Z:0cc1b2f1-5925-4a23-8a0d-32f7481bf999"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:37:05 GMT"
-        ],
-        "Content-Length": [
-          "108"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"efc446c9-55a8-4aad-b0f4-df3f7fcab75a\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:36:19.663Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/efc446c9-55a8-4aad-b0f4-df3f7fcab75a?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2VmYzQ0NmM5LTU1YTgtNGFhZC1iMGY0LWRmM2Y3ZmNhYjc1YT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "9b56a452-da90-4d47-98ac-208884969bcb"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14989"
-        ],
-        "x-ms-correlation-request-id": [
-          "5bcfa535-9fb4-4bc8-9ba2-b0a96adb4bee"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183721Z:5bcfa535-9fb4-4bc8-9ba2-b0a96adb4bee"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:37:20 GMT"
-        ],
-        "Content-Length": [
-          "108"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"name\": \"efc446c9-55a8-4aad-b0f4-df3f7fcab75a\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-10-06T18:36:19.663Z\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/databaseAzureAsyncOperation/efc446c9-55a8-4aad-b0f4-df3f7fcab75a?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL3NvdXRoZWFzdGFzaWEvZGF0YWJhc2VBenVyZUFzeW5jT3BlcmF0aW9uL2VmYzQ0NmM5LTU1YTgtNGFhZC1iMGY0LWRmM2Y3ZmNhYjc1YT9hcGktdmVyc2lvbj0yMDE5LTA2LTAxLXByZXZpZXc=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "x-ms-request-id": [
-          "f08afa44-9a32-4a5b-ab01-8f0eff27ccfa"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14988"
-        ],
-        "x-ms-correlation-request-id": [
-          "fe16c6cf-acf6-4bfa-9a6c-738a86b60193"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183736Z:fe16c6cf-acf6-4bfa-9a6c-738a86b60193"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:37:36 GMT"
+          "Tue, 03 Nov 2020 04:28:52 GMT"
         ],
         "Content-Length": [
           "107"
@@ -936,20 +756,260 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"efc446c9-55a8-4aad-b0f4-df3f7fcab75a\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-10-06T18:36:19.663Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"693b00ef-e6f3-4942-be2f-80a030e2e7c6\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:28:37.79Z\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766?api-version=2019-06-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2P2FwaS12ZXJzaW9uPTIwMTktMDYtMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/693b00ef-e6f3-4942-be2f-80a030e2e7c6?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vNjkzYjAwZWYtZTZmMy00OTQyLWJlMmYtODBhMDMwZTJlN2M2P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "bd2942aa-35ec-4af8-865b-450bcd0a6923"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11990"
+        ],
+        "x-ms-correlation-request-id": [
+          "7f2a769b-6006-43dd-a913-81e1bf0de21d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T042908Z:7f2a769b-6006-43dd-a913-81e1bf0de21d"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:29:08 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"693b00ef-e6f3-4942-be2f-80a030e2e7c6\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:28:37.79Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/693b00ef-e6f3-4942-be2f-80a030e2e7c6?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vNjkzYjAwZWYtZTZmMy00OTQyLWJlMmYtODBhMDMwZTJlN2M2P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "f538ea9d-a7f4-4c7f-b8ef-683959fd886b"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11989"
+        ],
+        "x-ms-correlation-request-id": [
+          "abc388f8-f6e7-4553-a1a1-043795c4f731"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T042923Z:abc388f8-f6e7-4553-a1a1-043795c4f731"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:29:23 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"693b00ef-e6f3-4942-be2f-80a030e2e7c6\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:28:37.79Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/693b00ef-e6f3-4942-be2f-80a030e2e7c6?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vNjkzYjAwZWYtZTZmMy00OTQyLWJlMmYtODBhMDMwZTJlN2M2P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "a4aa7f15-408b-4e3b-b750-fa27d40690c5"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11988"
+        ],
+        "x-ms-correlation-request-id": [
+          "57ecf62e-fde0-4c2e-a87d-8d65b382d356"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T042938Z:57ecf62e-fde0-4c2e-a87d-8d65b382d356"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:29:38 GMT"
+        ],
+        "Content-Length": [
+          "107"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"693b00ef-e6f3-4942-be2f-80a030e2e7c6\",\r\n  \"status\": \"InProgress\",\r\n  \"startTime\": \"2020-11-03T04:28:37.79Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/databaseAzureAsyncOperation/693b00ef-e6f3-4942-be2f-80a030e2e7c6?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvbG9jYXRpb25zL2Vhc3R1cy9kYXRhYmFzZUF6dXJlQXN5bmNPcGVyYXRpb24vNjkzYjAwZWYtZTZmMy00OTQyLWJlMmYtODBhMDMwZTJlN2M2P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-request-id": [
+          "e8ef6483-7594-4206-958d-31a15d7b5182"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11987"
+        ],
+        "x-ms-correlation-request-id": [
+          "69147bc1-b405-4d1d-963a-4b7a76159597"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS:20201103T042953Z:69147bc1-b405-4d1d-963a-4b7a76159597"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Tue, 03 Nov 2020 04:29:53 GMT"
+        ],
+        "Content-Length": [
+          "106"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"693b00ef-e6f3-4942-be2f-80a030e2e7c6\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2020-11-03T04:28:37.79Z\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757?api-version=2020-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC03NzU3P2FwaS12ZXJzaW9uPTIwMjAtMDgtMDEtcHJldmlldw==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -960,19 +1020,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "54c00f9c-10a9-4dbf-b096-55c8f484f2c4"
+          "ff525422-f942-43d3-a756-775067ffb600"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14987"
+          "11986"
         ],
         "x-ms-correlation-request-id": [
-          "cd1a0f7d-025c-4643-97fa-07adea103afa"
+          "d12a3965-ac88-4e6d-84f7-e3b941cc9941"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183736Z:cd1a0f7d-025c-4643-97fa-07adea103afa"
+          "WESTUS:20201103T042954Z:d12a3965-ac88-4e6d-84f7-e3b941cc9941"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -981,10 +1041,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:37:36 GMT"
+          "Tue, 03 Nov 2020 04:29:53 GMT"
         ],
         "Content-Length": [
-          "905"
+          "872"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -993,26 +1053,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Premium\",\r\n    \"tier\": \"Premium\",\r\n    \"capacity\": 125\r\n  },\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": 536870912000,\r\n    \"status\": \"Online\",\r\n    \"databaseId\": \"f87712c8-222e-4ed4-9078-4d3d48f7cfd6\",\r\n    \"creationDate\": \"2020-10-06T18:37:29.213Z\",\r\n    \"currentServiceObjectiveName\": \"P1\",\r\n    \"requestedServiceObjectiveName\": \"P1\",\r\n    \"defaultSecondaryLocation\": \"northeurope\",\r\n    \"catalogCollation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"zoneRedundant\": false,\r\n    \"earliestRestoreDate\": \"2020-10-06T19:07:29.213Z\",\r\n    \"readScale\": \"Enabled\",\r\n    \"readReplicaCount\": 1,\r\n    \"currentSku\": {\r\n      \"name\": \"Premium\",\r\n      \"tier\": \"Premium\",\r\n      \"capacity\": 125\r\n    },\r\n    \"storageAccountType\": \"GRS\"\r\n  },\r\n  \"location\": \"southeastasia\",\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766\",\r\n  \"name\": \"sqlcrudtest-8766\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\"\r\n}",
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Premium\",\r\n    \"tier\": \"Premium\",\r\n    \"capacity\": 125\r\n  },\r\n  \"kind\": \"v12.0,user\",\r\n  \"properties\": {\r\n    \"collation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"maxSizeBytes\": 536870912000,\r\n    \"status\": \"Online\",\r\n    \"databaseId\": \"d41387d7-de86-43ff-9013-af70a3dc6b66\",\r\n    \"creationDate\": \"2020-11-03T04:29:39.383Z\",\r\n    \"currentServiceObjectiveName\": \"P1\",\r\n    \"requestedServiceObjectiveName\": \"P1\",\r\n    \"defaultSecondaryLocation\": \"westus\",\r\n    \"catalogCollation\": \"SQL_Latin1_General_CP1_CI_AS\",\r\n    \"zoneRedundant\": false,\r\n    \"earliestRestoreDate\": \"2020-11-03T04:59:39.383Z\",\r\n    \"readScale\": \"Enabled\",\r\n    \"currentSku\": {\r\n      \"name\": \"Premium\",\r\n      \"tier\": \"Premium\",\r\n      \"capacity\": 125\r\n    },\r\n    \"storageAccountType\": \"GRS\"\r\n  },\r\n  \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757\",\r\n  \"name\": \"sqlcrudtest-7757\",\r\n  \"type\": \"Microsoft.Sql/servers/databases\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC03NzU3L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "395882b7-2322-47c2-8664-f03d04a01848"
+          "09de3911-cc12-4994-8b8c-fcc2056c7c5d"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1023,19 +1083,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "53cf7472-a575-431c-b6f4-4fb0faecfb92"
+          "72881fdf-699b-4a67-a612-7d41b2bbc6fb"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14986"
+          "11985"
         ],
         "x-ms-correlation-request-id": [
-          "5e13c5ff-b6fe-418c-8b39-e4b12a90190a"
+          "9048300e-5b51-486f-9c33-dd27aa020a69"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183737Z:5e13c5ff-b6fe-418c-8b39-e4b12a90190a"
+          "WESTUS:20201103T042954Z:9048300e-5b51-486f-9c33-dd27aa020a69"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1044,10 +1104,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:37:37 GMT"
+          "Tue, 03 Nov 2020 04:29:53 GMT"
         ],
         "Content-Length": [
-          "364"
+          "333"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1056,26 +1116,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC03NzU3L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "af1caf19-be61-4ddc-85d2-07e3618afcc7"
+          "e63eed5f-98e0-49a6-ac16-02f7d742ce24"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1086,19 +1146,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "a649e4f0-167c-428f-b843-b837b873bd4b"
+          "5bab3bbd-19fd-4dd8-a65f-1b9fc5f860d7"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14985"
+          "11984"
         ],
         "x-ms-correlation-request-id": [
-          "19c5f535-9260-4f31-8e3e-ff1ad1efcd46"
+          "06a4dc2c-2139-4895-9701-183f69aa2683"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183740Z:19c5f535-9260-4f31-8e3e-ff1ad1efcd46"
+          "WESTUS:20201103T042957Z:06a4dc2c-2139-4895-9701-183f69aa2683"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1107,10 +1167,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:37:39 GMT"
+          "Tue, 03 Nov 2020 04:29:56 GMT"
         ],
         "Content-Length": [
-          "364"
+          "333"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1119,26 +1179,26 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC03NzU3L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4ec8a0a0-d573-46bd-8a38-da6ea8e6222f"
+          "8631ccf7-cd4c-48a0-8d56-e988685ef4cb"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ]
       },
       "ResponseHeaders": {
@@ -1149,19 +1209,19 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "2c5feb2f-bb47-4fd3-b360-91ae362bf8a3"
+          "514eb823-3964-4fe5-b963-528aef2e496a"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14984"
+          "11983"
         ],
         "x-ms-correlation-request-id": [
-          "183ac893-5df5-4ac9-a66a-923d4d82763a"
+          "e00f7c80-ced7-4826-87f6-1d95276a1093"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183743Z:183ac893-5df5-4ac9-a66a-923d4d82763a"
+          "WESTUS:20201103T043000Z:e00f7c80-ced7-4826-87f6-1d95276a1093"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1170,10 +1230,10 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:37:43 GMT"
+          "Tue, 03 Nov 2020 04:29:59 GMT"
         ],
         "Content-Length": [
-          "364"
+          "334"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -1182,158 +1242,32 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35\r\n  },\r\n  \"id\": \"/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "32e36f4c-a0b4-4fa3-91c6-e7318fc0ef95"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "5e723638-bc86-4782-b2da-b3270c00fb85"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14983"
-        ],
-        "x-ms-correlation-request-id": [
-          "845ec213-4bd5-4607-9d36-000718926254"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183747Z:845ec213-4bd5-4607-9d36-000718926254"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:37:46 GMT"
-        ],
-        "Content-Length": [
-          "365"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35,\r\n    \"diffBackupIntervalInHours\": 24\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "e8083d92-7135-4fad-80e8-dc665d096d87"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "7c43d8f0-b2d3-402f-ab02-9de5a6ef74b2"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14982"
-        ],
-        "x-ms-correlation-request-id": [
-          "3b295da2-20a6-479a-a0ba-185df4795d93"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183750Z:3b295da2-20a6-479a-a0ba-185df4795d93"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:37:50 GMT"
-        ],
-        "Content-Length": [
-          "364"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  },\r\n  \"id\": \"/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default\",\r\n  \"name\": \"default\",\r\n  \"type\": \"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies\"\r\n}",
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC03NzU3L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 36,\r\n    \"diffBackupIntervalInHours\": 24\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 36\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "372c5711-26c9-4c8f-9550-b020518bdac5"
+          "1bfe6ded-ffef-4054-a969-87f1dbe52d3f"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "91"
+          "53"
         ]
       },
       "ResponseHeaders": {
@@ -1344,7 +1278,7 @@
           "no-cache"
         ],
         "x-ms-request-id": [
-          "9a7feb05-f2cf-4f9e-814e-b9285db13a16"
+          "ee47b8fe-65d5-4ab9-af07-f80b5523d2c3"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -1353,10 +1287,10 @@
           "1197"
         ],
         "x-ms-correlation-request-id": [
-          "0e191306-e71b-4a52-9f62-5a03dfb8c070"
+          "bf5f09d3-07dc-4793-bebc-1814556dea97"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183737Z:0e191306-e71b-4a52-9f62-5a03dfb8c070"
+          "WESTUS:20201103T042954Z:bf5f09d3-07dc-4793-bebc-1814556dea97"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1365,7 +1299,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:37:37 GMT"
+          "Tue, 03 Nov 2020 04:29:53 GMT"
         ],
         "Content-Length": [
           "172"
@@ -1381,28 +1315,28 @@
       "StatusCode": 400
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/servers/sqlcrudtest-7893/databases/sqlcrudtest-7757/backupShortTermRetentionPolicies/default?api-version=2017-10-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQyNTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC03ODkzL2RhdGFiYXNlcy9zcWxjcnVkdGVzdC03NzU3L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAxNy0xMC0wMS1wcmV2aWV3",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35,\r\n    \"diffBackupIntervalInHours\": 20\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35\r\n  }\r\n}",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "90e9a527-83ca-4ec5-9ec1-ecc152283c6a"
+          "25a4fd0d-f2c8-4ece-9c13-bef60f88da2f"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.47.0.0"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "91"
+          "53"
         ]
       },
       "ResponseHeaders": {
@@ -1412,8 +1346,17 @@
         "Pragma": [
           "no-cache"
         ],
+        "Location": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyOperationResults/a8c4b2df-c816-4ffc-864c-b158f4ad1077?api-version=2017-10-01-preview"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourceGroups/sqlcrudtest-4257/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/a8c4b2df-c816-4ffc-864c-b158f4ad1077?api-version=2017-10-01-preview"
+        ],
         "x-ms-request-id": [
-          "695e2cba-4c5e-4a33-8713-0953d28b4465"
+          "a8c4b2df-c816-4ffc-864c-b158f4ad1077"
         ],
         "Server": [
           "Microsoft-HTTPAPI/2.0"
@@ -1422,10 +1365,10 @@
           "1196"
         ],
         "x-ms-correlation-request-id": [
-          "3b39c1bd-061b-44ea-b979-36a2396b0a5d"
+          "f0af713c-73a9-49bc-9e5d-2281044d92cd"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183741Z:3b39c1bd-061b-44ea-b979-36a2396b0a5d"
+          "WESTUS:20201103T042957Z:f0af713c-73a9-49bc-9e5d-2281044d92cd"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1434,85 +1377,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:37:40 GMT"
-        ],
-        "Content-Length": [
-          "205"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"InvalidDiffBackupIntervalHours\",\r\n    \"message\": \"The differential backup interval hours of 20 is not a valid configuration. Valid differential backup interval must be 0.08 or 12 or 24 hours.\"\r\n  }\r\n}",
-      "StatusCode": 400
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 35,\r\n    \"diffBackupIntervalInHours\": 24\r\n  }\r\n}",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "270a2851-4f72-49a1-ac52-06ad1267e894"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "91"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyOperationResults/d7107549-9f9a-459a-99d9-91e571093a42?api-version=2020-02-02-preview"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyAzureAsyncOperation/d7107549-9f9a-459a-99d9-91e571093a42?api-version=2020-02-02-preview"
-        ],
-        "x-ms-request-id": [
-          "d7107549-9f9a-459a-99d9-91e571093a42"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
-        ],
-        "x-ms-correlation-request-id": [
-          "eb598c36-f20e-4e3d-bcbf-1335f2bde438"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183744Z:eb598c36-f20e-4e3d-bcbf-1335f2bde438"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:37:43 GMT"
+          "Tue, 03 Nov 2020 04:29:57 GMT"
         ],
         "Content-Length": [
           "76"
@@ -1524,103 +1389,25 @@
           "-1"
         ]
       },
-      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-06T18:37:44.447Z\"\r\n}",
+      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-11-03T04:29:57.493Z\"\r\n}",
       "StatusCode": 202
     },
     {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/servers/sqlcrudtest-3505/databases/sqlcrudtest-8766/backupShortTermRetentionPolicies/default?api-version=2020-02-02-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlR3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTcvcHJvdmlkZXJzL01pY3Jvc29mdC5TcWwvc2VydmVycy9zcWxjcnVkdGVzdC0zNTA1L2RhdGFiYXNlcy9zcWxjcnVkdGVzdC04NzY2L2JhY2t1cFNob3J0VGVybVJldGVudGlvblBvbGljaWVzL2RlZmF1bHQ/YXBpLXZlcnNpb249MjAyMC0wMi0wMi1wcmV2aWV3",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"properties\": {\r\n    \"retentionDays\": 7,\r\n    \"diffBackupIntervalInHours\": 12\r\n  }\r\n}",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "c457c59e-540e-4a62-beb4-7210ae417ac3"
-        ],
-        "Accept-Language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.29220.03",
-          "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
-          "Microsoft.Azure.Management.Sql.SqlManagementClient/1.45.0.0"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "90"
-        ]
-      },
-      "ResponseHeaders": {
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyOperationResults/cf89a502-af29-4921-b033-25afc578de3b?api-version=2020-02-02-preview"
-        ],
-        "Retry-After": [
-          "15"
-        ],
-        "Azure-AsyncOperation": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourceGroups/sqlcrudtest-4857/providers/Microsoft.Sql/locations/southeastasia/shortTermRetentionPolicyAzureAsyncOperation/cf89a502-af29-4921-b033-25afc578de3b?api-version=2020-02-02-preview"
-        ],
-        "x-ms-request-id": [
-          "cf89a502-af29-4921-b033-25afc578de3b"
-        ],
-        "Server": [
-          "Microsoft-HTTPAPI/2.0"
-        ],
-        "x-ms-ratelimit-remaining-subscription-writes": [
-          "1194"
-        ],
-        "x-ms-correlation-request-id": [
-          "a85d6cd4-82ed-4a77-9773-5c2905af87f2"
-        ],
-        "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183747Z:a85d6cd4-82ed-4a77-9773-5c2905af87f2"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Date": [
-          "Tue, 06 Oct 2020 18:37:47 GMT"
-        ],
-        "Content-Length": [
-          "76"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"operation\": \"UpdateLogicalDatabase\",\r\n  \"startTime\": \"2020-10-06T18:37:47.757Z\"\r\n}",
-      "StatusCode": 202
-    },
-    {
-      "RequestUri": "/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/resourcegroups/sqlcrudtest-4857?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNGI2YWFhZjItNmZkOC00MThiLWEwNmQtNmVkZTM5YTMyMjcwL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTQ4NTc/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/resourcegroups/sqlcrudtest-4257?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGMxNzg5YTgtMDc2Mi00ZGZiLTg5MDEtNGMwZGEwOGI4M2QzL3Jlc291cmNlZ3JvdXBzL3NxbGNydWR0ZXN0LTQyNTc/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "404f8d29-e952-41c5-972e-96b6ab8531fa"
+          "28cec983-fed3-4f53-8ddc-6d1ec0fd4d12"
         ],
         "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.29220.03",
+          "FxVersion/4.6.29321.03",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19041.",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
@@ -1632,7 +1419,7 @@
           "no-cache"
         ],
         "Location": [
-          "https://api-dogfood.resources.windows-int.net/subscriptions/4b6aaaf2-6fd8-418b-a06d-6ede39a32270/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDQ4NTctU09VVEhFQVNUQVNJQSIsImpvYkxvY2F0aW9uIjoic291dGhlYXN0YXNpYSJ9?api-version=2017-05-10"
+          "https://management.azure.com/subscriptions/dc1789a8-0762-4dfb-8901-4c0da08b83d3/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TUUxDUlVEVEVTVDoyRDQyNTctRUFTVFVTIiwiam9iTG9jYXRpb24iOiJlYXN0dXMifQ?api-version=2017-05-10"
         ],
         "Retry-After": [
           "15"
@@ -1641,13 +1428,13 @@
           "14999"
         ],
         "x-ms-request-id": [
-          "170339f3-49fa-4f04-bd5a-15bd296288f8"
+          "31671f31-6c7f-46fd-9ad5-ad7174f49dd9"
         ],
         "x-ms-correlation-request-id": [
-          "170339f3-49fa-4f04-bd5a-15bd296288f8"
+          "31671f31-6c7f-46fd-9ad5-ad7174f49dd9"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20201006T183756Z:170339f3-49fa-4f04-bd5a-15bd296288f8"
+          "WESTUS:20201103T043002Z:31671f31-6c7f-46fd-9ad5-ad7174f49dd9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -1656,7 +1443,7 @@
           "nosniff"
         ],
         "Date": [
-          "Tue, 06 Oct 2020 18:37:56 GMT"
+          "Tue, 03 Nov 2020 04:30:01 GMT"
         ],
         "Expires": [
           "-1"
@@ -1671,17 +1458,17 @@
   ],
   "Names": {
     "CreateResourceGroup": [
-      "sqlcrudtest-4857"
+      "sqlcrudtest-4257"
     ],
     "CreateServer": [
-      "sqlcrudtest-3505"
+      "sqlcrudtest-7893"
     ],
     "TestShortTermRetentionPolicyOnPremium": [
-      "sqlcrudtest-8766"
+      "sqlcrudtest-7757"
     ]
   },
   "Variables": {
-    "SubscriptionId": "4b6aaaf2-6fd8-418b-a06d-6ede39a32270",
-    "DefaultLocation": "southeast asia"
+    "SubscriptionId": "dc1789a8-0762-4dfb-8901-4c0da08b83d3",
+    "DefaultLocation": "eastus"
   }
 }

--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/ShortTermRetentionTests.cs
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/tests/ShortTermRetentionTests.cs
@@ -21,9 +21,6 @@ namespace Sql.Tests
 {
     public class ShortTermRetentionTests
     {
-        // NOTE: We plan to config defaultDiffBackupIntervalHours value from 12 to 24 for new database. Then below tests will failed. 
-        // Please modify three defaultDiffBackupIntervalHours from 12 to 24 to be re-success if necessary. - 10/5/2020
-
         [Fact]
         public void TestShortTermRetentionPolicyOnBasic()
         {
@@ -31,9 +28,6 @@ namespace Sql.Tests
             {
                 // Valid Retention Days for Basic DB is 1 to 7 days. 
                 int defaultRetentionDays = 7;
-
-                // Valid Differential Backup Interval Hours is 12 or 24. 
-                int defaultDiffBackupIntervalHours = 12;
 
                 // Create a DTU - Basic DB.
                 ResourceGroup resourceGroup = context.CreateResourceGroup();
@@ -50,39 +44,20 @@ namespace Sql.Tests
                 // Test GET operation can get default retention days and diffbackupinterval value. 
                 BackupShortTermRetentionPolicy policyDefault = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(defaultRetentionDays, policyDefault.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policyDefault.DiffBackupIntervalInHours);
 
-                // Attempt to set retention period to 8 days (invalid); Attemp to set the differential backup interval to 12 hours (valid); Verify the operation fails on updating the policy.
-                BackupShortTermRetentionPolicy parameters1 = new BackupShortTermRetentionPolicy(retentionDays: 8, diffBackupIntervalInHours: 12);
+                // Attempt to set retention period to 8 days (invalid); Verify the operation fails on updating the policy.
+                BackupShortTermRetentionPolicy parameters1 = new BackupShortTermRetentionPolicy(retentionDays: 8);
                 sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters1);
                 Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
                 BackupShortTermRetentionPolicy policy1 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(defaultRetentionDays, policy1.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policy1.DiffBackupIntervalInHours);
 
-                // Attempt to set retention period to 6 days (valid); Attemp to set the differential backup interval to 6 hours (invalid); Verify the operation fails on updating the policy.
-                BackupShortTermRetentionPolicy parameters2 = new BackupShortTermRetentionPolicy(retentionDays: 6, diffBackupIntervalInHours: 6);
-                sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters2);
-                Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
-                BackupShortTermRetentionPolicy policy2 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
-                Assert.Equal(defaultRetentionDays, policy2.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policy2.DiffBackupIntervalInHours);
-
-                // Attempt to set retention period to 6 days (valid); Attemp to set the differential backup interval to 12 hours (valid); Verify the operation success.
-                BackupShortTermRetentionPolicy parameters3 = new BackupShortTermRetentionPolicy(retentionDays: 6, diffBackupIntervalInHours: 24);
+                // Attempt to set retention period to 6 days (valid); Verify the operation success.
+                BackupShortTermRetentionPolicy parameters3 = new BackupShortTermRetentionPolicy(retentionDays: 6);
                 sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters3);
                 Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
                 BackupShortTermRetentionPolicy policy3 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(parameters3.RetentionDays, policy3.RetentionDays);
-                Assert.Equal(parameters3.DiffBackupIntervalInHours, policy3.DiffBackupIntervalInHours);
-
-                // Attempt to set retention period to 7 days (valid); Attemp to set the differential backup interval to 12 hours (valid); Verify the operation success.
-                BackupShortTermRetentionPolicy parameters4 = new BackupShortTermRetentionPolicy(retentionDays: 6, diffBackupIntervalInHours: 24);
-                sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters4);
-                Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
-                BackupShortTermRetentionPolicy policy4 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
-                Assert.Equal(parameters3.RetentionDays, policy4.RetentionDays);
-                Assert.Equal(parameters3.DiffBackupIntervalInHours, policy4.DiffBackupIntervalInHours);
             }
         }
 
@@ -93,9 +68,6 @@ namespace Sql.Tests
             {
                 // Valid Retention Days for Basic DB is 1 to 35 days. 
                 int defaultRetentionDays = 7;
-
-                // Valid Differential Backup Interval Hours is 12 or 24. 
-                int defaultDiffBackupIntervalHours = 12;
 
                 // Create a DTU - Premium DB.
                 ResourceGroup resourceGroup = context.CreateResourceGroup();
@@ -109,55 +81,34 @@ namespace Sql.Tests
                         Sku = new Microsoft.Azure.Management.Sql.Models.Sku(ServiceObjectiveName.P1)
                     });
 
-                // Test GET operation can get default retention days and diffbackupinterval value. 
+                // Test GET operation can get default retention days
                 BackupShortTermRetentionPolicy policyDefault = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(defaultRetentionDays, policyDefault.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policyDefault.DiffBackupIntervalInHours);
 
-                // Attempt to set retention period to 36 days (invalid); Attemp to set the differential backup interval to 24 hours (valid); Verify the operation fails on updating the policy.
-                BackupShortTermRetentionPolicy parameters1 = new BackupShortTermRetentionPolicy(retentionDays: 36, diffBackupIntervalInHours: 24);
+                // Attempt to set retention period to 36 days (invalid); Verify the operation fails on updating the policy.
+                BackupShortTermRetentionPolicy parameters1 = new BackupShortTermRetentionPolicy(retentionDays: 36);
                 sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters1);
                 Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
                 BackupShortTermRetentionPolicy policy = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(defaultRetentionDays, policy.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policy.DiffBackupIntervalInHours);
 
-                // Attempt to set retention period to 35 days (valid); Attemp to set the differential backup interval to 20 hours (invalid); Verify the operation fails on updating the policy.
-                BackupShortTermRetentionPolicy parameters2 = new BackupShortTermRetentionPolicy(retentionDays: 35, diffBackupIntervalInHours: 20);
-                sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters2);
-                Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
-                BackupShortTermRetentionPolicy policy2 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
-                Assert.Equal(defaultRetentionDays, policy2.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policy2.DiffBackupIntervalInHours);
-
-                // Increase retention period to 35 days (valid); Increase differential backup interval to 24 hours (valid); Verify the operation success.
-                BackupShortTermRetentionPolicy parameters3 = new BackupShortTermRetentionPolicy(retentionDays: 35, diffBackupIntervalInHours: 24);
+                // Increase retention period to 35 days (valid); Verify the operation success.
+                BackupShortTermRetentionPolicy parameters3 = new BackupShortTermRetentionPolicy(retentionDays: 35);
                 sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters3);
                 Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
                 BackupShortTermRetentionPolicy policy3 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(parameters3.RetentionDays, policy3.RetentionDays);
-                Assert.Equal(parameters3.DiffBackupIntervalInHours, policy3.DiffBackupIntervalInHours);
-
-                // Decrease retention period to 7 days again; Decrease differential backup interval to 12 hours again (valid); Verify the operation success.
-                BackupShortTermRetentionPolicy parameters4 = new BackupShortTermRetentionPolicy(retentionDays: 7, diffBackupIntervalInHours: 12);
-                sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters4);
-                Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
-                BackupShortTermRetentionPolicy policy4 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
-                Assert.Equal(parameters4.RetentionDays, policy4.RetentionDays);
-                Assert.Equal(parameters4.DiffBackupIntervalInHours, policy4.DiffBackupIntervalInHours);
             }
         }
 
         [Fact]
         public void TestShortTermRetentionPolicyOnGeneralPurpose()
         {
+            // Currently the tier 'GeneralPurpose' does not support the sku 'SQLDB_GP_Gen5'. 
             using (SqlManagementTestContext context = new SqlManagementTestContext(this))
             {
                 // Valid Retention Days for GeneralPurpose DB is 1 to 35 days. 
                 int defaultRetentionDays = 7;
-
-                // Valid Differential Backup Interval Hours is 12 or 24. 
-                int defaultDiffBackupIntervalHours = 12;
 
                 // Create a vCore - GeneralPurpose DB.
                 ResourceGroup resourceGroup = context.CreateResourceGroup();
@@ -174,41 +125,49 @@ namespace Sql.Tests
                 // Test GET operation can get default retention days and diffbackupinterval value. 
                 BackupShortTermRetentionPolicy policyDefault = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(defaultRetentionDays, policyDefault.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policyDefault.DiffBackupIntervalInHours);
 
-                // Attempt to set retention period to 36 days (invalid); Attemp to set the differential backup interval to 24 hours (valid); Verify the operation fails on updating the policy.
-                BackupShortTermRetentionPolicy parameters1 = new BackupShortTermRetentionPolicy(retentionDays: 36, diffBackupIntervalInHours: 24);
+                // Attempt to set retention period to 36 days (invalid); Verify the operation fails on updating the policy.
+                BackupShortTermRetentionPolicy parameters1 = new BackupShortTermRetentionPolicy(retentionDays: 36);
                 sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters1);
                 Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
                 BackupShortTermRetentionPolicy policy = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(defaultRetentionDays, policy.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policy.DiffBackupIntervalInHours);
 
-                // Attempt to set retention period to 35 days (valid); Attemp to set the differential backup interval to 25 hours (invalid); Verify the operation fails on updating the policy.
-                BackupShortTermRetentionPolicy parameters2 = new BackupShortTermRetentionPolicy(retentionDays: 35, diffBackupIntervalInHours: 25);
-                sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters2);
-                Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
-                BackupShortTermRetentionPolicy policy2 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
-                Assert.Equal(defaultRetentionDays, policy2.RetentionDays);
-                Assert.Equal(defaultDiffBackupIntervalHours, policy2.DiffBackupIntervalInHours);
-
-                // Increase retention period to 35 days (valid); Increase differential backup interval to 24 hours (valid); Verify the operation success.
-                BackupShortTermRetentionPolicy parameters3 = new BackupShortTermRetentionPolicy(retentionDays: 35, diffBackupIntervalInHours: 24);
+                // Increase retention period to 35 days (valid); Verify the operation success.
+                BackupShortTermRetentionPolicy parameters3 = new BackupShortTermRetentionPolicy(retentionDays: 35);
                 sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters3);
                 Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
                 BackupShortTermRetentionPolicy policy3 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
                 Assert.Equal(parameters3.RetentionDays, policy3.RetentionDays);
-                Assert.Equal(parameters3.DiffBackupIntervalInHours, policy3.DiffBackupIntervalInHours);
-
-                // Decrease retention period to 7 days again; Decrease differential backup interval to 12 hours again (valid); Verify the operation success.
-                BackupShortTermRetentionPolicy parameters4 = new BackupShortTermRetentionPolicy(retentionDays: 7, diffBackupIntervalInHours: 12);
-                sqlClient.BackupShortTermRetentionPolicies.CreateOrUpdateWithHttpMessagesAsync(resourceGroup.Name, server.Name, database.Name, parameters4);
-                Microsoft.Rest.ClientRuntime.Azure.TestFramework.TestUtilities.Wait(TimeSpan.FromSeconds(3));
-                BackupShortTermRetentionPolicy policy4 = sqlClient.BackupShortTermRetentionPolicies.Get(resourceGroup.Name, server.Name, database.Name);
-                Assert.Equal(parameters4.RetentionDays, policy4.RetentionDays);
-                Assert.Equal(parameters4.DiffBackupIntervalInHours, policy4.DiffBackupIntervalInHours);
             }
         }
 
+        [Fact]
+        public async void TestShortTermRetentionPolicyOnGeneralPurposeScriptUse()
+        {
+            using (SqlManagementTestContext context = new SqlManagementTestContext(this))
+            {
+                // Valid Retention Days for GeneralPurpose DB is 1 to 35 days. 
+                int defaultRetentionDays = 7;
+
+                // Create a vCore - GeneralPurpose DB.
+                ResourceGroup resourceGroup = context.CreateResourceGroup();
+                Server server = context.CreateServer(resourceGroup);
+                SqlManagementClient sqlClient = context.GetClient<SqlManagementClient>();
+                Database database = sqlClient.Databases.CreateOrUpdate(
+                    resourceGroup.Name, server.Name, SqlManagementTestUtilities.GenerateName(),
+                    new Database
+                    {
+                        Location = server.Location,
+                        Sku = new Microsoft.Azure.Management.Sql.Models.Sku(ServiceObjectiveName.P1)
+                    });
+
+                // Test Update operation through GET operation.
+                var strPolicy = await sqlClient.BackupShortTermRetentionPolicies.GetAsync(resourceGroup.Name.ToString(), server.Name.ToString(), database.Name.ToString());
+                strPolicy.RetentionDays = 28;        
+                await sqlClient.BackupShortTermRetentionPolicies.BeginCreateOrUpdateAsync(resourceGroup.Name.ToString(), server.Name.ToString(), database.Name.ToString(), strPolicy);
+                Assert.Equal(28, strPolicy.RetentionDays);
+            }
+        }
     }
 }


### PR DESCRIPTION
**Remove V2020-02-02-Preview ShortTermRetentionPolicy since there is a bug in the service and it is not ready to publish new feature to customer yet. We need this new version SDK merged asap to avoid customer calling service through .net sdk.** 