### PR TITLE
Azure Monitor Exporter - Set types for Remote Dependency

### DIFF
--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/AttributeHelper.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/AttributeHelper.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
 {
-    internal class HttpHelper
+    internal class AttributeHelper
     {
         private const string SchemePostfix = "://";
         private const string Colon = ":";
@@ -17,15 +17,17 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
         /// Reference: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#http-client.
         /// </summary>
         /// <param name="tags">Activity Tags</param>
-        /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string GetUrl(Dictionary<string, string> tags)
+        /// <param name="url">URL</param>
+        /// <param name="urlAuthority">Host name or IP address and the port number </param>
+        internal static void GenerateUrlAndAuthority(Dictionary<string, string> tags, out string url, out string urlAuthority)
         {
-            if (tags.TryGetValue(SemanticConventions.AttributeHttpUrl, out var url))
+            urlAuthority = null;
+            if (tags.TryGetValue(SemanticConventions.AttributeHttpUrl, out url))
             {
                 if (Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri) && uri.IsAbsoluteUri)
                 {
-                    return url;
+                    urlAuthority = uri.Authority;
+                    return;
                 }
             }
 
@@ -38,23 +40,29 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
                     if (httpPort != null && httpPort != "80" && httpPort != "443")
                     {
                         url = $"{httpScheme}{SchemePostfix}{httpHost}{Colon}{httpPort}{httpTarget}";
+                        urlAuthority = $"{httpHost}{Colon}{httpPort}";
                     }
                     else
                     {
                         url = $"{httpScheme}{SchemePostfix}{httpHost}{httpTarget}";
+                        urlAuthority = $"{httpHost}";
                     }
 
-                    return url;
+                    return;
                 }
                 else if (tags.TryGetValue(SemanticConventions.AttributeNetPeerName, out var netPeerName)
                          && tags.TryGetValue(SemanticConventions.AttributeNetPeerPort, out var netPeerPort))
                 {
-                    return string.IsNullOrWhiteSpace(netPeerName) ? null :  $"{httpScheme}{SchemePostfix}{netPeerName}{(string.IsNullOrWhiteSpace(netPeerPort) ? null : Colon)}{netPeerPort}{httpTarget}";
+                    url = string.IsNullOrWhiteSpace(netPeerName) ? null :  $"{httpScheme}{SchemePostfix}{netPeerName}{(string.IsNullOrWhiteSpace(netPeerPort) ? null : Colon)}{netPeerPort}{httpTarget}";
+                    urlAuthority = url == null ? null : $"{netPeerName}{(string.IsNullOrWhiteSpace(netPeerPort) ? null : Colon)}{netPeerPort}";
+                    return;
                 }
                 else if (tags.TryGetValue(SemanticConventions.AttributeNetPeerIp, out var netPeerIP)
                          && tags.TryGetValue(SemanticConventions.AttributeNetPeerPort, out netPeerPort))
                 {
-                    return string.IsNullOrWhiteSpace(netPeerIP) ? null : $"{httpScheme}{SchemePostfix}{netPeerIP}{(string.IsNullOrWhiteSpace(netPeerPort) ? null : Colon)}{netPeerPort}{httpTarget}";
+                    url = string.IsNullOrWhiteSpace(netPeerIP) ? null : $"{httpScheme}{SchemePostfix}{netPeerIP}{(string.IsNullOrWhiteSpace(netPeerPort) ? null : Colon)}{netPeerPort}{httpTarget}";
+                    urlAuthority = url == null ? null : $"{netPeerIP}{(string.IsNullOrWhiteSpace(netPeerPort) ? null : Colon)}{netPeerPort}";
+                    return;
                 }
             }
 
@@ -63,35 +71,19 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
                 tags.TryGetValue(SemanticConventions.AttributeHttpTarget, out var httpTarget);
                 tags.TryGetValue(SemanticConventions.AttributeHttpHostPort, out var httpPort);
                 url = $"{host}{(string.IsNullOrWhiteSpace(httpPort) ? null : Colon)}{httpPort}{httpTarget}";
