### PR TITLE
[Identity] Fix ProcessRunner dispose race condition

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0-beta.3 (Unreleased)
 
 ### Fixes and improvements
+- Fix race condition in `ProcessRunner` causing `VisualStudioCredential` and `AzureCliCredential` to fail intermittently ([#16211](https://github.com/Azure/azure-sdk-for-net/issues/16211))
 - Fix `VisualStudioCodeCredential` to raise `CredentialUnavailableException` when reads from libsecret fail ([#16795](https://github.com/Azure/azure-sdk-for-net/issues/16795))
 - Prevent `VisualStudioCodeCredential` using invalid authentication data when no user is signed in to Visual Studio Code ([#15870](https://github.com/Azure/azure-sdk-for-net/issues/15870))
 

--- a/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
+++ b/sdk/identity/Azure.Identity/src/AzureCliCredential.cs
@@ -103,7 +103,7 @@ namespace Azure.Identity
 
             GetFileNameAndArguments(resource, out string fileName, out string argument);
             ProcessStartInfo processStartInfo = GetAzureCliProcessStartInfo(fileName, argument);
-            var processRunner = new ProcessRunner(_processService.Create(processStartInfo), TimeSpan.FromMilliseconds(CliProcessTimeoutMs), cancellationToken);
+            using var processRunner = new ProcessRunner(_processService.Create(processStartInfo), TimeSpan.FromMilliseconds(CliProcessTimeoutMs), cancellationToken);
 
             string output;
             try

--- a/sdk/identity/Azure.Identity/src/ProcessRunner.cs
+++ b/sdk/identity/Azure.Identity/src/ProcessRunner.cs
@@ -9,9 +9,7 @@ using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
-#pragma warning disable CA1001 // Types that own disposable fields should be disposable. Disposing of _process and _ctRegistration / _timeoutCtRegistration fields from outside may result in _tcs being incomplete or process handle leak.
     internal sealed class ProcessRunner : IDisposable
-#pragma warning restore CA1001 // Types that own disposable fields should be disposable
     {
         private readonly IProcess _process;
         private readonly TimeSpan _timeout;

--- a/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
+++ b/sdk/identity/Azure.Identity/src/VisualStudioCredential.cs
@@ -107,7 +107,7 @@ namespace Azure.Identity
                 string output = string.Empty;
                 try
                 {
-                    var processRunner = new ProcessRunner(_processService.Create(processStartInfo), TimeSpan.FromSeconds(30), cancellationToken);
+                    using var processRunner = new ProcessRunner(_processService.Create(processStartInfo), TimeSpan.FromSeconds(30), cancellationToken);
                     output = async
                         ? await processRunner.RunAsync().ConfigureAwait(false)
                         : processRunner.Run();

--- a/sdk/identity/Azure.Identity/tests/ProcessRunnerTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ProcessRunnerTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity.Tests
         {
             var output = "Test output";
             var process = new TestProcess { Output = output };
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
             var result = await Run(runner);
 
             Assert.AreEqual(output, result);
@@ -40,7 +40,7 @@ namespace Azure.Identity.Tests
         {
             var output = "Test output";
             var process = CreateRealProcess($"echo {output}", $"echo {output}");
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
             var result = await Run(runner);
 
             Assert.AreEqual(output, result);
@@ -52,7 +52,7 @@ namespace Azure.Identity.Tests
             var output = string.Concat(Enumerable.Repeat("Test output", 500));
             var command = $"echo {output}";
             var process = CreateRealProcess(command, command);
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
             var result = await Run(runner);
 
             Assert.AreEqual(output, result);
@@ -64,7 +64,7 @@ namespace Azure.Identity.Tests
             var output = "Test output";
             var command = string.Join("&&", Enumerable.Repeat($"echo {output}", 100));
             var process = CreateRealProcess(command, command);
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
             var result = await Run(runner);
 
             Assert.AreEqual(string.Join(Environment.NewLine, Enumerable.Repeat(output, 100)), result);
@@ -74,7 +74,7 @@ namespace Azure.Identity.Tests
         public void ProcessRunnerProcessFailsToStart()
         {
             var process = new TestProcess { FailedToStart = true };
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
 
             Assert.CatchAsync<InvalidOperationException>(async () => await Run(runner));
         }
@@ -84,7 +84,7 @@ namespace Azure.Identity.Tests
         {
             var cts = new CancellationTokenSource();
             var process = new TestProcess { Output =  "Test output", Timeout = 5000 };
-            var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(100), cts.Token);
+            using var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(100), cts.Token);
 
             Assert.CatchAsync<OperationCanceledException>(async () => await Run(runner));
         }
@@ -94,7 +94,7 @@ namespace Azure.Identity.Tests
         {
             var cts = new CancellationTokenSource();
             var process = new TestProcess { Output =  "Test output", Timeout = 5000 };
-            var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(5000), cts.Token);
+            using var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(5000), cts.Token);
             cts.CancelAfter(100);
 
             Assert.CatchAsync<OperationCanceledException>(async () => await Run(runner));
@@ -105,7 +105,7 @@ namespace Azure.Identity.Tests
         {
             var process = new TestProcess { Output =  "Test output", Timeout = 5000 };
             var cancellationToken = new CancellationToken(true);
-            var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(5000), cancellationToken);
+            using var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(5000), cancellationToken);
 
             Assert.CatchAsync<OperationCanceledException>(async () => await Run(runner));
         }
@@ -115,7 +115,7 @@ namespace Azure.Identity.Tests
         {
             var cts = new CancellationTokenSource();
             var process = new TestProcess { Output =  "Test output", Timeout = 5000 };
-            var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(5000), cts.Token);
+            using var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(5000), cts.Token);
 
             cts.Cancel();
 
@@ -127,7 +127,7 @@ namespace Azure.Identity.Tests
         {
             var cts = new CancellationTokenSource();
             var process = new TestProcess { Output =  "Test output" };
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(5000), cts.Token);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(5000), cts.Token);
             await Run(runner);
             cts.Cancel();
         }
@@ -137,7 +137,7 @@ namespace Azure.Identity.Tests
         {
             var error = "Test error";
             var process = new TestProcess { Error = error };
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
 
             var exception = Assert.CatchAsync<InvalidOperationException>(async () => await Run(runner));
             Assert.AreEqual(error, exception.Message);
@@ -148,7 +148,7 @@ namespace Azure.Identity.Tests
         {
             var error = "Test error";
             var process = CreateRealProcess($"echo {error} 1>&2 & exit 1", $">&2 echo {error} & exit 1");
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
 
             var exception = Assert.CatchAsync<InvalidOperationException>(async () => await Run(runner));
             Assert.AreEqual(error, exception.Message.Trim());
@@ -159,7 +159,7 @@ namespace Azure.Identity.Tests
         {
             var error = string.Concat(Enumerable.Repeat("Test error", 500));;
             var process = CreateRealProcess($"echo {error} 1>&2 & exit 1", $">&2 echo {error} & exit 1");
-            var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromSeconds(30), default);
 
             var exception = Assert.CatchAsync<InvalidOperationException>(async () => await Run(runner));
             Assert.AreEqual(error, exception.Message.Trim());
@@ -170,7 +170,7 @@ namespace Azure.Identity.Tests
         {
             var output = "Test output";
             var process = new TestProcess { Output = output, ExceptionOnProcessKill = new Win32Exception(1), Timeout = 5000 };
-            var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(50), default);
+            using var runner = new ProcessRunner(process, TimeSpan.FromMilliseconds(50), default);
 
             var exception = Assert.CatchAsync<Win32Exception>(async () => await Run(runner));
             Assert.AreEqual(1, exception.NativeErrorCode);


### PR DESCRIPTION
This updates the `ProcessRunner` class to be disposable to fix a race condition causing credentials using the `ProcessRunner` to fail with an error complaining that StandardError has not been redirected. The underlying issue was that the `ProcessRunner` was disposing of the underlying `Process` instance from the `Exited` event handler, and this races with the call to `BeginOutputReadLine` and `BeginErrorReadLine`, as described in this .NET framework issue discussion, https://github.com/dotnet/runtime/issues/34097#issuecomment-605734299.

Fixes #16211