### PR TITLE
[Event Hubs Client] Live Test Troubleshooting Tweaks

### DIFF
--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
-    MaxParallel: 6
+    MaxParallel: 1
     ServiceDirectory: eventhub
-    TimeoutInMinutes: 300
+    TimeoutInMinutes: 130
     Clouds: 'Public,Canary'


### PR DESCRIPTION
# Summary

The focus of these changes is to reduce parallelism in the test run to a single suite at a time and reduce the maximum run time.  This is intended to allow for farming the test run logs to track which tests have executed before the timeout occurs, to try and reduce the number of failure candidates.

# Last Upstream Rebase

Wednesday, November 18, 4:41pm (EST)