### PR TITLE
[MetricsAdvisor] Added GetIncidentRootCauses overloads

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -21,10 +21,11 @@
 - In `MetricsAdvisorAdministrationClient`, changed return types of sync and async `Create` methods (e.g., `CreateDataFeed`) to a `Response<string>` containing the ID of the created resource.
 - In `MetricsAdvisorAdministrationClient`, changed return types of sync and async methods `GetAnomalyAlertConfigurations` and `GetMetricAnomalyDetectionConfigurations` to pageables.
 - In `MetricsAdvisorAdministrationClient`, renamed parameter `alertConfigurationId` to `detectionConfigurationId` in sync and async `GetAnomalyAlertConfigurations` methods.
+- Updated `DataFeed.MetricIds` to a `Dictionary<string, string>` that maps a metric name to its ID.
 - In `DataFeedIngestionStatus`, made `Timestamp` and `Status` non-nullables.
-- In `AnomalyIncident`, made `Status` non-nullable.
-- In `EnrichmentStatus`, made `Timestamp` non-nullable.
 - In `MetricEnrichedSeriesData`, made elements of `ExpectedValues`, `Periods`, `IsAnomaly`, `LowerBoundaries` and `UpperBoundaries` nullables.
+- Made `AnomalyIncident.State` non-nullable.
+- Made `EnrichmentStatus.Timestamp` non-nullable.
 - Removed `MetricsAdvisorClientOptions` and `MetricsAdvisorAdministrationOptions` and replaced both with `MetricsAdvisorClientsOptions`.
 - Removed `DataFeedOptions`. All of its properties were moved directly into `DataFeed`.
 - Renamed `GetMetricFeedbacksOptions` to `GetAllMetricFeedbackOptions`.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-beta.2 (Unreleased)
 
 ### New Features
+- Added new sync and async `GetIncidentRootCauses` overloads to `MetricsAdvisorClient` to list root causes for a given `AnomalyIncident` instance.
 - Added a public constructor to `DataFeed`.
 - Added the `DataSource` property to `DataFeed`.
 - All `DataSource`s now have public properties exposing the associated parameters used to get the data, such as endpoints, connection strings, and query strings.
@@ -15,6 +16,7 @@
 - In `MetricsAdvisorClient`, renamed sync and async `GetMetricDimensionValues` methods to `GetDimensionValues`.
 - In `MetricsAdvisorClient`, changed return types of sync and async `CreateMetricFeedback` methods to a `Response<string>` containing the ID of the created feedback.
 - In `MetricsAdvisorClient`, changed return types of sync and async methods `GetIncidentRootCauses`, `GetMetricEnrichedSeriesData`, and `GetMetricSeriesData` to pageables.
+- In `MetricsAdvisorClient`, updated sync and async `GetIncidentsForDetectionConfiguration` methods to always populate the `DetectionConfigurationId` of returned incidents.
 - In `MetricsAdvisorAdministrationClient`, renamed the sync and async `AnomalyAlertConfiguration` CRUD methods, removing the `Anomaly` word from their names (e.g., `GetAnomalyAlertConfiguration` became `GetAlertConfiguration`).
 - In `MetricsAdvisorAdministrationClient`, renamed the sync and async `MetricAnomalyDetectionConfiguration` CRUD methods, removing the `MetricAnomaly` term from their names (e.g., `GetMetricAnomalyDetectionConfiguration` became `GetDetectionConfiguration`).
 - In `MetricsAdvisorAdministrationClient`, updated `CreateDataFeed` and `CreateDataFeedAsync` to take a whole `DataFeed` object as a parameter.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Updated `DataFeed.MetricIds` to a `Dictionary<string, string>` that maps a metric name to its ID.
 - In `DataFeedIngestionStatus`, made `Timestamp` and `Status` non-nullables.
 - In `MetricEnrichedSeriesData`, made elements of `ExpectedValues`, `Periods`, `IsAnomaly`, `LowerBoundaries` and `UpperBoundaries` nullables.
