### PR TITLE
Update activity kind and do not set extra tags

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticExtensions.cs
@@ -16,46 +16,14 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
             return arraySegment.Array == null ? string.Empty : Encoding.ASCII.GetString(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
         }
 
-        public static void SetMessageTags(this DiagnosticScope scope, IEnumerable<ServiceBusReceivedMessage> messages)
-        {
-            // set the message Ids on the scope
-            var messageIds = messages.Where(m => m.MessageId != null).Select(m => m.MessageId).ToArray();
-            var sessionIds = messages.Where(m => m.SessionId != null).Select(m => m.SessionId).Distinct().ToArray();
-            scope.SetMessageTags(messageIds, sessionIds);
-        }
-
-        private static void SetMessageTags(this DiagnosticScope scope, IEnumerable<ServiceBusMessage> messages)
-        {
-            var messageIds = messages.Where(m => m.MessageId != null).Select(m => m.MessageId).ToArray();
-            var sessionIds = messages.Where(m => m.SessionId != null).Select(m => m.SessionId).Distinct().ToArray();
-            scope.SetMessageTags(messageIds, sessionIds);
-        }
-
-        private static void SetMessageTags(this DiagnosticScope scope, string[] messageIds, string[] sessionIds)
-        {
-            // set the message Ids on the scope
-            if (messageIds.Any())
-            {
-                scope.AddAttribute(DiagnosticProperty.MessageIdAttribute, string.Join(",", messageIds));
-            }
-
-            // set any session Ids on the scope
-            if (sessionIds.Any())
-            {
-                scope.AddAttribute(DiagnosticProperty.SessionIdAttribute, string.Join(",", sessionIds));
-            }
-        }
-
         public static void SetMessageData(this DiagnosticScope scope, IEnumerable<ServiceBusReceivedMessage> messages)
         {
             scope.AddLinkedDiagnostics(messages);
-            scope.SetMessageTags(messages);
         }
 
         public static void SetMessageData(this DiagnosticScope scope, IEnumerable<ServiceBusMessage> messages)
         {
             scope.AddLinkedDiagnostics(messages);
-            scope.SetMessageTags(messages);
         }
 
         private static void AddLinkedDiagnostics(this DiagnosticScope scope, IEnumerable<ServiceBusReceivedMessage> messages)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticProperty.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/DiagnosticProperty.cs
@@ -9,29 +9,8 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
     ///
     internal static class DiagnosticProperty
     {
-        /// <summary>The common root for activity names in the Service Bus context.</summary>
-        public const string BaseActivityName = "Azure.Messaging.ServiceBus";
-
         /// <summary>The attribute which represents a unique identifier for the diagnostics context.</summary>
         public const string DiagnosticIdAttribute = "Diagnostic-Id";
-
-        /// <summary>The attribute which represents the message Id.</summary>
-        public const string MessageIdAttribute = "MessageId";
-
-        /// <summary>The attribute which represents the session Id. Only populated for sessions.</summary>
-        public const string SessionIdAttribute = "SessionId";
-
-        /// <summary>The attribute which represents the sequence number.</summary>
-        public const string SequenceNumbersAttribute = "SequenceNumber";
-
-        /// <summary>The attribute which represents the requested message count for peek/receive operations.</summary>
-        public const string RequestedMessageCountAttribute = "RequestedMessageCount";
-
-        /// <summary>The attribute which represents the lock tokens.</summary>
-        public const string LockTokensAttribute = "LockTokens";
-
-        /// <summary>The attribute which represents the message lock expiration time.</summary>
-        public const string LockedUntilAttribute = "LockedUntilUtc";
 
         /// <summary>The attribute which represents the type of diagnostics information.</summary>
         public const string TypeAttribute = "kind";
@@ -51,14 +30,14 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         /// <summary>The attribute which represents the kind of diagnostic scope.</summary>
         public const string KindAttribute = "kind";
 
-        /// <summary>The value which identifies the Event Processor scope kind.</summary>
-        public const string ServerKind = "server";
+        /// <summary>The value which identifies activities related to receiving or processing messages.</summary>
+        public const string ConsumerKind = "consumer";
 
         /// <summary>The value which identifies the message client scope kind.</summary>
         public const string ClientKind = "client";
 
         /// <summary>The value which identifies an Service Bus entity producer as the type associated with the diagnostics information.</summary>
-        public const string SenderKind = "sender";
+        public const string ProducerKind = "producer";
 
         /// <summary>
         ///   The activity name associated with events.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/EntityScopeFactory.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/EntityScopeFactory.cs
@@ -60,30 +60,15 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
 
         public DiagnosticScope CreateScope(
             string activityName,
-            string kindAttribute = default,
-            string lockToken = default,
-            string sessionId = default,
-            int? requestedMessageCount = default)
+            string kindAttribute)
         {
             DiagnosticScope scope = _scopeFactory.CreateScope(activityName);
-            scope.AddAttribute(DiagnosticProperty.KindAttribute, kindAttribute ?? DiagnosticProperty.ClientKind);
+            scope.AddAttribute(DiagnosticProperty.KindAttribute, kindAttribute);
             scope.AddAttribute(
                 DiagnosticProperty.ServiceContextAttribute,
                 DiagnosticProperty.ServiceBusServiceContext);
             scope.AddAttribute(DiagnosticProperty.EntityAttribute, _entityPath);
             scope.AddAttribute(DiagnosticProperty.EndpointAttribute, _fullyQualifiedNamespace);
-            if (lockToken != null)
-            {
-                scope.AddAttribute(DiagnosticProperty.LockTokensAttribute, lockToken);
-            }
-            if (sessionId != null)
-            {
-                scope.AddAttribute(DiagnosticProperty.SessionIdAttribute, sessionId);
-            }
-            if (requestedMessageCount != null)
-            {
-                scope.AddAttribute(DiagnosticProperty.RequestedMessageCountAttribute, requestedMessageCount);
-            }
             return scope;
         }
     }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ReceiverManager.cs
