### PR TITLE
Ensure that sequence numbers are passed as arrays; make validation ordering consistent

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -1159,13 +1159,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// Throws if the messages have not been deferred.</returns>
         /// <seealso cref="DeferAsync"/>
         public override async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
-            IReadOnlyList<long> sequenceNumbers,
+            long[] sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
             IReadOnlyList<ServiceBusReceivedMessage> messages = null;
             await _retryPolicy.RunOperation(
                 async (timeout) => messages = await ReceiveDeferredMessagesAsyncInternal(
-                    sequenceNumbers.ToArray(),
+                    sequenceNumbers,
                     timeout).ConfigureAwait(false),
                 _connectionScope,
                 cancellationToken).ConfigureAwait(false);
@@ -1173,7 +1173,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         }
 
         internal virtual async Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsyncInternal(
-            IReadOnlyList<long> sequenceNumbers,
+            long[] sequenceNumbers,
             TimeSpan timeout)
         {
             var messages = new List<ServiceBusReceivedMessage>();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -492,7 +492,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public override async Task CancelScheduledMessagesAsync(
-            IReadOnlyList<long> sequenceNumbers,
+            long[] sequenceNumbers,
             CancellationToken cancellationToken = default)
         {
             Task cancelMessageTask = _retryPolicy.RunOperation(async (timeout) =>
@@ -515,7 +515,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         internal async Task CancelScheduledMessageInternalAsync(
-            IReadOnlyList<long> sequenceNumbers,
+            long[] sequenceNumbers,
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportReceiver.cs
@@ -180,7 +180,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// Throws if the messages have not been deferred.</returns>
         /// <seealso cref="DeferAsync"/>
         public abstract Task<IReadOnlyList<ServiceBusReceivedMessage>> ReceiveDeferredMessagesAsync(
-            IReadOnlyList<long> sequenceNumbers,
+            long[] sequenceNumbers,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Core/TransportSender.cs
@@ -90,7 +90,7 @@ namespace Azure.Messaging.ServiceBus.Core
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public abstract Task CancelScheduledMessagesAsync(
-            IReadOnlyList<long> sequenceNumbers,
+            long[] sequenceNumbers,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -285,12 +285,12 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [NonEvent]
-        public virtual void ReceiveDeferredMessageStart(string identifier, IReadOnlyList<long> sequenceNumbers)
+        public virtual void ReceiveDeferredMessageStart(string identifier, long[] sequenceNumbers)
         {
             if (IsEnabled())
             {
                 var formattedSequenceNumbers = StringUtility.GetFormattedSequenceNumbers(sequenceNumbers);
-                ReceiveDeferredMessageStartCore(identifier, sequenceNumbers.Count, formattedSequenceNumbers);
+                ReceiveDeferredMessageStartCore(identifier, sequenceNumbers.Length, formattedSequenceNumbers);
             }
         }
 
@@ -371,12 +371,12 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         }
 
         [NonEvent]
-        public virtual void CancelScheduledMessagesStart(string identifier, IReadOnlyList<long> sequenceNumbers)
+        public virtual void CancelScheduledMessagesStart(string identifier, long[] sequenceNumbers)
         {
             if (IsEnabled())
             {
                 var formattedSequenceNumbers = StringUtility.GetFormattedSequenceNumbers(sequenceNumbers);
-                CancelScheduledMessagesStartCore(identifier, sequenceNumbers.Count, formattedSequenceNumbers);
+                CancelScheduledMessagesStartCore(identifier, sequenceNumbers.Length, formattedSequenceNumbers);
             }
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.Designer.cs
@@ -511,15 +511,6 @@ namespace Azure.Messaging.ServiceBus {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The operation is not supported for peeked message. Only received message can be settled..
-        /// </summary>
-        internal static string SettlementOperationNotSupported {
-            get {
-                return ResourceManager.GetString("SettlementOperationNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to In order to update the signature, a shared access key must have been provided when the shared access signature was created..
         /// </summary>
         internal static string SharedAccessKeyIsRequired {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Resources.resx
@@ -288,9 +288,6 @@
   <data name="MessageBatchIsLocked" xml:space="preserve">
     <value>The message batch is currently being used in communication with the Service Bus service; messages may not be added until the active operation is complete.</value>
   </data>
-  <data name="SettlementOperationNotSupported" xml:space="preserve">
-    <value>The operation is not supported for peeked message. Only received message can be settled.</value>
-  </data>
   <data name="SendViaCannotBeUsedWithEntityInConnectionString" xml:space="preserve">
     <value>When sending via a different entity, an entity path is not allowed to specified in the connection string.</value>
   </data>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusSender.cs
@@ -507,18 +507,19 @@ namespace Azure.Messaging.ServiceBus
             Argument.AssertNotNull(sequenceNumbers, nameof(sequenceNumbers));
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
-            IReadOnlyList<long> sequenceList = sequenceNumbers switch
+            // the sequence numbers MUST be in array form for them to be encoded correctly
+            long[] sequenceArray = sequenceNumbers switch
             {
-                IReadOnlyList<long> alreadyList => alreadyList,
-                _ => sequenceNumbers.ToList()
+                long[] alreadyArray => alreadyArray,
+                _ => sequenceNumbers.ToArray()
             };
 
-            if (sequenceList.Count == 0)
+            if (sequenceArray.Length == 0)
             {
                 return;
             }
 
-            Logger.CancelScheduledMessagesStart(Identifier, sequenceList);
+            Logger.CancelScheduledMessagesStart(Identifier, sequenceArray);
             using DiagnosticScope scope = _scopeFactory.CreateScope(
                 DiagnosticProperty.CancelActivityName,
                 DiagnosticProperty.ClientKind);
@@ -527,7 +528,7 @@ namespace Azure.Messaging.ServiceBus
             scope.Start();
             try
             {
-                await _innerSender.CancelScheduledMessagesAsync(sequenceList, cancellationToken).ConfigureAwait(false);
+                await _innerSender.CancelScheduledMessagesAsync(sequenceArray, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Receiver/ReceiverLiveTests.cs
@@ -316,7 +316,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
         }
 
         [Test]
-        public async Task DeferMessages()
+        public async Task DeferMessagesList()
         {
             await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
             {
@@ -365,6 +365,110 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 // verify that an empty list can be passed
                 deferredMessages = await receiver.ReceiveDeferredMessagesAsync(Array.Empty<long>());
+                Assert.IsEmpty(deferredMessages);
+            }
+        }
+
+        [Test]
+        public async Task DeferMessagesArray()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                var messageCount = 10;
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
+                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+
+                await sender.SendMessagesAsync(batch);
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var messageEnum = messages.GetEnumerator();
+                long[] sequenceNumbers = new long[messageCount];
+                var remainingMessages = messageCount;
+                int idx = 0;
+                while (remainingMessages > 0)
+                {
+                    foreach (var item in await receiver.ReceiveMessagesAsync(remainingMessages))
+                    {
+                        remainingMessages--;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        sequenceNumbers[idx++] = item.SequenceNumber;
+                        await receiver.DeferMessageAsync(item.LockToken);
+                    }
+                }
+                Assert.AreEqual(0, remainingMessages);
+
+                IReadOnlyList<ServiceBusReceivedMessage> deferredMessages = await receiver.ReceiveDeferredMessagesAsync(sequenceNumbers);
+
+                var messageList = messages.ToList();
+                Assert.AreEqual(messageList.Count, deferredMessages.Count);
+                for (int i = 0; i < messageList.Count; i++)
+                {
+                    Assert.AreEqual(messageList[i].MessageId, deferredMessages[i].MessageId);
+                    Assert.AreEqual(messageList[i].Body.ToArray(), deferredMessages[i].Body.ToArray());
+                }
+
+                // verify that an empty array can be passed
+                deferredMessages = await receiver.ReceiveDeferredMessagesAsync(Array.Empty<long>());
+                Assert.IsEmpty(deferredMessages);
+            }
+        }
+
+        [Test]
+        public async Task DeferMessagesEnumerable()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+                var messageCount = 10;
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
+                IEnumerable<ServiceBusMessage> messages = AddMessages(batch, messageCount).AsEnumerable<ServiceBusMessage>();
+
+                await sender.SendMessagesAsync(batch);
+
+                var receiver = client.CreateReceiver(scope.QueueName);
+                var messageEnum = messages.GetEnumerator();
+                long[] sequenceNumbers = new long[messageCount];
+                var remainingMessages = messageCount;
+                int idx = 0;
+                while (remainingMessages > 0)
+                {
+                    foreach (var item in await receiver.ReceiveMessagesAsync(remainingMessages))
+                    {
+                        remainingMessages--;
+                        messageEnum.MoveNext();
+                        Assert.AreEqual(messageEnum.Current.MessageId, item.MessageId);
+                        sequenceNumbers[idx++] = item.SequenceNumber;
+                        await receiver.DeferMessageAsync(item.LockToken);
+                    }
+                }
+                Assert.AreEqual(0, remainingMessages);
+
+                IReadOnlyList<ServiceBusReceivedMessage> deferredMessages = await receiver.ReceiveDeferredMessagesAsync(GetEnumerable());
+
+                IEnumerable<long> GetEnumerable()
+                {
+                    foreach (long seq in sequenceNumbers)
+                    {
+                        yield return seq;
+                    }
+                }
+
+                var messageList = messages.ToList();
+                Assert.AreEqual(messageList.Count, deferredMessages.Count);
+                for (int i = 0; i < messageList.Count; i++)
+                {
+                    Assert.AreEqual(messageList[i].MessageId, deferredMessages[i].MessageId);
+                    Assert.AreEqual(messageList[i].Body.ToArray(), deferredMessages[i].Body.ToArray());
+                }
+
+                // verify that an empty enumerable can be passed
+                deferredMessages = await receiver.ReceiveDeferredMessagesAsync(Enumerable.Empty<long>());
                 Assert.IsEmpty(deferredMessages);
             }
         }
@@ -556,7 +660,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 Assert.That(
                     async () => await receiver.CompleteMessageAsync(peekedMessage),
-                    Throws.InstanceOf<InvalidOperationException>());
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("peeked message"));
             }
         }
 
@@ -576,7 +680,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 Assert.That(
                     async () => await receiver.AbandonMessageAsync(peekedMessage),
-                    Throws.InstanceOf<InvalidOperationException>());
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("peeked message"));
             }
         }
 
@@ -596,7 +700,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 Assert.That(
                     async () => await receiver.DeferMessageAsync(peekedMessage),
-                    Throws.InstanceOf<InvalidOperationException>());
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("peeked message"));
             }
         }
 
