### PR TITLE
[Storage] Fix test.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -2811,6 +2811,7 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        [ServiceVersion(Min = BlobClientOptions.ServiceVersion.V2019_12_12)]
         public async Task CanGetParentBlobServiceClient_WithAccountSAS()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -30,7 +30,7 @@ namespace Azure.Storage.Test.Shared
             // https://github.com/Azure/azure-sdk-for-net/issues/9087
             // .NET framework defaults to 2, which causes issues for the parallel upload/download tests.
 #if !NETCOREAPP
-            ServicePointManager.DefaultConnectionLimit = 100;
+            ServicePointManager.DefaultConnectionLimit = 200;
 #endif
         }
 


### PR DESCRIPTION
- Fix test that works with version 2019-12-12 or higher.
- Bump connection limit on NET FX. We're seeing obvious symptoms of starvation in live tests.