### PR TITLE
Avoid unnecessary allocations

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpMessageExtensions.cs
@@ -134,7 +134,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
             {
                 return dataBody.ConvertAndFlattenData();
             }
-            throw new NotSupportedException($"{message.Body.GetType()} is not a supported message body type.");
+            throw new NotSupportedException($"{message.Body.BodyType} is not a supported message body type.");
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using Azure.Core;
 using Azure.Core.Amqp;
 using Azure.Messaging.ServiceBus.Amqp;
@@ -33,7 +34,7 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="body">The payload of the message as a string.</param>
         public ServiceBusMessage(string body) :
-            this(new BinaryData(body))
+            this(Encoding.UTF8.GetBytes(body))
         {
         }
 
@@ -41,16 +42,16 @@ namespace Azure.Messaging.ServiceBus
         /// Creates a new message from the specified payload.
         /// </summary>
         /// <param name="body">The payload of the message in bytes.</param>
-        public ServiceBusMessage(ReadOnlyMemory<byte> body) :
-            this(BinaryData.FromBytes(body))
+        public ServiceBusMessage(ReadOnlyMemory<byte> body)
         {
+            AmqpMessage = new AmqpAnnotatedMessage(new ReadOnlyMemory<byte>[] { body });
         }
 
         /// <summary>
         /// Creates a new message from the specified <see cref="BinaryData"/> instance.
         /// </summary>
         /// <param name="body">The payload of the message.</param>
-        public ServiceBusMessage(BinaryData body)
+        public ServiceBusMessage(BinaryData body) : this (body?.ToMemory() ?? default)
         {
             AmqpMessageBody amqpBody = new AmqpMessageBody(new ReadOnlyMemory<byte>[] { body ?? new BinaryData(Array.Empty<byte>()) });
             AmqpMessage = new AmqpAnnotatedMessage(amqpBody);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusReceivedMessage.cs
@@ -61,13 +61,7 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>
         /// Gets the body of the message.
         /// </summary>
-        public BinaryData Body
-        {
-            get
-            {
-                return AmqpMessage.GetBody();
-            }
-        }
+        public BinaryData Body => AmqpMessage.GetBody();
 
         /// <summary>
         /// Gets the MessageId to identify the message.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -101,8 +101,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
 
                 await client.CreateSender(scope.QueueName).SendMessageAsync(maxSizeMessage);
                 var receiver = client.CreateReceiver(scope.QueueName);
-                var receivedMaxSizeMessage = await receiver.ReceiveMessageAsync();
-                await receiver.CompleteMessageAsync(receivedMaxSizeMessage.LockToken);
+                var receivedMessage = await receiver.ReceiveMessageAsync();
+                Assert.IsNotNull(receivedMessage);
+                await receiver.CompleteMessageAsync(receivedMessage.LockToken);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Message/MessageLiveTests.cs
@@ -91,6 +91,22 @@ namespace Azure.Messaging.ServiceBus.Tests.Message
         }
 
         [Test]
+        public async Task CanSendNullBodyMessage()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                var maxSizeMessage = new ServiceBusMessage((BinaryData)null);
+
+                await client.CreateSender(scope.QueueName).SendMessageAsync(maxSizeMessage);
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var receivedMaxSizeMessage = await receiver.ReceiveMessageAsync();
+                await receiver.CompleteMessageAsync(receivedMaxSizeMessage.LockToken);
+            }
+        }
+
+        [Test]
         public async Task CreateFromReceivedMessageCopiesProperties()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: true, enableSession: true))


### PR DESCRIPTION
Since the Core AMQP type no longer uses BinaryData, we can avoid allocations from a few of the the SBMessage constructors.