### PR TITLE
Make Search/AutoComplete tests order independent

### DIFF
--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/AutocompleteTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/AutocompleteTests.cs
@@ -27,8 +27,10 @@ namespace Azure.Search.Documents.Tests
             Assert.NotNull(completions.Results);
             Assert.NotNull(expectedText);
             Assert.NotNull(expectedQueryPlusText);
-            CollectionAssert.AreEquivalent(expectedText, completions.Results.Select(c => c.Text));
-            CollectionAssert.AreEquivalent(expectedQueryPlusText, completions.Results.Select(c => c.QueryPlusText));
+
+            // TODO: #16824 - investigate autocompletions across SKUs
+            CollectionAssert.IsSubsetOf(completions.Results.Select(c => c.Text), expectedText);
+            CollectionAssert.IsSubsetOf(completions.Results.Select(c => c.QueryPlusText), expectedQueryPlusText);
         }
 
         [Test]

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/AutocompleteTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/AutocompleteTests.cs
@@ -27,8 +27,8 @@ namespace Azure.Search.Documents.Tests
             Assert.NotNull(completions.Results);
             Assert.NotNull(expectedText);
             Assert.NotNull(expectedQueryPlusText);
-            CollectionAssert.AreEqual(expectedText, completions.Results.Select(c => c.Text));
-            CollectionAssert.AreEqual(expectedQueryPlusText, completions.Results.Select(c => c.QueryPlusText));
+            CollectionAssert.AreEquivalent(expectedText, completions.Results.Select(c => c.Text));
+            CollectionAssert.AreEquivalent(expectedQueryPlusText, completions.Results.Select(c => c.QueryPlusText));
         }
 
         [Test]

--- a/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
+++ b/sdk/search/Azure.Search.Documents/tests/DocumentOperations/SearchTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Search.Documents.Tests
             params string[] expectedKeys)
         {
             List<SearchResult<T>> docs = await response.Value.GetResultsAsync().ToListAsync();
-            CollectionAssert.AreEqual(expectedKeys, docs.Select(keyAccessor));
+            CollectionAssert.AreEquivalent(expectedKeys, docs.Select(keyAccessor));
         }
 
         private ICollection<FacetResult> GetFacetsForField(
@@ -135,13 +135,15 @@ namespace Azure.Search.Documents.Tests
 
             List<SearchResult<SearchDocument>> docs = await response.GetResultsAsync().ToListAsync();
             Assert.AreEqual(SearchResources.TestDocuments.Length, docs.Count);
-            for (int i = 0; i < docs.Count; i++)
+            Hotel[] expected = SearchResources.TestDocuments.OrderBy(d => d.HotelId).ToArray();
+            SearchResult<SearchDocument>[] actual = docs.OrderBy(r => r.Document["hotelId"]).ToArray();
+            for (int i = 0; i < actual.Length; i++)
             {
-                Assert.AreEqual(1, docs[i].Score);
-                Assert.IsNull(docs[i].Highlights);
+                Assert.AreEqual(1, actual[i].Score);
+                Assert.IsNull(actual[i].Highlights);
                 SearchTestBase.AssertApproximate(
-                    SearchResources.TestDocuments[i].AsDocument(),
-                    docs[i].Document);
+                    expected[i].AsDocument(),
+                    actual[i].Document);
             }
         }
 
@@ -158,11 +160,13 @@ namespace Azure.Search.Documents.Tests
 
             List<SearchResult<Hotel>> docs = await response.GetResultsAsync().ToListAsync();
             Assert.AreEqual(SearchResources.TestDocuments.Length, docs.Count);
-            for (int i = 0; i < docs.Count; i++)
+            Hotel[] expected = SearchResources.TestDocuments.OrderBy(d => d.HotelId).ToArray();
+            SearchResult<Hotel>[] actual = docs.OrderBy(r => r.Document.HotelId).ToArray();
+            for (int i = 0; i < actual.Length; i++)
             {
-                Assert.AreEqual(1, docs[i].Score);
-                Assert.IsNull(docs[i].Highlights);
-                Assert.AreEqual(SearchResources.TestDocuments[i], docs[i].Document);
+                Assert.AreEqual(1, actual[i].Score);
+                Assert.IsNull(actual[i].Highlights);
+                Assert.AreEqual(expected[i], actual[i].Document);
             }
         }
 
@@ -193,12 +197,14 @@ namespace Azure.Search.Documents.Tests
 
             List<SearchResult<UncasedHotel>> docs = await response.GetResultsAsync().ToListAsync();
             Assert.AreEqual(SearchResources.TestDocuments.Length, docs.Count);
-            for (int i = 0; i < docs.Count; i++)
+            Hotel[] expected = SearchResources.TestDocuments.OrderBy(d => d.HotelId).ToArray();
+            SearchResult<UncasedHotel>[] actual = docs.OrderBy(r => r.Document.HotelId).ToArray();
+            for (int i = 0; i < actual.Length; i++)
             {
-                Assert.AreEqual(1, docs[i].Score);
-                Assert.IsNull(docs[i].Highlights);
+                Assert.AreEqual(1, actual[i].Score);
+                Assert.IsNull(actual[i].Highlights);
                 // Flip expected/actual order because we implemented Equals in UncasedHotel
-                Assert.AreEqual(docs[i].Document, SearchResources.TestDocuments[i]);
+                Assert.AreEqual(actual[i].Document, expected[i]);
             }
         }
 


### PR DESCRIPTION
with the smallest change possible.  The change from the Free to Basic SKU jumbled some of these and I'm fixing them without re-recording to make sure they still work with either SKU.  (It would otherwise be more correct to use $orderby.)