@@ -125,7 +125,7 @@ namespace Azure.Messaging.ServiceBus
 
         protected async Task ProcessOneMessageWithinScopeAsync(ServiceBusReceivedMessage message, string activityName, CancellationToken cancellationToken)
         {
-            using DiagnosticScope scope = _scopeFactory.CreateScope(activityName);
+            using DiagnosticScope scope = _scopeFactory.CreateScope(activityName, DiagnosticProperty.ConsumerKind);
             scope.Start();
             scope.SetMessageData(new ServiceBusReceivedMessage[] { message });
             try

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -250,9 +250,11 @@ namespace Azure.Messaging.ServiceBus
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             Logger.ReceiveMessageStart(Identifier, maxMessages);
+
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.ReceiveActivityName,
-                requestedMessageCount: maxMessages);
+                DiagnosticProperty.ConsumerKind);
+
             scope.Start();
 
             IReadOnlyList<ServiceBusReceivedMessage> messages = null;
@@ -430,7 +432,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.PeekMessageStart(Identifier, sequenceNumber, maxMessages);
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.PeekActivityName,
-                requestedMessageCount: maxMessages);
+                DiagnosticProperty.ProducerKind);
             scope.Start();
 
             IReadOnlyList<ServiceBusReceivedMessage> messages = new List<ServiceBusReceivedMessage>();
@@ -512,7 +514,7 @@ namespace Azure.Messaging.ServiceBus
                 lockToken);
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.CompleteActivityName,
-                lockToken: lockToken);
+                DiagnosticProperty.ClientKind);
             scope.Start();
 
             try
@@ -587,7 +589,8 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.AbandonActivityName,
-                lockToken: lockToken);
+                DiagnosticProperty.ClientKind);
+
             scope.Start();
 
             try
@@ -750,7 +753,8 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.DeadLetterActivityName,
-                lockToken: lockToken);
+                DiagnosticProperty.ClientKind);
+
             scope.Start();
 
             try
@@ -832,7 +836,8 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.DeferActivityName,
-                lockToken: lockToken);
+                DiagnosticProperty.ClientKind);
+
             scope.Start();
 
             try
@@ -924,10 +929,10 @@ namespace Azure.Messaging.ServiceBus
 
             Logger.ReceiveDeferredMessageStart(Identifier, sequenceArray);
 
-            using DiagnosticScope scope = ScopeFactory.CreateScope(DiagnosticProperty.ReceiveDeferredActivityName);
-            scope.AddAttribute(
-                DiagnosticProperty.SequenceNumbersAttribute,
-                string.Join(",", sequenceNumbers));
+            using DiagnosticScope scope = ScopeFactory.CreateScope(
+                DiagnosticProperty.ReceiveDeferredActivityName,
+                DiagnosticProperty.ConsumerKind);
+
             scope.Start();
 
             IReadOnlyList<ServiceBusReceivedMessage> deferredMessages = null;
@@ -1000,7 +1005,7 @@ namespace Azure.Messaging.ServiceBus
 
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.RenewMessageLockActivityName,
-                lockToken: lockToken);
+                DiagnosticProperty.ClientKind);
             scope.Start();
 
             DateTimeOffset lockedUntil;
