### PR TITLE
Add Update-dotnet-CIConfig

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -13,7 +13,7 @@ jobs:
             pwsh: true
             workingDirectory: $(Build.SourcesDirectory)
             filePath: eng/scripts/SetTestPipelineVersion.ps1
-            arguments: '-BuildNumber $(Build.BuildNumber)'
+            arguments: '-BuildID $(Build.BuildId)'
       - pwsh: |
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -63,7 +63,7 @@ stages:
                           pwsh: true
                           workingDirectory: $(Build.SourcesDirectory)
                           filePath: eng/scripts/SetTestPipelineVersion.ps1
-                          arguments: '-BuildNumber $(Build.BuildNumber)'
+                          arguments: '-BuildID $(Build.BuildId)'
                     - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
                       parameters:
                         PackageName: ${{artifact.name}}

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -110,7 +110,7 @@ function Publish-dotnet-GithubIODocs ($DocLocation, $PublicArtifactLocation)
   New-Item -ItemType directory -Path $TempDir
 
   Expand-Archive -LiteralPath $PublishedDocs[0].FullName -DestinationPath $DocsStagingDir
-  $pkgProperties = ParseNugetPackage -pkg $PublishedPkgs[0].FullName -workingDirectory $TempDir
+  $pkgProperties = Get-dotnet-PackageInfoFromPackageFile -pkg $PublishedPkgs[0].FullName -workingDirectory $TempDir
 
   Write-Host "Start Upload for $($pkgProperties.ReleaseTag)"
   Write-Host "DocDir $($DocsStagingDir)"
@@ -128,4 +128,47 @@ function Get-dotnet-GithubIoDocIndex() {
   $tocContent = Get-TocMapping -metadata $metadata -artifacts $artifacts
   # Generate yml/md toc files and build site.
   GenerateDocfxTocContent -tocContent $tocContent -lang "NET"
+}
+
+# details on CSV schema can be found here
+# https://review.docs.microsoft.com/en-us/help/onboard/admin/reference/dotnet/documenting-nuget?branch=master#set-up-the-ci-job
+function Update-dotnet-CIConfig($pkgs, $ciRepo, $locationInDocRepo, $monikerId=$null){
+  $csvLoc = (Join-Path -Path $ciRepo -ChildPath $locationInDocRepo)
+  
+  if (-not (Test-Path $csvLoc)) {
+    Write-Error "Unable to locate package csv at location $csvLoc, exiting."
+    exit(1)
+  }
+
+  $allCSVRows = Get-Content $csvLoc
+  $visibleInCI = @{}
+
+  # first pull what's already available
+  for ($i=0; $i -lt $allCSVRows.Length; $i++) {
+    $pkgDef = $allCSVRows[$i]
+
+    # get rid of the modifiers to get just the package id
+    $id = $pkgDef.split(",")[1] -replace "\[.*?\]", ""
+
+    $visibleInCI[$id] = $i
+  }
+
+  foreach ($releasingPkg in $pkgs) {
+    $installModifiers = "tfm=netstandard2.0"
+    if ($releasingPkg.IsPrerelease) {
+      $installModifiers += ";isPrerelease=true"
+    }
+    $lineId = $releasingPkg.PackageId.Replace(".","").ToLower()
+
+    if ($visibleInCI.ContainsKey($releasingPkg.PackageId)) {
+      $packagesIndex = $visibleInCI[$releasingPkg.PackageId]
+      $allCSVRows[$packagesIndex] = "$($lineId),[$installModifiers]$($releasingPkg.PackageId)"
+    }
+    else {
+      $newItem = "$($lineId),[$installModifiers]$($releasingPkg.PackageId)"
+      $allCSVRows += ($newItem)
+    }
+  }
+
+  Set-Content -Path $csvLoc -Value $allCSVRows
 }

--- a/eng/scripts/SetTestPipelineVersion.ps1
+++ b/eng/scripts/SetTestPipelineVersion.ps1
@@ -3,7 +3,7 @@
 
 param (
   [Parameter(mandatory = $true)]
-  $BuildNumber
+  $BuildID
 )
 
 . "${PSScriptRoot}\..\common\scripts\common.ps1"
@@ -22,7 +22,7 @@ LogDebug "Last Published Version $($semVarsSorted[0])"
 
 $newVersion = [AzureEngSemanticVersion]::ParseVersionString($semVarsSorted[0])
 $newVersion.PrereleaseLabel = "beta"
-$newVersion.PrereleaseNumber = $BuildNumber
+$newVersion.PrereleaseNumber = $BuildID
 
 LogDebug "Version to publish [ $($newVersion.ToString()) ]"
 


### PR DESCRIPTION
- Move `UpdateCSVBasedCI` from `https://github.com/Azure/azure-sdk-tools/blob/master/eng/common/scripts/update-docs-ci.ps1` to LanguageSettings.ps1.
- Rename function to `Update-dotnet-CIConfig`
- Add default `$monikerId=$null` argument to help function reuse across the languages.
- Fix call to Get-dotnet-PackageInfoFromPackageFile
- Switch from `BuildNumber` to `BuildID` for test release version.