### PR TITLE
Fix parameters.location reference in live test yaml

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -67,7 +67,7 @@ jobs:
 
           - template: /eng/common/TestResources/deploy-test-resources.yml
             parameters:
-              Location: ${{ cloudConfig.value.Location }}
+              Location: ${{ coalesce(parameters.Location, cloudConfig.value.Location, 'westus2') }}
               ServiceDirectory: '${{ parameters.ServiceDirectory }}'
               SubscriptionConfiguration: ${{ cloudConfig.value.SubscriptionConfiguration }}
               ArmTemplateParameters: ${{ cloudConfig.value.ArmTemplateParameters }}


### PR DESCRIPTION
This fixes a regression that did not plumb through a location override for live tests.