@@ -1018,7 +1023,6 @@ namespace Azure.Messaging.ServiceBus
             }
 
             Logger.RenewMessageLockComplete(Identifier);
-            scope.AddAttribute(DiagnosticProperty.LockedUntilAttribute, lockedUntil);
             return lockedUntil;
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusSessionReceiver.cs
@@ -103,7 +103,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.GetSessionStateStart(Identifier, SessionId);
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.GetSessionStateActivityName,
-                sessionId: SessionId);
+                DiagnosticProperty.ClientKind);
             scope.Start();
 
             BinaryData sessionState;
@@ -142,7 +142,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.SetSessionStateStart(Identifier, SessionId);
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.SetSessionStateActivityName,
-                sessionId: SessionId);
+                DiagnosticProperty.ClientKind);
             scope.Start();
 
             try
@@ -182,7 +182,7 @@ namespace Azure.Messaging.ServiceBus
             Logger.RenewSessionLockStart(Identifier, SessionId);
             using DiagnosticScope scope = ScopeFactory.CreateScope(
                 DiagnosticProperty.RenewSessionLockActivityName,
-                sessionId: SessionId);
+                DiagnosticProperty.ClientKind);
             scope.Start();
 
             try

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -519,11 +519,12 @@ namespace Azure.Messaging.ServiceBus
             }
 
             Logger.CancelScheduledMessagesStart(Identifier, sequenceArray);
+
             using DiagnosticScope scope = _scopeFactory.CreateScope(
                 DiagnosticProperty.CancelActivityName,
                 DiagnosticProperty.ClientKind);
-
             scope.Start();
+
             try
             {
                 await _innerSender.CancelScheduledMessagesAsync(sequenceArray, cancellationToken).ConfigureAwait(false);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -262,7 +262,7 @@ namespace Azure.Messaging.ServiceBus
                 {
                     using DiagnosticScope messageScope = _scopeFactory.CreateScope(
                         DiagnosticProperty.MessageActivityName,
-                        DiagnosticProperty.SenderKind);
+                        DiagnosticProperty.ProducerKind);
                     messageScope.Start();
 
                     Activity activity = Activity.Current;
@@ -477,7 +477,6 @@ namespace Azure.Messaging.ServiceBus
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.ScheduleMessagesComplete(Identifier);
-            scope.AddAttribute(DiagnosticProperty.SequenceNumbersAttribute, sequenceNumbers);
             return sequenceNumbers;
         }
 
@@ -524,7 +523,6 @@ namespace Azure.Messaging.ServiceBus
                 DiagnosticProperty.CancelActivityName,
                 DiagnosticProperty.ClientKind);
 
-            scope.AddAttribute(DiagnosticProperty.SequenceNumbersAttribute, sequenceNumbers);
             scope.Start();
             try
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
@@ -70,26 +70,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                     Activity receiveActivity = (Activity)receiveStart.Value;
                     AssertCommonTags(receiveActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                    CollectionAssert.Contains(
-                        receiveActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.RequestedMessageCountAttribute,
-                            remaining.ToString()));
-                    CollectionAssert.Contains(
-                        receiveActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.MessageIdAttribute,
-                            string.Join(",", received.Select(m => m.MessageId).ToArray())));
-                    remaining -= received.Count;
 
-                    if (useSessions)
-                    {
-                        CollectionAssert.Contains(
-                            receiveActivity.Tags,
-                            new KeyValuePair<string, string>(
-                                DiagnosticProperty.SessionIdAttribute,
-                                string.Join(",", msgs.Select(m => m.SessionId).Distinct().ToArray())));
-                    }
                     var receiveLinkedActivities = ((IEnumerable<Activity>)receiveActivity.GetType().GetProperty("Links").GetValue(receiveActivity)).ToArray();
                     for (int i = 0; i < receiveLinkedActivities.Length; i++)
                     {
@@ -108,7 +89,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.CompleteActivityName + ".Start", completeStart.Key);
                 Activity completeActivity = (Activity)completeStart.Value;
                 AssertCommonTags(completeActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                AssertLockTokensTag(completeActivity, completed.LockToken);
                 (string Key, object Value, DiagnosticListener) completeStop = _listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.CompleteActivityName + ".Stop", completeStop.Key);
 
@@ -118,7 +98,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.DeferActivityName + ".Start", deferStart.Key);
                 Activity deferActivity = (Activity)deferStart.Value;
                 AssertCommonTags(deferActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                AssertLockTokensTag(deferActivity, deferred.LockToken);
                 (string Key, object Value, DiagnosticListener) deferStop = _listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.DeferActivityName + ".Stop", deferStop.Key);
 
