### PR TITLE
Azure Monitor Exporter - Modified ExtractRoleInfo to read roleinstance and rolename once 

### DIFF
--- a/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
+++ b/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter
         internal static TelemetryItem GeneratePartAEnvelope(Activity activity)
         {
             TelemetryItem telemetryItem = new TelemetryItem(PartA_Name_Mapping[activity.GetTelemetryType()], activity.StartTimeUtc.ToString(CultureInfo.InvariantCulture));
-            ExtractRoleInfo(activity);
+            InitRoleInfo(activity);
             telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()] = RoleName;
             telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = RoleInstance;
             telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter
             return telemetryItem;
         }
 
-        internal static void ExtractRoleInfo(Activity activity)
+        internal static void InitRoleInfo(Activity activity)
         {
             if (RoleName != null || RoleInstance != null)
             {

--- a/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
+++ b/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter
             [TelemetryType.Event] = "Event",
         };
 
+        internal static string RoleName { get; set; } = null;
+
+        internal static string RoleInstance { get; set; } = null;
+
         internal static List<TelemetryItem> Convert(Batch<Activity> batchActivity, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
@@ -57,9 +61,9 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter
         internal static TelemetryItem GeneratePartAEnvelope(Activity activity)
         {
             TelemetryItem telemetryItem = new TelemetryItem(PartA_Name_Mapping[activity.GetTelemetryType()], activity.StartTimeUtc.ToString(CultureInfo.InvariantCulture));
-            ExtractRoleInfo(activity.GetResource(), out var roleName, out var roleInstance);
-            telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()] = roleName;
-            telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = roleInstance;
+            ExtractRoleInfo(activity);
+            telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()] = RoleName;
+            telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = RoleInstance;
             telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
             if (activity.Parent != null)
             {
@@ -71,18 +75,22 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter
             return telemetryItem;
         }
 
-        internal static void ExtractRoleInfo(Resource resource, out string roleName, out string roleInstance)
+        internal static void ExtractRoleInfo(Activity activity)
         {
+            if (RoleName != null || RoleInstance != null)
+            {
+                return;
+            }
+
+            var resource = activity.GetResource();
+
             if (resource == null)
             {
-                roleName = null;
-                roleInstance = null;
                 return;
             }
 
             string serviceName = null;
             string serviceNamespace = null;
-            roleInstance = null;
 
             foreach (var attribute in resource.Attributes)
             {
@@ -96,17 +104,17 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter
                 }
                 else if (attribute.Key == Resource.ServiceInstanceIdKey && attribute.Value is string)
                 {
-                    roleInstance = attribute.Value.ToString();
+                    RoleInstance = attribute.Value.ToString();
                 }
             }
 
             if (serviceName != null && serviceNamespace != null)
             {
-                roleName = string.Concat(serviceNamespace, ".", serviceName);
+                RoleName = string.Concat(serviceNamespace, ".", serviceName);
             }
             else
             {
-                roleName = serviceName;
+                RoleName = serviceName;
             }
         }
 

--- a/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/tests/Microsoft.Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorConverterTests.cs
+++ b/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/tests/Microsoft.Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorConverterTests.cs
@@ -30,68 +30,81 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
             ActivitySource.AddActivityListener(listener);
         }
 
