### PR TITLE
[DataFactory] Set computeType, coreCount to object type to allow expressions

### DIFF
--- a/eng/mgmt/mgmtmetadata/datafactory_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/datafactory_resource-manager.txt
@@ -4,11 +4,11 @@ Commencing code generation
 Generating CSharp code
 Executing AutoRest command
 cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datafactory/resource-manager/readme.md --csharp --version=v2 --reflect-api-versions --tag=package-2018-06 --csharp-sdks-folder=D:\Projects\azure-sdk-for-net\sdk
-2020-11-10 02:30:44 UTC
+2020-11-18 07:45:56 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      f8f89f01c1d1438ea2ef835105712ca3c610a978
+Commit:      146aefa430221f1dba5befb2d8dad17b8e4c88b7
 AutoRest information
 Requested version: v2
 Bootstrapper version:    autorest@2.0.4413

--- a/eng/mgmt/mgmtmetadata/datafactory_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/datafactory_resource-manager.txt
@@ -4,11 +4,11 @@ Commencing code generation
 Generating CSharp code
 Executing AutoRest command
 cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datafactory/resource-manager/readme.md --csharp --version=v2 --reflect-api-versions --tag=package-2018-06 --csharp-sdks-folder=D:\Projects\azure-sdk-for-net\sdk
-2020-10-28 02:50:39 UTC
+2020-11-10 02:30:44 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      e86a6eed316503ed17c2f7dfab94b2fa0f0c4129
+Commit:      f8f89f01c1d1438ea2ef835105712ca3c610a978
 AutoRest information
 Requested version: v2
 Bootstrapper version:    autorest@2.0.4413

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/CHANGELOG.md
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added authenticationType and sessionToken properties into AmazonS3 linkedService
 - Added support for more frequency types for TumblingWindowTrigger
 - Set computeType, coreCount to object type to allow expressions
+- Change PartitionOption to object to allow expression
 
 ## Version 4.12.0
 ###  Feature Additions

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/CHANGELOG.md
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added authenticationType and sessionToken properties into AmazonS3 linkedService
 - Added support for more frequency types for TumblingWindowTrigger
 - Set computeType, coreCount to object type to allow expressions
-- Change PartitionOption to object to allow expression
+- Change property PartitionOption type to object for NetezzaSource, OracleSource, SapHanaSource, SapTableSource, SqlDWSource, SqlMISource, SqlServerSource, SqlSource, TeradataSource. 
 
 ## Version 4.12.0
 ###  Feature Additions

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/CHANGELOG.md
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added connectionProperties property into Concur linkedService
 - Added authenticationType and sessionToken properties into AmazonS3 linkedService
 - Added support for more frequency types for TumblingWindowTrigger
+- Set computeType, coreCount to object type to allow expressions
 
 ## Version 4.12.0
 ###  Feature Additions

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/AzureSqlSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/AzureSqlSource.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="produceAdditionalTypes">Which additional types to
         /// produce.</param>
         /// <param name="partitionOption">The partition mechanism that will be
-        /// used for Sql read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'</param>
+        /// used for Sql read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for Sql source partitioning.</param>
-        public AzureSqlSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object produceAdditionalTypes = default(object), string partitionOption = default(string), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
+        public AzureSqlSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object produceAdditionalTypes = default(object), object partitionOption = default(object), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             SqlReaderQuery = sqlReaderQuery;
@@ -110,11 +110,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for Sql read
-        /// in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'
+        /// in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for Sql source

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/ExecuteDataFlowActivity.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/ExecuteDataFlowActivity.cs
@@ -51,13 +51,27 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// reference.</param>
         /// <param name="compute">Compute properties for data flow
         /// activity.</param>