@@ -128,7 +107,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.DeadLetterActivityName + ".Start", deadLetterStart.Key);
                 Activity deadLetterActivity = (Activity)deadLetterStart.Value;
                 AssertCommonTags(deadLetterActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                AssertLockTokensTag(deadLetterActivity, deadLettered.LockToken);
                 (string Key, object Value, DiagnosticListener) deadletterStop = _listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.DeadLetterActivityName + ".Stop", deadletterStop.Key);
 
@@ -138,7 +116,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.AbandonActivityName + ".Start", abandonStart.Key);
                 Activity abandonActivity = (Activity)abandonStart.Value;
                 AssertCommonTags(abandonActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                AssertLockTokensTag(abandonActivity, abandoned.LockToken);
                 (string Key, object Value, DiagnosticListener) abandonStop = _listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.AbandonActivityName + ".Stop", abandonStop.Key);
 
@@ -147,16 +124,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Assert.AreEqual(DiagnosticProperty.ReceiveDeferredActivityName + ".Start", receiveDeferStart.Key);
                 Activity receiveDeferActivity = (Activity)receiveDeferStart.Value;
                 AssertCommonTags(receiveDeferActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                CollectionAssert.Contains(
-                    receiveDeferActivity.Tags,
-                    new KeyValuePair<string, string>(
-                        DiagnosticProperty.MessageIdAttribute,
-                        deferred.MessageId));
-                CollectionAssert.Contains(
-                    receiveDeferActivity.Tags,
-                    new KeyValuePair<string, string>(
-                        DiagnosticProperty.SequenceNumbersAttribute,
-                        deferred.SequenceNumber.ToString()));
+
                 (string Key, object Value, DiagnosticListener) receiveDeferStop = _listener.Events.Dequeue();
                 Assert.AreEqual(DiagnosticProperty.ReceiveDeferredActivityName + ".Stop", receiveDeferStop.Key);
 
@@ -169,11 +137,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     Assert.AreEqual(DiagnosticProperty.RenewSessionLockActivityName + ".Start", renewStart.Key);
                     Activity renewActivity = (Activity)renewStart.Value;
                     AssertCommonTags(renewActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                    CollectionAssert.Contains(
-                        renewActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.SessionIdAttribute,
-                            "sessionId"));
 
                     (string Key, object Value, DiagnosticListener) renewStop = _listener.Events.Dequeue();
                     Assert.AreEqual(DiagnosticProperty.RenewSessionLockActivityName + ".Stop", renewStop.Key);
@@ -185,11 +148,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     Assert.AreEqual(DiagnosticProperty.SetSessionStateActivityName + ".Start", setStateStart.Key);
                     Activity setStateActivity = (Activity)setStateStart.Value;
                     AssertCommonTags(setStateActivity, sessionReceiver.EntityPath, sessionReceiver.FullyQualifiedNamespace);
-                    CollectionAssert.Contains(
-                        setStateActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.SessionIdAttribute,
-                            "sessionId"));
 
                     (string Key, object Value, DiagnosticListener) setStateStop = _listener.Events.Dequeue();
                     Assert.AreEqual(DiagnosticProperty.SetSessionStateActivityName + ".Stop", setStateStop.Key);
@@ -201,11 +159,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     Assert.AreEqual(DiagnosticProperty.GetSessionStateActivityName + ".Start", getStateStart.Key);
                     Activity getStateActivity = (Activity)getStateStart.Value;
                     AssertCommonTags(getStateActivity, sessionReceiver.EntityPath, sessionReceiver.FullyQualifiedNamespace);
-                    CollectionAssert.Contains(
-                        getStateActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.SessionIdAttribute,
-                            "sessionId"));
 
                     (string Key, object Value, DiagnosticListener) getStateStop = _listener.Events.Dequeue();
                     Assert.AreEqual(DiagnosticProperty.GetSessionStateActivityName + ".Stop", getStateStop.Key);
@@ -217,12 +170,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     Assert.AreEqual(DiagnosticProperty.RenewMessageLockActivityName + ".Start", renewStart.Key);
                     Activity renewActivity = (Activity)renewStart.Value;
                     AssertCommonTags(renewActivity, receiver.EntityPath, receiver.FullyQualifiedNamespace);
