### PR TITLE
feat(e2e): Added bicep template to help generate the ARM template

### DIFF
--- a/sdk/digitaltwins/test-resources.bicep
+++ b/sdk/digitaltwins/test-resources.bicep
@@ -1,0 +1,110 @@
+param testApplicationOid string {
+    metadata: {
+        description: 'The client OID to grant access to test resources.'
+    }
+}
+
+param baseName string {
+    default : resourceGroup().name
+    minLength: 6
+    maxLength: 50
+    metadata: {
+        description: 'The base resource name.'
+    }
+}
+
+param location string {
+    default: resourceGroup().location
+    metadata: {
+        description: 'The location of the resource. By default, this is the same as the resource group.'
+    }
+} 
+
+var rbacOwnerRoleDefinitionId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
+var adtOwnerRoleDefinitionId = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe'
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2018-09-01-preview' = {
+    name: guid(resourceGroup().id)
+    properties: {
+        roleDefinitionId: rbacOwnerRoleDefinitionId
+        principalId: testApplicationOid
+    }
+}
+
+resource digitaltwin 'Microsoft.DigitalTwins/digitalTwinsInstances@2020-03-01-preview' = {
+    name: baseName
+    location: location
+    sku: {
+        name: 'S1'
+    }
+    properties: {}
+}
+
+resource digitaltwinRoleAssignment 'Microsoft.DigitalTwins/digitalTwinsInstances/providers/roleAssignments@2020-03-01-preview' = {
+    name: '${digitaltwin.name}/Microsoft.Authorization/${guid(uniqueString(baseName))}'
+    properties: {
+        roleDefinitionId: adtOwnerRoleDefinitionId
+        principalId: testApplicationOid
+    }
+}
+
+resource eventHubNamespace 'Microsoft.EventHub/namespaces@2018-01-01-preview' = {
+    name: baseName
+    location: location
+    sku: {
+        name: 'Standard'
+        tier: 'Standard'
+        capacity: 1
+    }
+    properties: {
+        zoneRedundant: false
+        isAutoInflateEnabled: false
+        maximumThroughputUnits: 0
+        kafkaEnabled: false
+    }
+}
+
+resource eventHubNamespaceEventHub 'Microsoft.EventHub/namespaces/eventhubs@2017-04-01' = {
+    name: '${eventHubNamespace.name}/${baseName}'
+    location: location
+    properties: {
+        messageRetentionInDays: 7
+        partitionCount: 4
+        status: 'Active'
+    }
+}
+
+resource eventHubNamespaceAuthRules 'Microsoft.EventHub/namespaces/AuthorizationRules@2017-04-01' = {
+    name: '${eventHubNamespace.name}/RootManageSharedAccessKey'
+    location: location
+    properties: {
+        rights: [
+            'Listen'
+            'Manage'
+            'Send'
+        ]
+    }
+}
+ 
+resource eventHubNamespaceEventHubAuthRules 'Microsoft.EventHub/namespaces/eventhubs/authorizationRules@2017-04-01' = {
+    name: '${eventHubNamespaceEventHub.name}/owner'
+    location: location
+    properties: {
+        rights: [
+            'Listen'
+            'Manage'
+            'Send'
+        ]
+    }
+}
+
+resource digitaltwinEndpoints 'Microsoft.DigitalTwins/digitalTwinsInstances/endpoints@2020-03-01-preview' = {
+    name: '${digitaltwin.name}/someEventHubEndpoint'
+    properties: {
+        endpointType: 'EventHub'
+        'connectionString-PrimaryKey': listKeys(eventHubNamespaceEventHubAuthRules.id, '2017-04-01').primaryConnectionString
+        'connectionString-SecondaryKey': listKeys(eventHubNamespaceEventHubAuthRules.id, '2017-04-01').secondaryConnectionString
+    }
+}
+
+output DIGITALTWINS_URL string = 'https://${digitaltwin.properties.hostName}'

--- a/sdk/digitaltwins/test-resources.json
+++ b/sdk/digitaltwins/test-resources.json
@@ -1,37 +1,34 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "baseName": {
-      "type": "string",
-      "minLength": 6,
-      "maxLength": 50,
-      "defaultValue": "[resourceGroup().name]",
-      "metadata": {
-        "description": "The base resource name."
-      }
-    },
     "testApplicationOid": {
       "type": "string",
       "metadata": {
         "description": "The client OID to grant access to test resources."
       }
     },
+    "baseName": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 50,
+      "metadata": {
+        "description": "The base resource name."
+      },
+      "defaultValue": "[resourceGroup().name]"
+    },
     "location": {
       "type": "string",
-      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "The location of the resource. By default, this is the same as the resource group."
-      }
+      },
+      "defaultValue": "[resourceGroup().location]"
     }
   },