-        public ExecuteDataFlowActivity(string name, DataFlowReference dataFlow, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), IList<UserProperty> userProperties = default(IList<UserProperty>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), DataFlowStagingInfo staging = default(DataFlowStagingInfo), IntegrationRuntimeReference integrationRuntime = default(IntegrationRuntimeReference), ExecuteDataFlowActivityTypePropertiesCompute compute = default(ExecuteDataFlowActivityTypePropertiesCompute))
+        /// <param name="traceLevel">Trace level setting used for data flow
+        /// monitoring output. Supported values are: 'coarse', 'fine', and
+        /// 'none'. Type: string (or Expression with resultType string)</param>
+        /// <param name="continueOnError">Continue on error setting used for
+        /// data flow execution. Enables processing to continue if a sink
+        /// fails. Type: boolean (or Expression with resultType
+        /// boolean)</param>
+        /// <param name="runConcurrently">Concurrent run setting used for data
+        /// flow execution. Allows sinks with the same save order to be
+        /// processed concurrently. Type: boolean (or Expression with
+        /// resultType boolean)</param>
+        public ExecuteDataFlowActivity(string name, DataFlowReference dataFlow, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), IList<UserProperty> userProperties = default(IList<UserProperty>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), DataFlowStagingInfo staging = default(DataFlowStagingInfo), IntegrationRuntimeReference integrationRuntime = default(IntegrationRuntimeReference), ExecuteDataFlowActivityTypePropertiesCompute compute = default(ExecuteDataFlowActivityTypePropertiesCompute), object traceLevel = default(object), object continueOnError = default(object), object runConcurrently = default(object))
             : base(name, additionalProperties, description, dependsOn, userProperties, linkedServiceName, policy)
         {
             DataFlow = dataFlow;
             Staging = staging;
             IntegrationRuntime = integrationRuntime;
             Compute = compute;
+            TraceLevel = traceLevel;
+            ContinueOnError = continueOnError;
+            RunConcurrently = runConcurrently;
             CustomInit();
         }
 
@@ -89,6 +103,30 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         [JsonProperty(PropertyName = "typeProperties.compute")]
         public ExecuteDataFlowActivityTypePropertiesCompute Compute { get; set; }
+
+        /// <summary>
+        /// Gets or sets trace level setting used for data flow monitoring
+        /// output. Supported values are: 'coarse', 'fine', and 'none'. Type:
+        /// string (or Expression with resultType string)
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.traceLevel")]
+        public object TraceLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets continue on error setting used for data flow
+        /// execution. Enables processing to continue if a sink fails. Type:
+        /// boolean (or Expression with resultType boolean)
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.continueOnError")]
+        public object ContinueOnError { get; set; }
+
+        /// <summary>
+        /// Gets or sets concurrent run setting used for data flow execution.
+        /// Allows sinks with the same save order to be processed concurrently.
+        /// Type: boolean (or Expression with resultType boolean)
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.runConcurrently")]
+        public object RunConcurrently { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/ExecuteDataFlowActivityTypePropertiesCompute.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/ExecuteDataFlowActivityTypePropertiesCompute.cs
@@ -33,11 +33,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="computeType">Compute type of the cluster which will
         /// execute data flow job. Possible values include: 'General',
-        /// 'MemoryOptimized', 'ComputeOptimized'</param>
+        /// 'MemoryOptimized', 'ComputeOptimized'. Type: string (or Expression
+        /// with resultType string)</param>
         /// <param name="coreCount">Core count of the cluster which will
         /// execute data flow job. Supported values are: 8, 16, 32, 48, 80, 144
-        /// and 272.</param>
-        public ExecuteDataFlowActivityTypePropertiesCompute(string computeType = default(string), int? coreCount = default(int?))
+        /// and 272. Type: integer (or Expression with resultType
+        /// integer)</param>
+        public ExecuteDataFlowActivityTypePropertiesCompute(object computeType = default(object), object coreCount = default(object))
         {
             ComputeType = computeType;
             CoreCount = coreCount;
@@ -52,17 +54,19 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Gets or sets compute type of the cluster which will execute data
         /// flow job. Possible values include: 'General', 'MemoryOptimized',
-        /// 'ComputeOptimized'
+        /// 'ComputeOptimized'. Type: string (or Expression with resultType
+        /// string)
         /// </summary>
         [JsonProperty(PropertyName = "computeType")]
-        public string ComputeType { get; set; }
+        public object ComputeType { get; set; }
 
         /// <summary>
         /// Gets or sets core count of the cluster which will execute data flow
-        /// job. Supported values are: 8, 16, 32, 48, 80, 144 and 272.
+        /// job. Supported values are: 8, 16, 32, 48, 80, 144 and 272. Type:
+        /// integer (or Expression with resultType integer)
         /// </summary>
         [JsonProperty(PropertyName = "coreCount")]
-        public int? CoreCount { get; set; }
+        public object CoreCount { get; set; }
 
     }
 }

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/NetezzaSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/NetezzaSource.cs
@@ -50,11 +50,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
         /// <param name="partitionOption">The partition mechanism that will be