-                return url;
+                urlAuthority = $"{host}{(string.IsNullOrWhiteSpace(httpPort) ? null : Colon)}{httpPort}";
+                return;
             }
 
-            return string.IsNullOrWhiteSpace(url) ? null : url;
+            url = string.IsNullOrWhiteSpace(url) ? null : url;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string GetHttpStatusCode(Dictionary<string, string> tags)
+        internal static string GetTagValue(Dictionary<string, string> tags, string attributeSemanticsKey)
         {
-            if (tags != null && tags.TryGetValue(SemanticConventions.AttributeHttpStatusCode, out var status))
+            if (tags != null && attributeSemanticsKey !=null && tags.TryGetValue(attributeSemanticsKey, out var value))
             {
-                return status;
-            }
-
-            return "0";
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool GetSuccessFromHttpStatusCode(string statusCode)
-        {
-            return statusCode == "200" || statusCode == "Ok";
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string GetHost(Dictionary<string, string> tags)
-        {
-            if (tags != null && tags.TryGetValue(SemanticConventions.AttributeHttpHost, out var host))
-            {
-                return host;
+                return value;
             }
 
             return null;

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/SemanticConventions.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/SemanticConventions.cs
@@ -103,9 +103,10 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
         public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
         public const string AttributeDbMongoDbCollection = "db.mongodb.collection";
 
-        public const string AttributeRpcSystem = "rpc.system";
-        public const string AttributeRpcService = "rpc.service";
         public const string AttributeRpcMethod = "rpc.method";
+        public const string AttributeRpcStatus = "rpc.grpc.status_code";
+        public const string AttributeRpcService = "rpc.service";
+        public const string AttributeRpcSystem = "rpc.system";
 
         public const string AttributeMessageType = "message.type";
         public const string AttributeMessageId = "message.id";

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/TagsExtension.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/TagsExtension.cs
@@ -11,9 +11,8 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
     {
         private static readonly IReadOnlyDictionary<string, PartBType> Part_B_Mapping = new Dictionary<string, PartBType>()
         {
+            [SemanticConventions.AttributeDbStatement] = PartBType.Db,
             [SemanticConventions.AttributeDbSystem] = PartBType.Db,
-            [SemanticConventions.AttributeDbConnectionString] = PartBType.Db,
-            [SemanticConventions.AttributeDbUser] = PartBType.Db,
 
             [SemanticConventions.AttributeHttpMethod] = PartBType.Http,
             [SemanticConventions.AttributeHttpUrl] = PartBType.Http,
@@ -32,9 +31,9 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
             [SemanticConventions.AttributeNetHostName] = PartBType.Common,
             [SemanticConventions.AttributeComponent] = PartBType.Common,
 
-            [SemanticConventions.AttributeRpcSystem] = PartBType.Rpc,
             [SemanticConventions.AttributeRpcService] = PartBType.Rpc,
-            [SemanticConventions.AttributeRpcMethod] = PartBType.Rpc,
+            [SemanticConventions.AttributeRpcSystem] = PartBType.Rpc,
+            [SemanticConventions.AttributeRpcStatus] = PartBType.Rpc,
 
             [SemanticConventions.AttributeFaasTrigger] = PartBType.FaaS,
             [SemanticConventions.AttributeFaasExecution] = PartBType.FaaS,
@@ -47,13 +46,11 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
             [SemanticConventions.AttributeFaasTime] = PartBType.FaaS,
 
             [SemanticConventions.AttributeAzureNameSpace] = PartBType.Azure,
-            [SemanticConventions.AttributeEndpointAddress] = PartBType.Azure,
             [SemanticConventions.AttributeMessageBusDestination] = PartBType.Azure,
 
+            [SemanticConventions.AttributeEndpointAddress] = PartBType.Messaging,
             [SemanticConventions.AttributeMessagingSystem] = PartBType.Messaging,
             [SemanticConventions.AttributeMessagingDestination] = PartBType.Messaging,
-            [SemanticConventions.AttributeMessagingDestinationKind] = PartBType.Messaging,
-            [SemanticConventions.AttributeMessagingTempDestination] = PartBType.Messaging,
             [SemanticConventions.AttributeMessagingUrl] = PartBType.Messaging
         };
 

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Demo.Tracing/DemoTrace.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Demo.Tracing/DemoTrace.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using OpenTelemetry;
 using OpenTelemetry.Resources;
 using System.Diagnostics;
 
@@ -16,7 +17,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Demo.Tracing
         public static void Main()
         {
             var resource = Resources.CreateServiceResource("my-service", "roleinstance1", "my-namespace");
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetResource(resource)
                 .AddSource("Demo.DemoServer")
                 .AddSource("Demo.DemoClient")

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Tests/AttributeHelperTests.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Tests/AttributeHelperTests.cs
@@ -6,328 +6,328 @@ using Xunit;
 
 namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
 {
-    public class HttpHelperTests
+    public class AttributeHelperTests
     {
         [Fact]
         public void GetUrl_Null()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>());
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>(), out var url, out var urlAuthority);
             Assert.Null(url);
+            Assert.Null(urlAuthority);
         }
 
         [Fact]
         public void GetUrl_HttpUrl_NullOrEmpty()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string> { [SemanticConventions.AttributeHttpUrl] = null });
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string> { [SemanticConventions.AttributeHttpUrl] = null }, out var url, out var urlAuthority);
             Assert.Null(url);
-            url = HttpHelper.GetUrl(new Dictionary<string, string> { [SemanticConventions.AttributeHttpUrl] = string.Empty });
+            Assert.Null(urlAuthority);
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string> { [SemanticConventions.AttributeHttpUrl] = string.Empty }, out url, out urlAuthority);
             Assert.Null(url);
+            Assert.Null(urlAuthority);
         }
 
         [Fact]
         public void GetUrl_HttpScheme_NullOrEmpty()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string> { [SemanticConventions.AttributeHttpScheme] = null });
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string> { [SemanticConventions.AttributeHttpScheme] = null }, out var url, out var urlAuthority);
             Assert.Null(url);
