### PR TITLE
Flip JsonDateTokens sanitizer condition

### DIFF
--- a/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/Infrastructure/AnomalyDetectorRecordedTestSanitizer.cs
+++ b/sdk/anomalydetector/Azure.AI.AnomalyDetector/tests/Infrastructure/AnomalyDetectorRecordedTestSanitizer.cs
@@ -13,6 +13,8 @@ namespace Azure.AI.AnomalyDetector.Tests
         {
             JsonPathSanitizers.Add("$..accessToken");
             JsonPathSanitizers.Add("$..source");
+            // TODO: Remove when re-recording
+            LegacyConvertJsonDateTokens = true;
         }
 
         public override void SanitizeHeaders(IDictionary<string, string[]> headers)

--- a/sdk/communication/Azure.Communication.Administration/tests/Infrastructure/CommunicationIdentityClientRecordedTestSanitizer.cs
+++ b/sdk/communication/Azure.Communication.Administration/tests/Infrastructure/CommunicationIdentityClientRecordedTestSanitizer.cs
@@ -17,6 +17,8 @@ namespace Azure.Communication.Administration.Tests
         {
             JsonPathSanitizers.Add("$..token");
             JsonPathSanitizers.Add("$..id");
+            // TODO: Remove when re-recording
+            LegacyConvertJsonDateTokens = true;
         }
 
         public override void SanitizeHeaders(IDictionary<string, string[]> headers)

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/Infrastructure/EventGridLiveTestBase.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/Infrastructure/EventGridLiveTestBase.cs
@@ -13,7 +13,6 @@ namespace Azure.Messaging.EventGrid.Tests
             Sanitizer.SanitizedHeaders.Add(Constants.SasKeyName);
             Sanitizer.SanitizedHeaders.Add(Constants.SasTokenName);
             Sanitizer.JsonPathSanitizers.Add("$..traceparent");
-            Sanitizer.DoNotConvertJsonDateTokens = true;
         }
     }
 }

--- a/sdk/iot/Azure.Iot.Hub.Service/tests/CustomRequestSanitizer.cs
+++ b/sdk/iot/Azure.Iot.Hub.Service/tests/CustomRequestSanitizer.cs
@@ -22,6 +22,8 @@ namespace Azure.Iot.Hub.Service.Tests
             JsonPathSanitizers.Add("inputBlobContainerUri");
             JsonPathSanitizers.Add("..primaryKey");
             JsonPathSanitizers.Add("..secondaryKey");
+            // TODO: Remove when re-recording
+            LegacyConvertJsonDateTokens = true;
         }
 
         public override string SanitizeUri(string uri)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorRecordedTestSanitizer.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorRecordedTestSanitizer.cs
@@ -18,6 +18,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             JsonPathSanitizers.Add("$..accountKey");
             JsonPathSanitizers.Add("$..authHeader");
             JsonPathSanitizers.Add("$..httpHeader");
+            // TODO: Remove when re-recording
+            LegacyConvertJsonDateTokens = true;
         }
 
         public override string SanitizeTextBody(string contentType, string body)


### PR DESCRIPTION
We had a bug in sanitizer code that converted date format as part of sanitizing JSON. The bug was fixed but we needed a switch not to break existing recordings. Flip the switch to be opt-out and avoid adding more broken recordings.