### PR TITLE
Use the InitialTransferSize option for the downloader

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -69,7 +69,7 @@ namespace Azure.Storage.Blobs
             if (transferOptions.InitialTransferSize.HasValue
                 && transferOptions.InitialTransferSize.Value > 0)
             {
-                _initialRangeSize = Math.Min(transferOptions.InitialTransferSize.Value, Constants.Blob.Block.MaxDownloadBytes);
+                _initialRangeSize = Math.Min(transferOptions.InitialTransferSize.Value, _rangeSize);
             }
             else
             {

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -69,7 +69,7 @@ namespace Azure.Storage.Blobs
             if (transferOptions.InitialTransferSize.HasValue
                 && transferOptions.InitialTransferSize.Value > 0)
             {
-                _initialRangeSize = transferOptions.MaximumTransferSize.Value;
+                _initialRangeSize = Math.Min(transferOptions.InitialTransferSize.Value, Constants.Blob.Block.MaxDownloadBytes);
             }
             else
             {

--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -69,7 +69,7 @@ namespace Azure.Storage.Blobs
             if (transferOptions.InitialTransferSize.HasValue
                 && transferOptions.InitialTransferSize.Value > 0)
             {
-                _initialRangeSize = Math.Min(transferOptions.InitialTransferSize.Value, _rangeSize);
+                _initialRangeSize = transferOptions.InitialTransferSize.Value;
             }
             else
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/PartitionedDownloaderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PartitionedDownloaderTests.cs
@@ -100,6 +100,35 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public async Task RespectsInitialTransferSizeBeforeDownloadingInBlocks()
+        {
+            MemoryStream stream = new MemoryStream();
+            MockDataSource dataSource = new MockDataSource(100);
+            Mock<BlobBaseClient> blockClient = new Mock<BlobBaseClient>(MockBehavior.Strict, new Uri("http://mock"), new BlobClientOptions());
+            blockClient.SetupGet(c => c.ClientDiagnostics).CallBase();
+            BlobProperties smallLengthProperties = new BlobProperties()
+            {
+                ContentLength = 100
+            };
+
+            SetupDownload(blockClient, dataSource);
+
+            PartitionedDownloader downloader = new PartitionedDownloader(
+                blockClient.Object,
+                new StorageTransferOptions()
+                {
+                    MaximumTransferLength = 40,
+                    InitialTransferLength = 10
+                });
+
+            Response result = await InvokeDownloadToAsync(downloader, stream);
+
+            Assert.AreEqual(dataSource.Requests.Count, 4);
+            AssertContent(100, stream);
+            Assert.NotNull(result);
+        }
+
+        [Test]
         public async Task IncludesEtagInConditions()
         {
             MemoryStream stream = new MemoryStream();

--- a/sdk/storage/Azure.Storage.Blobs/tests/PartitionedDownloaderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/PartitionedDownloaderTests.cs
@@ -94,7 +94,7 @@ namespace Azure.Storage.Blobs.Test
 
             Response result = await InvokeDownloadToAsync(downloader, stream);
 
-            Assert.AreEqual(dataSource.Requests.Count, 10);
+            Assert.AreEqual(dataSource.Requests.Count, 9);
             AssertContent(100, stream);
             Assert.NotNull(result);
         }


### PR DESCRIPTION
The option was validated but then the MaximumTransferSize was used instead to fill the field. Updated it to use the right option, and capped it to the maximum constant while I was there.