### PR TITLE
Fix regression that de-serializes ETag as null for custom ITableEntity models

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/Extensions/DictionaryTableExtensions.cs
+++ b/sdk/tables/Azure.Data.Tables/src/Extensions/DictionaryTableExtensions.cs
@@ -205,7 +205,7 @@ namespace Azure.Data.Tables
             }
 
             // Populate the ETag if present.
-            if (entity.TryGetValue(TableConstants.PropertyNames.ETag, out var etag))
+            if (entity.TryGetValue(TableConstants.PropertyNames.EtagOdata, out var etag))
             {
                 result.ETag = new ETag((etag as string)!);
             }

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientLiveTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientLiveTests.cs
@@ -888,6 +888,7 @@ namespace Azure.Data.Tables.Tests
                 Assert.That(entityResults[i].PartitionKey, Is.EqualTo(entitiesToCreate[i].PartitionKey), "The entities should be equivalent");
                 Assert.That(entityResults[i].RowKey, Is.EqualTo(entitiesToCreate[i].RowKey), "The entities should be equivalent");
                 Assert.That(entityResults[i].StringTypeProperty, Is.EqualTo(entitiesToCreate[i].StringTypeProperty), "The entities should be equivalent");
+                Assert.That(entityResults[i].ETag, Is.Not.EqualTo(default(ETag)), $"ETag value should not be default: {entityResults[i].ETag}");
             }
         }
 


### PR DESCRIPTION
fixes #16974 