### PR TITLE
Mitigate breaking build using SaveDebugRecordingsOnFailure

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -34,16 +34,27 @@ namespace Azure.Core.TestFramework
             (char)31, ':', '*', '?', '\\', '/'
         });
 
-#if DEBUG
         /// <summary>
         /// Flag you can (temporarily) enable to save failed test recordings
         /// and debug/re-run at the point of failure without re-running
         /// potentially lengthy live tests.  This should never be checked in
-        /// and will be compiled out of release builds to help make that easier
+        /// and will throw an exception from CI builds to help make that easier
         /// to spot.
         /// </summary>
-        public bool SaveDebugRecordingsOnFailure { get; set; } = false;
-#endif
+        public bool SaveDebugRecordingsOnFailure
+        {
+            get => _saveDebugRecordingsOnFailure;
+            set
+            {
+                if (value && !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SYSTEM_TEAMPROJECTID")))
+                {
+                    throw new AssertionException($"Setting {nameof(SaveDebugRecordingsOnFailure)} must not be merged");
+                }
+
+                _saveDebugRecordingsOnFailure = value;
+            }
+        }
+        private bool _saveDebugRecordingsOnFailure;
 
         protected RecordedTestBase(bool isAsync) : this(isAsync, RecordedTestUtilities.GetModeFromEnvironment())
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/tests/AccessControlClientTestBase.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/tests/AccessControlClientTestBase.cs
@@ -16,9 +16,6 @@ namespace Azure.Analytics.Synapse.Tests.AccessControl
 
         protected AccessControlClientTestBase(bool isAsync) : base(isAsync)
         {
-#if DEBUG
-            SaveDebugRecordingsOnFailure = true;
-#endif
         }
 
         public override void StartTestRecording()

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/ArtifactsClientTestBase.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/ArtifactsClientTestBase.cs
@@ -26,9 +26,6 @@ namespace Azure.Analytics.Synapse.Tests.Artifacts
 
         protected ArtifactsClientTestBase(bool isAsync) : base(isAsync)
         {
-#if DEBUG
-            SaveDebugRecordingsOnFailure = true;
-#endif
         }
 
         public override void StartTestRecording()

--- a/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/ManagedPrivateEndpointsClientTestBase.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/ManagedPrivateEndpointsClientTestBase.cs
@@ -16,9 +16,6 @@ namespace Azure.Analytics.Synapse.Tests.ManagedPrivateEndpoints
 
         protected ManagedPrivateEndpointsClientTestBase(bool isAsync) : base(isAsync)
         {
-#if DEBUG
-            SaveDebugRecordingsOnFailure = true;
-#endif
         }
 
         public override void StartTestRecording()

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/MonitoringClientTestBase.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/MonitoringClientTestBase.cs
@@ -16,9 +16,6 @@ namespace Azure.Analytics.Synapse.Tests.Monitoring
 
         protected MonitoringClientTestBase(bool isAsync) : base(isAsync)
         {
-#if DEBUG
-            SaveDebugRecordingsOnFailure = true;
-#endif
         }
 
         public override void StartTestRecording()

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/SparkClientTestBase.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/SparkClientTestBase.cs
@@ -19,9 +19,6 @@ namespace Azure.Analytics.Synapse.Spark.Tests
 
         protected SparkClientTestBase(bool isAsync) : base(isAsync)
         {
-#if DEBUG
-            SaveDebugRecordingsOnFailure = true;
-#endif
         }
 
         public override void StartTestRecording()


### PR DESCRIPTION
Tested with debug and release builds with and without SYSTEM_TEAMPROJECTID defined (used in a few projects for detecting AzDO). Doing this in the setter works when set in either a fixture's constructor or in a test method, while doing so in SetUp is too early, and in TearDown doesn't propagate.