@@ -616,7 +720,41 @@ namespace Azure.Messaging.ServiceBus.Tests.Receiver
 
                 Assert.That(
                     async () => await receiver.DeadLetterMessageAsync(peekedMessage),
-                    Throws.InstanceOf<InvalidOperationException>());
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("peeked message"));
+            }
+        }
+
+        [Test]
+        public async Task ThrowIfSettleInReceiveAndDeleteMode()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                await using var client = new ServiceBusClient(TestEnvironment.ServiceBusConnectionString);
+
+                ServiceBusSender sender = client.CreateSender(scope.QueueName);
+                await sender.SendMessageAsync(GetMessage());
+
+                var receiver = client.CreateReceiver(
+                    scope.QueueName,
+                    new ServiceBusReceiverOptions { ReceiveMode = ReceiveMode.ReceiveAndDelete });
+
+                var peekedMessage = await receiver.PeekMessageAsync();
+
+                Assert.That(
+                    async () => await receiver.DeadLetterMessageAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("receive mode"));
+
+                Assert.That(
+                    async () => await receiver.DeferMessageAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("receive mode"));
+
+                Assert.That(
+                    async () => await receiver.CompleteMessageAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("receive mode"));
+
+                Assert.That(
+                    async () => await receiver.AbandonMessageAsync(peekedMessage),
+                    Throws.InstanceOf<InvalidOperationException>().And.Property(nameof(InvalidOperationException.Message)).Contains("receive mode"));
             }
         }
 


### PR DESCRIPTION
When making a request involving a list of primitives on the management link, the list needs to be encoded as an array. Otherwise the service throws a generic error.