### PR TITLE
[Event Hubs Client] Enhance EventHubsException.ToString

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/README.md
@@ -10,7 +10,7 @@ The Event Processor client library is a companion to the Azure Event Hubs client
 
 - Managing checkpoints and state for processing in a durable manner using Azure Storage blobs as the underlying data store.
 
-[Source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor/) | [API reference documentation](https://aka.ms/azsdk-dotnet-eventhubs-processor-docs) | [Product documentation](https://docs.microsoft.com/azure/event-hubs/)
+[Source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs.Processor/) | [API reference documentation](https://docs.microsoft.com/dotnet/api/azure.messaging.eventhubs?view=azure-dotnet) | [Product documentation](https://docs.microsoft.com/azure/event-hubs/)
 
 ## Getting started
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -12,7 +12,7 @@ The Azure Event Hubs client library allows for publishing and consuming of Azure
 
 - Receive events from one or more publishers, transform them to better meet the needs of your ecosystem, then publish the transformed events to a new stream for consumers to observe.
 
-[Source code](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/src) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs/) | [API reference documentation](https://aka.ms/azsdk-dotnet-eventhubs-docs) | [Product documentation](https://docs.microsoft.com/azure/event-hubs/) | [Migration guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md)
+[Source code](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/src) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs/) | [API reference documentation](https://docs.microsoft.com/dotnet/api/azure.messaging.eventhubs?view=azure-dotnet)) | [Product documentation](https://docs.microsoft.com/azure/event-hubs/) | [Migration guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md)
 
 ## Getting started
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
@@ -183,7 +183,8 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         ///
-        public override string ToString() => $"{ typeof(EventHubsException).Name }({ Reason })";
+        public override string ToString() =>
+            $"{ typeof(EventHubsException).FullName }({ Reason }): { Message }{ Environment.NewLine }{ StackTrace }";
 
         /// <summary>
         ///   The set of well-known reasons for an Event Hubs operation failure that

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
@@ -164,16 +164,29 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ToStringValueContainsTheTypeNameAndFailureReason()
+        public void ToStringContainsExceptionDetails()
         {
             var message = "Test message!";
-            var namespaceValue = "the-namespace";
+            var eventHubName = "the-thub";
             var reason = EventHubsException.FailureReason.QuotaExceeded;
-            var instance = new EventHubsException(false, namespaceValue, message, reason);
 
-            Assert.That(instance.ToString(), Is.Not.Null.And.Not.Empty, "The ToString value should be populated.");
-            Assert.That(instance.ToString(), Contains.Substring(typeof(EventHubsException).Name), "The ToString value should contain the type name.");
-            Assert.That(instance.ToString(), Contains.Substring(reason.ToString()), "The ToString value should contain the failure reason.");
+            EventHubsException instance;
+
+            try
+            {
+                throw new EventHubsException(false, eventHubName, message, reason);
+            }
+            catch (EventHubsException ex)
+            {
+                instance = ex;
+            }
+
+            var exceptionString = instance.ToString();
+            Assert.That(exceptionString, Is.Not.Null.And.Not.Empty, "The ToString value should be populated.");
+            Assert.That(exceptionString, Contains.Substring(typeof(EventHubsException).FullName), "The ToString value should contain the type name.");
+            Assert.That(exceptionString, Contains.Substring(reason.ToString()), "The ToString value should contain the failure reason.");
+            Assert.That(exceptionString, Contains.Substring(eventHubName), "The ToString value should contain the Event Hub name.");
+            Assert.That(exceptionString, Contains.Substring($"{ Environment.NewLine }{ instance.StackTrace }"), "The ToString value should contain the stack trace on a new line.");
         }
     }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to enhance the string format returned by `ToString` on the `EventHubsException`, matching the information and format of the default implementation and enriching to include the failure reason.

Also included are fixes for legacy documentation links which are no longer valid.

# Last Upstream Rebase

Friday, November 6, 10:33am (EST)

# References and Related

- [EventHubException ToString() Has No Helping Details (#15894)](https://github.com/Azure/azure-sdk-for-net/issues/15894)