### PR TITLE
[Storage][Webjobs] Base64 encoding in Queues.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobQueueTriggerExecutor.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobQueueTriggerExecutor.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
 
         public async Task<FunctionResult> ExecuteAsync(QueueMessage value, CancellationToken cancellationToken)
         {
-            BlobTriggerMessage message = JsonConvert.DeserializeObject<BlobTriggerMessage>(value.MessageText, JsonSerialization.Settings);
+            BlobTriggerMessage message = JsonConvert.DeserializeObject<BlobTriggerMessage>(value.Body.ToValidUTF8String(), JsonSerialization.Settings);
 
             if (message == null)
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerQueueWriter.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerQueueWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         public async Task<(string QueueName, string MessageId)> EnqueueAsync(BlobTriggerMessage message, CancellationToken cancellationToken)
         {
             string contents = JsonConvert.SerializeObject(message, JsonSerialization.Settings);
-            var receipt = await _queue.AddMessageAndCreateIfNotExistsAsync(contents, cancellationToken).ConfigureAwait(false);
+            var receipt = await _queue.AddMessageAndCreateIfNotExistsAsync(BinaryData.FromString(contents), cancellationToken).ConfigureAwait(false);
             _watcher.Notify(_queue.Name);
             return (QueueName: _queue.Name, MessageId: receipt.MessageId);
         }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/SharedBlobQueueListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/SharedBlobQueueListenerFactory.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                     throw new ArgumentNullException(nameof(message));
                 }
 
