### PR TITLE
[documentation] README.md to use add package instead of install

### DIFF
--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
@@ -9,7 +9,7 @@ This package follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Azure Key Vault management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-dotnet install Azure.ResourceManager.KeyVault -Version 1.0.0-preview.2 
+dotnet add package Azure.ResourceManager.KeyVault -Version 1.0.0-preview.2
 ```
 
 ### Prerequisites

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
@@ -9,7 +9,7 @@ This package follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Azure Key Vault management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-dotnet add package Azure.ResourceManager.KeyVault -Version 1.0.0-preview.2
+dotnet add package Azure.ResourceManager.KeyVault --version 1.0.0-preview.2
 ```
 
 ### Prerequisites

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/README.md
@@ -9,7 +9,7 @@ This package follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Azure Key Vault management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-dotnet add package Azure.ResourceManager.KeyVault --version 1.0.0-preview.2
+dotnet add package Azure.ResourceManager.KeyVault --version 1.0.0-preview.1
 ```
 
 ### Prerequisites

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/README.md
@@ -13,7 +13,7 @@ The Azure Key Vault administration library clients support administrative tasks 
 Install the Azure Key Vault administration client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-dotnet install Azure.Security.KeyVault.Administration --version 4.0.0-beta.1
+dotnet add package Azure.Security.KeyVault.Administration --version 4.0.0-beta.1
 ```
 
 ### Prerequisites
@@ -32,7 +32,7 @@ Client secret credential authentication is being used in this getting started se
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
 ```PowerShell
-dotnet install Azure.Identity
+dotnet add package Azure.Identity
 ```
 
 #### Create/Get credentials

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
@@ -11,7 +11,7 @@ The Azure Key Vault certificates client library enables programmatically managin
 Install the Azure Key Vault certificates client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-dotnet add package Azure.Security.KeyVault.Certificates --prerelease
+dotnet add package Azure.Security.KeyVault.Certificates --version 4.2.0-beta.3
 ```
 
 ### Prerequisites

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
@@ -11,7 +11,7 @@ The Azure Key Vault certificates client library enables programmatically managin
 Install the Azure Key Vault certificates client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-dotnet install Azure.Security.KeyVault.Certificates -IncludePrerelease
+dotnet add package Azure.Security.KeyVault.Certificates -IncludePrerelease
 ```
 
 ### Prerequisites
@@ -32,7 +32,7 @@ Client secret credential authentication is being used in this getting started se
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
 ```PowerShell
-dotnet install Azure.Identity
+dotnet add package Azure.Identity
 ```
 
 #### Create/Get credentials

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/README.md
@@ -11,7 +11,7 @@ The Azure Key Vault certificates client library enables programmatically managin
 Install the Azure Key Vault certificates client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-dotnet add package Azure.Security.KeyVault.Certificates -IncludePrerelease
+dotnet add package Azure.Security.KeyVault.Certificates --prerelease
 ```
 
 ### Prerequisites

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md
@@ -16,7 +16,7 @@ The Azure Key Vault keys library client supports RSA keys and Elliptic Curve (EC
 Install the Azure Key Vault keys client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-dotnet install Azure.Security.KeyVault.Keys
+dotnet add package Azure.Security.KeyVault.Keys
 ```
 
 ### Prerequisites
@@ -33,7 +33,7 @@ Client secret credential authentication is being used in this getting started se
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
 ```PowerShell
-dotnet install Azure.Identity
+dotnet add package Azure.Identity
 ```
 
 #### Create/Get credentials

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/README.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/README.md
@@ -11,7 +11,7 @@ The Azure Key Vault secrets client library allows you to securely store and cont
 Install the Azure Key Vault secrets client library for .NET with [NuGet][nuget]:
 
 ```PowerShell
-dotnet install Azure.Security.KeyVault.Secrets
+dotnet add package Azure.Security.KeyVault.Secrets
 ```
 
 ### Prerequisites
@@ -32,7 +32,7 @@ Client secret credential authentication is being used in this getting started se
 or other credential providers provided with the Azure SDK, you should install the Azure.Identity package:
 
 ```PowerShell
-dotnet install Azure.Identity
+dotnet add package Azure.Identity
 ```
 
 #### Create/Get credentials


### PR DESCRIPTION
- dotnet install does not work on my machine, but dotnet add package does
- We have 51 references to 'add package' and 9 for 'install' in readme right now