### PR TITLE
[Event Hubs Client] Processor Release Prep (November)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Azure.Messaging.EventHubs.Processor.csproj
@@ -12,15 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-
     <!-- TEMP -->
-      <!--
-        Project reference is temporary, due to the changes to the EventData model. Don't forget to also remove the project reference in the
-        solution under the "External" folder.
-      -->
-      <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs\src\Azure.Messaging.EventHubs.csproj" />
-      <ProjectReference Include="..\..\..\core\Azure.Core\src\Azure.Core.csproj" />
-      <!--<PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.3.0-beta.4" /> --><!-- This override will be removed when v5.3.0 is released for GA -->
+      <PackageReference Include="Azure.Messaging.EventHubs" VersionOverride="5.3.0-beta.4" /><!-- This override will be removed when v5.3.0 is released for GA -->
     <!--END TEMP-->
 
     <PackageReference Include="Azure.Storage.Blobs" />


### PR DESCRIPTION
# Summary

The focus of these changes is to update the references for the Event  Processor package to the latest beta of the core Event Hubs package.

# Last Upstream Rebase

Tuesday, November 10, 11:28am (EST)