+  "functions": [],
   "variables": {
-    "digitalTwinInstanceResourceId": "[resourceId('Microsoft.DigitalTwins/digitalTwinsInstances', parameters('baseName'))]",
-    "namespaceResourceId": "[resourceId('Microsoft.EventHub/namespaces', parameters('baseName'))]",
-    "eventHubResourceId": "[resourceId('Microsoft.EventHub/namespaces/eventhubs', parameters('baseName'), parameters('baseName'))]",
-    "eventHubAuthorizationResourceId": "[resourceId('Microsoft.EventHub/namespaces/eventhubs/authorizationRules', parameters('baseName'), parameters('baseName'), 'owner')]",
-    "rbacOwnerRoleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-    "AdtOwnerRoleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'bcd981a7-7f74-457b-83e1-cceb9e632ffe')]"
+    "rbacOwnerRoleDefinitionId": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635', subscription().subscriptionId)]",
+    "adtOwnerRoleDefinitionId": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe', subscription().subscriptionId)]"
   },
   "resources": [
     {
@@ -56,13 +53,13 @@
     {
       "type": "Microsoft.DigitalTwins/digitalTwinsInstances/providers/roleAssignments",
       "apiVersion": "2020-03-01-preview",
-      "name": "[concat(parameters('baseName'),'/Microsoft.Authorization/', guid(uniqueString(parameters('baseName'))))]",
+      "name": "[format('{0}/Microsoft.Authorization/{1}', parameters('baseName'), guid(uniqueString(parameters('baseName'))))]",
       "properties": {
-        "roleDefinitionId": "[variables('AdtOwnerRoleDefinitionId')]",
+        "roleDefinitionId": "[variables('adtOwnerRoleDefinitionId')]",
         "principalId": "[parameters('testApplicationOid')]"
       },
       "dependsOn": [
-        "[variables('digitalTwinInstanceResourceId')]"
+        "[resourceId('Microsoft.DigitalTwins/digitalTwinsInstances', parameters('baseName'))]"
       ]
     },
     {
@@ -79,77 +76,74 @@
         "zoneRedundant": false,
         "isAutoInflateEnabled": false,
         "maximumThroughputUnits": 0,
-        "kafkaEnabled": true
+        "kafkaEnabled": false
       }
     },
     {
       "type": "Microsoft.EventHub/namespaces/eventhubs",
       "apiVersion": "2017-04-01",
-      "name": "[concat(parameters('baseName'), '/', parameters('baseName'))]",
+      "name": "[format('{0}/{1}', parameters('baseName'), parameters('baseName'))]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('namespaceResourceId')]"
-      ],
       "properties": {
         "messageRetentionInDays": 7,
         "partitionCount": 4,
         "status": "Active"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.EventHub/namespaces', parameters('baseName'))]"
+      ]
     },
     {
       "type": "Microsoft.EventHub/namespaces/AuthorizationRules",
       "apiVersion": "2017-04-01",
-      "name": "[concat(parameters('baseName'), '/RootManageSharedAccessKey')]",
+      "name": "[format('{0}/RootManageSharedAccessKey', parameters('baseName'))]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('namespaceResourceId')]"
-      ],
       "properties": {
         "rights": [
           "Listen",
           "Manage",
           "Send"
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.EventHub/namespaces', parameters('baseName'))]"
+      ]
     },
     {
       "type": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules",
       "apiVersion": "2017-04-01",
-      "name": "[concat(parameters('baseName'), '/', parameters('baseName'), '/owner')]",
+      "name": "[format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName')))]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('namespaceResourceId')]",
-        "[variables('eventHubResourceId')]"
-      ],
       "properties": {
         "rights": [
+          "Listen",
           "Manage",
-          "Send",
-          "Listen"
+          "Send"
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.EventHub/namespaces/eventhubs', split(format('{0}/{1}', parameters('baseName'), parameters('baseName')), '/')[0], split(format('{0}/{1}', parameters('baseName'), parameters('baseName')), '/')[1])]"
+      ]
     },
     {
       "type": "Microsoft.DigitalTwins/digitalTwinsInstances/endpoints",
       "apiVersion": "2020-03-01-preview",
-      "name": "[concat(parameters('baseName'), '/someEventHubEndpoint')]",
-      "dependsOn": [
-        "[variables('digitalTwinInstanceResourceId')]",
-        "[variables('namespaceResourceId')]",
-        "[variables('eventHubResourceId')]",
-        "[variables('eventHubAuthorizationResourceId')]"
-      ],
+      "name": "[format('{0}/someEventHubEndpoint', parameters('baseName'))]",
       "properties": {
         "endpointType": "EventHub",
-        "connectionString-PrimaryKey": "[listKeys(variables('eventHubAuthorizationResourceId'),'2017-04-01').primaryConnectionString]",
-        "connectionString-SecondaryKey": "[listKeys(variables('eventHubAuthorizationResourceId'),'2017-04-01').secondaryConnectionString]"
-      }
+        "connectionString-PrimaryKey": "[listKeys(resourceId('Microsoft.EventHub/namespaces/eventhubs/authorizationRules', split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[0], split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[1], split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[2]), '2017-04-01').primaryConnectionString]",
+        "connectionString-SecondaryKey": "[listKeys(resourceId('Microsoft.EventHub/namespaces/eventhubs/authorizationRules', split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[0], split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[1], split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[2]), '2017-04-01').secondaryConnectionString]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DigitalTwins/digitalTwinsInstances', parameters('baseName'))]",
+        "[resourceId('Microsoft.EventHub/namespaces/eventhubs/authorizationRules', split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[0], split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[1], split(format('{0}/owner', format('{0}/{1}', parameters('baseName'), parameters('baseName'))), '/')[2])]"
+      ]
     }
   ],
   "outputs": {
     "DIGITALTWINS_URL": {
       "type": "string",
-      "value": "[concat('https://', reference(variables('digitalTwinInstanceResourceId'), '2020-03-01-preview').hostName)]"
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.DigitalTwins/digitalTwinsInstances', parameters('baseName'))).hostName)]"
     }
   }
 }


### PR DESCRIPTION
Bicep is a Domain Specific Language (DSL) for deploying Azure resources declaratively. It aims to drastically simplify the authoring experience with a cleaner syntax and better support for modularity and code re-use. Bicep is a transparent abstraction over ARM and ARM templates.

This PR creates a Bicep template to deploy the resources needed in our ADT tests. It seems very readable and easy to use. After the Azure Connect day, we decided to give this a try and I have been happy so far and looking forward to feedback.

Note: The ARM template is now auto generated by the command - bicep build 'test-resouces.bicep'