### PR TITLE
change BugFix to Patch

### DIFF
--- a/eng/scripts/Prepare-Release.ps1
+++ b/eng/scripts/Prepare-Release.ps1
@@ -214,11 +214,11 @@ if ($releasing)
         }
         elseif ($parsedNewVersion.Patch -ne $parsedVersion.Patch)
         {
-            $releaseType = "Bugfix"
+            $releaseType = "Patch"
         }
         elseif ($parsedNewVersion.IsPrerelease)
         {
-            $releaseType = "Bugfix"
+            $releaseType = "Patch"
         }
     }
     else


### PR DESCRIPTION
DevOps removed the `BugFix` release type and replaced it with `Patch`

![image](https://user-images.githubusercontent.com/1279263/98261194-cbf77d00-1f49-11eb-9b21-bea2d92a4a8a.png)