-        /// used for Netezza read in parallel. Possible values include: 'None',
-        /// 'DataSlice', 'DynamicRange'</param>
+        /// used for Netezza read in parallel. Possible values include: "None",
+        /// "DataSlice", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for Netezza source partitioning.</param>
-        public NetezzaSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object query = default(object), string partitionOption = default(string), NetezzaPartitionSettings partitionSettings = default(NetezzaPartitionSettings))
+        public NetezzaSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object query = default(object), object partitionOption = default(object), NetezzaPartitionSettings partitionSettings = default(NetezzaPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             Query = query;
@@ -77,11 +77,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for Netezza
-        /// read in parallel. Possible values include: 'None', 'DataSlice',
-        /// 'DynamicRange'
+        /// read in parallel. Possible values include: "None", "DataSlice",
+        /// "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for Netezza source

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/OracleSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/OracleSource.cs
@@ -47,14 +47,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="partitionOption">The partition mechanism that will be
-        /// used for Oracle read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'</param>
+        /// used for Oracle read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for Oracle source partitioning.</param>
         /// <param name="additionalColumns">Specifies the additional columns to
         /// be added to source data. Type: array of objects (or Expression with
         /// resultType array of objects).</param>
-        public OracleSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object oracleReaderQuery = default(object), object queryTimeout = default(object), string partitionOption = default(string), OraclePartitionSettings partitionSettings = default(OraclePartitionSettings), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>))
+        public OracleSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object oracleReaderQuery = default(object), object queryTimeout = default(object), object partitionOption = default(object), OraclePartitionSettings partitionSettings = default(OraclePartitionSettings), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections)
         {
             OracleReaderQuery = oracleReaderQuery;
@@ -87,11 +87,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for Oracle
-        /// read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'
+        /// read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for Oracle source

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SapHanaSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SapHanaSource.cs
@@ -53,10 +53,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// HANA. Type: integer(or Expression with resultType integer).</param>
         /// <param name="partitionOption">The partition mechanism that will be
         /// used for SAP HANA read in parallel. Possible values include:
-        /// 'None', 'PhysicalPartitionsOfTable', 'SapHanaDynamicRange'</param>
+        /// "None", "PhysicalPartitionsOfTable", "SapHanaDynamicRange".
+        /// </param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for SAP HANA source partitioning.</param>
-        public SapHanaSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object query = default(object), object packetSize = default(object), string partitionOption = default(string), SapHanaPartitionSettings partitionSettings = default(SapHanaPartitionSettings))
+        public SapHanaSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object query = default(object), object packetSize = default(object), object partitionOption = default(object), SapHanaPartitionSettings partitionSettings = default(SapHanaPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             Query = query;
@@ -87,11 +88,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for SAP HANA
-        /// read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'SapHanaDynamicRange'
+        /// read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "SapHanaDynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for SAP HANA

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SapTableSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SapTableSource.cs
@@ -69,12 +69,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// string).</param>
         /// <param name="partitionOption">The partition mechanism that will be
         /// used for SAP table read in parallel. Possible values include:
-        /// 'None', 'PartitionOnInt', 'PartitionOnCalendarYear',
-        /// 'PartitionOnCalendarMonth', 'PartitionOnCalendarDate',
-        /// 'PartitionOnTime'</param>
+        /// "None", "PartitionOnInt", "PartitionOnCalendarYear",
+        /// "PartitionOnCalendarMonth", "PartitionOnCalendarDate",
+        /// "PartitionOnTime".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for SAP table source partitioning.</param>
-        public SapTableSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object rowCount = default(object), object rowSkips = default(object), object rfcTableFields = default(object), object rfcTableOptions = default(object), object batchSize = default(object), object customRfcReadTableFunctionModule = default(object), object sapDataColumnDelimiter = default(object), string partitionOption = default(string), SapTablePartitionSettings partitionSettings = default(SapTablePartitionSettings))
+        public SapTableSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object rowCount = default(object), object rowSkips = default(object), object rfcTableFields = default(object), object rfcTableOptions = default(object), object batchSize = default(object), object customRfcReadTableFunctionModule = default(object), object sapDataColumnDelimiter = default(object), object partitionOption = default(object), SapTablePartitionSettings partitionSettings = default(SapTablePartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             RowCount = rowCount;
@@ -150,13 +150,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for SAP
-        /// table read in parallel. Possible values include: 'None',
-        /// 'PartitionOnInt', 'PartitionOnCalendarYear',
-        /// 'PartitionOnCalendarMonth', 'PartitionOnCalendarDate',
-        /// 'PartitionOnTime'
+        /// table read in parallel. Possible values include: "None",
+        /// "PartitionOnInt", "PartitionOnCalendarYear",
+        /// "PartitionOnCalendarMonth", "PartitionOnCalendarDate",
+        /// "PartitionOnTime".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for SAP table

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlDWSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlDWSource.cs
@@ -58,11 +58,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// type: "int"}}". Type: object (or Expression with resultType
         /// object), itemType: StoredProcedureParameter.</param>
         /// <param name="partitionOption">The partition mechanism that will be
-        /// used for Sql read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'</param>
+        /// used for Sql read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for Sql source partitioning.</param>
-        public SqlDWSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), object storedProcedureParameters = default(object), string partitionOption = default(string), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
+        public SqlDWSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), object storedProcedureParameters = default(object), object partitionOption = default(object), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             SqlReaderQuery = sqlReaderQuery;
@@ -104,11 +104,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for Sql read
-        /// in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'
+        /// in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for Sql source

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlMISource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlMISource.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="produceAdditionalTypes">Which additional types to
         /// produce.</param>
         /// <param name="partitionOption">The partition mechanism that will be
