### PR TITLE
[Event Hubs Client] Test Timeout Tweak

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConnectionOptions.cs
@@ -18,6 +18,8 @@ namespace Azure.Messaging.EventHubs
         ///   service.
         /// </summary>
         ///
+        /// <value>The default transport is AMQP over TCP.</value>
+        ///
         public EventHubsTransportType TransportType { get; set; } = EventHubsTransportType.AmqpTcp;
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsRetryOptions.cs
@@ -37,6 +37,8 @@ namespace Azure.Messaging.EventHubs
         ///   to have failed.
         /// </summary>
         ///
+        /// <value>The default retry limit is 3.</value>
+        ///
         public int MaximumRetries
         {
             get => _maximumRetries;
@@ -53,6 +55,8 @@ namespace Azure.Messaging.EventHubs
         ///   on which to base calculations for a backoff-based approach.
         /// </summary>
         ///
+        /// <value>The default delay is 0.8 seconds.</value>
+        ///
         public TimeSpan Delay
         {
             get => _delay;
@@ -67,6 +71,8 @@ namespace Azure.Messaging.EventHubs
         /// <summary>
         ///   The maximum permissible delay between retry attempts.
         /// </summary>
+        ///
+        /// <value>The default maximum delay is 60 seconds.</value>
         ///
         public TimeSpan MaximumDelay
         {
@@ -83,6 +89,8 @@ namespace Azure.Messaging.EventHubs
         ///   The maximum duration to wait for completion of a single attempt, whether the initial
         ///   attempt or a retry.
         /// </summary>
+        ///
+        /// <value>The default timeout is 60 seconds.</value>
         ///
         [SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "We believe using the property name instead of 'value' is more intuitive")]
         public TimeSpan TryTimeout

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -5,5 +5,5 @@ extends:
   parameters:
     MaxParallel: 6
     ServiceDirectory: eventhub
-    TimeoutInMinutes: 150
+    TimeoutInMinutes: 300
     Clouds: 'Public,Canary'


### PR DESCRIPTION
# Summary

The focus of these changes is to bump up the timeout applied to the Event Hubs live test runs.  This is intended to help provide a benchmark for how long the run is taking, as it has recently begun to exceed the timeout for reasons under investigation.   _(and which are not observed locally)_

The current suspicion is that the use of canary and/or throttling or contention in the management plane are contributing.  Once a baseline run time is understood, we'll experiment with the level of parallelism.

Also riding along are a few small documentation changes that were accidentally not included with the last set of changes.

# Last Upstream Rebase

Tuesday, November 17, 11:38am (EST)