-            url = HttpHelper.GetUrl(new Dictionary<string, string> { [SemanticConventions.AttributeHttpScheme] = string.Empty });
+            Assert.Null(urlAuthority);
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string> { [SemanticConventions.AttributeHttpScheme] = string.Empty }, out url, out urlAuthority);
             Assert.Null(url);
+            Assert.Null(urlAuthority);
         }
 
         [Fact]
         public void GetUrl_HttpHost_NullOrEmpty()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string> { [SemanticConventions.AttributeHttpHost] = null });
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string> { [SemanticConventions.AttributeHttpHost] = null }, out var url, out var urlAuthority);
             Assert.Null(url);
-            url = HttpHelper.GetUrl(new Dictionary<string, string> { [SemanticConventions.AttributeHttpHost] = string.Empty });
+            Assert.Null(urlAuthority);
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string> { [SemanticConventions.AttributeHttpHost] = string.Empty }, out url, out urlAuthority);
             Assert.Null(url);
+            Assert.Null(urlAuthority);
         }
 
         [Fact]
         public void GetUrl_With_HttpScheme_And_Null_HttpHost()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
                       { [SemanticConventions.AttributeHttpScheme] = "https",
-                        [SemanticConventions.AttributeHttpHost] = null});
+                        [SemanticConventions.AttributeHttpHost] = null},
+                        out var url, out var urlAuthority);
 
             Assert.Null(url);
+            Assert.Null(urlAuthority);
         }
 
         [Fact]
         public void GetUrl_NetPeerName_NullOrEmpty()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerName] = null,
                 [SemanticConventions.AttributeNetPeerPort] = null
-            });
+            }, out var url, out var urlAuthority);
 
             Assert.Null(url);
+            Assert.Null(urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerName] = string.Empty,
                 [SemanticConventions.AttributeNetPeerPort] = null
-            });
+            }, out url, out urlAuthority);
 
             Assert.Null(url);
