### PR TITLE
Update sample to use API_LEARN_ENDPOINT which works on macOS

### DIFF
--- a/sdk/api-learn/Azure.Learn.AppConfig/tests/Samples/Sample1_HelloWorld.cs
+++ b/sdk/api-learn/Azure.Learn.AppConfig/tests/Samples/Sample1_HelloWorld.cs
@@ -16,7 +16,7 @@ namespace Azure.Learn.AppConfig.Samples
         [Test]
         public void GetConfigurationSetting()
         {
-            string endpoint = Environment.GetEnvironmentVariable("API-LEARN_ENDPOINT");
+            string endpoint = Environment.GetEnvironmentVariable("API_LEARN_ENDPOINT");
             ConfigurationClient client = new ConfigurationClient(new Uri(endpoint), new DefaultAzureCredential());
 
             ConfigurationSetting color = client.GetConfigurationSetting("FontColor");

--- a/sdk/api-learn/Azure.Learn.AppConfig/tests/Samples/Sample2_GetSettingIfChanged.cs
+++ b/sdk/api-learn/Azure.Learn.AppConfig/tests/Samples/Sample2_GetSettingIfChanged.cs
@@ -16,7 +16,7 @@ namespace Azure.Learn.AppConfig.Samples
         [Test]
         public async Task GetConfigurationSettingIfChanged()
         {
-            string endpoint = Environment.GetEnvironmentVariable("API-LEARN_ENDPOINT");
+            string endpoint = Environment.GetEnvironmentVariable("API_LEARN_ENDPOINT");
 
             ConfigurationClient client = new ConfigurationClient(new Uri(endpoint), new DefaultAzureCredential());
 


### PR DESCRIPTION
- API-LEARN_ENDPOINT is not a valid POSIX environmental variable ('-' is not allowed)
- We'll need equivalent updates for other languages.