+        public AzureMonitorConverterTests()
+        {
+            AzureMonitorConverter.RoleName = null;
+            AzureMonitorConverter.RoleInstance = null;
+        }
+
         [Fact]
         public void ExtractRoleInfo_NullResource()
         {
-            AzureMonitorConverter.ExtractRoleInfo(null, out var roleName, out var roleInstance);
-            Assert.Null(roleName);
-            Assert.Null(roleInstance);
+            AzureMonitorConverter.ExtractRoleInfo(null);
+
+            Assert.Null(AzureMonitorConverter.RoleName);
+            Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
         public void ExtractRoleInfo_Empty()
         {
-            var resource = Resources.CreateServiceResource(null);
-            AzureMonitorConverter.ExtractRoleInfo(resource, out var roleName, out var roleInstance);
-            Assert.Null(roleName);
-            Assert.Null(roleInstance);
+            using var activity = new Activity("ExtractRoleInfo_Empty");
+            activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource(null));
+
+            AzureMonitorConverter.ExtractRoleInfo(activity);
+            Assert.Null(AzureMonitorConverter.RoleName);
+            Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
         public void ExtractRoleInfo_ServiceName()
         {
-            var resource = Resources.CreateServiceResource("my-service");
-            AzureMonitorConverter.ExtractRoleInfo(resource, out var roleName, out var roleInstance);
-            Assert.Equal("my-service", roleName);
-            Assert.True(Guid.TryParse(roleInstance, out var guid));
+            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource("my-service"));
+            AzureMonitorConverter.ExtractRoleInfo(activity);
+            Assert.Equal("my-service", AzureMonitorConverter.RoleName);
+            Assert.True(Guid.TryParse(AzureMonitorConverter.RoleInstance, out var guid));
         }
 
         [Fact]
         public void ExtractRoleInfo_ServiceInstance()
         {
-            var resource = Resources.CreateServiceResource(null, "roleInstance_1");
-            AzureMonitorConverter.ExtractRoleInfo(resource, out var roleName, out var roleInstance);
-            Assert.Empty(resource.Attributes);
-            Assert.Null(roleName);
-            Assert.Null(roleInstance);
+            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource(null, "roleInstance_1"));
+            AzureMonitorConverter.ExtractRoleInfo(activity);
+
+            Assert.Null(AzureMonitorConverter.RoleName);
+            Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
         public void ExtractRoleInfo_ServiceNamespace()
         {
-            var resource = Resources.CreateServiceResource(null, null, "my-namespace");
-            AzureMonitorConverter.ExtractRoleInfo(resource, out var roleName, out var roleInstance);
-            Assert.Empty(resource.Attributes);
-            Assert.Null(roleName);
-            Assert.Null(roleInstance);
+            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource(null, null, "my-namespace"));
+            AzureMonitorConverter.ExtractRoleInfo(activity);
+            Assert.Null(AzureMonitorConverter.RoleName);
+            Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
         public void ExtractRoleInfo_ServiceNameAndInstance()
         {
-            var resource = Resources.CreateServiceResource("my-service", "roleInstance_1");
-            AzureMonitorConverter.ExtractRoleInfo(resource, out var roleName, out var roleInstance);
-            Assert.Equal("my-service", roleName);
-            Assert.Equal("roleInstance_1", roleInstance);
+            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource("my-service", "roleInstance_1"));
+            AzureMonitorConverter.ExtractRoleInfo(activity);
+            Assert.Equal("my-service", AzureMonitorConverter.RoleName);
+            Assert.Equal("roleInstance_1", AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
         public void ExtractRoleInfo_ServiceNameAndInstanceAndNamespace()
         {
-            var resource = Resources.CreateServiceResource("my-service", "roleInstance_1", "my-namespace");
-            AzureMonitorConverter.ExtractRoleInfo(resource, out var roleName, out var roleInstance);
-            Assert.Equal("my-namespace.my-service", roleName);
-            Assert.Equal("roleInstance_1", roleInstance);
+            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource("my-service", "roleInstance_1", "my-namespace"));
+            AzureMonitorConverter.ExtractRoleInfo(activity);
+            Assert.Equal("my-namespace.my-service", AzureMonitorConverter.RoleName);
+            Assert.Equal("roleInstance_1", AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]

--- a/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/tests/Microsoft.Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorConverterTests.cs
+++ b/sdk/monitor/Microsoft.Azure.Monitor.OpenTelemetry.Exporter/tests/Microsoft.Azure.Monitor.OpenTelemetry.Exporter.Tests/AzureMonitorConverterTests.cs
@@ -37,72 +37,72 @@ namespace Microsoft.Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
         }
 
         [Fact]
