### PR TITLE
Changing FileSmbProperties empty constructor from internal to public

### DIFF
--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added ability to set Position on streams created with ShareFileClient.OpenRead().
 - Added CanGenerateSasUri property and GenerateSasUri() to ShareFileClient, ShareDirectoryClient and ShareClient.
 - Added CanGenerateSasUri property and GenerateAccountSasUri() to ShareServiceClient.
+- Change FileSmbProperties empty constructor from internal to public.
 
 ## 12.5.0-preview.1 (2020-09-30)
 - Added support for service version 2020-02-10.

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added ability to set Position on streams created with ShareFileClient.OpenRead().
 - Added CanGenerateSasUri property and GenerateSasUri() to ShareFileClient, ShareDirectoryClient and ShareClient.
 - Added CanGenerateSasUri property and GenerateAccountSasUri() to ShareServiceClient.
-- Change FileSmbProperties empty constructor from internal to public.
+- Changed default constructor for FileSmbProperties from internal to public.
 
 ## 12.5.0-preview.1 (2020-09-30)
 - Added support for service version 2020-02-10.

--- a/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/api/Azure.Storage.Files.Shares.netstandard2.0.cs
@@ -360,7 +360,7 @@ namespace Azure.Storage.Files.Shares.Models
     }
     public partial class FileSmbProperties
     {
-        internal FileSmbProperties() { }
+        public FileSmbProperties() { }
         public Azure.Storage.Files.Shares.Models.NtfsFileAttributes? FileAttributes { get { throw null; } set { } }
         public System.DateTimeOffset? FileChangedOn { get { throw null; } }
         public System.DateTimeOffset? FileCreatedOn { get { throw null; } set { } }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/Models/FileSmbProperties.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/Models/FileSmbProperties.cs
@@ -52,7 +52,10 @@ namespace Azure.Storage.Files.Shares.Models
         /// </summary>
         public string ParentId { get; internal set; }
 
-        internal FileSmbProperties()
+        /// <summary>
+        /// Creates a new FileSmbProperties instance.
+        /// </summary>
+        public FileSmbProperties()
         {
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -12,14 +12,13 @@ using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Storage.Files.Shares.Models;
 using Azure.Storage.Files.Shares.Specialized;
-using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using BenchmarkDotNet.Toolchains.Roslyn;
 using NUnit.Framework;
 
-namespace Azure.Storage.Files.Shares.Test
+namespace Azure.Storage.Files.Shares.Tests
 {
     public class FileClientTests : FileTestBase
     {


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/15853