### PR TITLE
[Event Hubs Client] Fix Flaky Tests

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_ProcessingEvents.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_ProcessingEvents.md
@@ -213,7 +213,6 @@ async Task processEventHandler(ProcessEventArgs args)
             args.Partition,
             args.CancellationToken);
 
-
         // If the number of events that have been processed
         // since the last checkpoint was created exceeds the
         // checkpointing threshold, a new checkpoint will be

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample04_ProcessingEventsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample04_ProcessingEventsLiveTests.cs
@@ -243,7 +243,6 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                         args.Partition,
                         args.CancellationToken);
 
-
                     // If the number of events that have been processed
                     // since the last checkpoint was created exceeds the
                     // checkpointing threshold, a new checkpoint will be

--- a/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.TestFramework", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{2DB233D3-E757-423C-8F8D-742B0AFF4713}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Memory.Data", "..\..\core\System.Memory.Data\src\System.Memory.Data.csproj", "{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,25 +57,12 @@ Global
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x64.Build.0 = Release|Any CPU
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x86.ActiveCfg = Release|Any CPU
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433}.Release|x86.Build.0 = Release|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Debug|x64.Build.0 = Debug|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Debug|x86.Build.0 = Debug|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Release|x64.ActiveCfg = Release|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Release|x64.Build.0 = Release|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Release|x86.ActiveCfg = Release|Any CPU
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2CFDB3D6-5CFB-428C-9C89-29DD169B5433} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
-		{EDC6F52C-48FA-410A-9EC3-B77C33576ECF} = {2DB233D3-E757-423C-8F8D-742B0AFF4713}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {509F2EE0-3348-4506-8AC7-9945B602CB43}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/MigrationGuide.md
@@ -77,7 +77,7 @@ In order to allow for a single focus and clear responsibility, the core function
 |------------------------------------------------|------------------------------------------------------------------|--------|
 | `EventHubClient.CreateFromConnectionString()`    | `new EventHubProducerClient()` or `new EventHubConsumerClient()` | [Publishing Events](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishingEvents.md), [Reading Events](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadingEvents.md) |
 | `EventHubClient.CreateWithAzureActiveDirectory()` or `EventHubClient.CreateWithManagedIdentity()`  | `new EventHubProducerClient(..., TokenCredential)` or `new EventHubConsumerClient(..., TokenCredential)` | [Identity and Shared Access Credentials](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_IdentityAndSharedAccessCredentials.md)
-| `new EventProcessorHost()`                           | `new EventProcessorClient(BlobContainerClient, ...)`               | [Basic Event Processing](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample03_BasicEventProcessing.cs) |
+| `new EventProcessorHost()`                           | `new EventProcessorClient(BlobContainerClient, ...)`               | [Basic Event Processing](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_ProcessingEvents.md) |
 
 ### Publish events
 
@@ -93,7 +93,7 @@ The v4 client allowed for sending a single event or an enumerable of events, whi
 | In v4                                          | Equivalent in v5                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
 | `PartitionReceiver.ReceiveAsync()` or `PartitionReceiver.SetReceiveHandler()`                      | `EventHubConsumerClient.ReadEventsFromPartitionAsync()`                               | [Reading Events](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_ReadingEvents.md) |
-| `new EventProcessorHost()`                           | `new EventProcessorClient(blobContainerClient, ...)`               | [Basic Event Processing](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample03_BasicEventProcessing.cs) |
+| `new EventProcessorHost()`                           | `new EventProcessorClient(blobContainerClient, ...)`               | [Basic Event Processing](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample04_ProcessingEvents.md) |
 
 ## Migration samples
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Consumer/EventHubConsumerClientTests.cs
@@ -552,7 +552,11 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25), CacheEventCount = 999 };
 
             await using var enumerator = consumer.ReadEventsFromPartitionAsync("0", EventPosition.FromOffset(12), options).GetAsyncEnumerator();
-            await enumerator.MoveNextAsync();
+
+            for (var index = 0; index < 5; ++index)
+            {
+                await enumerator.MoveNextAsync();
+            }
 
             var (receiveBatchSize, _) = transportConsumer.ReceiveCalledWith;
             Assert.That(receiveBatchSize, Is.EqualTo(options.CacheEventCount), "Receive should have used the cache event count for the batch size");
@@ -1287,7 +1291,11 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new ReadEventOptions { MaximumWaitTime = TimeSpan.FromMilliseconds(25), CacheEventCount = 543 };
 
             await using var enumerator = consumer.ReadEventsAsync(options).GetAsyncEnumerator();
-            await enumerator.MoveNextAsync();
+
+            for (var index = 0; index < 5; ++index)
+            {
+                await enumerator.MoveNextAsync();
+            }
 
             var (receiveBatchSize, _) = transportConsumer.ReceiveCalledWith;
             Assert.That(receiveBatchSize, Is.EqualTo(options.CacheEventCount), "Receive should have used the cache event count for the batch size");


### PR DESCRIPTION
# Summary

The focus of these changes is to fix race conditions in:

- `StopProcessingIsSafeToCallInTheErrorHandler`
- `ReadEventsAsyncWithOptionsRespectsTheCacheEventCount`

A spacing issue was also fixed in the snippet for event processing samples.

# Last Upstream Rebase

Friday, November 13, 12:22pm (EST)

# References and Related

- [[Flaky tests] StopProcessingIsSafeToCallInTheErrorHandler and ReadEventsAsyncWithOptionsRespectsTheCacheEventCount (#16653)](https://github.com/Azure/azure-sdk-for-net/issues/16653)