### PR TITLE
[Storage] Fix live test - SAS with parent resource.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -6161,6 +6161,7 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task CanGetParentContainerClient_WithAccountSAS()
         {
             // Arrange


### PR DESCRIPTION
This test works with 2019-12-12 or later SV.