### PR TITLE
[Identity] Update VisualStudioCodeCredential to wrap all libsecret failures

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixes and improvements
 - Fix `VisualStudioCodeCredential` to raise `CredentialUnavailableException` when reads from libsecret fail ([#16795](https://github.com/Azure/azure-sdk-for-net/issues/16795))
-- Fix `VisualStudioCodeCredential` to raise `CredentialUnavailableException` when reads from libsecret fail ([#16795](https://github.com/Azure/azure-sdk-for-net/issues/16795))
 - Prevent `VisualStudioCodeCredential` using invalid authentication data when no user is signed in to Visual Studio Code ([#15870](https://github.com/Azure/azure-sdk-for-net/issues/15870))
 
 ### Breaking Changes

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release History
+
 ## 1.3.0-beta.3 (Unreleased)
 
 ### Fixes and improvements
+- Fix `VisualStudioCodeCredential` to raise `CredentialUnavailableException` when reads from libsecret fail ([#16795](https://github.com/Azure/azure-sdk-for-net/issues/16795))
+- Fix `VisualStudioCodeCredential` to raise `CredentialUnavailableException` when reads from libsecret fail ([#16795](https://github.com/Azure/azure-sdk-for-net/issues/16795))
 - Prevent `VisualStudioCodeCredential` using invalid authentication data when no user is signed in to Visual Studio Code ([#15870](https://github.com/Azure/azure-sdk-for-net/issues/15870))
 
 ### Breaking Changes

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -96,7 +96,7 @@ namespace Azure.Identity
 
                 return storedCredentials;
             }
-            catch (InvalidOperationException ex)
+            catch (Exception ex) when (!(ex is OperationCanceledException))
             {
                 throw new CredentialUnavailableException("Stored credentials not found. Need to authenticate user in VSCode Azure Account.", ex);
             }

--- a/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCodeCredential.cs
@@ -96,7 +96,7 @@ namespace Azure.Identity
 
                 return storedCredentials;
             }
-            catch (Exception ex) when (!(ex is OperationCanceledException))
+            catch (Exception ex) when (!(ex is OperationCanceledException || ex is CredentialUnavailableException))
             {
                 throw new CredentialUnavailableException("Stored credentials not found. Need to authenticate user in VSCode Azure Account.", ex);
             }


### PR DESCRIPTION
This PR updates the error handling around reading the VS code stored refresh token to wrap all failures in `CredentialUnavailableException` to prevent them stopping the `DefaultAzureCredential` auth flow.

Fixes #16795