-                    AssertLockTokensTag(renewActivity, receivedMsgs[4].LockToken);
-                    CollectionAssert.Contains(
-                        renewActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.LockedUntilAttribute,
-                            receivedMsgs[4].LockedUntil.ToString()));
 
                     (string Key, object Value, DiagnosticListener) renewStop = _listener.Events.Dequeue();
                     Assert.AreEqual(DiagnosticProperty.RenewMessageLockActivityName + ".Stop", renewStop.Key);
@@ -316,11 +263,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     Assert.AreEqual(DiagnosticProperty.ProcessMessageActivityName + ".Start", processStart.Key);
                     Activity processActivity = (Activity)processStart.Value;
                     AssertCommonTags(processActivity, processor.EntityPath, processor.FullyQualifiedNamespace);
-                    CollectionAssert.Contains(
-                        processActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.MessageIdAttribute,
-                            msgs[i].MessageId));
+
                     (string Key, object Value, DiagnosticListener) processStop = _listener.Events.Dequeue();
                     Assert.AreEqual(DiagnosticProperty.ProcessMessageActivityName + ".Stop", processStop.Key);
                 }
@@ -369,16 +312,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     Assert.AreEqual(DiagnosticProperty.ProcessSessionMessageActivityName + ".Start", processStart.Key);
                     Activity processActivity = (Activity)processStart.Value;
                     AssertCommonTags(processActivity, processor.EntityPath, processor.FullyQualifiedNamespace);
-                    CollectionAssert.Contains(
-                        processActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.MessageIdAttribute,
-                            msgs[i].MessageId));
-                    CollectionAssert.Contains(
-                        processActivity.Tags,
-                        new KeyValuePair<string, string>(
-                            DiagnosticProperty.SessionIdAttribute,
-                            msgs[i].SessionId));
+
                     (string Key, object Value, DiagnosticListener) processStop = _listener.Events.Dequeue();
                     Assert.AreEqual(DiagnosticProperty.ProcessSessionMessageActivityName + ".Stop", processStop.Key);
                 }
@@ -404,19 +338,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             Assert.AreEqual(DiagnosticProperty.SendActivityName + ".Start", startSend.Key);
             Activity sendActivity = (Activity)startSend.Value;
             AssertCommonTags(sendActivity, sender.EntityPath, sender.FullyQualifiedNamespace);
-            CollectionAssert.Contains(
-                sendActivity.Tags,
-                new KeyValuePair<string, string>(
-                    DiagnosticProperty.MessageIdAttribute,
-                    string.Join(",", msgs.Select(m => m.MessageId).ToArray())));
-            if (useSessions)
-            {
-                CollectionAssert.Contains(
-                    sendActivity.Tags,
-                    new KeyValuePair<string, string>(
-                        DiagnosticProperty.SessionIdAttribute,
-                        string.Join(",", msgs.Select(m => m.SessionId).Distinct().ToArray())));
-            }
 
             (string Key, object Value, DiagnosticListener) stopSend = _listener.Events.Dequeue();
             Assert.AreEqual(DiagnosticProperty.SendActivityName + ".Stop", stopSend.Key);
@@ -428,16 +349,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             }
             return sendLinkedActivities;
         }
-
-        private void AssertLockTokensTag(Activity activity, string lockToken)
-        {
-            CollectionAssert.Contains(
-                    activity.Tags,
-                    new KeyValuePair<string, string>(
-                        DiagnosticProperty.LockTokensAttribute,
-                        lockToken));
-        }
-
         private void AssertCommonTags(Activity activity, string entityName, string fullyQualifiedNamespace)
         {
             var tags = activity.Tags;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/DiagnosticScopeLiveTests.cs
@@ -79,6 +79,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     (string Key, object Value, DiagnosticListener) receiveStop = _listener.Events.Dequeue();
 
                     Assert.AreEqual(DiagnosticProperty.ReceiveActivityName + ".Stop", receiveStop.Key);
+                    remaining -= received.Count;
                 }
 
                 var msgIndex = 0;


### PR DESCRIPTION

Helpful code pointers when reviewing:
- [DiagnosticScope ](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/Shared/DiagnosticScope.cs)primitive that we are using throughout the .NET SDK codebase.
- Start Diagnostic scope when [sending messages](https://github.com/JoshLove-msft/azure-sdk-for-net/blob/tracing-updates/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs#L191-L192).
- Start Diagnostic scope when [receiving messages](https://github.com/JoshLove-msft/azure-sdk-for-net/blob/tracing-updates/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs#L253-L257).
- [Service Bus factory](https://github.com/JoshLove-msft/azure-sdk-for-net/blob/tracing-updates/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/EntityScopeFactory.cs#L15) for creating Diagnostic scope and containing helper methods.