-        /// used for Sql read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'</param>
+        /// used for Sql read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for Sql source partitioning.</param>
-        public SqlMISource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object produceAdditionalTypes = default(object), string partitionOption = default(string), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
+        public SqlMISource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object produceAdditionalTypes = default(object), object partitionOption = default(object), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             SqlReaderQuery = sqlReaderQuery;
@@ -111,11 +111,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for Sql read
-        /// in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'
+        /// in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for Sql source

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlServerSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlServerSource.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="produceAdditionalTypes">Which additional types to
         /// produce.</param>
         /// <param name="partitionOption">The partition mechanism that will be
-        /// used for Sql read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'</param>
+        /// used for Sql read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for Sql source partitioning.</param>
-        public SqlServerSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object produceAdditionalTypes = default(object), string partitionOption = default(string), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
+        public SqlServerSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object produceAdditionalTypes = default(object), object partitionOption = default(object), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             SqlReaderQuery = sqlReaderQuery;
@@ -110,11 +110,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for Sql read
-        /// in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'
+        /// in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for Sql source

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/SqlSource.cs
@@ -62,11 +62,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// The default value is ReadCommitted. Type: string (or Expression
         /// with resultType string).</param>
         /// <param name="partitionOption">The partition mechanism that will be
-        /// used for Sql read in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'</param>
+        /// used for Sql read in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for Sql source partitioning.</param>
-        public SqlSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object isolationLevel = default(object), string partitionOption = default(string), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
+        public SqlSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>), object isolationLevel = default(object), object partitionOption = default(object), SqlPartitionSettings partitionSettings = default(SqlPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             SqlReaderQuery = sqlReaderQuery;
@@ -117,11 +117,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for Sql read
-        /// in parallel. Possible values include: 'None',
-        /// 'PhysicalPartitionsOfTable', 'DynamicRange'
+        /// in parallel. Possible values include: "None",
+        /// "PhysicalPartitionsOfTable", "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for Sql source

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/TeradataSource.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Generated/Models/TeradataSource.cs
@@ -51,10 +51,10 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// with resultType string).</param>
         /// <param name="partitionOption">The partition mechanism that will be
         /// used for teradata read in parallel. Possible values include:
-        /// 'None', 'Hash', 'DynamicRange'</param>
+        /// "None", "Hash", "DynamicRange".</param>
         /// <param name="partitionSettings">The settings that will be leveraged
         /// for teradata source partitioning.</param>
-        public TeradataSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object query = default(object), string partitionOption = default(string), TeradataPartitionSettings partitionSettings = default(TeradataPartitionSettings))
+        public TeradataSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object maxConcurrentConnections = default(object), object queryTimeout = default(object), IList<AdditionalColumns> additionalColumns = default(IList<AdditionalColumns>), object query = default(object), object partitionOption = default(object), TeradataPartitionSettings partitionSettings = default(TeradataPartitionSettings))
             : base(additionalProperties, sourceRetryCount, sourceRetryWait, maxConcurrentConnections, queryTimeout, additionalColumns)
         {
             Query = query;
@@ -77,11 +77,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 
         /// <summary>
         /// Gets or sets the partition mechanism that will be used for teradata
-        /// read in parallel. Possible values include: 'None', 'Hash',
-        /// 'DynamicRange'
+        /// read in parallel. Possible values include: "None", "Hash",
+        /// "DynamicRange".
         /// </summary>
         [JsonProperty(PropertyName = "partitionOption")]
-        public string PartitionOption { get; set; }
+        public object PartitionOption { get; set; }
 
         /// <summary>
         /// Gets or sets the settings that will be leveraged for teradata

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
@@ -16,7 +16,7 @@
 - Added authenticationType and sessionToken properties into AmazonS3 linkedService
 - Added support for more frequency types for TumblingWindowTrigger
 - Set computeType, coreCount to object type to allow expressions
-- Change PartitionOption to object to allow expression
+- Change property PartitionOption type to object for NetezzaSource, OracleSource, SapHanaSource, SapTableSource, SqlDWSource, SqlMISource, SqlServerSource, SqlSource, TeradataSource. 
   ]]></PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
