### PR TITLE
[Azure.Core] Remove TestFramework Target Duplicate

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks);net461;net47</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net47</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/Azure.Security.KeyVault.Keys.Tests.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/Azure.Security.KeyVault.Keys.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- ECParameters is defined in netstandard2.0 but not net461 (introduced in net47). Test against net461 to make sure a TypeLoadException is not thrown when referencing JsonWebKey. -->
     <!-- We also execute a limited set of tests on netcoreapp3.1 for light-up feature support. -->
-    <TargetFrameworks>$(RequiredTargetFrameworks);net461;net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks);net47;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\Azure.Security.KeyVault.Shared\tests\Azure.Security.KeyVault.Shared.Tests.projitems" Label="Shared" />


### PR DESCRIPTION
# Summary

The focus of these changes is to remove a redundant specification of the `net461` target; one is implicity brought in as part of the `$(RequiredTargetFrameworks)` variable _([ref](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/Directory.Build.Data.props#L86))_ and another was hard-coded into the list.

When using Visual Studio, this was causing a warning in the Package Manager output stating:

    Error occurred while restoring NuGet packages: Invalid restore input. 
    The original target frameworks value must match the aliases. 
    Original target frameworks: netcoreapp2.1;net461;net461;net47

While this wasn't impactful, removing the duplicate framework resolves it.

# Last Upstream Rebase

Friday, November 13, 10:04am (EST)