### PR TITLE
[Storage] Unbound connection limit in NET FX test suite

### DIFF
--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -30,7 +30,7 @@ namespace Azure.Storage.Test.Shared
             // https://github.com/Azure/azure-sdk-for-net/issues/9087
             // .NET framework defaults to 2, which causes issues for the parallel upload/download tests.
 #if !NETCOREAPP
-            ServicePointManager.DefaultConnectionLimit = 200;
+            ServicePointManager.DefaultConnectionLimit = int.MaxValue;
 #endif
         }
 


### PR DESCRIPTION
Bump connection limit to int.Max . We already run tests with int.Max on .netcore . Revisiting this setting when when we change parallelization/volume of tests is annoying.