+            Assert.Null(urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerName] = "netpeername",
                 [SemanticConventions.AttributeNetPeerPort] = null
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("https://netpeername", url);
+            Assert.Equal("netpeername", urlAuthority);
         }
 
         [Fact]
         public void GetUrl_NetPeerIP_NullOrEmpty()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerIp] = null,
                 [SemanticConventions.AttributeNetPeerPort] = null
-            });
+            }, out var url, out var urlAuthority);
 
             Assert.Null(url);
+            Assert.Null(urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerIp] = string.Empty,
                 [SemanticConventions.AttributeNetPeerPort] = null
-            });
+            }, out url, out urlAuthority);
 
             Assert.Null(url);
+            Assert.Null(urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerIp] = "127.0.0.1",
                 [SemanticConventions.AttributeNetPeerPort] = null
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("https://127.0.0.1", url);
+            Assert.Equal("127.0.0.1", urlAuthority);
         }
 
         [Fact]
         public void GetUrl_HttpPort_NullEmptyOrDefault()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = null
-            });
+            }, out var url, out var urlAuthority);
 
             Assert.Equal("https://localhost", url);
+            Assert.Equal("localhost", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "http",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "80"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("http://localhost", url);
+            Assert.Equal("localhost", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "443"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("https://localhost", url);
+            Assert.Equal("localhost", urlAuthority);
         }
 
         [Fact]
         public void GetUrl_HttpPort_RandomPort_With_HttpTarget()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "8888"
-            });
+            }, out var url, out var urlAuthority);
 
             Assert.Equal("https://localhost:8888", url);
+            Assert.Equal("localhost:8888", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "http",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "80",
                 [SemanticConventions.AttributeHttpTarget] = "/test"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("http://localhost/test", url);
+            Assert.Equal("localhost", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "443",
                 [SemanticConventions.AttributeHttpTarget] = "/test"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("https://localhost/test", url);
+            Assert.Equal("localhost", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "8888",
                 [SemanticConventions.AttributeHttpTarget] = "/test"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("https://localhost:8888/test", url);
+            Assert.Equal("localhost:8888", urlAuthority);
         }
 
         [Fact]
         public void GetUrl_NetPeerIP_Success()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerIp] = "10.0.0.1",
                 [SemanticConventions.AttributeNetPeerPort] = "443"
-            });
+            }, out var url, out var urlAuthority);
 
             Assert.Equal("https://10.0.0.1:443", url);
+            Assert.Equal("10.0.0.1:443", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerIp] = "10.0.0.1",
                 [SemanticConventions.AttributeNetPeerPort] = "443",
                 [SemanticConventions.AttributeHttpTarget] = "/test"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("https://10.0.0.1:443/test", url);
+            Assert.Equal("10.0.0.1:443", urlAuthority);
         }
 
         [Fact]
         public void GetUrl_NetPeerName_Success()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerName] = "localhost",
                 [SemanticConventions.AttributeNetPeerPort] = "443"
-            });
+            }, out var url, out var urlAuthority);
 
             Assert.Equal("https://localhost:443", url);
+            Assert.Equal("localhost:443", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpScheme] = "https",
                 [SemanticConventions.AttributeNetPeerName] = "localhost",
                 [SemanticConventions.AttributeNetPeerPort] = "443",
                 [SemanticConventions.AttributeHttpTarget] = "/test"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("https://localhost:443/test", url);
+            Assert.Equal("localhost:443", urlAuthority);
         }
 
         [Fact]
         public void GetUrl_HttpHost_Success()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpHost] = "localhost",
-            });
+            }, out var url, out var urlAuthority);
 
             Assert.Equal("localhost", url);