-                var blobTriggerMessage = JsonConvert.DeserializeObject<BlobTriggerMessage>(message.MessageText);
+                var blobTriggerMessage = JsonConvert.DeserializeObject<BlobTriggerMessage>(message.Body.ToValidUTF8String());
 
                 BlobQueueRegistration registration = null;
                 if (_executor.TryGetRegistration(blobTriggerMessage.FunctionId, out registration))

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/QueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/QueueServiceClientProvider.cs
@@ -5,27 +5,36 @@ using System;
 using Azure.Core;
 using Azure.Storage.Queues;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 {
     internal class QueueServiceClientProvider : StorageClientProvider<QueueServiceClient, QueueClientOptions>
     {
-        public QueueServiceClientProvider(IConfiguration configuration, AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder)
-            : base(configuration, componentFactory, logForwarder) {}
+        private readonly QueuesOptions _queuesOptions;
+
+        public QueueServiceClientProvider(
+            IConfiguration configuration,
+            AzureComponentFactory componentFactory,
+            AzureEventSourceLogForwarder logForwarder,
+            IOptions<QueuesOptions> queueOptions)
+            : base(configuration, componentFactory, logForwarder)
+        {
+            _queuesOptions = queueOptions?.Value;
+        }
 
         protected override QueueServiceClient CreateClientFromConnectionString(string connectionString, QueueClientOptions options)
         {
-            // TODO (kasobol-msft) configure this
-            options.MessageEncoding = QueueMessageEncoding.Base64;
+            options.MessageEncoding = _queuesOptions.MessageEncoding;
             return new QueueServiceClient(connectionString, options);
         }
 
         protected override QueueServiceClient CreateClientFromTokenCredential(Uri endpointUri, TokenCredential tokenCredential, QueueClientOptions options)
         {
-            // TODO (kasobol-msft) configure this
-            options.MessageEncoding = QueueMessageEncoding.Base64;
+            options.MessageEncoding = _queuesOptions.MessageEncoding;
             return new QueueServiceClient(endpointUri, tokenCredential, options);
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/QueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/QueueServiceClientProvider.cs
@@ -17,11 +17,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 
         protected override QueueServiceClient CreateClientFromConnectionString(string connectionString, QueueClientOptions options)
         {
+            // TODO (kasobol-msft) configure this
+            options.MessageEncoding = QueueMessageEncoding.Base64;
             return new QueueServiceClient(connectionString, options);
         }
 
         protected override QueueServiceClient CreateClientFromTokenCredential(Uri endpointUri, TokenCredential tokenCredential, QueueClientOptions options)
         {
+            // TODO (kasobol-msft) configure this
+            options.MessageEncoding = QueueMessageEncoding.Base64;
             return new QueueServiceClient(endpointUri, tokenCredential, options);
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageLoadBalancerQueue.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageLoadBalancerQueue.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
                     item,
                     JsonSerialization.Settings);
 
-                await _queue.AddMessageAndCreateIfNotExistsAsync(contents, cancellationToken).ConfigureAwait(false);
+                await _queue.AddMessageAndCreateIfNotExistsAsync(BinaryData.FromString(contents), cancellationToken).ConfigureAwait(false);
 
                 _parent._sharedWatcher.Notify(_queue.Name);
             }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageLoadBalancerQueue.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageLoadBalancerQueue.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 
             public Task<FunctionResult> ExecuteAsync(QueueMessage value, CancellationToken cancellationToken)
             {
-                return _callback(value.MessageText, cancellationToken);
+                return _callback(value.Body.ToValidUTF8String(), cancellationToken);
             }
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/FakeQueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/FakeQueueServiceClientProvider.cs
@@ -4,6 +4,8 @@
 using System;
 using Azure.Core;
 using Azure.Storage.Queues;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
 {
@@ -12,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs
         private readonly QueueServiceClient _queueServiceClient;
 
         public FakeQueueServiceClientProvider(QueueServiceClient queueServiceClient)
-            : base(null, null, null)
+            : base(null, null, null, null)
         {
             _queueServiceClient = queueServiceClient;
         }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/BinaryDataExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/BinaryDataExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
+{
+    internal static class BinaryDataExtensions
+    {
+        private static readonly UTF8Encoding encoding = new UTF8Encoding(false, true);
+
+        public static string ToValidUTF8String(this BinaryData binaryData)
+        {
+            if (MemoryMarshal.TryGetArray(binaryData.ToMemory(), out ArraySegment<byte> data))
+            {
+                return encoding.GetString(data.Array, data.Offset, data.Count);
+            }
+            return encoding.GetString(binaryData.ToArray());
+        }
+
+        public static string TryGetAsString(this BinaryData binaryData)
+        {
+            if (binaryData == null)
+            {
+                throw new ArgumentNullException(nameof(binaryData));
+            }
+
+            string value;
+
+            try
+            {
+                value = binaryData.ToValidUTF8String();
+            }
+            catch (Exception ex)
+            {
+                if (ex is DecoderFallbackException || ex is FormatException)
+                {
+                    value = null;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/BinaryDataExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/BinaryDataExtensions.cs
@@ -19,33 +19,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
             }
             return encoding.GetString(binaryData.ToArray());
         }
-
-        public static string TryGetAsString(this BinaryData binaryData)
-        {
-            if (binaryData == null)
-            {
-                throw new ArgumentNullException(nameof(binaryData));
-            }
-
-            string value;
-
-            try
-            {
-                value = binaryData.ToValidUTF8String();
-            }
-            catch (Exception ex)
-            {
-                if (ex is DecoderFallbackException || ex is FormatException)
-                {
-                    value = null;
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            return value;
-        }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/QueueMessageExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/QueueMessageExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using Azure.Storage.Queues.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
+{
+    internal static class QueueMessageExtensions
+    {
+        public static string TryGetAsString(this QueueMessage message, ILogger logger)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            string value;
+
+            try
+            {
+                value = message.Body.ToValidUTF8String();
+            }
+            catch (Exception ex)
+            {
+                if (ex is DecoderFallbackException || ex is FormatException)
+                {
+                    logger.LogWarning($"Queue message's body cannot be converted to string because it contains non-UTF8 bytes, message id={message.MessageId}");
+                    value = null;
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueProcessor.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueProcessor.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Host.Queues
             string msg = string.Format(CultureInfo.InvariantCulture, "Message has reached MaxDequeueCount of {0}. Moving message to queue '{1}'.", QueuesOptions.MaxDequeueCount, poisonQueue.Name);
             _logger?.LogWarning(msg);
 
-            await poisonQueue.AddMessageAndCreateIfNotExistsAsync(message.MessageText, cancellationToken).ConfigureAwait(false);
+            await poisonQueue.AddMessageAndCreateIfNotExistsAsync(message.Body, cancellationToken).ConfigureAwait(false);
 
             var eventArgs = new PoisonMessageEventArgs(message, poisonQueue);
             OnMessageAddedToPoisonQueue(eventArgs);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using Azure.Storage.Queues;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
 using Microsoft.Azure.WebJobs.Hosting;
@@ -33,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Host
         private TimeSpan _maxPollingInterval = QueuePollingIntervals.DefaultMaximum;
         private TimeSpan _visibilityTimeout = TimeSpan.Zero;
         private int _maxDequeueCount = DefaultMaxDequeueCount;
+        private QueueMessageEncoding _messageEncoding = QueueMessageEncoding.Base64;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueuesOptions"/> class.
@@ -159,6 +161,22 @@ namespace Microsoft.Azure.WebJobs.Host
             }
         }
 
+        /// <summary>
+        /// Gets or sets a message encoding that determines how queue message body is represented in HTTP requests and responses.
+        /// The default is <see cref="QueueMessageEncoding.Base64"/>.
+        /// </summary>
+        public QueueMessageEncoding MessageEncoding
+        {
+            get
+            {
+                return _messageEncoding;
+            }
+            set
+            {
+                _messageEncoding = value;
+            }
+        }
+
         /// <inheritdoc/>
         public string Format()
         {
@@ -168,7 +186,8 @@ namespace Microsoft.Azure.WebJobs.Host
                 { nameof(NewBatchThreshold), NewBatchThreshold },
                 { nameof(MaxPollingInterval), MaxPollingInterval },
                 { nameof(MaxDequeueCount), MaxDequeueCount },
-                { nameof(VisibilityTimeout), VisibilityTimeout }
+                { nameof(VisibilityTimeout), VisibilityTimeout },
+                { nameof(MessageEncoding), MessageEncoding.ToString() }
             };
 
             return options.ToString(Formatting.Indented);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/StorageQueueExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/StorageQueueExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
     internal static class StorageQueueExtensions
     {
         public static async Task<SendReceipt> AddMessageAndCreateIfNotExistsAsync(this QueueClient queue,
-            string message, CancellationToken cancellationToken)
+            BinaryData body, CancellationToken cancellationToken)
         {
             if (queue == null)
             {
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
             SendReceipt receipt = null;
             try
             {
-                receipt = await queue.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
+                receipt = await queue.SendMessageAsync(body, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return receipt;
             }
             catch (RequestFailedException exception)
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common
 
             Debug.Assert(isQueueNotFoundException);
             await queue.CreateAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            receipt = await queue.SendMessageAsync(message, cancellationToken).ConfigureAwait(false);
+            receipt = await queue.SendMessageAsync(body, cancellationToken: cancellationToken).ConfigureAwait(false);
             return receipt;
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/UpdateQueueMessageVisibilityCommand.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/UpdateQueueMessageVisibilityCommand.cs
@@ -17,9 +17,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         private readonly QueueMessage _message;
         private readonly TimeSpan _visibilityTimeout;
         private readonly IDelayStrategy _speedupStrategy;
+        private readonly Action<UpdateReceipt> _onUpdateReceipt;
 
         public UpdateQueueMessageVisibilityCommand(QueueClient queue, QueueMessage message,
-            TimeSpan visibilityTimeout, IDelayStrategy speedupStrategy)
+            TimeSpan visibilityTimeout, IDelayStrategy speedupStrategy, Action<UpdateReceipt> onUpdateReceipt)
         {
             if (queue == null)
             {
@@ -40,6 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             _message = message;
             _visibilityTimeout = visibilityTimeout;
             _speedupStrategy = speedupStrategy;
+            _onUpdateReceipt = onUpdateReceipt;
         }
 
         public async Task<TaskSeriesCommandResult> ExecuteAsync(CancellationToken cancellationToken)
@@ -48,7 +50,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
             try
             {
-                await _queue.UpdateMessageAsync(_message.MessageId, _message.PopReceipt, visibilityTimeout: _visibilityTimeout, cancellationToken: cancellationToken).ConfigureAwait(false);
+                UpdateReceipt updateReceipt = await _queue.UpdateMessageAsync(_message.MessageId, _message.PopReceipt, visibilityTimeout: _visibilityTimeout, cancellationToken: cancellationToken).ConfigureAwait(false);
+                _onUpdateReceipt?.Invoke(updateReceipt);
                 // The next execution should occur after a normal delay.
                 delay = _speedupStrategy.GetNextDelay(executionSucceeded: true);
             }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
@@ -140,13 +140,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
             });
         }
 
-        public QueueServiceClient GetQueueServiceClient()
+        public QueueServiceClient GetQueueServiceClient(QueueClientOptions queueClientOptions = default)
         {
-            var transport = GetTransport();
-            return new QueueServiceClient(account.ConnectionString, new QueueClientOptions()
+            if (queueClientOptions == default)
             {
-                Transport = transport
-            });
+                queueClientOptions = new QueueClientOptions()
+                {
+                    MessageEncoding = QueueMessageEncoding.Base64
+                };
+            }
+
+            queueClientOptions.Transport = GetTransport();
+            return new QueueServiceClient(account.ConnectionString, queueClientOptions);
         }
 
         public HttpClientTransport GetTransport()

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/api/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.netstandard2.0.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/api/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.netstandard2.0.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Host
         public int BatchSize { get { throw null; } set { } }
         public int MaxDequeueCount { get { throw null; } set { } }
         public System.TimeSpan MaxPollingInterval { get { throw null; } set { } }
+        public Azure.Storage.Queues.QueueMessageEncoding MessageEncoding { get { throw null; } set { } }
         public int NewBatchThreshold { get { throw null; } set { } }
         public System.TimeSpan VisibilityTimeout { get { throw null; } set { } }
         public string Format() { throw null; }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
@@ -24,13 +24,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
         private readonly IContextGetter<IMessageEnqueuedWatcher> _contextGetter;
         private readonly QueueServiceClientProvider _queueServiceClientProvider;
         private readonly QueueTriggerAttributeBindingProvider _triggerProvider;
+        private readonly QueueCausalityManager _queueCausalityManager;
 
         public QueuesExtensionConfigProvider(QueueServiceClientProvider queueServiceClientProvider, IContextGetter<IMessageEnqueuedWatcher> contextGetter,
-            QueueTriggerAttributeBindingProvider triggerProvider)
+            QueueTriggerAttributeBindingProvider triggerProvider, QueueCausalityManager queueCausalityManager)
         {
             _contextGetter = contextGetter;
             _queueServiceClientProvider = queueServiceClientProvider;
             _triggerProvider = triggerProvider;
+            _queueCausalityManager = queueCausalityManager;
         }
 
         public void Initialize(ExtensionConfigContext context)
@@ -43,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
             context.AddBindingRule<QueueTriggerAttribute>().BindToTrigger(_triggerProvider);
 
             var config = new PerHostConfig();
-            config.Initialize(context, _queueServiceClientProvider, _contextGetter);
+            config.Initialize(context, _queueServiceClientProvider, _contextGetter, _queueCausalityManager);
         }
 
         // $$$ Get rid of PerHostConfig part?
@@ -59,10 +61,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
             // This is per-host (not per-config)
             private IContextGetter<IMessageEnqueuedWatcher> _messageEnqueuedWatcherGetter;
 
-            public void Initialize(ExtensionConfigContext context, QueueServiceClientProvider queueServiceClientProvider, IContextGetter<IMessageEnqueuedWatcher> contextGetter)
+            private QueueCausalityManager _queueCausalityManager;
+
+            public void Initialize(
+                ExtensionConfigContext context,
+                QueueServiceClientProvider queueServiceClientProvider,
+                IContextGetter<IMessageEnqueuedWatcher> contextGetter,
+                QueueCausalityManager queueCausalityManager)
             {
                 _queueServiceClientProvider = queueServiceClientProvider;
                 _messageEnqueuedWatcherGetter = contextGetter;
+                _queueCausalityManager = queueCausalityManager;
 
                 // IStorageQueueMessage is the core testing interface
                 var binding = context.AddBindingRule<QueueAttribute>();

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
@@ -64,9 +64,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
                 _queueServiceClientProvider = queueServiceClientProvider;
                 _messageEnqueuedWatcherGetter = contextGetter;
 
-                // TODO: FACAVAL replace this with queue options. This should no longer be needed.
-                //context.ApplyConfig(context.Config.Queues, "queues");
-
                 // IStorageQueueMessage is the core testing interface
                 var binding = context.AddBindingRule<QueueAttribute>();
                 binding
@@ -139,18 +136,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
 
             private byte[] ConvertCloudQueueMessageToByteArray(QueueMessage arg)
             {
-                return Encoding.UTF8.GetBytes(arg.MessageText);
+                return arg.Body.ToArray();
             }
 
             private static string ConvertCloudQueueMessageToString(QueueMessage arg)
             {
-                return arg.MessageText;
+                return arg.Body.ToString();
             }
 
             private static QueueMessage ConvertByteArrayToCloudQueueMessage(byte[] arg, QueueAttribute attrResolved)
             {
-                // TODO (kasobol-msft) revisit this base64/BinaryData
-                return QueuesModelFactory.QueueMessage(null, null, Encoding.UTF8.GetString(arg), 0);
+                return QueuesModelFactory.QueueMessage(null, null, new BinaryData(arg), 0);
             }
 
             private static QueueMessage ConvertStringToCloudQueueMessage(string arg, QueueAttribute attrResolved)
@@ -214,7 +210,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
                     throw new InvalidOperationException("Cannot enqueue a null queue message instance.");
                 }
 
-                await _queue.AddMessageAndCreateIfNotExistsAsync(message.MessageText, cancellationToken).ConfigureAwait(false);
+                await _queue.AddMessageAndCreateIfNotExistsAsync(message.Body, cancellationToken).ConfigureAwait(false);
 
                 if (_messageEnqueuedWatcher != null)
                 {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
@@ -69,11 +69,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
                 binding
                     .AddConverter<byte[], QueueMessage>(ConvertByteArrayToCloudQueueMessage)
                     .AddConverter<string, QueueMessage>(ConvertStringToCloudQueueMessage)
+                    .AddConverter<BinaryData, QueueMessage>(ConvertBinaryDataToCloudQueueMessage)
                     .AddOpenConverter<OpenType.Poco, QueueMessage>(ConvertPocoToCloudQueueMessage);
 
                 context // global converters, apply to multiple attributes.
                      .AddConverter<QueueMessage, byte[]>(ConvertCloudQueueMessageToByteArray)
-                     .AddConverter<QueueMessage, string>(ConvertCloudQueueMessageToString);
+                     .AddConverter<QueueMessage, string>(ConvertCloudQueueMessageToString)
+                     .AddConverter<QueueMessage, BinaryData>(ConvertCloudQueueMessageToBinaryData);
 
                 var builder = new QueueBuilder(this);
 
@@ -139,6 +141,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
                 return arg.Body.ToArray();
             }
 
+            private BinaryData ConvertCloudQueueMessageToBinaryData(QueueMessage arg)
+            {
+                return arg.Body;
+            }
+
             private static string ConvertCloudQueueMessageToString(QueueMessage arg)
             {
                 return arg.Body.ToValidUTF8String();
@@ -147,6 +154,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
             private static QueueMessage ConvertByteArrayToCloudQueueMessage(byte[] arg, QueueAttribute attrResolved)
             {
                 return QueuesModelFactory.QueueMessage(null, null, new BinaryData(arg), 0);
+            }
+
+            private static QueueMessage ConvertBinaryDataToCloudQueueMessage(BinaryData arg, QueueAttribute attrResolved)
+            {
+                return QueuesModelFactory.QueueMessage(null, null, arg, 0);
             }
 
             private static QueueMessage ConvertStringToCloudQueueMessage(string arg, QueueAttribute attrResolved)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Config/QueuesExtensionConfigProvider.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Config
 
             private static string ConvertCloudQueueMessageToString(QueueMessage arg)
             {
-                return arg.Body.ToString();
+                return arg.Body.ToValidUTF8String();
             }
 
             private static QueueMessage ConvertByteArrayToCloudQueueMessage(byte[] arg, QueueAttribute attrResolved)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueTriggerExecutor.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Listeners/QueueTriggerExecutor.cs
@@ -16,15 +16,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Listeners
     internal class QueueTriggerExecutor : ITriggerExecutor<QueueMessage>
     {
         private readonly ITriggeredFunctionExecutor _innerExecutor;
+        private readonly QueueCausalityManager _queueCausalityManager;
 
-        public QueueTriggerExecutor(ITriggeredFunctionExecutor innerExecutor)
+        public QueueTriggerExecutor(ITriggeredFunctionExecutor innerExecutor, QueueCausalityManager queueCausalityManager)
         {
             _innerExecutor = innerExecutor;
+            _queueCausalityManager = queueCausalityManager;
         }
 
         public async Task<FunctionResult> ExecuteAsync(QueueMessage value, CancellationToken cancellationToken)
         {
-            Guid? parentId = QueueCausalityManager.GetOwner(value);
+            Guid? parentId = _queueCausalityManager.GetOwner(value);
             TriggeredFunctionData input = new TriggeredFunctionData
             {
                 ParentId = parentId,

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueAttribute.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs
     /// <item><description><see cref="QueueMessage"/> (out parameter)</description></item>
     /// <item><description><see cref="string"/> (out parameter)</description></item>
     /// <item><description><see cref="T:byte[]"/> (out parameter)</description></item>
+    /// <item><description><see cref="BinaryData"/> (out parameter)</description></item>
     /// <item><description>A user-defined type (out parameter, serialized as JSON)</description></item>
     /// <item><description><see cref="ICollector{T}"/> of these types (to enqueue multiple messages via <see cref="ICollector{T}.Add"/></description></item>
     /// <item><description><see cref="IAsyncCollector{T}"/> of these types (to enqueue multiple messages via <see cref="IAsyncCollector{T}.AddAsync(T, System.Threading.CancellationToken)"/></description></item>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueCausalityManager.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueCausalityManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Protocols;
 using Newtonsoft.Json.Linq;
 
@@ -41,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         [DebuggerNonUserCode]
         public static Guid? GetOwner(QueueMessage msg)
         {
-            string text = msg.MessageText;
+            string text = msg.Body.TryGetAsString();
 
             if (text == null)
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueServiceClientProvider.cs
@@ -5,27 +5,36 @@ using System;
 using Azure.Core;
 using Azure.Storage.Queues;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
 {
     internal class QueueServiceClientProvider : StorageClientProvider<QueueServiceClient, QueueClientOptions>
     {
-        public QueueServiceClientProvider(IConfiguration configuration, AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder)
-            : base(configuration, componentFactory, logForwarder) {}
+        private readonly QueuesOptions _queuesOptions;
+
+        public QueueServiceClientProvider(
+            IConfiguration configuration,
+            AzureComponentFactory componentFactory,
+            AzureEventSourceLogForwarder logForwarder,
+            IOptions<QueuesOptions> queueOptions)
+            : base(configuration, componentFactory, logForwarder)
+        {
+            _queuesOptions = queueOptions?.Value;
+        }
 
         protected override QueueServiceClient CreateClientFromConnectionString(string connectionString, QueueClientOptions options)
         {
-            // TODO (kasobol-msft) make this configurable
-            options.MessageEncoding = QueueMessageEncoding.Base64;
+            options.MessageEncoding = _queuesOptions.MessageEncoding;
             return new QueueServiceClient(connectionString, options);
         }
 
         protected override QueueServiceClient CreateClientFromTokenCredential(Uri endpointUri, TokenCredential tokenCredential, QueueClientOptions options)
         {
-            // TODO (kasobol-msft) make this configurable
-            options.MessageEncoding = QueueMessageEncoding.Base64;
+            options.MessageEncoding = _queuesOptions.MessageEncoding;
             return new QueueServiceClient(endpointUri, tokenCredential, options);
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueServiceClientProvider.cs
@@ -17,11 +17,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
 
         protected override QueueServiceClient CreateClientFromConnectionString(string connectionString, QueueClientOptions options)
         {
+            // TODO (kasobol-msft) make this configurable
+            options.MessageEncoding = QueueMessageEncoding.Base64;
             return new QueueServiceClient(connectionString, options);
         }
 
         protected override QueueServiceClient CreateClientFromTokenCredential(Uri endpointUri, TokenCredential tokenCredential, QueueClientOptions options)
         {
+            // TODO (kasobol-msft) make this configurable
+            options.MessageEncoding = QueueMessageEncoding.Base64;
             return new QueueServiceClient(endpointUri, tokenCredential, options);
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueTriggerAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueTriggerAttribute.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs
     /// <item><description><see cref="QueueMessage"/></description></item>
     /// <item><description><see cref="string"/></description></item>
     /// <item><description><see cref="T:byte[]"/></description></item>
+    /// <item><description><see cref="BinaryData"/></description></item>
     /// <item><description>A user-defined type (serialized as JSON)</description></item>
     /// </list>
     /// </remarks>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/StorageQueuesWebJobsBuilderExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/StorageQueuesWebJobsBuilderExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Extensions.Hosting
             builder.Services.TryAddSingleton<ISharedContextProvider, SharedContextProvider>();
 
             builder.Services.TryAddSingleton<QueueServiceClientProvider>();
+            builder.Services.TryAddSingleton<QueueCausalityManager>();
 
             builder.Services.TryAddSingleton<IContextSetter<IMessageEnqueuedWatcher>>((p) => new ContextAccessor<IMessageEnqueuedWatcher>());
             builder.Services.TryAddSingleton((p) => p.GetService<IContextSetter<IMessageEnqueuedWatcher>>() as IContextGetter<IMessageEnqueuedWatcher>);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/ConverterArgumentBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/ConverterArgumentBindingProvider.cs
@@ -9,16 +9,19 @@ using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Triggers;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 {
     internal class ConverterArgumentBindingProvider<T> : IQueueTriggerArgumentBindingProvider
     {
         private readonly IConverter<QueueMessage, T> _converter;
+        private readonly ILoggerFactory _loggerFactory;
 
-        public ConverterArgumentBindingProvider(IConverter<QueueMessage, T> converter)
+        public ConverterArgumentBindingProvider(IConverter<QueueMessage, T> converter, ILoggerFactory loggerFactory)
         {
             _converter = converter;
+            _loggerFactory = loggerFactory;
         }
 
         public ITriggerDataArgumentBinding<QueueMessage> TryCreate(ParameterInfo parameter)
@@ -28,16 +31,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                 return null;
             }
 
-            return new ConverterArgumentBinding(_converter);
+            return new ConverterArgumentBinding(_converter, _loggerFactory);
         }
 
         internal class ConverterArgumentBinding : ITriggerDataArgumentBinding<QueueMessage>
         {
             private readonly IConverter<QueueMessage, T> _converter;
+            private readonly ILoggerFactory _loggerFactory;
 
-            public ConverterArgumentBinding(IConverter<QueueMessage, T> converter)
+            public ConverterArgumentBinding(IConverter<QueueMessage, T> converter, ILoggerFactory loggerFactory)
             {
                 _converter = converter;
+                _loggerFactory = loggerFactory;
             }
 
             public Type ValueType
@@ -53,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             public Task<ITriggerData> BindAsync(QueueMessage value, ValueBindingContext context)
             {
                 object converted = _converter.Convert(value);
-                IValueProvider provider = new QueueMessageValueProvider(value, converted, typeof(T));
+                IValueProvider provider = new QueueMessageValueProvider(value, converted, typeof(T), _loggerFactory);
                 return Task.FromResult<ITriggerData>(new TriggerData(provider, null));
             }
         }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueMessageValueProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueMessageValueProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
         {
             // Potential enhancement: Base64-encoded AsBytes might replay correctly when use to create a new message.
             // return _message.TryGetAsString() ?? Convert.ToBase64String(_message.AsBytes);
-            return _message.MessageText; // TODO (kasobol-msft) revisit this when Base64/BinaryData is added to SDK
+            return _message.Body.ToString(); // TODO (kasobol-msft) revisit this when Base64/BinaryData is added to SDK
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueMessageValueProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueMessageValueProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
@@ -38,9 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 
         public string ToInvokeString()
         {
-            // Potential enhancement: Base64-encoded AsBytes might replay correctly when use to create a new message.
-            // return _message.TryGetAsString() ?? Convert.ToBase64String(_message.AsBytes);
-            return _message.Body.ToString(); // TODO (kasobol-msft) revisit this when Base64/BinaryData is added to SDK
+            return _message.Body.TryGetAsString();
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueMessageValueProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueMessageValueProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 {
@@ -14,8 +15,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
         private readonly QueueMessage _message;
         private readonly object _value;
         private readonly Type _valueType;
+        private readonly ILogger<QueueMessageValueProvider> _logger;
 
-        public QueueMessageValueProvider(QueueMessage message, object value, Type valueType)
+        public QueueMessageValueProvider(QueueMessage message, object value, Type valueType, ILoggerFactory loggerFactory)
         {
             if (value != null && !valueType.IsAssignableFrom(value.GetType()))
             {
@@ -25,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             _message = message;
             _value = value;
             _valueType = valueType;
+            _logger = loggerFactory.CreateLogger<QueueMessageValueProvider>();
         }
 
         public Type Type
@@ -39,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 
         public string ToInvokeString()
         {
-            return _message.Body.TryGetAsString();
+            return _message.TryGetAsString(_logger);
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
@@ -20,14 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 {
     internal class QueueTriggerAttributeBindingProvider : ITriggerBindingProvider
     {
-        private static readonly IQueueTriggerArgumentBindingProvider InnerProvider =
-            new CompositeArgumentBindingProvider(
-                new ConverterArgumentBindingProvider<QueueMessage>(new CloudQueueMessageDirectConverter()), // $$$: Is this the best way to handle a direct CloudQueueMessage? TODO (kasobol-msft) is this needed?
-                new ConverterArgumentBindingProvider<string>(new StorageQueueMessageToStringConverter()),
-                new ConverterArgumentBindingProvider<byte[]>(new StorageQueueMessageToByteArrayConverter()),
-                new ConverterArgumentBindingProvider<BinaryData>(new StorageQueueMessageToBinaryDataConverter()),
-                new UserTypeArgumentBindingProvider()); // Must come last, because it will attempt to bind all types.
-
+        private readonly IQueueTriggerArgumentBindingProvider _innerProvider;
         private readonly INameResolver _nameResolver;
         private readonly QueueServiceClientProvider _queueServiceClientProvider;
         private readonly QueuesOptions _queueOptions;
@@ -35,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
         private readonly SharedQueueWatcher _messageEnqueuedWatcherSetter;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IQueueProcessorFactory _queueProcessorFactory;
+        private readonly QueueCausalityManager _queueCausalityManager;
 
         public QueueTriggerAttributeBindingProvider(INameResolver nameResolver,
             QueueServiceClientProvider queueServiceClientProvider,
@@ -42,16 +36,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             IWebJobsExceptionHandler exceptionHandler,
             SharedQueueWatcher messageEnqueuedWatcherSetter,
             ILoggerFactory loggerFactory,
-            IQueueProcessorFactory queueProcessorFactory)
+            IQueueProcessorFactory queueProcessorFactory,
+            QueueCausalityManager queueCausalityManager)
         {
             _queueServiceClientProvider = queueServiceClientProvider ?? throw new ArgumentNullException(nameof(queueServiceClientProvider));
             _queueOptions = (queueOptions ?? throw new ArgumentNullException(nameof(queueOptions))).Value;
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _messageEnqueuedWatcherSetter = messageEnqueuedWatcherSetter ?? throw new ArgumentNullException(nameof(messageEnqueuedWatcherSetter));
+            _queueCausalityManager = queueCausalityManager ?? throw new ArgumentNullException(nameof(queueCausalityManager));
 
             _nameResolver = nameResolver;
             _loggerFactory = loggerFactory;
             _queueProcessorFactory = queueProcessorFactory;
+
+            _innerProvider =
+            new CompositeArgumentBindingProvider(
+                new ConverterArgumentBindingProvider<QueueMessage>(new CloudQueueMessageDirectConverter(), loggerFactory), // $$$: Is this the best way to handle a direct CloudQueueMessage? TODO (kasobol-msft) is this needed?
+                new ConverterArgumentBindingProvider<string>(new StorageQueueMessageToStringConverter(), loggerFactory),
+                new ConverterArgumentBindingProvider<byte[]>(new StorageQueueMessageToByteArrayConverter(), loggerFactory),
+                new ConverterArgumentBindingProvider<BinaryData>(new StorageQueueMessageToBinaryDataConverter(), loggerFactory),
+                new UserTypeArgumentBindingProvider(loggerFactory)); // Must come last, because it will attempt to bind all types.
         }
 
         public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
@@ -67,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             string queueName = Resolve(queueTrigger.QueueName);
             queueName = NormalizeAndValidate(queueName);
 
-            ITriggerDataArgumentBinding<QueueMessage> argumentBinding = InnerProvider.TryCreate(parameter);
+            ITriggerDataArgumentBinding<QueueMessage> argumentBinding = _innerProvider.TryCreate(parameter);
 
             if (argumentBinding == null)
             {
@@ -80,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 
             ITriggerBinding binding = new QueueTriggerBinding(parameter.Name, client, queue, argumentBinding,
                 _queueOptions, _exceptionHandler, _messageEnqueuedWatcherSetter,
-                _loggerFactory, _queueProcessorFactory);
+                _loggerFactory, _queueProcessorFactory, _queueCausalityManager);
             return Task.FromResult(binding);
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerAttributeBindingProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                 new ConverterArgumentBindingProvider<QueueMessage>(new CloudQueueMessageDirectConverter()), // $$$: Is this the best way to handle a direct CloudQueueMessage? TODO (kasobol-msft) is this needed?
                 new ConverterArgumentBindingProvider<string>(new StorageQueueMessageToStringConverter()),
                 new ConverterArgumentBindingProvider<byte[]>(new StorageQueueMessageToByteArrayConverter()),
+                new ConverterArgumentBindingProvider<BinaryData>(new StorageQueueMessageToBinaryDataConverter()),
                 new UserTypeArgumentBindingProvider()); // Must come last, because it will attempt to bind all types.
 
         private readonly INameResolver _nameResolver;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerBinding.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerBinding.cs
@@ -33,8 +33,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
         private readonly IWebJobsExceptionHandler _exceptionHandler;
         private readonly SharedQueueWatcher _messageEnqueuedWatcherSetter;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger<QueueTriggerBinding> _logger;
         private readonly IObjectToTypeConverter<QueueMessage> _converter;
         private readonly IQueueProcessorFactory _queueProcessorFactory;
+        private readonly QueueCausalityManager _queueCausalityManager;
 
         public QueueTriggerBinding(string parameterName,
             QueueServiceClient queueServiceClient,
@@ -44,7 +46,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             IWebJobsExceptionHandler exceptionHandler,
             SharedQueueWatcher messageEnqueuedWatcherSetter,
             ILoggerFactory loggerFactory,
-            IQueueProcessorFactory queueProcessorFactory)
+            IQueueProcessorFactory queueProcessorFactory,
+            QueueCausalityManager queueCausalityManager)
         {
             _queueServiceClient = queueServiceClient ?? throw new ArgumentNullException(nameof(queueServiceClient));
             _queue = queue ?? throw new ArgumentNullException(nameof(queue));
@@ -53,11 +56,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             _queueOptions = queueOptions ?? throw new ArgumentNullException(nameof(queueOptions));
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _messageEnqueuedWatcherSetter = messageEnqueuedWatcherSetter ?? throw new ArgumentNullException(nameof(messageEnqueuedWatcherSetter));
+            _queueCausalityManager = queueCausalityManager ?? throw new ArgumentNullException(nameof(queueCausalityManager));
 
             _parameterName = parameterName;
             _loggerFactory = loggerFactory;
             _queueProcessorFactory = queueProcessorFactory;
             _converter = CreateConverter(_queue);
+            _logger = loggerFactory.CreateLogger<QueueTriggerBinding>();
         }
 
         public Type TriggerValueType
@@ -131,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             }
 
             var factory = new QueueListenerFactory(_queueServiceClient, _queue, _queueOptions, _exceptionHandler,
-                    _messageEnqueuedWatcherSetter, _loggerFactory, context.Executor, _queueProcessorFactory, context.Descriptor);
+                    _messageEnqueuedWatcherSetter, _loggerFactory, context.Executor, _queueProcessorFactory, _queueCausalityManager, context.Descriptor);
 
             return factory.CreateAsync(context.CancellationToken);
         }
@@ -146,12 +151,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
             };
         }
 
-        private static IReadOnlyDictionary<string, object> CreateBindingData(QueueMessage value,
+        private IReadOnlyDictionary<string, object> CreateBindingData(QueueMessage value,
             IReadOnlyDictionary<string, object> bindingDataFromValueType)
         {
             Dictionary<string, object> bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
-            string queueMessageString = value.Body.TryGetAsString();
+            string queueMessageString = value.TryGetAsString(_logger);
 
             // Don't provide the QueueTrigger binding data when the queue message is not a valid string.
             if (queueMessageString != null)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerBinding.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/QueueTriggerBinding.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Converters;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Triggers;
@@ -150,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
         {
             Dictionary<string, object> bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
-            string queueMessageString = value.MessageText;
+            string queueMessageString = value.Body.TryGetAsString();
 
             // Don't provide the QueueTrigger binding data when the queue message is not a valid string.
             if (queueMessageString != null)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToBinaryDataConverter.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToBinaryDataConverter.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using Azure.Storage.Queues.Models;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
+{
+    internal class StorageQueueMessageToBinaryDataConverter : IConverter<QueueMessage, BinaryData>
+    {
+        public BinaryData Convert(QueueMessage input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            return input.Body;
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToByteArrayConverter.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToByteArrayConverter.cs
@@ -16,8 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                 throw new ArgumentNullException(nameof(input));
             }
 
-            // TODO (kasobol-msft) revisit this base64/BinaryData
-            return Encoding.UTF8.GetBytes(input.MessageText);
+            return input.Body.ToArray();
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToStringConverter.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToStringConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                 throw new ArgumentNullException(nameof(input));
             }
 
-            return input.MessageText;
+            return input.Body.ToString();
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToStringConverter.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/StorageQueueMessageToStringConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                 throw new ArgumentNullException(nameof(input));
             }
 
-            return input.Body.ToString();
+            return input.Body.ToValidUTF8String();
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/UserTypeArgumentBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/UserTypeArgumentBindingProvider.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Protocols;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Triggers;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -55,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                 object convertedValue;
                 try
                 {
-                    convertedValue = JsonConvert.DeserializeObject(value.MessageText, ValueType, JsonSerialization.Settings);
+                    convertedValue = JsonConvert.DeserializeObject(value.Body.ToValidUTF8String(), ValueType, JsonSerialization.Settings);
                 }
                 catch (JsonException e)
                 {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/UserTypeArgumentBindingProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/Triggers/UserTypeArgumentBindingProvider.cs
@@ -12,28 +12,38 @@ using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Protocols;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Triggers;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
 {
     internal class UserTypeArgumentBindingProvider : IQueueTriggerArgumentBindingProvider
     {
+        private readonly ILoggerFactory _loggerFactory;
+
+        public UserTypeArgumentBindingProvider(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+        }
+
         public ITriggerDataArgumentBinding<QueueMessage> TryCreate(ParameterInfo parameter)
         {
             // At indexing time, attempt to bind all types.
             // (Whether or not actual binding is possible depends on the message shape at runtime.)
-            return new UserTypeArgumentBinding(parameter.ParameterType);
+            return new UserTypeArgumentBinding(parameter.ParameterType, _loggerFactory);
         }
 
         private class UserTypeArgumentBinding : ITriggerDataArgumentBinding<QueueMessage>
         {
             private readonly Type _valueType;
             private readonly IBindingDataProvider _bindingDataProvider;
+            private readonly ILoggerFactory _loggerFactory;
 
-            public UserTypeArgumentBinding(Type valueType)
+            public UserTypeArgumentBinding(Type valueType, ILoggerFactory loggerFactory)
             {
                 _valueType = valueType;
                 _bindingDataProvider = BindingDataProvider.FromType(_valueType);
+                _loggerFactory = loggerFactory;
             }
 
             public Type ValueType
@@ -69,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Triggers
                     throw new InvalidOperationException(msg);
                 }
 
-                IValueProvider provider = new QueueMessageValueProvider(value, convertedValue, ValueType);
+                IValueProvider provider = new QueueMessageValueProvider(value, convertedValue, ValueType, _loggerFactory);
 
                 IReadOnlyDictionary<string, object> bindingData = (_bindingDataProvider != null)
                     ? _bindingDataProvider.GetBindingData(convertedValue) : null;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/FakeQueueServiceClientProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/FakeQueueServiceClientProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         private readonly QueueServiceClient _queueServiceClient;
 
         public FakeQueueServiceClientProvider(QueueServiceClient queueServiceClient)
-            : base(null, null, null)
+            : base(null, null, null, null)
         {
             _queueServiceClient = queueServiceClient;
         }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/HostCallTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/HostCallTests.cs
@@ -87,23 +87,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         public async Task Queue_IfBoundToIAsyncCollectorByteArray_CanCall()
         {
             // Act
-            await CallAsync(typeof(QueueProgram), "BindToIAsyncCollectorByteArray"); // TODO (kasobol-msft) revisit when BinaryData is in SDK
+            await CallAsync(typeof(QueueProgram), "BindToIAsyncCollectorByteArray");
 
             // Assert
             var queue = queueServiceClient.GetQueueClient(OutputQueueName);
             QueueMessage[] messages = await queue.ReceiveMessagesAsync(32);
             Assert.NotNull(messages);
             Assert.AreEqual(3, messages.Count());
-            QueueMessage[] sortedMessages = messages.OrderBy((m) => m.MessageText).ToArray();
+            QueueMessage[] sortedMessages = messages.OrderBy((m) => m.Body.ToString()).ToArray();
 
-            // TODO (kasobol-msft) revisit this when base64/BinaryData is in the SDK
-            Assert.AreEqual("test1", sortedMessages[0].MessageText);
-            Assert.AreEqual("test2", sortedMessages[1].MessageText);
-            Assert.AreEqual("test3", sortedMessages[2].MessageText);
+            Assert.AreEqual("test1", sortedMessages[0].Body.ToString());
+            Assert.AreEqual("test2", sortedMessages[1].Body.ToString());
+            Assert.AreEqual("test3", sortedMessages[2].Body.ToString());
         }
 
         [Test]
-        public async Task Queue_IfBoundToICollectorByteArray_CanCall() // TODO (kasobol-msft) revisit when BinaryData is in SDK
+        public async Task Queue_IfBoundToICollectorByteArray_CanCall()
         {
             // Act
             await CallAsync(typeof(QueueProgram), "BindToICollectorByteArray");
@@ -113,11 +112,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
             QueueMessage[] messages = await queue.ReceiveMessagesAsync(32);
             Assert.NotNull(messages);
             Assert.AreEqual(3, messages.Count());
-            QueueMessage[] sortedMessages = messages.OrderBy((m) => m.MessageText).ToArray();
+            QueueMessage[] sortedMessages = messages.OrderBy((m) => m.Body.ToString()).ToArray();
 
-            Assert.AreEqual("test1", sortedMessages[0].MessageText);
-            Assert.AreEqual("test2", sortedMessages[1].MessageText);
-            Assert.AreEqual("test3", sortedMessages[2].MessageText);
+            Assert.AreEqual("test1", sortedMessages[0].Body.ToString());
+            Assert.AreEqual("test2", sortedMessages[1].Body.ToString());
+            Assert.AreEqual("test3", sortedMessages[2].Body.ToString());
         }
 
         [Test]

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/HostCallTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/HostCallTests.cs
@@ -120,6 +120,58 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         }
 
         [Test]
+        public async Task Queue_IfBoundToIAsyncCollectorBinaryData_CanCall()
+        {
+            // Act
+            await CallAsync(typeof(QueueProgram), "BindToIAsyncCollectorBinaryData");
+
+            // Assert
+            var queue = queueServiceClient.GetQueueClient(OutputQueueName);
+            QueueMessage[] messages = await queue.ReceiveMessagesAsync(32);
+            Assert.NotNull(messages);
+            Assert.AreEqual(3, messages.Count());
+            QueueMessage[] sortedMessages = messages.OrderBy((m) => m.Body.ToString()).ToArray();
+
+            Assert.AreEqual("test1", sortedMessages[0].Body.ToString());
+            Assert.AreEqual("test2", sortedMessages[1].Body.ToString());
+            Assert.AreEqual("test3", sortedMessages[2].Body.ToString());
+        }
+
+        [Test]
+        public async Task Queue_IfBoundToICollectorBinaryData_CanCall()
+        {
+            // Act
+            await CallAsync(typeof(QueueProgram), "BindToICollectorBinaryData");
+
+            // Assert
+            var queue = queueServiceClient.GetQueueClient(OutputQueueName);
+            QueueMessage[] messages = await queue.ReceiveMessagesAsync(32);
+            Assert.NotNull(messages);
+            Assert.AreEqual(3, messages.Count());
+            QueueMessage[] sortedMessages = messages.OrderBy((m) => m.Body.ToString()).ToArray();
+
+            Assert.AreEqual("test1", sortedMessages[0].Body.ToString());
+            Assert.AreEqual("test2", sortedMessages[1].Body.ToString());
+            Assert.AreEqual("test3", sortedMessages[2].Body.ToString());
+        }
+
+        [Test]
+        public async Task Queue_IfBoundToBinaryData_CanCall()
+        {
+            // Act
+            await CallAsync(typeof(QueueProgram), "BindToBinaryData");
+
+            // Assert
+            var queue = queueServiceClient.GetQueueClient(OutputQueueName);
+            QueueMessage[] messages = await queue.ReceiveMessagesAsync(32);
+            Assert.NotNull(messages);
+            Assert.AreEqual(1, messages.Count());
+            QueueMessage[] sortedMessages = messages.OrderBy((m) => m.Body.ToString()).ToArray();
+
+            Assert.AreEqual("test", sortedMessages[0].Body.ToString());
+        }
+
+        [Test]
         public void Queue_IfBoundToIAsyncCollectorInt_NotSupported()
         {
             // Act
@@ -389,6 +441,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
                 output.Add(Encoding.UTF8.GetBytes("test1"));
                 output.Add(Encoding.UTF8.GetBytes("test2"));
                 output.Add(Encoding.UTF8.GetBytes("test3"));
+            }
+
+            public static async Task BindToIAsyncCollectorBinaryData(
+                [Queue(OutputQueueName)] IAsyncCollector<BinaryData> output)
+            {
+                await output.AddAsync(BinaryData.FromString("test1"));
+                await output.AddAsync(BinaryData.FromString("test2"));
+                await output.AddAsync(BinaryData.FromString("test3"));
+            }
+
+            public static void BindToICollectorBinaryData(
+                [Queue(OutputQueueName)] ICollector<BinaryData> output)
+            {
+                output.Add(BinaryData.FromString("test1"));
+                output.Add(BinaryData.FromString("test2"));
+                output.Add(BinaryData.FromString("test3"));
+            }
+
+            public static void BindToBinaryData(
+                [Queue(OutputQueueName)] out BinaryData output)
+            {
+                output = BinaryData.FromString("test");
             }
 
             public static async Task BindToIAsyncCollectorEnqueuesImmediately(

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueCausalityManagerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueCausalityManagerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -11,6 +12,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
 {
     public class QueueCausalityManagerTests
     {
+        private QueueCausalityManager queueCausalityManager;
+
+        [SetUp]
+        public void Setup()
+        {
+            queueCausalityManager = new QueueCausalityManager(new NullLoggerFactory());
+        }
+
         [Test]
         public void SetOwner_IfEmptyOwner_DoesNotAddOwner()
         {
@@ -95,13 +104,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
             TestOwnerEqual(expected, json.ToString());
         }
 
-        private static void AssertOwnerEqual(Guid expectedOwner, string message)
+        private void AssertOwnerEqual(Guid expectedOwner, string message)
         {
             Guid? owner = GetOwner(message);
             Assert.AreEqual(expectedOwner, owner);
         }
 
-        private static void TestOwnerEqual(Guid expectedOwner, string message)
+        private void TestOwnerEqual(Guid expectedOwner, string message)
         {
             // Act
             Guid? owner = GetOwner(message);
@@ -110,29 +119,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
             Assert.AreEqual(expectedOwner, owner);
         }
 
-        private static void TestOwnerIsNull(string message)
+        private void TestOwnerIsNull(string message)
         {
             TestOwnerIsNull(CreateMessage(message));
         }
 
-        private static void TestOwnerIsNull(QueueMessage message)
+        private void TestOwnerIsNull(QueueMessage message)
         {
             // Act
-            Guid? owner = QueueCausalityManager.GetOwner(message);
+            Guid? owner = queueCausalityManager.GetOwner(message);
 
             // Assert
             Assert.Null(owner);
         }
 
-        private static void AssertOwnerIsNull(string message)
+        private void AssertOwnerIsNull(string message)
         {
             Guid? owner = GetOwner(message);
             Assert.Null(owner);
         }
 
-        private static Guid? GetOwner(string message)
+        private Guid? GetOwner(string message)
         {
-            return QueueCausalityManager.GetOwner(CreateMessage(message));
+            return queueCausalityManager.GetOwner(CreateMessage(message));
         }
 
         private static JObject CreateJsonObject(object value)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTests.cs
@@ -304,58 +304,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
             }
         }
 
-        // Nice failure when no storage account is set
-        [Test]
-        [Ignore("Re-enable when StorageAccountParser returns")]
-        public void Fails_When_No_Storage_is_set()
-        {
-            // TODO: We shouldn't have to do this, but our default parser
-            //       does not allow for null Storage/Dashboard.
-            //var mockParser = new Mock<IStorageAccountParser>();
-            //mockParser
-            //    .Setup(p => p.ParseAccount(null, It.IsAny<string>()))
-            //    .Returns<string>(null);
-
-            //// no storage account!
-            //IHost host = new HostBuilder()
-            //    .ConfigureDefaultTestHost<ProgramSimple>()
-            //    .ConfigureServices(services =>
-            //    {
-            //        services.AddSingleton<IStorageAccountParser>(mockParser.Object);
-            //    })
-            //    .ConfigureAppConfiguration(config =>
-            //    {
-            //        config.AddInMemoryCollection(new Dictionary<string, string>
-            //        {
-            //            { "AzureWebJobsStorge", null },
-            //            { "AzureWebJobsDashboard", null }
-            //        });
-            //    })
-            //    .Build();
-
-            //string message = StorageAccountParser.FormatParseAccountErrorMessage(StorageAccountParseResult.MissingOrEmptyConnectionStringError, "Storage");
-            //TestHelpers.AssertIndexingError(() => host.GetJobHost().Call<ProgramSimple>("Func"), "ProgramSimple.Func", message);
-        }
-
-        [Test]
-        [Ignore("Re-enable when StorageAccountParser returns")]
-        public void Sanitizes_Exception_If_Connection_String()
-        {
-            //// people accidentally use their connection string; we want to make sure we sanitize it
-            //IHost host = new HostBuilder()
-            //    .ConfigureDefaultTestHost<ProgramSimple2>()
-            //    .Build();
-
-            //string message = StorageAccountParser.FormatParseAccountErrorMessage(StorageAccountParseResult.MissingOrEmptyConnectionStringError, ProgramSimple2.ConnectionString);
-
-            //TestHelpers.AssertIndexingError(() => host.GetJobHost().Call<ProgramSimple2>(nameof(ProgramSimple2.Func2)),
-            //    "ProgramSimple2.Func2", message);
-
-            //Assert.DoesNotContain(ProgramSimple2.ConnectionString, message);
-            //Assert.DoesNotContain("AzureWebJobs", message); // prefix should not be added
-            //Assert.Contains("[Hidden Credential]", message);
-        }
-
         public class ProgramBadContract
         {
             public void Func([QueueTrigger(QueueName)] string triggers, [Queue("queuName-{xyz}")] ICollector<string> q)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerBindingIntegrationTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerBindingIntegrationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         public void SetUp()
         {
             _invariantCultureFixture = new InvariantCultureFixture();
-            IQueueTriggerArgumentBindingProvider provider = new UserTypeArgumentBindingProvider();
+            IQueueTriggerArgumentBindingProvider provider = new UserTypeArgumentBindingProvider(new NullLoggerFactory());
             ParameterInfo pi = new StubParameterInfo("parameterName", typeof(UserDataType));
             var argumentBinding = provider.TryCreate(pi);
 
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
             _binding = new QueueTriggerBinding("parameterName", queueServiceClient, queue, argumentBinding,
                 new QueuesOptions(), exceptionHandler,
                 enqueueWatcher,
-                null, null);
+                new NullLoggerFactory(), null, new QueueCausalityManager(new NullLoggerFactory()));
         }
 
         [TearDown]

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerTests.cs
@@ -97,13 +97,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         }
 
         [Test]
-        [Ignore("TODO (kasobol-msft) reenable when we get base64/BinaryData in SDK")]
         public async Task QueueTrigger_IfBoundToStringAndMessageIsNotUtf8ByteArray_DoesNotBind()
         {
             // Arrange
             byte[] content = new byte[] { 0xFF, 0x00 }; // Not a valid UTF-8 byte sequence.
             var queue = await CreateQueue(queueServiceClient, QueueName);
-            await queue.SendMessageAsync(Convert.ToBase64String(content));
+            await queue.SendMessageAsync(BinaryData.FromBytes(content));
 
             // Act
             Exception exception = await RunTriggerFailureAsync<string>(typeof(BindToStringProgram),
@@ -298,13 +297,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         }
 
         [Test]
-        [Ignore("TODO (kasobol-msft) revisit that when we get base64/BinaryData in the SDK")]
         public async Task QueueTrigger_IfMessageIsNonUtf8ByteArray_DoesNotProvideQueueTriggerBindingData()
         {
             // Arrange
             byte[] content = new byte[] { 0xFF, 0x00 }; // Not a valid UTF-8 byte sequence.
             var queue = await CreateQueue(queueServiceClient, QueueName);
-            await queue.SendMessageAsync(Convert.ToBase64String(content));
+            await queue.SendMessageAsync(BinaryData.FromBytes(content));
 
             // Act
             Exception exception = await RunTriggerFailureAsync<string>(typeof(BindToQueueTriggerBindingDataProgram),

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueTriggerTests.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
 
         private async Task SetupAsync(QueueServiceClient client, object contents)
         {
-            string message;
+            BinaryData message;
             if (contents is string str)
             {
-                message = str;
+                message = BinaryData.FromString(str);
             }
-            else if (contents is byte[] bytearray) // TODO (kasobol-msft) revisit this when we have Base64/BinaryData
+            else if (contents is byte[] bytearray)
             {
-                message = Encoding.UTF8.GetString(bytearray);
+                message = BinaryData.FromBytes(bytearray);
             }
             else
             {
@@ -119,7 +119,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         }
 
         [Test]
-        [Ignore("TODO (kasobol-msft) revisit this when base64/BinaryData is in the SDK")]
         public async Task QueueTrigger_IfBoundToByteArray_Binds()
         {
             byte[] expectedContent = new byte[] { 0x31, 0x32, 0x33 };
@@ -134,18 +133,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         }
 
         [Test]
-        [Ignore("TODO (kasobol-msft) revisit this when base64/BinaryData is in the SDK")]
         public async Task QueueTrigger_IfBoundToByteArrayAndMessageIsNonUtf8_Binds()
         {
             byte[] expectedContent = new byte[] { 0xFF, 0x00 }; // Not a valid UTF-8 byte sequence.
             await TestBindToByteArray(expectedContent);
         }
 
-        private async Task TestBindToByteArray(byte[] expectedContent) // TODO (kasobol-msft) Revisit base64 encoding story
+        private async Task TestBindToByteArray(byte[] expectedContent)
         {
             // Arrange
             var queue = await CreateQueue(queueServiceClient, QueueName);
-            await queue.SendMessageAsync(Convert.ToBase64String(expectedContent));
+            await queue.SendMessageAsync(BinaryData.FromBytes(expectedContent));
 
             // Act
             byte[] result = await RunTriggerAsync<byte[]>(typeof(BindToByteArrayProgram),
@@ -287,9 +285,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         {
             // Arrange
             const string expectedQueueTrigger = "abc";
-            byte[] content = Encoding.UTF8.GetBytes(expectedQueueTrigger); // TODO (kasobol-msft) Revisit base64 encoding story
+            byte[] content = Encoding.UTF8.GetBytes(expectedQueueTrigger);
             var queue = await CreateQueue(queueServiceClient, QueueName);
-            await queue.SendMessageAsync(expectedQueueTrigger);
+            await queue.SendMessageAsync(BinaryData.FromBytes(content));
 
             // Act
             string result = await RunTriggerAsync<string>(typeof(BindToQueueTriggerBindingDataProgram),

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueuesEncodingTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueuesEncodingTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Hosting;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.ScenarioTests
+{
+    public class QueuesEncodingTests
+    {
+        private const string OriginQueueName = "queue-scenariotests-origin";
+        private const string DestinationQueueName = "queue-scenariotests-destination";
+        private QueueServiceClient queueServiceClient;
+
+        [SetUp]
+        public void SetUp()
+        {
+            queueServiceClient = AzuriteNUnitFixture.Instance.GetQueueServiceClient(
+                new QueueClientOptions() { MessageEncoding = QueueMessageEncoding.None });
+
+            queueServiceClient.GetQueueClient(OriginQueueName).DeleteIfExists();
+            queueServiceClient.GetQueueClient(DestinationQueueName).DeleteIfExists();
+            queueServiceClient.GetQueueClient(OriginQueueName).CreateIfNotExists();
+            queueServiceClient.GetQueueClient(DestinationQueueName).CreateIfNotExists();
+        }
+
+        [Test]
+        public async Task EncodesBase64InputAndOutputByDefault()
+        {
+            // Arrange
+            var content = Guid.NewGuid().ToString();
+            var encodedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes(content));
+
+            await queueServiceClient.GetQueueClient(OriginQueueName).SendMessageAsync(encodedContent);
+
+            // Act
+            var result = await RunTriggerAsync<string>(typeof(OriginQueueToDestinationQueueStringProgram),
+                (s) => OriginQueueToDestinationQueueStringProgram.TaskSource = s);
+
+            // Assert
+            Assert.AreEqual(content, result);
+        }
+
+        [Test]
+        public async Task EncodesBase64InputAndOutputIfOptionProvided()
+        {
+            // Arrange
+            var content = Guid.NewGuid().ToString();
+            var encodedContent = Convert.ToBase64String(Encoding.UTF8.GetBytes(content));
+
+            await queueServiceClient.GetQueueClient(OriginQueueName).SendMessageAsync(encodedContent);
+
+            // Act
+            var result = await RunTriggerAsync<string>(typeof(OriginQueueToDestinationQueueStringProgram),
+                (s) => OriginQueueToDestinationQueueStringProgram.TaskSource = s,
+                QueueMessageEncoding.Base64);
+
+            // Assert
+            Assert.AreEqual(content, result);
+        }
+
+        [Test]
+        public async Task CanHandleNonEncodedMessages()
+        {
+            // Arrange
+            var content = Guid.NewGuid().ToString();
+
+            await queueServiceClient.GetQueueClient(OriginQueueName).SendMessageAsync(content);
+
+            // Act
+            var result = await RunTriggerAsync<string>(typeof(OriginQueueToDestinationQueueStringProgram),
+                (s) => OriginQueueToDestinationQueueStringProgram.TaskSource = s,
+                QueueMessageEncoding.None);
+
+            // Assert
+            Assert.AreEqual(content, result);
+        }
+
+        private async Task<TResult> RunTriggerAsync<TResult>(Type programType,
+            Action<TaskCompletionSource<TResult>> setTaskSource, QueueMessageEncoding? messageEncoding = default)
+        {
+            return await FunctionalTest.RunTriggerAsync<TResult>(b =>
+            {
+                b.Services.AddAzureClients(builder =>
+                {
+                    builder.ConfigureDefaults(options => options.Transport = AzuriteNUnitFixture.Instance.GetTransport());
+                });
+                if (!messageEncoding.HasValue)
+                {
+                    b.AddAzureStorageQueues();
+                }
+                else
+                {
+                    b.AddAzureStorageQueues(options => options.MessageEncoding = messageEncoding.Value);
+                }
+            }, programType, setTaskSource,
+            settings: new Dictionary<string, string>() {
+                // This takes precedence over env variables.
+                { "ConnectionStrings:AzureWebJobsStorage", AzuriteNUnitFixture.Instance.GetAzureAccount().ConnectionString }
+            });
+        }
+
+        private class OriginQueueToDestinationQueueStringProgram
+        {
+            private const string CommittedQueueName = "committed";
+
+            public static TaskCompletionSource<string> TaskSource { get; set; }
+
+            public static void StepOne([QueueTrigger(OriginQueueName)] string messageIn, [Queue(DestinationQueueName)] out string messageOut)
+            {
+                messageOut = messageIn;
+            }
+
+            public static void StepTwo([QueueTrigger(DestinationQueueName)] string messageIn)
+            {
+                TaskSource.TrySetResult(messageIn);
+            }
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueuesOptionsTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueuesOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Azure.Storage.Queues;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
 using Microsoft.Azure.WebJobs.Host;
 using Newtonsoft.Json.Linq;
@@ -20,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
             Assert.AreEqual(16, options.BatchSize);
             Assert.AreEqual(8 * processorCount, options.NewBatchThreshold);
             Assert.AreEqual(QueuePollingIntervals.DefaultMaximum, options.MaxPollingInterval);
+            Assert.AreEqual(QueueMessageEncoding.Base64, options.MessageEncoding);
         }
 
         [Test]
@@ -65,10 +67,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues
         {
             var jo = new JObject
             {
-                { "MaxPollingInterval", "00:00:05" }
+                { "MaxPollingInterval", "00:00:05" },
+                { "MessageEncoding", "Base64" }
             };
             var options = jo.ToObject<QueuesOptions>();
             Assert.AreEqual(TimeSpan.FromMilliseconds(5000), options.MaxPollingInterval);
+            Assert.AreEqual(QueueMessageEncoding.Base64, options.MessageEncoding);
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/AzureStorageEndToEndTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/AzureStorageEndToEndTests.cs
@@ -374,7 +374,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.ScenarioTests
                     })
                     .Build();
 
-                this.QueueServiceClient = new QueueServiceClient(testEnvironment.PrimaryStorageAccountConnectionString);
+                var queueOptions = new QueueClientOptions() { MessageEncoding = QueueMessageEncoding.Base64 };
+                this.QueueServiceClient = new QueueServiceClient(testEnvironment.PrimaryStorageAccountConnectionString, queueOptions);
                 this.BlobServiceClient = new BlobServiceClient(testEnvironment.PrimaryStorageAccountConnectionString);
             }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/MultipleStorageAccountsEndToEndTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/MultipleStorageAccountsEndToEndTests.cs
@@ -222,8 +222,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.ScenarioTests
 
                 BlobServiceClient1 = new BlobServiceClient(testEnvironment.PrimaryStorageAccountConnectionString);
                 BlobServiceClient2 = new BlobServiceClient(testEnvironment.SecondaryStorageAccountConnectionString);
-                QueueServiceClient1 = new QueueServiceClient(testEnvironment.PrimaryStorageAccountConnectionString);
-                QueueServiceClient2 = new QueueServiceClient(testEnvironment.SecondaryStorageAccountConnectionString);
+                var queueOptions = new QueueClientOptions() { MessageEncoding = QueueMessageEncoding.Base64 };
+                QueueServiceClient1 = new QueueServiceClient(testEnvironment.PrimaryStorageAccountConnectionString, queueOptions);
+                QueueServiceClient2 = new QueueServiceClient(testEnvironment.SecondaryStorageAccountConnectionString, queueOptions);
 
                 await CleanContainersAsync();
 


### PR DESCRIPTION
In this PR:
- Expose Base64 encoding in queue messages. Made Base64 default.
- fix RenewedQueueMessage_DeletesCorrectly and make sure that queue message can be optimistically deleted after processing timeout (if it hasn't been grabbed by other worker/batch).