### PR TITLE
[TA] Enable ci in westus2 and new SKU

### DIFF
--- a/sdk/textanalytics/test-resources.json
+++ b/sdk/textanalytics/test-resources.json
@@ -51,6 +51,7 @@
     },
     "variables": {
         "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
+        "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('endpointSuffix'))]"
     },
     "resources": [
         {
@@ -59,12 +60,22 @@
             "name": "[variables('uniqueSubDomainName')]",
             "location":"[parameters('location')]",
             "sku": {
-                "name": "S0"
+                "name": "S"
             },
             "kind": "TextAnalytics",
             "properties": {
                 "customSubDomainName": "[variables('uniqueSubDomainName')]"
             }
         }
-    ]
+    ],
+    "outputs": {
+        "TEXT_ANALYTICS_API_KEY": {
+            "type": "string",
+            "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts',variables('uniqueSubDomainName')), '2017-04-18').key1]"
+        },
+        "TEXT_ANALYTICS_ENDPOINT": {
+            "type": "string",
+            "value": "[variables('endpointValue')]"
+        }
+    }
 }

--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -4,6 +4,5 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: textanalytics
-    EnvVars:
-      TEXT_ANALYTICS_API_KEY: $(net-textanalytics-test-api-key)
-      TEXT_ANALYTICS_ENDPOINT: $(net-textanalytics-test-ppe-endpoint-string)
+    Clouds: 'Preview'
+    UnsupportedClouds: 'China'


### PR DESCRIPTION
New functionalities (healthcare and analyze) in TA are only available in gated preview and in SKU Standard. The service is done with the deployment in `westus2` so changing out CI to that region.
It also excludes `China` cloud as it looks like `3.0.0` is not deployed there. More info https://github.com/Azure/azure-sdk-for-net/issues/13111