### PR TITLE
[Storage] Give service more breathing room in live tests.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChangeFeedTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChangeFeedTestBase.cs
@@ -43,8 +43,8 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
                 {
                     Mode = RetryMode.Exponential,
                     MaxRetries = Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 0.5),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 10)
+                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
+                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60)
                 },
                 Transport = GetTransport()
             };

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -73,8 +73,8 @@ namespace Azure.Storage.Test.Shared
                 {
                     Mode = RetryMode.Exponential,
                     MaxRetries = Storage.Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 0.5),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 10)
+                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
+                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60)
                 },
                 Transport = GetTransport()
             };

--- a/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/CommonTestBase.cs
@@ -35,8 +35,8 @@ namespace Azure.Storage.Test
                 {
                     Mode = RetryMode.Exponential,
                     MaxRetries = Azure.Storage.Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback? 0.01 : 0.5),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 10)
+                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback? 0.01 : 1),
+                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60)
                 }
             };
             if (Mode != RecordedTestMode.Live)

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -68,8 +68,8 @@ namespace Azure.Storage.Files.DataLake.Tests
                 {
                     Mode = RetryMode.Exponential,
                     MaxRetries = Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 0.5),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 10)
+                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
+                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60)
                 },
                 Transport = GetTransport()
             };

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileTestBase.cs
@@ -47,8 +47,8 @@ namespace Azure.Storage.Files.Shares.Tests
                 {
                     Mode = RetryMode.Exponential,
                     MaxRetries = Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 0.5),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 10)
+                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
+                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60)
                 },
                 Transport = GetTransport()
             };

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -42,8 +42,8 @@ namespace Azure.Storage.Queues.Tests
                 {
                     Mode = RetryMode.Exponential,
                     MaxRetries = Constants.MaxReliabilityRetries,
-                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 0.5),
-                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 10)
+                    Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
+                    MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60)
                 },
                 Transport = GetTransport()
         };


### PR DESCRIPTION
In this PR:
- increase retry delay boundaries to give more room for service in case it needs to scale out under test load.

We seem to retry too aggressively in data heavy tests like here https://dev.azure.com/azure-sdk/590cfd2a-581c-4dcb-a12e-6568ce786175/_apis/build/builds/617028/logs/89 .