-        public void ExtractRoleInfo_NullResource()
+        public void InitRoleInfo_NullResource()
         {
-            AzureMonitorConverter.ExtractRoleInfo(null);
+            AzureMonitorConverter.InitRoleInfo(null);
 
             Assert.Null(AzureMonitorConverter.RoleName);
             Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
-        public void ExtractRoleInfo_Empty()
+        public void InitRoleInfo_Empty()
         {
-            using var activity = new Activity("ExtractRoleInfo_Empty");
+            using var activity = new Activity("InitRoleInfo_Empty");
             activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource(null));
 
-            AzureMonitorConverter.ExtractRoleInfo(activity);
+            AzureMonitorConverter.InitRoleInfo(activity);
             Assert.Null(AzureMonitorConverter.RoleName);
             Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
-        public void ExtractRoleInfo_ServiceName()
+        public void InitRoleInfo_ServiceName()
         {
-            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            using var activity = new Activity("InitRoleInfo_ServiceName");
             activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource("my-service"));
-            AzureMonitorConverter.ExtractRoleInfo(activity);
+            AzureMonitorConverter.InitRoleInfo(activity);
             Assert.Equal("my-service", AzureMonitorConverter.RoleName);
             Assert.True(Guid.TryParse(AzureMonitorConverter.RoleInstance, out var guid));
         }
 
         [Fact]
-        public void ExtractRoleInfo_ServiceInstance()
+        public void InitRoleInfo_ServiceInstance()
         {
-            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            using var activity = new Activity("InitRoleInfo_ServiceInstance");
             activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource(null, "roleInstance_1"));
-            AzureMonitorConverter.ExtractRoleInfo(activity);
+            AzureMonitorConverter.InitRoleInfo(activity);
 
             Assert.Null(AzureMonitorConverter.RoleName);
             Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
-        public void ExtractRoleInfo_ServiceNamespace()
+        public void InitRoleInfo_ServiceNamespace()
         {
-            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            using var activity = new Activity("InitRoleInfo_ServiceNamespace");
             activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource(null, null, "my-namespace"));
-            AzureMonitorConverter.ExtractRoleInfo(activity);
+            AzureMonitorConverter.InitRoleInfo(activity);
             Assert.Null(AzureMonitorConverter.RoleName);
             Assert.Null(AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
-        public void ExtractRoleInfo_ServiceNameAndInstance()
+        public void InitRoleInfo_ServiceNameAndInstance()
         {
-            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            using var activity = new Activity("InitRoleInfo_ServiceNameAndInstance");
             activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource("my-service", "roleInstance_1"));
-            AzureMonitorConverter.ExtractRoleInfo(activity);
+            AzureMonitorConverter.InitRoleInfo(activity);
             Assert.Equal("my-service", AzureMonitorConverter.RoleName);
             Assert.Equal("roleInstance_1", AzureMonitorConverter.RoleInstance);
         }
 
         [Fact]
-        public void ExtractRoleInfo_ServiceNameAndInstanceAndNamespace()
+        public void InitRoleInfo_ServiceNameAndInstanceAndNamespace()
         {
-            using var activity = new Activity("ExtractRoleInfo_ServiceName");
+            using var activity = new Activity("InitRoleInfo_ServiceNameAndInstanceAndNamespace");
             activity.SetCustomProperty(ResourcePropertyName, Resources.CreateServiceResource("my-service", "roleInstance_1", "my-namespace"));
-            AzureMonitorConverter.ExtractRoleInfo(activity);
+            AzureMonitorConverter.InitRoleInfo(activity);
             Assert.Equal("my-namespace.my-service", AzureMonitorConverter.RoleName);
             Assert.Equal("roleInstance_1", AzureMonitorConverter.RoleInstance);
         }


### PR DESCRIPTION
* Introduced two internal properties `RoleName` and `RoleInstance` to avoid repeatedly reading role name and instance.