@@ -15,6 +15,7 @@
 - Added connectionProperties property into Concur linkedService
 - Added authenticationType and sessionToken properties into AmazonS3 linkedService
 - Added support for more frequency types for TumblingWindowTrigger
+- Set computeType, coreCount to object type to allow expressions
   ]]></PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/src/Microsoft.Azure.Management.DataFactory.csproj
@@ -16,6 +16,7 @@
 - Added authenticationType and sessionToken properties into AmazonS3 linkedService
 - Added support for more frequency types for TumblingWindowTrigger
 - Set computeType, coreCount to object type to allow expressions
+- Change PartitionOption to object to allow expression
   ]]></PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/tests/JsonSamples/PipelineJsonSamples.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/tests/JsonSamples/PipelineJsonSamples.cs
@@ -6444,6 +6444,51 @@ namespace DataFactory.Tests.JsonSamples
 ";
 
         [JsonSample]
+        public const string ExecuteDataFlowActivityPipelineWithExpression = @"
+{
+    name: ""My Execute Data Flow Activity pipeline"",
+    properties: 
+    {
+        activities:
+        [
+            {
+                name: ""TestActivity"",
+                description: ""Test activity description"", 
+                type: ""ExecuteDataFlow"",
+                typeProperties: {
+                    dataFlow: {
+                        referenceName: ""referenced1"",
+                        type: ""DataFlowReference""
+                    },
+                    staging: {
+                        linkedService: {
+                            referenceName: ""referenced2"",
+                            type: ""LinkedServiceReference""
+                        },
+                        folderPath: ""adfjobs/staging""
+                    },
+                    integrationRuntime: {
+                        referenceName: ""dataflowIR10minTTL"",
+                        type: ""IntegrationRuntimeReference""
+                    },
+                    compute: {
+                        computeType:  {
+                            value: ""@parameters('MemoryOptimized')"",
+                            type: ""Expression""
+                        },
+                        coreCount: {
+                           value: ""@parameters('8')"",
+                           type: ""Expression""
+                        },                       
+                    }
+                }
+            }
+        ]
+    }
+}
+";
+
+        [JsonSample]
         public const string CopyActivity_DelimitedText_GoogleCloudStorage = @"{
   ""properties"": {
     ""activities"": [

--- a/sdk/datafactory/Microsoft.Azure.Management.DataFactory/tests/JsonSamples/PipelineJsonSamples.cs
+++ b/sdk/datafactory/Microsoft.Azure.Management.DataFactory/tests/JsonSamples/PipelineJsonSamples.cs
@@ -599,7 +599,10 @@ namespace DataFactory.Tests.JsonSamples
                     {
                         type: ""AzureSqlSource"",
                         sqlReaderQuery: ""$EncryptedString$MyEncryptedQuery"",
-                        parallelOption: ""DynamicRange"",
+                        partitionOption: {
+                            ""value"": ""pipeline().parameters.parallelOption"",
+                            ""type"": ""Expression""
+                        },
                         partitionSettings: 
                         {
                             partitionColumnName: ""partitionColumnName"",
@@ -5610,13 +5613,11 @@ namespace DataFactory.Tests.JsonSamples
         ""typeProperties"": {
           ""source"": {
             ""type"": ""TeradataSource"",
-            ""partitionOption"": ""DynamicRange"",
-                        ""partitionSettings"": {
-                            ""partitionColumnName"": ""EmployeeKey"",
-                            ""partitionUpperBound"": ""1"",
-                            ""partitionLowerBound"": ""500""
-                        }
-          },
+            ""partitionOption"": {
+                            ""value"": ""pipeline().parameters.parallelOption"",
+                            ""type"": ""Expression""
+               }
+           },
           ""sink"": {
             ""type"": ""BinarySink"",
             ""storeSettings"": {
@@ -5873,7 +5874,10 @@ namespace DataFactory.Tests.JsonSamples
                         type: ""SapTableSource"",
                         rowCount: 3,
                         sapDataColumnDelimiter: ""|"",
-                        partitionOption: ""PartitionOnCalendarDate"",
+                        partitionOption: {
+                            ""value"": ""pipeline().parameters.parallelOption"",
+                            ""type"": ""Expression""
+                        },
                         partitionSettings: 
                         {
                              ""partitionColumnName"": ""fakeColumn"",
@@ -6042,7 +6046,10 @@ namespace DataFactory.Tests.JsonSamples
                     source:
                     {                               
                         type: ""NetezzaSource"",
-                        partitionOption: ""DataSlice""
+                        partitionOption: {
+                            ""value"": ""pipeline().parameters.parallelOption"",
+                            ""type"": ""Expression""
+                        },
                     },
                     sink:
                     {
@@ -6785,7 +6792,10 @@ namespace DataFactory.Tests.JsonSamples
                     {
                         ""type"": ""SapHanaSource"",
                         ""query"": ""$select=Column0"",
-                        ""partitionOption"": ""SapHanaDynamicRange"",
+                        ""partitionOption"": {
+                            ""value"": ""pipeline().parameters.parallelOption"",
+                            ""type"": ""Expression""
+                        },
                         ""partitionSettings"": {
                             ""partitionColumnName"": ""INTEGERTYPE""
                         }                        


### PR DESCRIPTION
Swagger PR:
Set computeType, coreCount to object type to allow expressions：https://github.com/Azure/azure-rest-api-specs/pull/10897

Change PartitionOption to object to allow expression :https://github.com/Azure/azure-rest-api-specs/pull/11613