### PR TITLE
[Identity] Fix VisualStudioCodeCredential to use refresh token for AzureCloud by default

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 ## 1.3.0-beta.3 (Unreleased)
 
+### Fixes and improvements
+- Prevent `VisualStudioCodeCredential` using invalid authentication data when no user is signed in to Visual Studio Code ([#15870](https://github.com/Azure/azure-sdk-for-net/issues/15870))
+
 ### Breaking Changes
 - Rename property `IncludeX5CClaimHeader` on `ClientCertificateCredentialOptions` to `SendCertificateChain`
 - Removing Application Authentication APIs for GA release. These will be reintroduced in 1.4.0-beta.1.

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -120,7 +120,7 @@ namespace Azure.Identity
         {
             var path = _vscAdapter.GetUserSettingsPath();
             tenant = _tenantId;
-            environmentName = "Azure";
+            environmentName = "AzureCloud";
 
             try
             {

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -164,7 +164,7 @@ namespace Azure.Identity
         private static AzureCloudInstance GetAzureCloudInstance(string name) =>
             name switch
             {
-                "Azure" => AzureCloudInstance.AzurePublic,
+                "AzureCloud" => AzureCloudInstance.AzurePublic,
                 "AzureChina" => AzureCloudInstance.AzureChina,
                 "AzureGermanCloud" => AzureCloudInstance.AzureGermany,
                 "AzureUSGovernment" => AzureCloudInstance.AzureUsGovernment,

--- a/sdk/identity/Azure.Identity/tests/ChainedTokenCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ChainedTokenCredentialLiveTests.cs
@@ -117,7 +117,7 @@ namespace Azure.Identity.Tests
         public async Task ChainedTokenCredential_UseAzureCliCredential()
         {
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
             var processService = new TestProcessService(new TestProcess { Output = processOutput });
 
@@ -148,7 +148,7 @@ namespace Azure.Identity.Tests
         public async Task ChainedTokenCredential_UseAzureCliCredential_ParallelCalls()
         {
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
             var processService = new TestProcessService { CreateHandler = psi => new TestProcess { Output = processOutput }};
 
@@ -177,7 +177,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void ChainedTokenCredential_AllCredentialsHaveFailed_CredentialUnavailableException()
         {
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", "{}");
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", "{}");
 
             var fileSystem = new TestFileSystemService();
             var processService = new TestProcessService(new TestProcess { Error = "'az' is not recognized" });
@@ -232,7 +232,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void ChainedTokenCredential_AllCredentialsHaveFailed_LastAuthenticationFailedException()
         {
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = new TestFileSystemService();
             var processService = new TestProcessService(new TestProcess {Error = "Error"});
 

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialLiveTests.cs
@@ -142,7 +142,7 @@ namespace Azure.Identity.Tests
 
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();
             var testProcess = new TestProcess { Output = processOutput };
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
 
             var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, new TestProcessService(testProcess), vscAdapter) { ManagedIdentitySourceFactory = () => default };
@@ -178,7 +178,7 @@ namespace Azure.Identity.Tests
 
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureCli();
             var processService = new TestProcessService { CreateHandler = psi => new TestProcess { Output = processOutput }};
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
 
             var factory = new TestDefaultAzureCredentialFactory(options, fileSystem, processService, vscAdapter) { ManagedIdentitySourceFactory = () => default };
@@ -210,7 +210,7 @@ namespace Azure.Identity.Tests
                 ExcludeSharedTokenCacheCredential = true,
             });
 
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", "{}");
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", "{}");
             var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "'az' is not recognized" }), vscAdapter) { ManagedIdentitySourceFactory = () => default };
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 
@@ -266,7 +266,7 @@ namespace Azure.Identity.Tests
                 ExcludeSharedTokenCacheCredential = true,
             });
 
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var factory = new TestDefaultAzureCredentialFactory(options, new TestFileSystemService(), new TestProcessService(new TestProcess { Error = "Error" }), vscAdapter) { ManagedIdentitySourceFactory = () => default };
             var credential = InstrumentClient(new DefaultAzureCredential(factory, options));
 

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialLiveTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Identity.Tests
         {
             var refreshToken = await CredentialTestHelpers.GetRefreshTokenAsync(TestEnvironment, Mode);
             var fileSystemService = new TestFileSystemService { ReadAllHandler = s => throw new FileNotFoundException() };
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", refreshToken);
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
@@ -52,7 +52,7 @@ namespace Azure.Identity.Tests
         {
             var refreshToken = await CredentialTestHelpers.GetRefreshTokenAsync(TestEnvironment, Mode);
             var fileSystemService = new TestFileSystemService { ReadAllHandler = s => "{a,}" };
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", refreshToken);
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
@@ -65,7 +65,7 @@ namespace Azure.Identity.Tests
         {
             var refreshToken = await CredentialTestHelpers.GetRefreshTokenAsync(TestEnvironment, Mode);
             var fileSystemService = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", refreshToken);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", refreshToken);
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = TestEnvironment.TestTenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
@@ -107,7 +107,7 @@ namespace Azure.Identity.Tests
         public void AuthenticateWithVscCredential_NoRefreshToken()
         {
             var tenantId = TestEnvironment.TestTenantId;
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", null);
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", null);
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId });
@@ -121,7 +121,7 @@ namespace Azure.Identity.Tests
         {
             var tenantId = TestEnvironment.TestTenantId;
             var fileSystemService = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", "{}");
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", "{}");
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));
@@ -134,7 +134,7 @@ namespace Azure.Identity.Tests
         {
             var tenantId = TestEnvironment.TestTenantId;
             var fileSystemService = CredentialTestHelpers.CreateFileSystemForVisualStudioCode(TestEnvironment);
-            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "Azure", Guid.NewGuid().ToString());
+            var vscAdapter = new TestVscAdapter(ExpectedServiceName, "AzureCloud", Guid.NewGuid().ToString());
 
             var options = InstrumentClientOptions(new VisualStudioCodeCredentialOptions { TenantId = tenantId });
             VisualStudioCodeCredential credential = InstrumentClient(new VisualStudioCodeCredential(options, default, default, fileSystemService, vscAdapter));


### PR DESCRIPTION
Fixes #15870