### PR TITLE
[Event Hubs Function Bindings] Ignore Failing Tests

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("Failing test.  Tracked by #16715")]
         public async Task EventHub_PocoBinding()
         {
             var tuple = BuildHost<EventHubTestBindToPocoJobs>();
@@ -53,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("Failing test.  Tracked by #16715")]
         public async Task EventHub_StringBinding()
         {
             var tuple = BuildHost<EventHubTestBindToStringJobs>();
@@ -71,6 +73,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("Failing test.  Tracked by #16715")]
         public async Task EventHub_SingleDispatch()
         {
             Tuple<JobHost, IHost> tuple = BuildHost<EventHubTestSingleDispatchJobs>();
@@ -104,6 +107,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("Failing test.  Tracked by #16715")]
         public async Task EventHub_MultipleDispatch()
         {
             Tuple<JobHost, IHost> tuple = BuildHost<EventHubTestMultipleDispatchJobs>();
@@ -140,6 +144,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
         }
 
         [Test]
+        [Ignore("Failing test.  Tracked by #16715")]
         public async Task EventHub_PartitionKey()
         {
             Tuple<JobHost, IHost> tuple = BuildHost<EventHubPartitionKeyTestJobs>();

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -5,5 +5,5 @@ extends:
   parameters:
     MaxParallel: 6
     ServiceDirectory: eventhub
-    TimeoutInMinutes: 120
+    TimeoutInMinutes: 150
     TestCanary: true


### PR DESCRIPTION
# Summary

The focus of these changes is to ignore the tests that are failing for Live runs consistently until they can be investigated.   Also riding along is a bump for the Live Test timeout.   With the addition of new tests, we're seeing some runs that require extra time.

# Last Upstream Rebase

Saturday, November 7, 11:29am (EST)

# References and Related

- [[Event Hubs Function Bindings] Live Test Failures (#16715)](https://github.com/Azure/azure-sdk-for-net/issues/16715)