-- Made `AnomalyIncident.State` non-nullable.
+- Made `AnomalyIncident.Status` non-nullable.
 - Made `EnrichmentStatus.Timestamp` non-nullable.
 - Removed `MetricsAdvisorClientOptions` and `MetricsAdvisorAdministrationOptions` and replaced both with `MetricsAdvisorClientsOptions`.
 - Removed `DataFeedOptions`. All of its properties were moved directly into `DataFeed`.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -17,7 +17,9 @@ namespace Azure.AI.MetricsAdvisor
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.DataPointAnomaly> GetAnomaliesAsync(string alertConfigurationId, string alertId, Azure.AI.MetricsAdvisor.Models.GetAnomaliesForAlertOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<string> GetDimensionValues(string metricId, string dimensionName, Azure.AI.MetricsAdvisor.Models.GetDimensionValuesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<string> GetDimensionValuesAsync(string metricId, string dimensionName, Azure.AI.MetricsAdvisor.Models.GetDimensionValuesOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.IncidentRootCause> GetIncidentRootCauses(Azure.AI.MetricsAdvisor.Models.AnomalyIncident incident, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.IncidentRootCause> GetIncidentRootCauses(string detectionConfigurationId, string incidentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.IncidentRootCause> GetIncidentRootCausesAsync(Azure.AI.MetricsAdvisor.Models.AnomalyIncident incident, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.AsyncPageable<Azure.AI.MetricsAdvisor.Models.IncidentRootCause> GetIncidentRootCausesAsync(string detectionConfigurationId, string incidentId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.AnomalyIncident> GetIncidents(string detectionConfigurationId, Azure.AI.MetricsAdvisor.Models.GetIncidentsForDetectionConfigurationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual Azure.Pageable<Azure.AI.MetricsAdvisor.Models.AnomalyIncident> GetIncidents(string alertConfigurationId, string alertId, Azure.AI.MetricsAdvisor.Models.GetIncidentsForAlertOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -368,7 +370,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         public string Id { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings IngestionSettings { get { throw null; } }
         public bool? IsAdministrator { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<string> MetricIds { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> MetricIds { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedMissingDataPointFillSettings MissingDataPointFillSettings { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedRollupSettings RollupSettings { get { throw null; } set { } }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyIncident.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/AnomalyIncident.cs
@@ -37,12 +37,10 @@ namespace Azure.AI.MetricsAdvisor.Models
 
         /// <summary>
         /// The unique identifier of the <see cref="AnomalyDetectionConfiguration"/> that detected
-        /// this <see cref="AnomalyIncident"/>. This property is only populated when calling
-        /// <see cref="MetricsAdvisorClient.GetIncidents(string, string, GetIncidentsForAlertOptions, CancellationToken)"/> or
-        /// <see cref="MetricsAdvisorClient.GetIncidentsAsync(string, string, GetIncidentsForAlertOptions, CancellationToken)"/>.
+        /// this <see cref="AnomalyIncident"/>.
         /// </summary>
         [CodeGenMember("AnomalyDetectionConfigurationId")]
-        public string DetectionConfigurationId { get; }
+        public string DetectionConfigurationId { get; internal set; }
 
         /// <summary>
         /// The unique identifier of the <see cref="DataFeedMetric"/> of the time series in which this

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -53,7 +53,7 @@ namespace Azure.AI.MetricsAdvisor.Models
             CreatedTime = dataFeedDetail.CreatedTime;
             Creator = dataFeedDetail.Creator;
             IsAdministrator = dataFeedDetail.IsAdmin;
-            MetricIds = dataFeedDetail.Metrics.Select(metric => metric.MetricId).ToList();
+            MetricIds = dataFeedDetail.Metrics.ToDictionary(metric => metric.MetricName, metric => metric.MetricId);
             Name = dataFeedDetail.DataFeedName;
             DataSource = DataFeedSource.GetDataFeedSource(dataFeedDetail);
             SourceType = dataFeedDetail.DataSourceType;
@@ -99,7 +99,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The unique identifiers of the metrics defined in this feed's <see cref="DataFeedSchema"/>.
         /// Set by the service.
         /// </summary>
-        public IReadOnlyList<string> MetricIds { get; }
+        public IReadOnlyDictionary<string, string> MetricIds { get; }
 
         /// <summary>
         /// A custom name for this <see cref="DataFeed"/> to be displayed on the web portal.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,14 +21,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [TestCase(false)]
         public async Task GetAnomalies(bool populateOptionalMembers)
         {
-            const int maximumSamplesCount = 10;
-
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var startTime = DateTimeOffset.Parse("2020-10-01T00:00:00Z");
-            var endTime = DateTimeOffset.Parse("2020-10-31T00:00:00Z");
-
-            var options = new GetAnomaliesForDetectionConfigurationOptions(startTime, endTime);
+            var options = new GetAnomaliesForDetectionConfigurationOptions(SamplingStartTime, SamplingEndTime);
 
             if (populateOptionalMembers)
             {
@@ -57,7 +51,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Assert.That(anomaly.ModifiedTime, Is.Null);
                 Assert.That(anomaly.Status, Is.Null);
 
-                Assert.That(anomaly.Timestamp, Is.InRange(startTime, endTime));
+                Assert.That(anomaly.Timestamp, Is.InRange(SamplingStartTime, SamplingEndTime));
                 Assert.That(anomaly.Severity, Is.Not.EqualTo(default(AnomalySeverity)));
                 Assert.That(anomaly.SeriesKey, Is.Not.Null);
 
@@ -79,7 +73,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     Assert.That((city == "Delhi" && category == "Handmade") || city == "Kolkata");
                 }
 
-                if (++anomalyCount >= maximumSamplesCount)
+                if (++anomalyCount >= MaximumSamplesCount)
                 {
                     break;
                 }
@@ -93,14 +87,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [TestCase(false)]
         public async Task GetIncidents(bool populateOptionalMembers)
         {
-            const int maximumSamplesCount = 10;
-
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var startTime = DateTimeOffset.Parse("2020-10-01T00:00:00Z");
-            var endTime = DateTimeOffset.Parse("2020-10-31T00:00:00Z");
-
-            var options = new GetIncidentsForDetectionConfigurationOptions(startTime, endTime);
+            var options = new GetIncidentsForDetectionConfigurationOptions(SamplingStartTime, SamplingEndTime);
 
             if (populateOptionalMembers)
             {
@@ -124,8 +113,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
                 Assert.That(incident.Id, Is.Not.Null.And.Not.Empty);
                 Assert.That(incident.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
-                Assert.That(incident.StartTime, Is.GreaterThanOrEqualTo(startTime));
-                Assert.That(incident.LastTime, Is.LessThanOrEqualTo(endTime));
+                Assert.That(incident.StartTime, Is.GreaterThanOrEqualTo(SamplingStartTime));
+                Assert.That(incident.LastTime, Is.LessThanOrEqualTo(SamplingEndTime));
                 Assert.That(incident.Status, Is.Not.EqualTo(default(AnomalyIncidentStatus)));
                 Assert.That(incident.Severity, Is.Not.EqualTo(default(AnomalySeverity)));
                 Assert.That(incident.DimensionKey, Is.Not.Null);
@@ -147,7 +136,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                     Assert.That((city == "Delhi" && category == "Handmade") || city == "Kolkata");
                 }
 
-                if (++incidentCount >= maximumSamplesCount)
+                if (++incidentCount >= MaximumSamplesCount)
                 {
                     break;
                 }
@@ -159,35 +148,93 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [RecordedTest]
         public async Task GetIncidentRootCauses()
         {
-            const int maximumSamplesCount = 10;
-
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
             var rootCauseCount = 0;
 
             await foreach (IncidentRootCause rootCause in client.GetIncidentRootCausesAsync(DetectionConfigurationId, IncidentId))
             {
-                Assert.That(rootCause, Is.Not.Null);
-                Assert.That(rootCause.Description, Is.Not.Null.And.Not.Empty);
-                Assert.That(rootCause.Score, Is.GreaterThan(0.0).And.LessThanOrEqualTo(1.0));
+                ValidateIncidentRootCause(rootCause);
 
-                foreach (string path in rootCause.Paths)
+                if (++rootCauseCount >= MaximumSamplesCount)
                 {
-                    Assert.That(path, Is.Not.Null.And.Not.Empty);
+                    break;
                 }
+            }
 
-                Assert.That(rootCause.DimensionKey, Is.Not.Null);
+            Assert.That(rootCauseCount, Is.GreaterThan(0));
+        }
 
-                Dictionary<string, string> dimensionColumns = rootCause.DimensionKey.AsDictionary();
+        [RecordedTest]
+        public async Task GetIncidentRootCausesForIncidentFromDetectionConfiguration()
+        {
+            MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-                Assert.That(dimensionColumns.Count, Is.EqualTo(2));
-                Assert.That(dimensionColumns.ContainsKey("city"));
-                Assert.That(dimensionColumns.ContainsKey("category"));
+            AnomalyIncident incident = null;
+            var options = new GetIncidentsForDetectionConfigurationOptions(SamplingStartTime, SamplingEndTime);
 
-                Assert.That(dimensionColumns["city"], Is.Not.Null.And.Not.Empty);
-                Assert.That(dimensionColumns["category"], Is.Not.Null.And.Not.Empty);
+            // We already know the the incident we want to get, so apply filters to make the
+            // service call cheaper.
 
-                if (++rootCauseCount >= maximumSamplesCount)
+            var groupKey = new DimensionKey();
+            groupKey.AddDimensionColumn("city", "__SUM__");
+            groupKey.AddDimensionColumn("category", "Grocery & Gourmet Food");
+
+            options.DimensionsToFilter.Add(groupKey);
+
+            await foreach (AnomalyIncident currentIncident in client.GetIncidentsAsync(DetectionConfigurationId, options))
+            {
+                if (currentIncident.Id == IncidentId)
+                {
+                    incident = currentIncident;
+                    break;
+                }
+            }
+
+            Assert.That(incident, Is.Not.Null);
+
+            var rootCauseCount = 0;
+
+            await foreach (IncidentRootCause rootCause in client.GetIncidentRootCausesAsync(incident))
+            {
+                ValidateIncidentRootCause(rootCause);
+
+                if (++rootCauseCount >= MaximumSamplesCount)
+                {
+                    break;
+                }
+            }
+
+            Assert.That(rootCauseCount, Is.GreaterThan(0));
+        }
+
+        [RecordedTest]
+        public async Task GetIncidentRootCausesForIncidentFromAlert()
+        {
+            const string incidentId = "5a0692283edccf37ce825b3a8d475f4e-17571a77000";
+
+            MetricsAdvisorClient client = GetMetricsAdvisorClient();
+
+            AnomalyIncident incident = null;
+
+            await foreach (AnomalyIncident currentIncident in client.GetIncidentsAsync(AlertConfigurationId, AlertId))
+            {
+                if (currentIncident.Id == incidentId)
+                {
+                    incident = currentIncident;
+                    break;
+                }
+            }
+
+            Assert.That(incident, Is.Not.Null);
+
+            var rootCauseCount = 0;
+
+            await foreach (IncidentRootCause rootCause in client.GetIncidentRootCausesAsync(incident))
+            {
+                ValidateIncidentRootCause(rootCause);
+
+                if (++rootCauseCount >= MaximumSamplesCount)
                 {
                     break;
                 }
@@ -201,15 +248,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
         [TestCase(false)]
         public async Task GetValuesOfDimensionWithAnomalies(bool populateOptionalMembers)
         {
-            const int maximumSamplesCount = 10;
             const string dimensionName = "city";
 
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var startTime = DateTimeOffset.Parse("2020-10-01T00:00:00Z");
-            var endTime = DateTimeOffset.Parse("2020-10-31T00:00:00Z");
-
-            var options = new GetValuesOfDimensionWithAnomaliesOptions(startTime, endTime);
+            var options = new GetValuesOfDimensionWithAnomaliesOptions(SamplingStartTime, SamplingEndTime);
 
             if (populateOptionalMembers)
             {
@@ -223,7 +266,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             {
                 Assert.That(value, Is.Not.Null.And.Not.Empty);
 
-                if (++valueCount >= maximumSamplesCount)
+                if (++valueCount >= MaximumSamplesCount)
                 {
                     break;
                 }
@@ -239,9 +282,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var startTime = DateTimeOffset.Parse("2020-10-01T00:00:00Z");
-            var endTime = DateTimeOffset.Parse("2020-10-31T00:00:00Z");
-
             var seriesKey1 = new DimensionKey();
             seriesKey1.AddDimensionColumn("city", "Delhi");
             seriesKey1.AddDimensionColumn("category", "Handmade");
@@ -253,7 +293,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var seriesKeys = new List<DimensionKey>() { seriesKey1, seriesKey2 };
             var returnedKeys = new List<DimensionKey>();
 
-            await foreach (MetricEnrichedSeriesData seriesData in client.GetMetricEnrichedSeriesDataAsync(seriesKeys, DetectionConfigurationId, startTime, endTime))
+            await foreach (MetricEnrichedSeriesData seriesData in client.GetMetricEnrichedSeriesDataAsync(seriesKeys, DetectionConfigurationId, SamplingStartTime, SamplingEndTime))
             {
                 Assert.That(seriesData, Is.Not.Null);
                 Assert.That(seriesData.SeriesKey, Is.Not.Null);
@@ -276,7 +316,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
                 for (int i = 0; i < pointsCount; i++)
                 {
-                    Assert.That(seriesData.Timestamps[i], Is.InRange(startTime, endTime));
+                    Assert.That(seriesData.Timestamps[i], Is.InRange(SamplingStartTime, SamplingEndTime));
                 }
 
                 returnedKeys.Add(seriesData.SeriesKey);
@@ -286,6 +326,29 @@ namespace Azure.AI.MetricsAdvisor.Tests
             IEnumerable<List<KeyValuePair<string, string>>> returnedKvps = returnedKeys.Select(key => key.AsDictionary().ToList());
 
             Assert.That(returnedKvps, Is.EquivalentTo(expectedKvps));
+        }
+
+        private void ValidateIncidentRootCause(IncidentRootCause rootCause)
+        {
+            Assert.That(rootCause, Is.Not.Null);
+            Assert.That(rootCause.Description, Is.Not.Null.And.Not.Empty);
+            Assert.That(rootCause.Score, Is.GreaterThan(0.0).And.LessThanOrEqualTo(1.0));
+
+            foreach (string path in rootCause.Paths)
+            {
+                Assert.That(path, Is.Not.Null.And.Not.Empty);
+            }
+
+            Assert.That(rootCause.DimensionKey, Is.Not.Null);
+
+            Dictionary<string, string> dimensionColumns = rootCause.DimensionKey.AsDictionary();
+
+            Assert.That(dimensionColumns.Count, Is.EqualTo(2));
+            Assert.That(dimensionColumns.ContainsKey("city"));
+            Assert.That(dimensionColumns.ContainsKey("category"));
+
+            Assert.That(dimensionColumns["city"], Is.Not.Null.And.Not.Empty);
+            Assert.That(dimensionColumns["category"], Is.Not.Null.And.Not.Empty);
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
@@ -120,10 +120,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             await foreach (AnomalyIncident incident in client.GetIncidentsAsync(DetectionConfigurationId, options))
             {
                 Assert.That(incident, Is.Not.Null);
-                Assert.That(incident.DetectionConfigurationId, Is.Null);
                 Assert.That(incident.MetricId, Is.Null);
 
                 Assert.That(incident.Id, Is.Not.Null.And.Not.Empty);
+                Assert.That(incident.DetectionConfigurationId, Is.EqualTo(DetectionConfigurationId));
                 Assert.That(incident.StartTime, Is.GreaterThanOrEqualTo(startTime));
                 Assert.That(incident.LastTime, Is.LessThanOrEqualTo(endTime));
                 Assert.That(incident.Status, Is.Not.EqualTo(default(AnomalyIncidentStatus)));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClientLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClientLiveTests.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             int totalcount = 0;
             foreach (DataFeed feed in feeds)
             {
-                foreach (var metricId in feed.MetricIds)
+                foreach (var metricId in feed.MetricIds.Values)
                 {
                     await foreach (MetricSeriesDefinition metricDef in client.GetMetricSeriesDefinitionsAsync(
                         metricId,
@@ -54,7 +54,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed feed = await GetFirstDataFeed(adminClient);
 
-            foreach (var metricId in feed.MetricIds)
+            foreach (var metricId in feed.MetricIds.Values)
             {
                 foreach (DataFeedDimension dimension in feed.Schema.DimensionColumns)
                 {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
@@ -73,7 +73,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         internal async Task<string> CreateDetectionConfiguration(MetricsAdvisorAdministrationClient adminClient)
         {
             DataFeed feed = await GetFirstDataFeed(adminClient).ConfigureAwait(false);
-            AnomalyDetectionConfiguration config = PopulateMetricAnomalyDetectionConfiguration(feed.MetricIds.First());
+            AnomalyDetectionConfiguration config = PopulateMetricAnomalyDetectionConfiguration(feed.MetricIds.First().Value);
 
             return await adminClient.CreateDetectionConfigurationAsync(config).ConfigureAwait(false);
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorLiveTestBase.cs
@@ -25,10 +25,16 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
         internal const string DetectionConfigurationId = "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c";
         internal const string IncidentId = "736eed64368bb6a372e855322a15a736-174e1756000";
-        internal const string AlertConfigurationId = "08318302-6006-4019-9afc-975bc63ee566";
-        internal const string AlertId = "174995c5800";
+        internal const string AlertConfigurationId = "204a211a-c5f4-45f3-a30e-512fb25d1d2c";
+        internal const string AlertId = "17571a77000";
         internal const string MetricId = "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5";
         internal const string DataFeedId = "0072a752-1476-4cfa-8cf0-f226995201a0";
+
+        protected int MaximumSamplesCount => 10;
+
+        protected DateTimeOffset SamplingStartTime => DateTimeOffset.Parse("2020-10-01T00:00:00Z");
+
+        protected DateTimeOffset SamplingEndTime => DateTimeOffset.Parse("2020-10-31T00:00:00Z");
 
         public void InitDataFeedSources()
         {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromAlert.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromAlert.json
@@ -1,0 +1,564 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "de70a2059b0f0c476503a5b00c1bc61d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "52730786-9ffd-4976-bf84-0c7441c77aec",
+        "Content-Length": "5870",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "454",
+        "X-Request-ID": "52730786-9ffd-4976-bf84-0c7441c77aec"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "0f099f2089162cab683d305ad1a9cba8-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Sao Paulo",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "incidentStatus": "Resolved"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "15ee0a88ee90d2b7580b07acac9b5f1b-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Bengaluru",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "2b03e492fd98f311dac5754867352e2f-17571a77000",
+            "startTime": "2020-10-28T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Los Angeles",
+                "category": "Camera \u0026 Photo"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "2dfaa266fcd69f2019345aee741a23a4-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Tehran",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "323c79b4e6fc7e6aef0a75852c909fde-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Tokyo",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "39545810eabd039e3c5bca795889e4d5-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Jakarta",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "596c3ea953875e9e69bfe44b2f9c6d9c-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Istanbul",
+                "category": "Electronics (Accessories)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "5a0692283edccf37ce825b3a8d475f4e-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "__SUM__"
+              }
+            },
+            "property": {
+              "maxSeverity": "High",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "740e015e72e8de201191854db904421b-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Mexico City",
+                "category": "Automotive \u0026 Powersports"
+              }
+            },
+            "property": {
+              "incidentStatus": "Resolved"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "ade81d2ff75a21ac9f496133d1484c89-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Rio de Janeiro",
+                "category": "Device Accessories"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "c3b1690cc5c7a724cb728eb74c084a4c-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Houston",
+                "category": "Automotive \u0026 Powersports"
+              }
+            },
+            "property": {
+              "incidentStatus": "Resolved"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "c87ace3b9f582c6a6142026c80f2de44-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Manila",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "ca46ba86922052929ece3d4c8794c442-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Mexico City",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "dd1566e6ab95777eab6d996389dba73d-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Lahore",
+                "category": "Electronics (Accessories)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "f0b8fda3844b8d12d646fadbad496347-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Cairo",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          }
+        ],
+        "@nextLink": null
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c/incidents/5a0692283edccf37ce825b3a8d475f4e-17571a77000/rootCause",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "67edc29bd64796db384baa173bd8cbd1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "78341776-6d78-4f46-af01-05364dd9d619",
+        "Content-Length": "4931",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "701",
+        "X-Request-ID": "78341776-6d78-4f46-af01-05364dd9d619"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Karachi"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.10291394635023254,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Karachi"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Mumbai"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.043172926670104361,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Mumbai"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Delhi"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.017047353056102055,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Delhi"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Beijing"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.015140109024445125,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Beijing"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Tianjin"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.012082483936165844,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Tianjin"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Miami"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.00922249776845746,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Miami"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Osaka"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0054018981305615221,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Osaka"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "New York"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0053687257364603558,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = New York"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Santiago"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0050133151962014622,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Santiago"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Dallas"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0036380155367801148,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Dallas"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Bogota"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0032654609662532419,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Bogota"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Lima"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0026858149980803492,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Lima"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Hong Kong"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0021137521086953548,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Hong Kong"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Bangkok"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0016667422373576324,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Bangkok"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Madrid"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0013846804126225187,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Madrid"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Shanghai"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0011379896220113372,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Shanghai"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Paris"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.00094771017909872635,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Paris"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "790475912"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromAlertAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromAlertAsync.json
@@ -1,0 +1,564 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "79045f3a3d07aeb14b5581bf6adea3c2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6a0a028e-8a17-4a75-aa1e-99d77c13438d",
+        "Content-Length": "5870",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1144",
+        "X-Request-ID": "6a0a028e-8a17-4a75-aa1e-99d77c13438d"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "0f099f2089162cab683d305ad1a9cba8-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Sao Paulo",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "incidentStatus": "Resolved"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "15ee0a88ee90d2b7580b07acac9b5f1b-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Bengaluru",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "2b03e492fd98f311dac5754867352e2f-17571a77000",
+            "startTime": "2020-10-28T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Los Angeles",
+                "category": "Camera \u0026 Photo"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "2dfaa266fcd69f2019345aee741a23a4-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Tehran",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "323c79b4e6fc7e6aef0a75852c909fde-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Tokyo",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "39545810eabd039e3c5bca795889e4d5-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Jakarta",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "596c3ea953875e9e69bfe44b2f9c6d9c-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Istanbul",
+                "category": "Electronics (Accessories)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "5a0692283edccf37ce825b3a8d475f4e-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "__SUM__"
+              }
+            },
+            "property": {
+              "maxSeverity": "High",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "740e015e72e8de201191854db904421b-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Mexico City",
+                "category": "Automotive \u0026 Powersports"
+              }
+            },
+            "property": {
+              "incidentStatus": "Resolved"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "ade81d2ff75a21ac9f496133d1484c89-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Rio de Janeiro",
+                "category": "Device Accessories"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "c3b1690cc5c7a724cb728eb74c084a4c-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Houston",
+                "category": "Automotive \u0026 Powersports"
+              }
+            },
+            "property": {
+              "incidentStatus": "Resolved"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "c87ace3b9f582c6a6142026c80f2de44-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Manila",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "ca46ba86922052929ece3d4c8794c442-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Mexico City",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "dd1566e6ab95777eab6d996389dba73d-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Lahore",
+                "category": "Electronics (Accessories)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "f0b8fda3844b8d12d646fadbad496347-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "Cairo",
+                "category": "Electronics (Consumer)"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          }
+        ],
+        "@nextLink": null
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c/incidents/5a0692283edccf37ce825b3a8d475f4e-17571a77000/rootCause",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "bdd407a21050acc187eec788fb5f4d6f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ce8f78f1-f860-4375-90d3-e106026b03cc",
+        "Content-Length": "4931",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "702",
+        "X-Request-ID": "ce8f78f1-f860-4375-90d3-e106026b03cc"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Karachi"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.10291394635023254,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Karachi"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Mumbai"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.043172926670104361,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Mumbai"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Delhi"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.017047353056102055,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Delhi"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Beijing"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.015140109024445125,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Beijing"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Tianjin"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.012082483936165844,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Tianjin"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Miami"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.00922249776845746,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Miami"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Osaka"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0054018981305615221,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Osaka"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "New York"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0053687257364603558,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = New York"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Santiago"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0050133151962014622,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Santiago"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Dallas"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0036380155367801148,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Dallas"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Bogota"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0032654609662532419,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Bogota"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Lima"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0026858149980803492,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Lima"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Hong Kong"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0021137521086953548,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Hong Kong"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Bangkok"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0016667422373576324,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Bangkok"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Madrid"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0013846804126225187,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Madrid"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Shanghai"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.0011379896220113372,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Shanghai"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Shoes Handbags \u0026 Sunglasses",
+                "city": "Paris"
+              }
+            },
+            "path": [
+              "category",
+              "city"
+            ],
+            "score": 0.00094771017909872635,
+            "description": "Several potential root causes has been identified, most contributors are: category = Shoes Handbags \u0026 Sunglasses | city = Paris"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "698976930"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromDetectionConfiguration.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromDetectionConfiguration.json
@@ -1,0 +1,214 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c/incidents/query",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "169",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1c960cc44410f81e2c2674f0aae217ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "{\u0022startTime\u0022:\u00222020-10-01T00:00:00Z\u0022,\u0022endTime\u0022:\u00222020-10-31T00:00:00Z\u0022,\u0022filter\u0022:{\u0022dimensionFilter\u0022:[{\u0022dimension\u0022:{\u0022city\u0022:\u0022__SUM__\u0022,\u0022category\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}}]}}",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "75f49a57-f2c0-4caa-ba06-64cba19e30f9",
+        "Content-Length": "1108",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "416",
+        "X-Request-ID": "75f49a57-f2c0-4caa-ba06-64cba19e30f9"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-17552c14800",
+            "startTime": "2020-10-23T00:00:00Z",
+            "lastTime": "2020-10-23T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-175434e3400",
+            "startTime": "2020-10-20T00:00:00Z",
+            "lastTime": "2020-10-20T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-175005b8800",
+            "startTime": "2020-10-07T00:00:00Z",
+            "lastTime": "2020-10-07T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-174e1756000",
+            "startTime": "2020-10-01T00:00:00Z",
+            "lastTime": "2020-10-01T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          }
+        ],
+        "@nextLink": null
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c/incidents/736eed64368bb6a372e855322a15a736-174e1756000/rootCause",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2b8664a63e3480e59c70cf880ea675ec",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d50704f8-b0dc-46fd-9512-69cb50ded8c3",
+        "Content-Length": "1631",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "269",
+        "X-Request-ID": "d50704f8-b0dc-46fd-9512-69cb50ded8c3"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Houston"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.093254247542794433,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Houston"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Manila"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.070565102895706888,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Manila"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Tianjin"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.034323946263572935,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Tianjin"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Shanghai"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.032546005599616623,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Shanghai"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Los Angeles"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.016092267995932552,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Los Angeles"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Madrid"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.011665019248226383,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Madrid"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1057209934"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromDetectionConfigurationAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetIncidentRootCausesForIncidentFromDetectionConfigurationAsync.json
@@ -1,0 +1,214 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c/incidents/query",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "169",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "39de847859688c3b51bcccfb6dc78c1b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "{\u0022startTime\u0022:\u00222020-10-01T00:00:00Z\u0022,\u0022endTime\u0022:\u00222020-10-31T00:00:00Z\u0022,\u0022filter\u0022:{\u0022dimensionFilter\u0022:[{\u0022dimension\u0022:{\u0022city\u0022:\u0022__SUM__\u0022,\u0022category\u0022:\u0022Grocery \u0026 Gourmet Food\u0022}}]}}",
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "073da2d8-bddd-440c-bc84-e0f8f3fa7542",
+        "Content-Length": "1108",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "218",
+        "X-Request-ID": "073da2d8-bddd-440c-bc84-e0f8f3fa7542"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-17552c14800",
+            "startTime": "2020-10-23T00:00:00Z",
+            "lastTime": "2020-10-23T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-175434e3400",
+            "startTime": "2020-10-20T00:00:00Z",
+            "lastTime": "2020-10-20T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-175005b8800",
+            "startTime": "2020-10-07T00:00:00Z",
+            "lastTime": "2020-10-07T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          },
+          {
+            "incidentId": "736eed64368bb6a372e855322a15a736-174e1756000",
+            "startTime": "2020-10-01T00:00:00Z",
+            "lastTime": "2020-10-01T00:00:00Z",
+            "rootNode": {
+              "dimension": {
+                "city": "__SUM__",
+                "category": "Grocery \u0026 Gourmet Food"
+              }
+            },
+            "property": {
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
+            }
+          }
+        ],
+        "@nextLink": null
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/enrichment/anomalyDetection/configurations/fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c/incidents/736eed64368bb6a372e855322a15a736-174e1756000/rootCause",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
+        ],
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e59bad3c8d959d62b17f38748d058a69",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f387f91b-d417-455c-9d12-0bf11127452a",
+        "Content-Length": "1631",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 04 Nov 2020 18:02:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "229",
+        "X-Request-ID": "f387f91b-d417-455c-9d12-0bf11127452a"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Houston"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.093254247542794433,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Houston"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Manila"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.070565102895706888,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Manila"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Tianjin"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.034323946263572935,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Tianjin"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Shanghai"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.032546005599616623,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Shanghai"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Los Angeles"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.016092267995932552,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Los Angeles"
+          },
+          {
+            "rootCause": {
+              "dimension": {
+                "category": "Grocery \u0026 Gourmet Food",
+                "city": "Madrid"
+              }
+            },
+            "path": [
+              "city"
+            ],
+            "score": 0.011665019248226383,
+            "description": "Several potential root causes has been identified, most contributors are: category = Grocery \u0026 Gourmet Food | city = Madrid"
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "761753680"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAlerts.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAlerts.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -9,43 +9,43 @@
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0854efda2067d48f44441a0c32b8743d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "startTime": "2015-09-29T23:42:32Z",
-        "endTime": "2020-09-29T23:42:32Z",
+        "startTime": "2015-11-04T17:47:10Z",
+        "endTime": "2020-11-04T17:47:10Z",
         "timeMode": "CreatedTime"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8ac655be-1df2-47d7-bef0-608810fe9834",
-        "Content-Length": "348",
+        "apim-request-id": "62131b4d-90e8-4e1b-b2ac-402c92ac94d9",
+        "Content-Length": "342",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:32 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "110",
-        "X-Request-ID": "8ac655be-1df2-47d7-bef0-608810fe9834"
+        "X-Request-ID": "62131b4d-90e8-4e1b-b2ac-402c92ac94d9"
       },
       "ResponseBody": {
         "value": [
           {
-            "alertId": "174a3a91000",
-            "timestamp": "2020-09-19T00:00:00Z",
-            "createdTime": "2020-09-20T16:34:42.071Z",
-            "modifiedTime": "2020-09-22T02:38:47.84Z"
+            "alertId": "1758b673c00",
+            "timestamp": "2020-11-03T00:00:00Z",
+            "createdTime": "2020-11-04T00:06:13.262Z",
+            "modifiedTime": "2020-11-04T00:11:03.272Z"
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=1"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=1"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=1",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -53,43 +53,43 @@
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9f016db4e280d1bd3b89ec160a341473",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "startTime": "2015-09-29T23:42:32Z",
-        "endTime": "2020-09-29T23:42:32Z",
+        "startTime": "2015-11-04T17:47:10Z",
+        "endTime": "2020-11-04T17:47:10Z",
         "timeMode": "CreatedTime"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c8f0df21-23e1-41ff-ab30-1b8c0122ab5d",
-        "Content-Length": "349",
+        "apim-request-id": "05db6ce0-dc3c-43ba-beba-9ed85cac4ecc",
+        "Content-Length": "342",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:32 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "110",
-        "X-Request-ID": "c8f0df21-23e1-41ff-ab30-1b8c0122ab5d"
+        "x-envoy-upstream-service-time": "109",
+        "X-Request-ID": "05db6ce0-dc3c-43ba-beba-9ed85cac4ecc"
       },
       "ResponseBody": {
         "value": [
           {
-            "alertId": "1749e82b400",
-            "timestamp": "2020-09-18T00:00:00Z",
-            "createdTime": "2020-09-19T21:35:29.225Z",
-            "modifiedTime": "2020-09-20T16:34:22.553Z"
+            "alertId": "1758640e000",
+            "timestamp": "2020-11-02T00:00:00Z",
+            "createdTime": "2020-11-03T00:06:12.487Z",
+            "modifiedTime": "2020-11-03T00:11:01.967Z"
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=2"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=2"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -97,45 +97,45 @@
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "284b743da3638e5bcd3107f314f52ee0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "startTime": "2015-09-29T23:42:32Z",
-        "endTime": "2020-09-29T23:42:32Z",
+        "startTime": "2015-11-04T17:47:10Z",
+        "endTime": "2020-11-04T17:47:10Z",
         "timeMode": "CreatedTime"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f3a22c09-d6b7-429f-b42d-47f410ca646e",
-        "Content-Length": "349",
+        "apim-request-id": "8a645df6-9c74-48e0-887e-c71b3d235617",
+        "Content-Length": "341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:32 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "87",
-        "X-Request-ID": "f3a22c09-d6b7-429f-b42d-47f410ca646e"
+        "x-envoy-upstream-service-time": "88",
+        "X-Request-ID": "8a645df6-9c74-48e0-887e-c71b3d235617"
       },
       "ResponseBody": {
         "value": [
           {
-            "alertId": "174995c5800",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:00.956Z",
-            "modifiedTime": "2020-09-18T19:46:05.762Z"
+            "alertId": "175811a8400",
+            "timestamp": "2020-11-01T00:00:00Z",
+            "createdTime": "2020-11-02T00:33:16.23Z",
+            "modifiedTime": "2020-11-04T00:11:03.014Z"
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=3"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=3"
       }
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-09-29T18:42:32.8558168-05:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-11-04T09:47:10.6538441-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAlertsAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAlertsAsync.json
@@ -1,7 +1,7 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -9,43 +9,43 @@
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f0e5a43e32d9474cb06f5f9d864f2d83",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "startTime": "2015-09-29T23:42:46Z",
-        "endTime": "2020-09-29T23:42:46Z",
+        "startTime": "2015-11-04T17:47:12Z",
+        "endTime": "2020-11-04T17:47:12Z",
         "timeMode": "CreatedTime"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "189f70a6-c8c6-4508-82c7-c6cf3012151b",
-        "Content-Length": "348",
+        "apim-request-id": "c2e8e2f1-b00f-42cf-8427-b88b5b9fd7b7",
+        "Content-Length": "342",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:45 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "81",
-        "X-Request-ID": "189f70a6-c8c6-4508-82c7-c6cf3012151b"
+        "x-envoy-upstream-service-time": "73",
+        "X-Request-ID": "c2e8e2f1-b00f-42cf-8427-b88b5b9fd7b7"
       },
       "ResponseBody": {
         "value": [
           {
-            "alertId": "174a3a91000",
-            "timestamp": "2020-09-19T00:00:00Z",
-            "createdTime": "2020-09-20T16:34:42.071Z",
-            "modifiedTime": "2020-09-22T02:38:47.84Z"
+            "alertId": "1758b673c00",
+            "timestamp": "2020-11-03T00:00:00Z",
+            "createdTime": "2020-11-04T00:06:13.262Z",
+            "modifiedTime": "2020-11-04T00:11:03.272Z"
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=1"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=1"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=1",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -53,43 +53,43 @@
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9d0a0f3c1a09718e2dde4035f7a1e8a0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "startTime": "2015-09-29T23:42:46Z",
-        "endTime": "2020-09-29T23:42:46Z",
+        "startTime": "2015-11-04T17:47:12Z",
+        "endTime": "2020-11-04T17:47:12Z",
         "timeMode": "CreatedTime"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cca8649f-864f-42df-8cd3-9b19350c55d6",
-        "Content-Length": "349",
+        "apim-request-id": "674e7058-9b92-42e7-a5ed-b94a72905dfa",
+        "Content-Length": "342",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:46 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "85",
-        "X-Request-ID": "cca8649f-864f-42df-8cd3-9b19350c55d6"
+        "x-envoy-upstream-service-time": "71",
+        "X-Request-ID": "674e7058-9b92-42e7-a5ed-b94a72905dfa"
       },
       "ResponseBody": {
         "value": [
           {
-            "alertId": "1749e82b400",
-            "timestamp": "2020-09-18T00:00:00Z",
-            "createdTime": "2020-09-19T21:35:29.225Z",
-            "modifiedTime": "2020-09-20T16:34:22.553Z"
+            "alertId": "1758640e000",
+            "timestamp": "2020-11-02T00:00:00Z",
+            "createdTime": "2020-11-03T00:06:12.487Z",
+            "modifiedTime": "2020-11-03T00:11:01.967Z"
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=2"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=2"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=2",
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
@@ -97,45 +97,45 @@
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "afc9b53350aea9367e90bfa5ae15821f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "startTime": "2015-09-29T23:42:46Z",
-        "endTime": "2020-09-29T23:42:46Z",
+        "startTime": "2015-11-04T17:47:12Z",
+        "endTime": "2020-11-04T17:47:12Z",
         "timeMode": "CreatedTime"
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f43ab72c-fd18-468a-8e9d-9a6369c9595c",
-        "Content-Length": "349",
+        "apim-request-id": "ae19cf87-7eab-4cb7-a28f-d08ced2ad324",
+        "Content-Length": "341",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:46 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "87",
-        "X-Request-ID": "f43ab72c-fd18-468a-8e9d-9a6369c9595c"
+        "x-envoy-upstream-service-time": "72",
+        "X-Request-ID": "ae19cf87-7eab-4cb7-a28f-d08ced2ad324"
       },
       "ResponseBody": {
         "value": [
           {
-            "alertId": "174995c5800",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:00.956Z",
-            "modifiedTime": "2020-09-18T19:46:05.762Z"
+            "alertId": "175811a8400",
+            "timestamp": "2020-11-01T00:00:00Z",
+            "createdTime": "2020-11-02T00:33:16.23Z",
+            "modifiedTime": "2020-11-04T00:11:03.014Z"
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/query?$top=1\u0026$skip=3"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/query?$top=1\u0026$skip=3"
       }
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-09-29T18:42:46.5681596-05:00",
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "DateTimeOffsetNow": "2020-11-04T09:47:12.4590697-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAnomaliesForAlert.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAnomaliesForAlert.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "17f99acbe548bf8532a2bf252fb719f7",
@@ -17,45 +17,45 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "89cae43a-8ba8-444c-99d2-3a38dc2ce864",
-        "Content-Length": "576",
+        "apim-request-id": "28021f2d-7257-453f-9f02-7ae33da13825",
+        "Content-Length": "573",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:32 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "78",
-        "X-Request-ID": "89cae43a-8ba8-444c-99d2-3a38dc2ce864"
+        "x-envoy-upstream-service-time": "67",
+        "X-Request-ID": "28021f2d-7257-453f-9f02-7ae33da13825"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:04.345Z",
-            "modifiedTime": "2020-09-18T19:36:04.345Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "timestamp": "2020-10-29T00:00:00Z",
+            "createdTime": "2020-10-30T00:06:12.66Z",
+            "modifiedTime": "2020-10-30T00:06:12.66Z",
             "dimension": {
-              "Dim1": "Common Ash",
-              "Dim2": "Bedbug"
+              "city": "Shanghai",
+              "category": "__SUM__"
             },
             "property": {
-              "anomalySeverity": "Low",
+              "anomalySeverity": "Medium",
               "anomalyStatus": "Active"
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=1"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=1"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "77e17ac67f877c6a6e2df5157fba331f",
@@ -64,26 +64,26 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4c126de6-cc89-47c1-afcf-388780c921dc",
-        "Content-Length": "603",
+        "apim-request-id": "fa939604-cb06-42e2-8a21-c5b4fa8d89ac",
+        "Content-Length": "572",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:33 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "67",
-        "X-Request-ID": "4c126de6-cc89-47c1-afcf-388780c921dc"
+        "x-envoy-upstream-service-time": "68",
+        "X-Request-ID": "fa939604-cb06-42e2-8a21-c5b4fa8d89ac"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:04.345Z",
-            "modifiedTime": "2020-09-18T19:36:04.345Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "timestamp": "2020-10-29T00:00:00Z",
+            "createdTime": "2020-10-30T00:06:12.66Z",
+            "modifiedTime": "2020-10-30T00:06:12.66Z",
             "dimension": {
-              "Dim1": "Chinese red-barked birch",
-              "Dim2": "African elephant"
+              "city": "Bangkok",
+              "category": "__SUM__"
             },
             "property": {
               "anomalySeverity": "Medium",
@@ -91,18 +91,18 @@
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=2"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=2"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "da2b2056ed3c79eeacef412c383bc0f3",
@@ -111,26 +111,26 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0d6edebc-08a5-49b0-a8a6-a4fd3e81764e",
-        "Content-Length": "574",
+        "apim-request-id": "8578c017-176c-4c10-9af0-8f16abc55ea6",
+        "Content-Length": "580",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:33 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "56",
-        "X-Request-ID": "0d6edebc-08a5-49b0-a8a6-a4fd3e81764e"
+        "x-envoy-upstream-service-time": "68",
+        "X-Request-ID": "8578c017-176c-4c10-9af0-8f16abc55ea6"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:04.345Z",
-            "modifiedTime": "2020-09-18T19:36:04.345Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "timestamp": "2020-10-29T00:00:00Z",
+            "createdTime": "2020-10-30T00:06:12.66Z",
+            "modifiedTime": "2020-10-30T00:06:12.66Z",
             "dimension": {
-              "Dim1": "Cherry",
-              "Dim2": "Basilisk"
+              "city": "__SUM__",
+              "category": "Personal Computers"
             },
             "property": {
               "anomalySeverity": "Low",
@@ -138,12 +138,12 @@
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=3"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=3"
       }
     }
   ],
   "Variables": {
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAnomaliesForAlertAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetAnomaliesForAlertAsync.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "474a97e46aa6572781a5be0aacf73ab4",
@@ -17,45 +17,45 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "acafc08a-7d7b-4fb0-ac92-e8a60a1f438e",
-        "Content-Length": "576",
+        "apim-request-id": "6be6eeed-ea26-441f-9a7c-7461efb07dff",
+        "Content-Length": "573",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:46 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "78",
-        "X-Request-ID": "acafc08a-7d7b-4fb0-ac92-e8a60a1f438e"
+        "x-envoy-upstream-service-time": "46",
+        "X-Request-ID": "6be6eeed-ea26-441f-9a7c-7461efb07dff"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:04.345Z",
-            "modifiedTime": "2020-09-18T19:36:04.345Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "timestamp": "2020-10-29T00:00:00Z",
+            "createdTime": "2020-10-30T00:06:12.66Z",
+            "modifiedTime": "2020-10-30T00:06:12.66Z",
             "dimension": {
-              "Dim1": "Common Ash",
-              "Dim2": "Bedbug"
+              "city": "Shanghai",
+              "category": "__SUM__"
             },
             "property": {
-              "anomalySeverity": "Low",
+              "anomalySeverity": "Medium",
               "anomalyStatus": "Active"
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=1"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=1"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9ff1bb94236e2b732e5cd3999e0f0d98",
@@ -64,26 +64,26 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "754c2bf5-11b8-4062-8edd-cbca7d226020",
-        "Content-Length": "603",
+        "apim-request-id": "d7ec2985-cb62-42e9-ac11-d6adb18dfa38",
+        "Content-Length": "572",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:46 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "62",
-        "X-Request-ID": "754c2bf5-11b8-4062-8edd-cbca7d226020"
+        "x-envoy-upstream-service-time": "49",
+        "X-Request-ID": "d7ec2985-cb62-42e9-ac11-d6adb18dfa38"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:04.345Z",
-            "modifiedTime": "2020-09-18T19:36:04.345Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "timestamp": "2020-10-29T00:00:00Z",
+            "createdTime": "2020-10-30T00:06:12.66Z",
+            "modifiedTime": "2020-10-30T00:06:12.66Z",
             "dimension": {
-              "Dim1": "Chinese red-barked birch",
-              "Dim2": "African elephant"
+              "city": "Bangkok",
+              "category": "__SUM__"
             },
             "property": {
               "anomalySeverity": "Medium",
@@ -91,18 +91,18 @@
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=2"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=2"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a4295fb14b53b7140b1964d5437b5c47",
@@ -111,26 +111,26 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "03649005-9a5f-460e-8388-8a893ff156d3",
-        "Content-Length": "574",
+        "apim-request-id": "cacc307c-9007-413d-9e36-4473acceb657",
+        "Content-Length": "580",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:46 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "55",
-        "X-Request-ID": "03649005-9a5f-460e-8388-8a893ff156d3"
+        "x-envoy-upstream-service-time": "51",
+        "X-Request-ID": "cacc307c-9007-413d-9e36-4473acceb657"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "timestamp": "2020-09-17T00:00:00Z",
-            "createdTime": "2020-09-18T19:36:04.345Z",
-            "modifiedTime": "2020-09-18T19:36:04.345Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "timestamp": "2020-10-29T00:00:00Z",
+            "createdTime": "2020-10-30T00:06:12.66Z",
+            "modifiedTime": "2020-10-30T00:06:12.66Z",
             "dimension": {
-              "Dim1": "Cherry",
-              "Dim2": "Basilisk"
+              "city": "__SUM__",
+              "category": "Personal Computers"
             },
             "property": {
               "anomalySeverity": "Low",
@@ -138,12 +138,12 @@
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/anomalies?$top=1\u0026$skip=3"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/anomalies?$top=1\u0026$skip=3"
       }
     }
   ],
   "Variables": {
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetIncidentsForAlert.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetIncidentsForAlert.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4ac4ca457343b083d33ad7b92c303eb1",
@@ -17,27 +17,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b6301448-fdcf-4130-91fc-a8b1e168854f",
-        "Content-Length": "579",
+        "apim-request-id": "0cd3b13d-e0e2-4051-b339-b2511a978c88",
+        "Content-Length": "591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:35 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "264",
-        "X-Request-ID": "b6301448-fdcf-4130-91fc-a8b1e168854f"
+        "x-envoy-upstream-service-time": "218",
+        "X-Request-ID": "0cd3b13d-e0e2-4051-b339-b2511a978c88"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "incidentId": "00b89c31c14766a9cff07ec7c4793042-174995c5800",
-            "startTime": "2020-09-17T00:00:00Z",
-            "lastTime": "2020-09-17T00:00:00Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "0f099f2089162cab683d305ad1a9cba8-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
             "rootNode": {
               "dimension": {
-                "Dim1": "Common Ash",
-                "Dim2": "Bedbug"
+                "city": "Sao Paulo",
+                "category": "Grocery \u0026 Gourmet Food"
               }
             },
             "property": {
@@ -45,18 +45,18 @@
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=1"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=1"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "823705ba76a0fa35010bf440cf3b7b3c",
@@ -65,47 +65,47 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e5ec380f-d08d-4fc9-8a9a-aa8518f7d8fa",
-        "Content-Length": "624",
+        "apim-request-id": "ab349041-49c6-46c4-bc45-2e983e0837b5",
+        "Content-Length": "609",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:36 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "398",
-        "X-Request-ID": "e5ec380f-d08d-4fc9-8a9a-aa8518f7d8fa"
+        "x-envoy-upstream-service-time": "232",
+        "X-Request-ID": "ab349041-49c6-46c4-bc45-2e983e0837b5"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "incidentId": "02f6731132bc11fd8609d89e7eefd6ba-174995c5800",
-            "startTime": "2020-09-16T00:00:00Z",
-            "lastTime": "2020-09-17T00:00:00Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "15ee0a88ee90d2b7580b07acac9b5f1b-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
             "rootNode": {
               "dimension": {
-                "Dim1": "Chinese red-barked birch",
-                "Dim2": "African elephant"
+                "city": "Bengaluru",
+                "category": "Grocery \u0026 Gourmet Food"
               }
             },
             "property": {
-              "maxSeverity": "Medium",
+              "maxSeverity": "Low",
               "incidentStatus": "Active"
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=2"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=2"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "24bc4f241348bfbdd1226d2be17af3c5",
@@ -114,40 +114,41 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e7582bbb-f2e4-4a48-89d4-e7eadbe5c746",
-        "Content-Length": "577",
+        "apim-request-id": "bbcfde92-9306-40ca-98bc-9f98b9f69869",
+        "Content-Length": "603",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:36 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "238",
-        "X-Request-ID": "e7582bbb-f2e4-4a48-89d4-e7eadbe5c746"
+        "x-envoy-upstream-service-time": "241",
+        "X-Request-ID": "bbcfde92-9306-40ca-98bc-9f98b9f69869"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "incidentId": "0da4f4ef4db7db9ba355c66e911e2b35-174995c5800",
-            "startTime": "2020-09-17T00:00:00Z",
-            "lastTime": "2020-09-17T00:00:00Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "2b03e492fd98f311dac5754867352e2f-17571a77000",
+            "startTime": "2020-10-28T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
             "rootNode": {
               "dimension": {
-                "Dim1": "Cherry",
-                "Dim2": "Basilisk"
+                "city": "Los Angeles",
+                "category": "Camera \u0026 Photo"
               }
             },
             "property": {
-              "incidentStatus": "Resolved"
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=3"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=3"
       }
     }
   ],
   "Variables": {
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetIncidentsForAlertAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/MetricsAdvisorClientLiveTests/GetIncidentsForAlertAsync.json
@@ -1,14 +1,14 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d9764eeacedf8816eb06a9116f8aebac",
@@ -17,27 +17,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ec51e0b2-dd59-4efa-bacc-4823fa6608ca",
-        "Content-Length": "579",
+        "apim-request-id": "0c661db3-5d19-4f15-b289-0f0374fd77c0",
+        "Content-Length": "591",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:48 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "257",
-        "X-Request-ID": "ec51e0b2-dd59-4efa-bacc-4823fa6608ca"
+        "x-envoy-upstream-service-time": "229",
+        "X-Request-ID": "0c661db3-5d19-4f15-b289-0f0374fd77c0"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "incidentId": "00b89c31c14766a9cff07ec7c4793042-174995c5800",
-            "startTime": "2020-09-17T00:00:00Z",
-            "lastTime": "2020-09-17T00:00:00Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "0f099f2089162cab683d305ad1a9cba8-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
             "rootNode": {
               "dimension": {
-                "Dim1": "Common Ash",
-                "Dim2": "Bedbug"
+                "city": "Sao Paulo",
+                "category": "Grocery \u0026 Gourmet Food"
               }
             },
             "property": {
@@ -45,18 +45,18 @@
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=1"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=1"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5f927ce54a711252346b0202aa74e094",
@@ -65,47 +65,47 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "246d9e8f-adba-4e75-a8f4-b453ef3c168b",
-        "Content-Length": "624",
+        "apim-request-id": "38e4f8ac-62a9-410b-9450-2615548ec281",
+        "Content-Length": "609",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:49 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "277",
-        "X-Request-ID": "246d9e8f-adba-4e75-a8f4-b453ef3c168b"
+        "x-envoy-upstream-service-time": "226",
+        "X-Request-ID": "38e4f8ac-62a9-410b-9450-2615548ec281"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "incidentId": "02f6731132bc11fd8609d89e7eefd6ba-174995c5800",
-            "startTime": "2020-09-16T00:00:00Z",
-            "lastTime": "2020-09-17T00:00:00Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "15ee0a88ee90d2b7580b07acac9b5f1b-17571a77000",
+            "startTime": "2020-10-29T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
             "rootNode": {
               "dimension": {
-                "Dim1": "Chinese red-barked birch",
-                "Dim2": "African elephant"
+                "city": "Bengaluru",
+                "category": "Grocery \u0026 Gourmet Food"
               }
             },
             "property": {
-              "maxSeverity": "Medium",
+              "maxSeverity": "Low",
               "incidentStatus": "Active"
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=2"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=2"
       }
     },
     {
-      "RequestUri": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
         "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20200929.1",
-          "(.NET Core 4.6.29220.03; Microsoft Windows 10.0.18363 )"
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201103.1",
+          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
         ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dc6c00f1f66f3296e1e7200ed25543aa",
@@ -114,40 +114,41 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e64d04ca-fea6-4221-acd2-387fb5ea2786",
-        "Content-Length": "577",
+        "apim-request-id": "dc1fede3-e88a-47c8-9393-8ca6ff1da4c4",
+        "Content-Length": "603",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Sep 2020 23:42:49 GMT",
+        "Date": "Wed, 04 Nov 2020 17:47:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "235",
-        "X-Request-ID": "e64d04ca-fea6-4221-acd2-387fb5ea2786"
+        "x-envoy-upstream-service-time": "256",
+        "X-Request-ID": "dc1fede3-e88a-47c8-9393-8ca6ff1da4c4"
       },
       "ResponseBody": {
         "value": [
           {
-            "metricId": "3d48ed3e-6e6e-4391-b78f-b00dfee1e6f5",
-            "anomalyDetectionConfigurationId": "c0f2539f-b804-4ab9-a70f-0da0c89c76d8",
-            "incidentId": "0da4f4ef4db7db9ba355c66e911e2b35-174995c5800",
-            "startTime": "2020-09-17T00:00:00Z",
-            "lastTime": "2020-09-17T00:00:00Z",
+            "metricId": "27e3015f-04fd-44ba-a20b-bc529a0aebae",
+            "anomalyDetectionConfigurationId": "fb5a6ed6-2b9e-4b72-8b0c-0046ead1c15c",
+            "incidentId": "2b03e492fd98f311dac5754867352e2f-17571a77000",
+            "startTime": "2020-10-28T00:00:00Z",
+            "lastTime": "2020-10-29T00:00:00Z",
             "rootNode": {
               "dimension": {
-                "Dim1": "Cherry",
-                "Dim2": "Basilisk"
+                "city": "Los Angeles",
+                "category": "Camera \u0026 Photo"
               }
             },
             "property": {
-              "incidentStatus": "Resolved"
+              "maxSeverity": "Low",
+              "incidentStatus": "Active"
             }
           }
         ],
-        "@nextLink": "https://anuchan-cg-metric-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/08318302-6006-4019-9afc-975bc63ee566/alerts/174995c5800/incidents?$top=1\u0026$skip=3"
+        "@nextLink": "https://js-metrics-advisor.cognitiveservices.azure.com:443/metricsadvisor/v1.0/alert/anomaly/configurations/204a211a-c5f4-45f3-a30e-512fb25d1d2c/alerts/17571a77000/incidents?$top=1\u0026$skip=3"
       }
     }
   ],
   "Variables": {
-    "METRICSADVISOR_ACCOUNT_NAME": "anuchan-cg-metric-advisor",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/15974.

Public API changes:
- `DataFeed.MetricIds` convenience property updated to return a `Map<string, string>` instead of a `List<string>`. This makes it easier for users to figure out what's the ID of a given metric (maps name => ID).
- Added a `GetIncidentRootCauses` overload that takes an `Incident` object. It needs the detection configuration ID of this incident to work, so we also needed to update the behavior of `GetIncidents(DetectionConfiguration)` to make sure it always populates the detection configuration ID.

Tests changes:
- Added two `GetIncidentRootCauses` tests. One of them using an `AnomalyIncident` instance that was obtained from a `GetIncidents(DetectionConfiguration)` overload. The other, using an instance that was obtained from a `GetIncidents(Alert)` overload.