### PR TITLE
Update arg validation

### DIFF
--- a/sdk/core/Azure.Core.Amqp/src/AmqpAddress.cs
+++ b/sdk/core/Azure.Core.Amqp/src/AmqpAddress.cs
@@ -22,6 +22,7 @@ namespace Azure.Core.Amqp
         /// <param name="address">The address.</param>
         public AmqpAddress(string address)
         {
+            Argument.AssertNotNull(address, nameof(address));
             _address = address;
         }
 

--- a/sdk/core/Azure.Core.Amqp/src/AmqpMessageBody.cs
+++ b/sdk/core/Azure.Core.Amqp/src/AmqpMessageBody.cs
@@ -30,7 +30,8 @@ namespace Azure.Core.Amqp
         /// <param name="data">The data sections.</param>
         public AmqpMessageBody(IEnumerable<ReadOnlyMemory<byte>> data)
         {
-            _data = data ?? Enumerable.Empty<ReadOnlyMemory<byte>>();
+            Argument.AssertNotNull(data, nameof(data));
+            _data = data;
             BodyType = AmqpMessageBodyType.Data;
         }
 

--- a/sdk/core/Azure.Core.Amqp/src/AmqpMessageId.cs
+++ b/sdk/core/Azure.Core.Amqp/src/AmqpMessageId.cs
@@ -12,7 +12,7 @@ namespace Azure.Core.Amqp
     /// </summary>
     public struct AmqpMessageId : IEquatable<AmqpMessageId>
     {
-        private readonly string? _messageIdString;
+        private readonly string _messageIdString;
 
         /// <summary>
         /// Initializes a new <see cref="AmqpMessageId"/> using the provided
@@ -22,6 +22,7 @@ namespace Azure.Core.Amqp
         /// <param name="messageId">The message Id.</param>
         public AmqpMessageId(string messageId)
         {
+            Argument.AssertNotNull(messageId, nameof(messageId));
             _messageIdString = messageId;
         }
 
@@ -30,7 +31,7 @@ namespace Azure.Core.Amqp
         /// </summary>
         ///
         /// <returns>A <see cref="string"/> from the value of this instance.</returns>
-        public override string ToString() => _messageIdString!;
+        public override string ToString() => _messageIdString;
 
         /// <summary>
         /// Determines whether the provided object is equal to the current object.
@@ -69,7 +70,7 @@ namespace Azure.Core.Amqp
         /// <see cref="AmqpMessageId"/>; otherwise, <see langword="false" />.
         /// </returns>
         public bool Equals(AmqpMessageId other) =>
-            other.Equals(_messageIdString!);
+            other.Equals(_messageIdString);
 
         /// <summary>
         /// Determines whether the provided <see cref="string"/> is equal to the current instance.

--- a/sdk/core/Azure.Core.Amqp/tests/AmqpAddressTests.cs
+++ b/sdk/core/Azure.Core.Amqp/tests/AmqpAddressTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using NUnit.Framework;
 
 namespace Azure.Core.Amqp.Tests
@@ -16,6 +17,14 @@ namespace Azure.Core.Amqp.Tests
             Assert.True(address.Equals(new AmqpAddress("address")));
             Assert.True(address.Equals((object)new AmqpAddress("address")));
             Assert.False(address.Equals(new AmqpMessageId("messageId2")));
+        }
+
+        [Test]
+        public void CannotCreateFromNullAddress()
+        {
+            Assert.That(
+                () => new AmqpAddress(null),
+                Throws.InstanceOf<ArgumentNullException>());
         }
     }
 }

--- a/sdk/core/Azure.Core.Amqp/tests/AmqpDataMessageBodyTests.cs
+++ b/sdk/core/Azure.Core.Amqp/tests/AmqpDataMessageBodyTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace Azure.Core.Amqp.Tests
@@ -16,11 +15,14 @@ namespace Azure.Core.Amqp.Tests
             Assert.AreEqual(AmqpMessageBodyType.Data, body.BodyType);
             Assert.IsTrue(body.TryGetData(out var data));
             Assert.NotNull(data);
+        }
 
-            body = new AmqpMessageBody(null);
-            Assert.AreEqual(AmqpMessageBodyType.Data, body.BodyType);
-            Assert.IsTrue(body.TryGetData(out data));
-            Assert.NotNull(data);
+        [Test]
+        public void CannotCreateFromNullBody()
+        {
+            Assert.That(
+                () => new AmqpMessageBody(null),
+                Throws.InstanceOf<ArgumentNullException>());
         }
     }
 }