+            Assert.Equal("localhost", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "8888",
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("localhost:8888", url);
+            Assert.Equal("localhost:8888", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = "8080",
                 [SemanticConventions.AttributeHttpTarget] = "/test"
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("localhost:8080/test", url);
+            Assert.Equal("localhost:8080", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = null,
                 [SemanticConventions.AttributeHttpTarget] = null
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("localhost", url);
+            Assert.Equal("localhost", urlAuthority);
 
-            url = HttpHelper.GetUrl(new Dictionary<string, string>
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string>
             {
                 [SemanticConventions.AttributeHttpHost] = "localhost",
                 [SemanticConventions.AttributeHttpHostPort] = string.Empty,
                 [SemanticConventions.AttributeHttpTarget] = string.Empty
-            });
+            }, out url, out urlAuthority);
 
             Assert.Equal("localhost", url);
+            Assert.Equal("localhost", urlAuthority);
         }
 
         [Fact]
         public void GetUrl_HttpUrl_Success()
         {
-            var url = HttpHelper.GetUrl(new Dictionary<string, string> { [SemanticConventions.AttributeHttpUrl] = "https://www.wiki.com" });
+            AttributeHelper.GenerateUrlAndAuthority(new Dictionary<string, string> { [SemanticConventions.AttributeHttpUrl] = "https://www.wiki.com" }, out var url, out var urlAuthority);
             Assert.Equal("https://www.wiki.com", url);
+            Assert.Equal("www.wiki.com", urlAuthority);
         }
 
-        // TODO: Order of precedence.
-
-        [Fact]
-        public void GetHttpStatusCode_Success()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Invalid Data")]
+        [InlineData(SemanticConventions.AttributeHttpStatusCode)]
+        public void GetTagValue_Tests(string attributeSemanticsKey)
         {
-            Assert.Equal("200", HttpHelper.GetHttpStatusCode(new Dictionary<string, string> { [SemanticConventions.AttributeHttpStatusCode] = "200" }));
-            Assert.Equal("Ok", HttpHelper.GetHttpStatusCode(new Dictionary<string, string> { [SemanticConventions.AttributeHttpStatusCode] = "Ok" }));
-            Assert.Equal("500", HttpHelper.GetHttpStatusCode(new Dictionary<string, string> { [SemanticConventions.AttributeHttpStatusCode] = "500" }));
-            Assert.Null(HttpHelper.GetHttpStatusCode(new Dictionary<string, string> { [SemanticConventions.AttributeHttpStatusCode] = null }));
-        }
-
-        [Fact]
-        public void GetHttpStatusCode_Failure()
-        {
-            Assert.Equal("0", HttpHelper.GetHttpStatusCode(null));
-            Assert.Equal("0", HttpHelper.GetHttpStatusCode(new Dictionary<string, string>()));
-        }
-
-        [Fact]
-        public void GetSuccessFromHttpStatusCode_Success()
-        {
-            Assert.True(HttpHelper.GetSuccessFromHttpStatusCode("200"));
-            Assert.True(HttpHelper.GetSuccessFromHttpStatusCode("Ok"));
-        }
-
-        [Fact]
-        public void GetSuccessFromHttpStatusCode_Failure()
-        {
-            Assert.False(HttpHelper.GetSuccessFromHttpStatusCode(null));
-            Assert.False(HttpHelper.GetSuccessFromHttpStatusCode(string.Empty));
-            Assert.False(HttpHelper.GetSuccessFromHttpStatusCode("500"));
-            Assert.False(HttpHelper.GetSuccessFromHttpStatusCode("0"));
-        }
-
-        [Fact]
-        public void GetHostTests()
-        {
-            Assert.Equal("test", HttpHelper.GetHost(new Dictionary<string, string> { [SemanticConventions.AttributeHttpHost] = "test" }));
-            Assert.Null(HttpHelper.GetHost(new Dictionary<string, string> { [SemanticConventions.AttributeHttpHost] = null }));
-            Assert.Null(HttpHelper.GetHost(new Dictionary<string, string>()));
-            Assert.Null(HttpHelper.GetHost(null));
+            Assert.Equal(attributeSemanticsKey == SemanticConventions.AttributeHttpStatusCode ? "200" : null,
+                    AttributeHelper.GetTagValue(new Dictionary<string, string> { [SemanticConventions.AttributeHttpStatusCode] = "200" }, attributeSemanticsKey));
         }
     }
 }


### PR DESCRIPTION
Modified `AzureMonitorConverter.cs` to set RemoteDependency mappings
