### PR TITLE
Add note about supporting a single lifetime action

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatePolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificatePolicy.cs
@@ -226,6 +226,7 @@ namespace Azure.Security.KeyVault.Certificates
 
         /// <summary>
         /// Gets the actions to be executed at specified times in the certificates lifetime.
+        /// Currently, only a single <see cref="LifetimeAction"/> is allowed.
         /// </summary>
         public IList<LifetimeAction> LifetimeActions { get; } = new List<LifetimeAction>();
 


### PR DESCRIPTION
Resolves #15633 without introducing a breaking API change or tight coupling with current service behavior despite their OpenAPI definition.
