### PR TITLE
[Identity] Adding Tenant Id and Authority Host validation

### DIFF
--- a/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
+++ b/sdk/identity/Azure.Identity/api/Azure.Identity.netstandard2.0.cs
@@ -132,7 +132,9 @@ namespace Azure.Identity
     {
         public InteractiveBrowserCredential() { }
         public InteractiveBrowserCredential(Azure.Identity.InteractiveBrowserCredentialOptions options) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public InteractiveBrowserCredential(string clientId) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public InteractiveBrowserCredential(string tenantId, string clientId, Azure.Identity.TokenCredentialOptions options = null) { }
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -155,6 +157,7 @@ namespace Azure.Identity
     {
         public SharedTokenCacheCredential() { }
         public SharedTokenCacheCredential(Azure.Identity.SharedTokenCacheCredentialOptions options) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public SharedTokenCacheCredential(string username, Azure.Identity.TokenCredentialOptions options = null) { }
         public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/identity/Azure.Identity/src/AuthorizationCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AuthorizationCodeCredential.cs
@@ -56,7 +56,8 @@ namespace Azure.Identity
         /// <param name="options">Options that allow to configure the management of the requests sent to the Azure Active Directory service.</param>
         public AuthorizationCodeCredential(string tenantId, string clientId, string clientSecret, string authorizationCode, TokenCredentialOptions options)
         {
-            if (tenantId is null) throw new ArgumentNullException(nameof(tenantId));
+            Validations.ValidateTenantId(tenantId, nameof(tenantId));
+
             if (clientSecret is null) throw new ArgumentNullException(nameof(clientSecret));
 
             _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));

--- a/sdk/identity/Azure.Identity/src/AzureAuthorityHosts.cs
+++ b/sdk/identity/Azure.Identity/src/AzureAuthorityHosts.cs
@@ -36,7 +36,12 @@ namespace Azure.Identity
 
         internal static Uri GetDefault()
         {
-            return EnvironmentVariables.AuthorityHost != null ? new Uri(EnvironmentVariables.AuthorityHost) : AzurePublicCloud;
+            if (EnvironmentVariables.AuthorityHost != null)
+            {
+                return new Uri(EnvironmentVariables.AuthorityHost);
+            }
+
+            return AzurePublicCloud;
         }
 
         internal static string GetDefaultScope(Uri authorityHost)

--- a/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientCertificateCredential.cs
@@ -125,7 +125,7 @@ namespace Azure.Identity
 
         internal ClientCertificateCredential(string tenantId, string clientId, IX509Certificate2Provider certificateProvider, TokenCredentialOptions options, CredentialPipeline pipeline, MsalConfidentialClient client)
         {
-            TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+            TenantId = Validations.ValidateTenantId(tenantId, nameof(tenantId));
 
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
 

--- a/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ClientSecretCredential.cs
@@ -79,7 +79,7 @@ namespace Azure.Identity
 
         internal ClientSecretCredential(string tenantId, string clientId, string clientSecret, TokenCredentialOptions options, CredentialPipeline pipeline, MsalConfidentialClient client)
         {
-            TenantId = tenantId ?? throw new ArgumentNullException(nameof(tenantId));
+            TenantId = Validations.ValidateTenantId(tenantId, nameof(tenantId));
 
             ClientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
 

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -57,7 +57,9 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="options">Options that configure the management of the requests sent to Azure Active Directory services, and determine which credentials are included in the <see cref="DefaultAzureCredential"/> authentication flow.</param>
         public DefaultAzureCredential(DefaultAzureCredentialOptions options)
-            : this(new DefaultAzureCredentialFactory(options), options)
+            // we call ValidateAuthoriyHostOption to validate that we have a valid authority host before constructing the DAC chain
+            // if we don't validate this up front it will end up throwing an exception out of a static initializer which obscures the error.
+            : this(new DefaultAzureCredentialFactory(ValidateAuthorityHostOption(options)), options)
         {
         }
 
@@ -215,6 +217,13 @@ namespace Azure.Identity
             }
 
             return chain;
+        }
+
+        private static DefaultAzureCredentialOptions ValidateAuthorityHostOption(DefaultAzureCredentialOptions options)
+        {
+            Validations.ValidateAuthorityHost(options?.AuthorityHost ?? AzureAuthorityHosts.GetDefault());
+
+            return options;
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredential.cs
@@ -67,7 +67,7 @@ namespace Azure.Identity
         /// <param name="options">The client options for the newly created DeviceCodeCredential</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public DeviceCodeCredential(Func<DeviceCodeInfo, CancellationToken, Task> deviceCodeCallback, string tenantId, string clientId,  TokenCredentialOptions options = default)
-            : this(deviceCodeCallback, tenantId, clientId, options, null)
+            : this(deviceCodeCallback, Validations.ValidateTenantId(tenantId, nameof(tenantId), allowNull:true), clientId, options, null)
         {
         }
 

--- a/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/DeviceCodeCredentialOptions.cs
@@ -12,6 +12,8 @@ namespace Azure.Identity
     /// </summary>
     public class DeviceCodeCredentialOptions : TokenCredentialOptions, ITokenCacheOptions
     {
+        private string _tenantId = null;
+
         /// <summary>
         /// Prevents the <see cref="DeviceCodeCredential"/> from automatically prompting the user. If automatic authentication is disabled a AuthenticationRequiredException will be thrown from <see cref="DeviceCodeCredential.GetToken"/> and <see cref="DeviceCodeCredential.GetTokenAsync"/> in the case that
         /// user interaction is necessary. The application is responsible for handling this exception, and calling <see cref="DeviceCodeCredential.Authenticate(CancellationToken)"/> or <see cref="DeviceCodeCredential.AuthenticateAsync(CancellationToken)"/> to authenticate the user interactively.
@@ -21,7 +23,11 @@ namespace Azure.Identity
         /// <summary>
         /// The tenant ID the user will be authenticated to. If not specified the user will be authenticated to their home tenant.
         /// </summary>
-        public string TenantId { get; set; }
+        public string TenantId
+        {
+            get { return _tenantId; }
+            set { _tenantId = Validations.ValidateTenantId(value, allowNull: true); }
+        }
 
         /// <summary>
         /// The client ID of the application used to authenticate the user. If not specified the user will be authenticated with an Azure development application.

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredential.cs
@@ -5,6 +5,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Identity.Client;
 using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -49,6 +50,7 @@ namespace Azure.Identity
         /// Creates a new <see cref="InteractiveBrowserCredential"/> with the specified options, which will authenticate users with the specified application.
         /// </summary>
         /// <param name="clientId">The client id of the application to which the users will authenticate</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public InteractiveBrowserCredential(string clientId)
             : this(null, clientId, null, null)
         {
@@ -62,8 +64,9 @@ namespace Azure.Identity
         /// <param name="clientId">The client id of the application to which the users will authenticate</param>
         /// TODO: need to link to info on how the application has to be created to authenticate users, for multiple applications
         /// <param name="options">The client options for the newly created <see cref="InteractiveBrowserCredential"/>.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public InteractiveBrowserCredential(string tenantId, string clientId, TokenCredentialOptions options = default)
-            : this(tenantId, clientId, options, null, null)
+            : this(Validations.ValidateTenantId(tenantId, nameof(tenantId), allowNull:true), clientId, options, null, null)
         {
         }
 

--- a/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/InteractiveBrowserCredentialOptions.cs
@@ -11,6 +11,8 @@ namespace Azure.Identity
     /// </summary>
     public class InteractiveBrowserCredentialOptions : TokenCredentialOptions, ITokenCacheOptions
     {
+        private string _tenantId = null;
+
         /// <summary>
         /// Prevents the <see cref="InteractiveBrowserCredential"/> from automatically prompting the user. If automatic authentication is disabled a AuthenticationRequiredException will be thrown from <see cref="InteractiveBrowserCredential.GetToken"/> and <see cref="InteractiveBrowserCredential.GetTokenAsync"/> in the case that
         /// user interaction is necessary. The application is responsible for handling this exception, and calling <see cref="InteractiveBrowserCredential.Authenticate(CancellationToken)"/> or <see cref="InteractiveBrowserCredential.AuthenticateAsync(CancellationToken)"/> to authenticate the user interactively.
@@ -20,7 +22,11 @@ namespace Azure.Identity
         /// <summary>
         /// The tenant ID the user will be authenticated to. If not specified the user will be authenticated to the home tenant.
         /// </summary>
-        public string TenantId { get; set; }
+        public string TenantId
+        {
+            get { return _tenantId; }
+            set { _tenantId = Validations.ValidateTenantId(value, allowNull: true); }
+        }
 
         /// <summary>
         /// The client ID of the application used to authenticate the user. If not specified the user will be authenticated with an Azure development application.

--- a/sdk/identity/Azure.Identity/src/MsalClientBase.cs
+++ b/sdk/identity/Azure.Identity/src/MsalClientBase.cs
@@ -27,6 +27,13 @@ namespace Azure.Identity
 
         protected MsalClientBase(CredentialPipeline pipeline, string tenantId, string clientId, ITokenCacheOptions cacheOptions)
         {
+            // This validation is preformed as a backstop. Validation in TokenCredentialOptions.AuthorityHost prevents users from explicitly
+            // setting AuthorityHost to a non TLS endpoint. However, the AuthorityHost can also be set by the AZURE_AUTHORITY_HOST environment
+            // variable rather than in code. In this case we need to validate the endpoint before we use it. However, we can't validate in
+            // CredentialPipeline as this is also used by the ManagedIdentityCredential which allows non TLS endpoints. For this reason
+            // we validate here as all other credentials will create an MSAL client.
+            Validations.ValidateAuthorityHost(pipeline.AuthorityHost);
+
             Pipeline = pipeline;
 
             TenantId = tenantId;

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredential.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
 using Azure.Core.Pipeline;
+using System.ComponentModel;
 
 namespace Azure.Identity
 {
@@ -53,6 +54,7 @@ namespace Azure.Identity
         /// </summary>
         /// <param name="username">The username of the user to authenticate</param>
         /// <param name="options">The client options for the newly created <see cref="SharedTokenCacheCredential"/></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public SharedTokenCacheCredential(string username, TokenCredentialOptions options = default)
             : this(null, username, options, null, null)
         {

--- a/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/SharedTokenCacheCredentialOptions.cs
@@ -8,6 +8,8 @@ namespace Azure.Identity
     /// </summary>
     public class SharedTokenCacheCredentialOptions : TokenCredentialOptions, ITokenCacheOptions
     {
+        private string _tenantId = null;
+
         /// <summary>
         /// Specifies the preferred authentication account username, or UPN, to be retrieved from the shared token cache for single sign on authentication with
         /// development tools, in the case multiple accounts are found in the shared token.
@@ -18,7 +20,11 @@ namespace Azure.Identity
         /// Specifies the tenant id of the preferred authentication account, to be retrieved from the shared token cache for single sign on authentication with
         /// development tools, in the case multiple accounts are found in the shared token.
         /// </summary>
-        public string TenantId { get; set; }
+        public string TenantId
+        {
+            get { return _tenantId; }
+            set { _tenantId = Validations.ValidateTenantId(value, allowNull: true); }
+        }
 
         /// <summary>
         /// The <see cref="Identity.AuthenticationRecord"/> captured from a previous authentication with an interactive credential, such as the <see cref="InteractiveBrowserCredential"/> or <see cref="DeviceCodeCredential"/>.

--- a/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCredentialOptions.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity
         public Uri AuthorityHost
         {
             get { return _authorityHost ?? AzureAuthorityHosts.GetDefault(); }
-            set { _authorityHost = value; }
+            set { _authorityHost = Validations.ValidateAuthorityHost(value); }
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/UsernamePasswordCredential.cs
+++ b/sdk/identity/Azure.Identity/src/UsernamePasswordCredential.cs
@@ -86,7 +86,7 @@ namespace Azure.Identity
 
             _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
 
-            if (tenantId == null) throw new ArgumentNullException(nameof(tenantId));
+            Validations.ValidateTenantId(tenantId, nameof(tenantId));
 
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(options);
 

--- a/sdk/identity/Azure.Identity/src/Validations.cs
+++ b/sdk/identity/Azure.Identity/src/Validations.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Identity
+{
+    internal static class Validations
+    {
+
+
+
+        private const string InvalidTenantIdErrorMessage = "Invalid tenant id provided. You can locate your tenant id by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names";
+
+        private const string NullTenantIdErrorMessage = "Tenant id cannot be null. You can locate your tenant id by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names";
+
+        /// <summary>
+        /// As tenant id is used in constructing authority endpoints and in command line invocation we validate the character set of the tenant id matches allowed characters.
+        /// </summary>
+        public static string ValidateTenantId(string tenantId, string argumentName = default, bool allowNull = false)
+        {
+            if (tenantId != null)
+            {
+                if (tenantId.Length == 0)
+                {
+                    throw (argumentName != null) ? new ArgumentException(InvalidTenantIdErrorMessage, argumentName) : new ArgumentException(InvalidTenantIdErrorMessage);
+                }
+
+                foreach (char c in tenantId)
+                {
+                    if (!IsValidTenantCharacter(c))
+                    {
+                        throw (argumentName != null) ? new ArgumentException(InvalidTenantIdErrorMessage, argumentName) : new ArgumentException(InvalidTenantIdErrorMessage);
+                    }
+                }
+            }
+            else if (!allowNull)
+            {
+                throw (argumentName != null) ? new ArgumentNullException(argumentName, NullTenantIdErrorMessage) : new ArgumentNullException(InvalidTenantIdErrorMessage, (Exception)null);
+            }
+
+            return tenantId;
+        }
+
+        private static bool IsValidTenantCharacter(char c)
+        {
+            return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '.') || (c == '-');
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/Validations.cs
+++ b/sdk/identity/Azure.Identity/src/Validations.cs
@@ -14,6 +14,8 @@ namespace Azure.Identity
 
         private const string NullTenantIdErrorMessage = "Tenant id cannot be null. You can locate your tenant id by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names";
 
+        private const string NonTlsAuthorityHostErrorMessage = "Authority host must be a TLS protected (https) endpoint.";
+
         /// <summary>
         /// As tenant id is used in constructing authority endpoints and in command line invocation we validate the character set of the tenant id matches allowed characters.
         /// </summary>
@@ -40,6 +42,19 @@ namespace Azure.Identity
             }
 
             return tenantId;
+        }
+
+        public static Uri ValidateAuthorityHost(Uri authorityHost)
+        {
+            if (authorityHost != null)
+            {
+                if (string.Compare(authorityHost.Scheme, "https", StringComparison.OrdinalIgnoreCase) != 0)
+                {
+                    throw new ArgumentException(NonTlsAuthorityHostErrorMessage);
+                }
+            }
+
+            return authorityHost;
         }
 
         private static bool IsValidTenantCharacter(char c)

--- a/sdk/identity/Azure.Identity/src/Validations.cs
+++ b/sdk/identity/Azure.Identity/src/Validations.cs
@@ -7,9 +7,6 @@ namespace Azure.Identity
 {
     internal static class Validations
     {
-
-
-
         private const string InvalidTenantIdErrorMessage = "Invalid tenant id provided. You can locate your tenant id by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names";
 
         private const string NullTenantIdErrorMessage = "Tenant id cannot be null. You can locate your tenant id by following the instructions listed here: https://docs.microsoft.com/partner-center/find-ids-and-domain-names";

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredentialOptions.cs
@@ -12,9 +12,15 @@ namespace Azure.Identity
     /// </summary>
     public class VisualStudioCodeCredentialOptions : TokenCredentialOptions
     {
+        private string _tenantId = null;
+
         /// <summary>
         /// The tenant ID the user will be authenticated to. If not specified the user will be authenticated to the tenant the user originally authenticated to via the Visual Studio Code Azure Account plugin.
         /// </summary>
-        public string TenantId { get; set; }
+        public string TenantId
+        {
+            get { return _tenantId; }
+            set { _tenantId = Validations.ValidateTenantId(value, allowNull: true); }
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/src/VisualStudioCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCredentialOptions.cs
@@ -8,9 +8,15 @@ namespace Azure.Identity
     /// </summary>
     public class VisualStudioCredentialOptions : TokenCredentialOptions
     {
+        private string _tenantId = null;
+
         /// <summary>
         /// The tenant ID the user will be authenticated to. If not specified the user will be authenticated to their home tenant.
         /// </summary>
-        public string TenantId { get; set; }
+        public string TenantId
+        {
+            get { return _tenantId; }
+            set { _tenantId = Validations.ValidateTenantId(value, allowNull: true); }
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/AzureIdentityEventSourceTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzureIdentityEventSourceTests.cs
@@ -53,7 +53,7 @@ namespace Azure.Identity.Tests
         {
             var mockMsalClient = new MockMsalConfidentialClient(AuthenticationResultFactory.Create());
 
-            var credential = InstrumentClient(new ClientSecretCredential("", "", "", default, default, mockMsalClient));
+            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), default, default, mockMsalClient));
 
             var method = "ClientSecretCredential.GetToken";
 
@@ -67,7 +67,7 @@ namespace Azure.Identity.Tests
 
             var mockAadClient = new MockAadIdentityClient(() => new AccessToken(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow.AddMinutes(10)));
 
-            var credential = InstrumentClient(new ClientCertificateCredential("", "", new X509Certificate2(), default, default, mockMsalClient));
+            var credential = InstrumentClient(new ClientCertificateCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new X509Certificate2(), default, default, mockMsalClient));
 
             var method = "ClientCertificateCredential.GetToken";
 
@@ -79,7 +79,7 @@ namespace Azure.Identity.Tests
         {
             var mockMsalClient = new MockMsalPublicClient() { DeviceCodeAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: Guid.NewGuid().ToString(), expiresOn: DateTimeOffset.UtcNow.AddMinutes(10)); } };
 
-            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, default, "", default, default, mockMsalClient));
+            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, default, Guid.NewGuid().ToString(), default, default, mockMsalClient));
 
             var method = "DeviceCodeCredential.GetToken";
 
@@ -91,7 +91,7 @@ namespace Azure.Identity.Tests
         {
             var mockMsalClient = new MockMsalPublicClient() { InteractiveAuthFactory = (_) => { return AuthenticationResultFactory.Create(accessToken: Guid.NewGuid().ToString(), expiresOn: DateTimeOffset.UtcNow.AddMinutes(10)); } };
 
-            var credential = InstrumentClient(new InteractiveBrowserCredential(default, "", default, default, mockMsalClient));
+            var credential = InstrumentClient(new InteractiveBrowserCredential(default, Guid.NewGuid().ToString(), default, default, mockMsalClient));
 
             var method = "InteractiveBrowserCredential.GetToken";
 
@@ -121,7 +121,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalConfidentialClient(new MockClientException(expExMessage));
 
-            var credential = InstrumentClient(new ClientSecretCredential("", "", "", default, default, mockMsalClient));
+            var credential = InstrumentClient(new ClientSecretCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), default, default, mockMsalClient));
 
             var method = "ClientSecretCredential.GetToken";
 
@@ -135,7 +135,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalConfidentialClient(new MockClientException(expExMessage));
 
-            var credential = InstrumentClient(new ClientCertificateCredential("", "", new X509Certificate2(), default, default, mockMsalClient));
+            var credential = InstrumentClient(new ClientCertificateCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), new X509Certificate2(), default, default, mockMsalClient));
 
             var method = "ClientCertificateCredential.GetToken";
 
@@ -149,7 +149,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalPublicClient() { DeviceCodeAuthFactory = (_) => throw new MockClientException(expExMessage) };
 
-            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, default, "", default, default, mockMsalClient));
+            var credential = InstrumentClient(new DeviceCodeCredential((_, __) => { return Task.CompletedTask; }, default, Guid.NewGuid().ToString(), default, default, mockMsalClient));
 
             var method = "DeviceCodeCredential.GetToken";
 
@@ -163,7 +163,7 @@ namespace Azure.Identity.Tests
 
             var mockMsalClient = new MockMsalPublicClient() { InteractiveAuthFactory = (_) => throw new MockClientException(expExMessage) };
 
-            var credential = InstrumentClient(new InteractiveBrowserCredential("", "", default, default, mockMsalClient));
+            var credential = InstrumentClient(new InteractiveBrowserCredential(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), default, default, mockMsalClient));
 
             var method = "InteractiveBrowserCredential.GetToken";
 

--- a/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
@@ -31,7 +31,5 @@ namespace Azure.Identity.Tests
         public string ServicePrincipalCertificatePfxPath => GetOptionalVariable("IDENTITY_SP_CERT_PFX") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
         public string ServicePrincipalCertificatePemPath => GetOptionalVariable("IDENTITY_SP_CERT_PEM") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pem");
         public string ServicePrincipalSniCertificatePath => GetOptionalVariable("IDENTITY_SP_CERT_SNI") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
-
-        public string NewId() => Guid.NewGuid().ToString();
     }
 }

