### PR TITLE
[live tests] Minor fixes for SupportedClouds and Location overrides/defaults

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-host.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-host.yml
@@ -20,7 +20,7 @@ jobs:
       UsePlatformContainer: false
       Platforms:
         ${{ each platform in parameters.Platforms }}:
-          ${{ if eq(platform.value.Container, '') }}:
+          ${{ if not(platform.value.Container) }}:
             ${{ platform.key }}: ${{ platform.value }}
       CloudConfig: ${{ parameters.CloudConfig }}
       ${{ each param in parameters.AdditionalParameters }}:
@@ -33,7 +33,7 @@ jobs:
         UsePlatformContainer: true
         Platforms:
           ${{ each platform in parameters.Platforms }}:
-            ${{ if ne(platform.value.Container, '') }}:
+            ${{ if platform.value.Container }}:
               ${{ platform.key }}: ${{ platform.value }}
         CloudConfig: ${{ parameters.CloudConfig }}
         ${{ each param in parameters.AdditionalParameters }}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -72,7 +72,8 @@ jobs:
 
       - template: /eng/common/TestResources/deploy-test-resources.yml
         parameters:
-          Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location, 'westus2') }}
+          ${{ if or(parameters.Location, parameters.CloudConfig.Location) }}:
+            Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location) }}
           ServiceDirectory: '${{ parameters.ServiceDirectory }}'
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           ArmTemplateParameters: $(ArmTemplateParameters)

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -114,8 +114,8 @@ stages:
           parameters:
             # Flag to include the job template with a container field
             ${{ each platform in parameters.AdditionalPlatforms }}:
-              ${{ if contains(coalesce(platform.value.SupportedClouds, parameters.Clouds), cloud.key) }}:
-                ${{ if ne(platform.value.Container, '') }}:
+              ${{ if or(not(platform.value.SupportedClouds), contains(platform.value.SupportedClouds, cloud.key)) }}:
+                ${{ if platform.value.Container }}:
                   UsePlatformContainer: true
             AdditionalParameters:
               PreSteps:
@@ -134,10 +134,10 @@ stages:
             Platforms:
               # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).
               ${{ each platform in parameters.Platforms }}:
-                ${{ if contains(coalesce(platform.value.SupportedClouds, parameters.Clouds), cloud.key) }}:
+                ${{ if or(not(platform.value.SupportedClouds), contains(platform.value.SupportedClouds, cloud.key)) }}:
                   ${{ platform.key }}: ${{ platform.value }}
               ${{ each platform in parameters.AdditionalPlatforms }}:
-                ${{ if contains(coalesce(platform.value.SupportedClouds, parameters.Clouds), cloud.key) }}:
+                ${{ if or(not(platform.value.SupportedClouds), contains(platform.value.SupportedClouds, cloud.key)) }}:
                   ${{ platform.key }}: ${{ platform.value }}
             CloudConfig:
               SubscriptionConfiguration: ${{ cloud.value.SubscriptionConfiguration }}


### PR DESCRIPTION
SupportedClouds: Since the `tests-weekly` pipeline convention includes all clouds by default, we need to update the conditional check to populate the platform matrix by defaulting to true always when SupportedClouds is not defined. Otherwise the matrix ends up rendering empty for clouds that aren't in the default `parameters.Clouds` string.

Location: Since the `coalesce` template expression function needs a non-empty fallback string, I had passed in 'westus2'. This does not work when no Location is specified for sovereign clouds, since we need to use a different default. This fixes the expression to ignore setting Location properly when not specified (allowing the provisioning script to set it instead).