--- a/sdk/core/Azure.Core.Amqp/tests/AmqpMessageIdTests.cs
+++ b/sdk/core/Azure.Core.Amqp/tests/AmqpMessageIdTests.cs
@@ -27,5 +27,13 @@ namespace Azure.Core.Amqp.Tests
             Assert.False(messageId.Equals(Guid.NewGuid()));
             Assert.False(messageId.Equals((object)"messageId"));
         }
+
+        [Test]
+        public void CannotCreateFromNullMessageId()
+        {
+            Assert.That(
+                () => new AmqpMessageId(null),
+                Throws.InstanceOf<ArgumentNullException>());
+        }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/api/Azure.Messaging.ServiceBus.netstandard2.0.cs
@@ -361,7 +361,7 @@ namespace Azure.Messaging.ServiceBus
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override int GetHashCode() { throw null; }
         public virtual System.Threading.Tasks.Task<long> ScheduleMessageAsync(Azure.Messaging.ServiceBus.ServiceBusMessage message, System.DateTimeOffset scheduledEnqueueTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<long[]> ScheduleMessagesAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.ServiceBus.ServiceBusMessage> messages, System.DateTimeOffset scheduledEnqueueTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<long>> ScheduleMessagesAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.ServiceBus.ServiceBusMessage> messages, System.DateTimeOffset scheduledEnqueueTime, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendMessageAsync(Azure.Messaging.ServiceBus.ServiceBusMessage message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendMessagesAsync(Azure.Messaging.ServiceBus.ServiceBusMessageBatch messageBatch, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task SendMessagesAsync(System.Collections.Generic.IEnumerable<Azure.Messaging.ServiceBus.ServiceBusMessage> messages, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -405,7 +405,7 @@ namespace Azure.Messaging.ServiceBus
         public int MaxConcurrentSessions { get { throw null; } set { } }
         public int PrefetchCount { get { throw null; } set { } }
         public Azure.Messaging.ServiceBus.ReceiveMode ReceiveMode { get { throw null; } set { } }
-        public string[] SessionIds { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> SessionIds { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool Equals(object obj) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -1159,7 +1159,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// Throws if the messages have not been deferred.</returns>
         /// <seealso cref="DeferAsync"/>
         public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
-            IList<long> sequenceNumbers,
+            IReadOnlyList<long> sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
             IReadOnlyList<ServiceBusReceivedMessage> messages = null;
@@ -1173,7 +1173,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         }
 
         internal virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsyncInternal(
-            long[] sequenceNumbers,
+            IReadOnlyList<long> sequenceNumbers,
             TimeSpan timeout)
         {
             var messages = new List<ServiceBusReceivedMessage>();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -304,7 +304,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="messages">The list of messages to send.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public override async Task SendAsync(
-            IList<ServiceBusMessage> messages,
+            IReadOnlyList<ServiceBusMessage> messages,
             CancellationToken cancellationToken)
         {
             AmqpMessage messageFactory() => AmqpMessageConverter.BatchSBMessagesAsAmqpMessage(messages);
@@ -374,8 +374,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="messages"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public override async Task<long[]> ScheduleMessagesAsync(
-            IList<ServiceBusMessage> messages,
+        public override async Task<IReadOnlyList<long>> ScheduleMessagesAsync(
+            IReadOnlyList<ServiceBusMessage> messages,
             CancellationToken cancellationToken = default)
         {
             long[] seqNumbers = null;
@@ -399,7 +399,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         internal async Task<long[]> ScheduleMessageInternalAsync(
-            IList<ServiceBusMessage> messages,
+            IReadOnlyList<ServiceBusMessage> messages,
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {
@@ -492,7 +492,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public override async Task CancelScheduledMessagesAsync(
-            long[] sequenceNumbers,
+            IReadOnlyList<long> sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
             Task cancelMessageTask = _retryPolicy.RunOperation(async (timeout) =>
@@ -515,7 +515,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         internal async Task CancelScheduledMessageInternalAsync(
-            long[] sequenceNumbers,
+            IReadOnlyList<long> sequenceNumbers,
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -180,7 +180,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// Throws if the messages have not been deferred.</returns>
         /// <seealso cref="DeferAsync"/>
         public abstract Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
-            IList<long> sequenceNumbers,
+            IReadOnlyList<long> sequenceNumbers,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
@@ -57,7 +57,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="messages">The list of messages to send.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         public abstract Task SendAsync(
-            IList<ServiceBusMessage> messages,
+            IReadOnlyList<ServiceBusMessage> messages,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="messages"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public abstract Task<long[]> ScheduleMessagesAsync(
-            IList<ServiceBusMessage> messages,
+        public abstract Task<IReadOnlyList<long>> ScheduleMessagesAsync(
+            IReadOnlyList<ServiceBusMessage> messages,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public abstract Task CancelScheduledMessagesAsync(
-            long[] sequenceNumbers,
+            IReadOnlyList<long> sequenceNumbers,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -285,7 +285,7 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [NonEvent]
-        public virtual void ReceiveDeferredMessageStart(string identifier, IList<long> sequenceNumbers)
+        public virtual void ReceiveDeferredMessageStart(string identifier, IReadOnlyList<long> sequenceNumbers)
         {
             if (IsEnabled())
             {
@@ -371,12 +371,12 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [NonEvent]
-        public virtual void CancelScheduledMessagesStart(string identifier, long[] sequenceNumbers)
+        public virtual void CancelScheduledMessagesStart(string identifier, IReadOnlyList<long> sequenceNumbers)
         {
             if (IsEnabled())
             {
                 var formattedSequenceNumbers = StringUtility.GetFormattedSequenceNumbers(sequenceNumbers);
-                CancelScheduledMessagesStartCore(identifier, sequenceNumbers.Length, formattedSequenceNumbers);
+                CancelScheduledMessagesStartCore(identifier, sequenceNumbers.Count, formattedSequenceNumbers);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusModelFactory.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusModelFactory.cs
@@ -44,11 +44,21 @@ namespace Azure.Messaging.ServiceBus
             DateTimeOffset enqueuedTime = default)
         {
             var amqpMessage = new AmqpAnnotatedMessage(new AmqpMessageBody(new ReadOnlyMemory<byte>[] { body }));
-            amqpMessage.Properties.CorrelationId = new AmqpMessageId(correlationId);
+
+            if (correlationId != default)
+            {
+                amqpMessage.Properties.CorrelationId = new AmqpMessageId(correlationId);
+            }
             amqpMessage.Properties.Subject = subject;
-            amqpMessage.Properties.To = new AmqpAddress(to);
+            if (to != default)
+            {
+                amqpMessage.Properties.To = new AmqpAddress(to);
+            }
             amqpMessage.Properties.ContentType = contentType;
-            amqpMessage.Properties.ReplyTo = new AmqpAddress(replyTo);
+            if (replyTo != default)
+            {
+                amqpMessage.Properties.ReplyTo = new AmqpAddress(replyTo);
+            }
             amqpMessage.MessageAnnotations[AmqpMessageConstants.ScheduledEnqueueTimeUtcName] = scheduledEnqueueTime.UtcDateTime;
 
             if (messageId != default)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Amqp;
@@ -94,7 +95,7 @@ namespace Azure.Messaging.ServiceBus
                 true,
                 plugins,
                 options.ToProcessorOptions(),
-                options.SessionIds,
+                options.SessionIds.ToArray(),
                 options.MaxConcurrentSessions,
                 options.MaxConcurrentCallsPerSession);
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessorOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Azure.Core;
 
@@ -126,12 +127,12 @@ namespace Azure.Messaging.ServiceBus
         private int _maxConcurrentCallsPerSessions = 1;
 
         /// <summary>
-        /// Gets or sets an optional list of session IDs to scope
-        /// the <see cref="ServiceBusSessionProcessor"/> to. If left
-        /// blank, the processor will not be limited to any specific
+        /// Gets an optional list of session IDs to scope
+        /// the <see cref="ServiceBusSessionProcessor"/> to. If the list is
+        /// left empty, the processor will not be limited to any specific
         /// session IDs.
         /// </summary>
-        public string[] SessionIds { get; set; }
+        public IList<string> SessionIds { get; } = new List<string>();
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object" /> is equal to this instance.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Receiver/ServiceBusReceiver.cs
@@ -423,6 +423,8 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
+            Argument.AssertAtLeast(maxMessages, 1, nameof(maxMessages));
+
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             Logger.PeekMessageStart(Identifier, sequenceNumber, maxMessages);
             using DiagnosticScope scope = ScopeFactory.CreateScope(
@@ -898,9 +900,13 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotDisposed(IsClosed, nameof(ServiceBusReceiver));
-            Argument.AssertNotNullOrEmpty(sequenceNumbers, nameof(sequenceNumbers));
+            Argument.AssertNotNull(sequenceNumbers, nameof(sequenceNumbers));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
             var sequenceNumbersList = sequenceNumbers.ToList();
+            if (sequenceNumbersList.Count == 0)
+            {
+                return Array.Empty<ServiceBusReceivedMessage>();
+            }
 
             Logger.ReceiveDeferredMessageStart(Identifier, sequenceNumbersList);
             using DiagnosticScope scope = ScopeFactory.CreateScope(DiagnosticProperty.ReceiveDeferredActivityName);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -396,12 +396,12 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(message, nameof(message));
-            long[] sequenceNumbers = await ScheduleMessagesAsync(
+            IReadOnlyList<long> sequenceNumbers = await ScheduleMessagesAsync(
                 new ServiceBusMessage[] { message },
                 scheduledEnqueueTime,
                 cancellationToken)
             .ConfigureAwait(false);
-            // if there isn't one sequence number in the array, an
+            // if there isn't one sequence number in the list, an
             // exception should have been thrown by this point.
             return sequenceNumbers[0];
         }
@@ -423,7 +423,7 @@ namespace Azure.Messaging.ServiceBus
         /// <see cref="SendMessagesAsync(ServiceBusMessageBatch, CancellationToken)"/>.</remarks>
         ///
         /// <returns>The sequence number of the message that was scheduled.</returns>
-        public virtual async Task<long[]> ScheduleMessagesAsync(
+        public virtual async Task<IReadOnlyList<long>> ScheduleMessagesAsync(
             IEnumerable<ServiceBusMessage> messages,
             DateTimeOffset scheduledEnqueueTime,
             CancellationToken cancellationToken = default)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -94,7 +94,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             mockTransportSender.Setup(
                 sender => sender.SendAsync(
-                    It.IsAny<IList<ServiceBusMessage>>(),
+                    It.IsAny<IReadOnlyList<ServiceBusMessage>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 
@@ -183,9 +183,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
             };
             mockTransportSender.Setup(
                 sender => sender.ScheduleMessagesAsync(
-                    It.IsAny<IList<ServiceBusMessage>>(),
+                    It.IsAny<IReadOnlyList<ServiceBusMessage>>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new long[] { 1 }));
+                .Returns(Task.FromResult((IReadOnlyList<long>) new List<long> { 1 }));
 
             var scheduleTime = DateTimeOffset.UtcNow.AddMinutes(1);
             await sender.ScheduleMessageAsync(GetMessage(), scheduleTime);
@@ -222,7 +222,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
             mockTransportSender.Setup(
                 sender => sender.ScheduleMessagesAsync(
-                    It.IsAny<IList<ServiceBusMessage>>(),
+                    It.IsAny<IReadOnlyList<ServiceBusMessage>>(),
                     It.IsAny<CancellationToken>()))
                 .Throws(new Exception());
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -541,7 +541,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     MaxConcurrentSessions = numThreads,
                     AutoComplete = autoComplete,
                     // using the last sessionId from the loop
-                    SessionIds = new string[] { sessionId }
+                    SessionIds = { sessionId }
                 };
 
                 await using var processor = client.CreateSessionProcessor(
@@ -898,11 +898,15 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
-                var sessionIds = new List<string>();
+                var options = new ServiceBusSessionProcessorOptions
+                {
+                    MaxConcurrentSessions = numThreads,
+                    AutoComplete = autoComplete,
+                };
                 for (int i = 0; i < specifiedSessionCount; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    sessionIds.Add(sessionId);
+                    options.SessionIds.Add(sessionId);
                     await sender.SendMessageAsync(GetMessage(sessionId));
                     sessions.TryAdd(sessionId, true);
                 }
@@ -922,13 +926,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 int messageCt = 0;
                 int sessionCloseEventCt = 0;
 
-                var options = new ServiceBusSessionProcessorOptions
-                {
-                    MaxConcurrentSessions = numThreads,
-                    AutoComplete = autoComplete,
-                    SessionIds = sessionIds.ToArray()
-                };
-
                 await using var processor = client.CreateSessionProcessor(
                     scope.QueueName,
                     options);
@@ -942,7 +939,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     Interlocked.Increment(ref sessionCloseEventCt);
                     await args.GetSessionStateAsync();
-                    Assert.IsTrue(sessionIds.Contains(args.SessionId));
+                    Assert.IsTrue(options.SessionIds.Contains(args.SessionId));
                 }
 
                 async Task ProcessMessage(ProcessSessionMessageEventArgs args)
@@ -955,8 +952,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                             await args.CompleteMessageAsync(message);
                         }
                         sessions.TryRemove(message.SessionId, out bool _);
-                        Assert.IsTrue(sessionIds.Contains(message.SessionId));
-                        Assert.IsTrue(sessionIds.Contains(args.SessionId));
+                        Assert.IsTrue(options.SessionIds.Contains(message.SessionId));
+                        Assert.IsTrue(options.SessionIds.Contains(args.SessionId));
                         Assert.IsNotNull(args.SessionLockedUntil);
                     }
                     finally
@@ -999,12 +996,16 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
 
                 ConcurrentDictionary<string, bool> sessions = new ConcurrentDictionary<string, bool>();
-                var sessionIds = new List<string>();
+                var options = new ServiceBusSessionProcessorOptions
+                {
+                    MaxConcurrentSessions = numThreads,
+                    MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(1)
+                };
                 int messagesPerSession = 20;
                 for (int i = 0; i < numSessions; i++)
                 {
                     var sessionId = Guid.NewGuid().ToString();
-                    sessionIds.Add(sessionId);
+                    options.SessionIds.Add(sessionId);
                     var messages = GetMessages(messagesPerSession, sessionId);
                     await sender.SendMessagesAsync(messages);
                     sessions.TryAdd(sessionId, true);
@@ -1019,13 +1020,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 ConcurrentDictionary<string, int> sessionClosedEvents = new ConcurrentDictionary<string, int>();
                 ConcurrentDictionary<string, int> sessionOpenEvents = new ConcurrentDictionary<string, int>();
                 ConcurrentDictionary<string, int> lockLostMap = new ConcurrentDictionary<string, int>();
-
-                var options = new ServiceBusSessionProcessorOptions
-                {
-                    MaxConcurrentSessions = numThreads,
-                    MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(1),
-                    SessionIds = sessionIds.ToArray()
-                };
 
                 await using var processor = client.CreateSessionProcessor(
                     scope.QueueName,
@@ -1104,8 +1098,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                         }
 
                         sessions.TryRemove(message.SessionId, out bool _);
-                        Assert.IsTrue(sessionIds.Contains(message.SessionId));
-                        Assert.IsTrue(sessionIds.Contains(args.SessionId));
+                        Assert.IsTrue(options.SessionIds.Contains(message.SessionId));
+                        Assert.IsTrue(options.SessionIds.Contains(args.SessionId));
                         Assert.IsNotNull(args.SessionLockedUntil);
                     }
                     finally
@@ -1119,7 +1113,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 }
                 await tcs.Task;
                 await processor.CloseAsync();
-                foreach (var sessionId in sessionIds)
+                foreach (var sessionId in options.SessionIds)
                 {
                     Assert.True(receivedMessagesAfterLockLost.ContainsKey(sessionId));
 
@@ -1167,7 +1161,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     MaxConcurrentSessions = 1,
                     MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(10),
-                    SessionIds = new string[] { sessionId }
+                    SessionIds = { sessionId }
                 };
 
                 await using var processor = client.CreateSessionProcessor(
@@ -1271,7 +1265,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     MaxConcurrentSessions = 1,
                     MaxAutoLockRenewalDuration = (errorSource == ServiceBusErrorSource.RenewLock ?
                         TimeSpan.FromSeconds(1) : TimeSpan.FromSeconds(0)),
-                    SessionIds = new string[] { sessionId }
+                    SessionIds = { sessionId }
                 };
 
                 await using var processor = client.CreateSessionProcessor(
@@ -1441,7 +1435,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 {
                     MaxConcurrentSessions = 1,
                     MaxAutoLockRenewalDuration = TimeSpan.FromSeconds(30),
-                    SessionIds = new string[] { sessionId }
+                    SessionIds = { sessionId }
                 };
 
                 await using var processor = client.CreateSessionProcessor(

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -362,6 +362,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                 Assert.That(
                     async () => await receiver.ReceiveDeferredMessagesAsync(sequenceNumbers),
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.MessageNotFound));
+
+                // verify that an empty list can be passed
+
+                deferredMessages = await receiver.ReceiveDeferredMessagesAsync(Array.Empty<long>());
+                Assert.IsEmpty(deferredMessages);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -364,7 +364,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
                     Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.MessageNotFound));
 
                 // verify that an empty list can be passed
-
                 deferredMessages = await receiver.ReceiveDeferredMessagesAsync(Array.Empty<long>());
                 Assert.IsEmpty(deferredMessages);
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverTests.cs
@@ -57,6 +57,38 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
+        public void PeekValidatesMaxMessageCount()
+        {
+            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var client = new ServiceBusClient(connString);
+            var receiver = client.CreateReceiver("queueName");
+            Assert.That(
+                async () => await receiver.PeekMessagesAsync(0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                async () => await receiver.PeekMessagesAsync(-1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void ReceiveValidatesMaxMessageCount()
+        {
+            var account = Encoding.Default.GetString(GetRandomBuffer(12));
+            var fullyQualifiedNamespace = new UriBuilder($"{account}.servicebus.windows.net/").Host;
+            var connString = $"Endpoint=sb://{fullyQualifiedNamespace};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey={Encoding.Default.GetString(GetRandomBuffer(64))}";
+            var client = new ServiceBusClient(connString);
+            var receiver = client.CreateReceiver("queueName");
+            Assert.That(
+                async () => await receiver.ReceiveMessagesAsync(0),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(
+                async () => await receiver.ReceiveMessagesAsync(-1),
+                Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
         public void ReceiverOptionsValidation()
         {
             var options = new ServiceBusReceiverOptions();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -228,7 +228,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 await using var sender = client.CreateSender(scope.QueueName);
                 var scheduleTime = DateTimeOffset.UtcNow.AddHours(10);
                 var sequenceNums = await sender.ScheduleMessagesAsync(GetMessages(5), scheduleTime);
-
                 await using var receiver = client.CreateReceiver(scope.QueueName);
                 foreach (long seq in sequenceNums)
                 {
@@ -244,6 +243,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
 
                 // can cancel empty array
                 await sender.CancelScheduledMessagesAsync(sequenceNumbers: Array.Empty<long>());
+
+                // cannot cancel null
+                Assert.That(
+                    async () => await sender.CancelScheduledMessagesAsync(sequenceNumbers: null),
+                    Throws.InstanceOf<ArgumentNullException>());
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderLiveTests.cs
@@ -241,6 +241,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                     ServiceBusReceivedMessage msg = await receiver.PeekMessageAsync(seq);
                     Assert.IsNull(msg);
                 }
+
+                // can cancel empty array
+                await sender.CancelScheduledMessagesAsync(sequenceNumbers: Array.Empty<long>());
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -101,7 +101,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
                 CallBase = true
             };
 
-            long[] sequenceNums = await mock.Object.ScheduleMessagesAsync(
+            IReadOnlyList<long> sequenceNums = await mock.Object.ScheduleMessagesAsync(
                 new List<ServiceBusMessage>(),
                 default);
             Assert.IsEmpty(sequenceNums);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Sender/SenderTests.cs
@@ -94,15 +94,17 @@ namespace Azure.Messaging.ServiceBus.Tests.Sender
         }
 
         [Test]
-        public void ScheduleEmptyListShouldThrow()
+        public async Task ScheduleEmptyListShouldNotThrow()
         {
             var mock = new Mock<ServiceBusSender>()
             {
                 CallBase = true
             };
-            Assert.ThrowsAsync<ArgumentException>(async () => await mock.Object.ScheduleMessagesAsync(
+
+            long[] sequenceNums = await mock.Object.ScheduleMessagesAsync(
                 new List<ServiceBusMessage>(),
-                default));
+                default);
+            Assert.IsEmpty(sequenceNums);
         }
 
         [Test]


### PR DESCRIPTION
- Assert that maxCount param is always >= 1
- Handle empty sequenceNumber lists gracefully
- Prevent null messageId/address/body in AMQP models
- Avoid calling ToList when passed in IEnumerable is already a list

Bonus - minor updates to API
- ServiceBusSessionProcessorOptions.SessionIds is List rather than array
- ScheduleMessage returns IReadOnlyList rather than array