--- a/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
+++ b/sdk/identity/Azure.Identity/tests/IdentityTestEnvironment.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -30,5 +31,7 @@ namespace Azure.Identity.Tests
         public string ServicePrincipalCertificatePfxPath => GetOptionalVariable("IDENTITY_SP_CERT_PFX") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
         public string ServicePrincipalCertificatePemPath => GetOptionalVariable("IDENTITY_SP_CERT_PEM") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pem");
         public string ServicePrincipalSniCertificatePath => GetOptionalVariable("IDENTITY_SP_CERT_SNI") ?? Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
+
+        public string NewId() => Guid.NewGuid().ToString();
     }
 }

--- a/sdk/identity/Azure.Identity/tests/TenantIdValidationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TenantIdValidationTests.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    public class TenantIdValidationTests
+    {
+        [Test]
+        public void AuthorizationCodeCredential([Values(null, "", "invalid?character")] string tenantId)
+        {
+            string clientId = Guid.NewGuid().ToString();
+            string clientSecret = Guid.NewGuid().ToString();
+            string authCode = Guid.NewGuid().ToString();
+
+            var ex = Assert.Catch<ArgumentException>(() => new AuthorizationCodeCredential(tenantId, clientId, clientSecret, authCode));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new AuthorizationCodeCredential(tenantId, clientId, clientSecret, authCode, new TokenCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+        }
+
+        [Test]
+        public void ClientCertificateCredential([Values(null, "", "invalid?character")] string tenantId)
+        {
+            var clientId = Guid.NewGuid().ToString();
+
+            var certificatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
+
+            var ex = Assert.Catch<ArgumentException>(() => new ClientCertificateCredential(tenantId, clientId, certificatePath));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new ClientCertificateCredential(tenantId, clientId, certificatePath, new TokenCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new ClientCertificateCredential(tenantId, clientId, certificatePath, new ClientCertificateCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            var certificate = new X509Certificate2(certificatePath);
+
+            ex = Assert.Catch<ArgumentException>(() => new ClientCertificateCredential(tenantId, clientId, certificate));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new ClientCertificateCredential(tenantId, clientId, certificate, new TokenCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new ClientCertificateCredential(tenantId, clientId, certificate, new ClientCertificateCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+        }
+        [Test]
+        public void ClientSecretCredential([Values(null, "", "invalid?character")] string tenantId)
+        {
+            var clientId = Guid.NewGuid().ToString();
+
+            var secret = Guid.NewGuid().ToString();
+
+            var ex = Assert.Catch<ArgumentException>(() => new ClientSecretCredential(tenantId, clientId, secret));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new ClientSecretCredential(tenantId, clientId, secret, new TokenCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new ClientSecretCredential(tenantId, clientId, secret, new ClientSecretCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+        }
+
+        [Test]
+        public void DeviceCodeCredentialOptionsInvalidTenantId([Values("", "invalid?character")] string tenantId)
+        {
+            var options = new DeviceCodeCredentialOptions();
+
+            var ex = Assert.Catch<ArgumentException>(() => options.TenantId = tenantId);
+
+            ValidateTenantIdArgumentException(tenantId, null, ex);
+        }
+
+        [Test]
+        public void DeviceCodeCredentialOptionsNullTenantId()
+        {
+            var options = new DeviceCodeCredentialOptions();
+
+            // validate no exception is thrown when setting TenantId to null
+            options.TenantId = null;
+        }
+
+        [Test]
+        public void DeviceCodeCredentialCtorInvalidTenantId([Values("", "invalid?character")] string tenantId)
+        {
+            var clientId = Guid.NewGuid().ToString();
+
+            var ex = Assert.Catch<ArgumentException>(() => new DeviceCodeCredential(DeviceCodeCredential.DefaultDeviceCodeHandler, tenantId, clientId));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new DeviceCodeCredential(DeviceCodeCredential.DefaultDeviceCodeHandler, tenantId, clientId, new TokenCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+        }
+
+        [Test]
+        public void DeviceCodeCredentialCtorNullTenantId()
+        {
+            var clientId = Guid.NewGuid().ToString();
+
+            // validate no exception is thrown when setting TenantId to null
+            var cred = new DeviceCodeCredential(DeviceCodeCredential.DefaultDeviceCodeHandler, null, clientId);
+
+            cred = new DeviceCodeCredential(DeviceCodeCredential.DefaultDeviceCodeHandler, null, clientId, new TokenCredentialOptions());
+        }
+
+        [Test]
+        public void InteractiveBrowserCredentialOptionsInvalidTenantId([Values("", "invalid?character")] string tenantId)
+        {
+            var options = new InteractiveBrowserCredentialOptions();
+
+            var ex = Assert.Catch<ArgumentException>(() => options.TenantId = tenantId);
+
+            ValidateTenantIdArgumentException(tenantId, null, ex);
+        }
+
+        [Test]
+        public void InteractiveBrowserCredentialOptionsNullTenantId()
+        {
+            var options = new InteractiveBrowserCredentialOptions();
+
+            // validate no exception is thrown when setting TenantId to null
+            options.TenantId = null;
+        }
+
+        [Test]
+        public void InteractiveBrowserCredentialCtorInvalidTenantId([Values("", "invalid?character")] string tenantId)
+        {
+            var clientId = Guid.NewGuid().ToString();
+
+            var ex = Assert.Catch<ArgumentException>(() => new InteractiveBrowserCredential(tenantId, clientId));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new InteractiveBrowserCredential(tenantId, clientId, new TokenCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+        }
+
+        [Test]
+        public void InteractiveBrowserCredentialCtorNullTenantId()
+        {
+            var clientId = Guid.NewGuid().ToString();
+
+            // validate no exception is thrown when setting TenantId to null
+            var cred = new InteractiveBrowserCredential(null, clientId);
+
+            cred = new InteractiveBrowserCredential(null, clientId, new TokenCredentialOptions());
+        }
+
+        [Test]
+        public void SharedTokenCacheCredentialOptionsInvalidTenantId([Values("", "invalid?character")] string tenantId)
+        {
+            var options = new SharedTokenCacheCredentialOptions();
+
+            var ex = Assert.Catch<ArgumentException>(() => options.TenantId = tenantId);
+
+            ValidateTenantIdArgumentException(tenantId, null, ex);
+        }
+
+        [Test]
+        public void SharedTokenCacheCredentialOptionsNullTenantId()
+        {
+            var options = new SharedTokenCacheCredentialOptions();
+
+            // validate no exception is thrown when setting TenantId to null
+            options.TenantId = null;
+        }
+
+        [Test]
+        public void UsernamePasswordCredential([Values(null, "", "invalid?character")] string tenantId)
+        {
+            var username = Guid.NewGuid().ToString();
+            var password = Guid.NewGuid().ToString();
+            var clientId = Guid.NewGuid().ToString();
+
+            var ex = Assert.Catch<ArgumentException>(() => new UsernamePasswordCredential(username, password, tenantId, clientId));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new UsernamePasswordCredential(username, password, tenantId, clientId, new TokenCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+
+            ex = Assert.Catch<ArgumentException>(() => new UsernamePasswordCredential(username, password, tenantId, clientId, new UsernamePasswordCredentialOptions()));
+
+            ValidateTenantIdArgumentException(tenantId, "tenantId", ex);
+        }
+
+        [Test]
+        public void VisualStudioCredentialOptionsInvalidTenantId([Values("", "invalid?character")] string tenantId)
+        {
+            var options = new VisualStudioCredentialOptions();
+
+            var ex = Assert.Catch<ArgumentException>(() => options.TenantId = tenantId);
+
+            ValidateTenantIdArgumentException(tenantId, null, ex);
+        }
+
+        [Test]
+        public void VisualStudioCredentialOptionsNullTenantId()
+        {
+            var options = new VisualStudioCredentialOptions();
+
+            // validate no exception is thrown when setting TenantId to null
+            options.TenantId = null;
+        }
+
+        [Test]
+        public void VisualStudioCodeCredentialOptionsInvalidTenantId([Values("", "invalid?character")] string tenantId)
+        {
+            var options = new VisualStudioCodeCredentialOptions();
+
+            var ex = Assert.Catch<ArgumentException>(() => options.TenantId = tenantId);
+
+            ValidateTenantIdArgumentException(tenantId, null, ex);
+        }
+
+        [Test]
+        public void VisualStudioCodeCredentialOptionsNullTenantId()
+        {
+            var options = new VisualStudioCodeCredentialOptions();
+
+            // validate no exception is thrown when setting TenantId to null
+            options.TenantId = null;
+        }
+
+        private void ValidateTenantIdArgumentException(string tenantId, string argumentName, ArgumentException ex)
+        {
+            Assert.AreEqual(argumentName, ex.ParamName);
+
+            if (tenantId == null)
+            {
+                Assert.True(ex is ArgumentNullException);
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenCredentialOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IO;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
 
@@ -67,6 +68,37 @@ namespace Azure.Identity.Tests
                 TokenCredentialOptions option = new TokenCredentialOptions();
 
                 Assert.AreEqual(option.AuthorityHost, AzureAuthorityHosts.AzurePublicCloud);
+            }
+        }
+
+        [Test]
+        public void SetAuthorityHostToNonHttpsEndpointThrows()
+        {
+            TokenCredentialOptions options = new TokenCredentialOptions();
+
+            Assert.Throws<ArgumentException>(() => options.AuthorityHost = new Uri("http://unprotected.login.com"));
+        }
+
+        [NonParallelizable]
+        [Test]
+        public void EnviornmentSpecifiedNonHttpsAuthorityHostFails()
+        {
+            string tenantId = Guid.NewGuid().ToString();
+            string clientId = Guid.NewGuid().ToString();
+            string username = Guid.NewGuid().ToString();
+            string password = Guid.NewGuid().ToString();
+            var certificatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
+
+            using (new TestEnvVar("AZURE_AUTHORITY_HOST", "http://unprotected.login.com"))
+            {
+                Assert.Throws<ArgumentException>(() => new ClientCertificateCredential(tenantId, clientId, certificatePath, new ClientCertificateCredentialOptions()));
+                Assert.Throws<ArgumentException>(() => new ClientSecretCredential(tenantId, clientId, password, new TokenCredentialOptions()));
+                Assert.Throws<ArgumentException>(() => new DefaultAzureCredential(new DefaultAzureCredentialOptions()));
+                Assert.Throws<ArgumentException>(() => new DeviceCodeCredential(new DeviceCodeCredentialOptions()));
+                Assert.Throws<ArgumentException>(() => new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions()));
+                Assert.Throws<ArgumentException>(() => new SharedTokenCacheCredential(new SharedTokenCacheCredentialOptions()));
+                Assert.Throws<ArgumentException>(() => new VisualStudioCodeCredential(new VisualStudioCodeCredentialOptions()));
+                Assert.Throws<ArgumentException>(() => new UsernamePasswordCredential(tenantId, clientId, username, password, new TokenCredentialOptions()));
             }
         }
     }


### PR DESCRIPTION
This PR adds validation to tenant id and authority host specified during credential construction or through the environment.

Fixes #15782