### PR TITLE
Use pre steps to determine whether to record live tests

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -42,7 +42,6 @@ jobs:
       maxParallel: ${{ parameters.MaxParallel }}
       matrix: ${{ parameters.Platforms }}
 
-    condition: and(succeededOrFailed(), eq(eq(variables['Record'], 'true'), eq('$(TestMode)', 'Record')))
     variables:
       - template: ../variables/globals.yml
       # ServiceDirectory references must get passed down by the caller as variable references

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -51,6 +51,8 @@ jobs:
         value: ''
       - name: ArmTemplateParameters
         value: '@{}'
+      - name: TestMode
+        value: 'None'
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
@@ -76,6 +78,13 @@ jobs:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           ArmTemplateParameters: $(ArmTemplateParameters)
 
+      - pwsh: |
+          if ($env:SupportsRecording -and $env:Record) {
+            Write-Host "Enabling Record mode"
+            Write-Host "##vso[task.setvariable variable=TestMode]Record"
+          }
+        displayName: Set Test Mode
+
       - pwsh: >
           dotnet test eng/service.proj
           --framework $(TestTargetFramework)
@@ -92,7 +101,7 @@ jobs:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
-          AZURE_TEST_MODE: "${{ coalesce(variables['TestMode'], 'None') }}"
+          AZURE_TEST_MODE: $(TestMode)
           ${{ each var in parameters.EnvVars }}:
             ${{ var.key }}: ${{ var.value }}
 

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -73,11 +73,6 @@ parameters:
       OSVmImage: "macOS-10.15"
       TestTargetFramework: netcoreapp2.1
       SupportedClouds: 'Public'
-    Windows_NetCore_Record:
-      OSVmImage: "windows-2019"
-      TestMode: Record
-      TestTargetFramework: netcoreapp2.1
-      SupportedClouds: 'Public'
 - name: PlatformPreSteps
   type: object
   default:
@@ -86,7 +81,7 @@ parameters:
   type: object
   default:
     - task: CopyFiles@2
-      condition: and(succeededOrFailed(), eq(variables['Agent.JobName'], 'Windows_NetCore_Record'))
+      condition: and(succeededOrFailed(), eq(variables['Record'], 'true'), eq(variables['Agent.JobName'], 'Windows_NetCore'))
       displayName: "Copy Test Recordings"
       inputs:
         sourceFolder: '$(Build.SourcesDirectory)'
@@ -95,7 +90,7 @@ parameters:
         contents: 'sdk/$(ServiceDirectory)/**/SessionRecords/**/*.json'
         targetFolder: '$(Build.ArtifactStagingDirectory)/SessionRecords'
     - task: PublishBuildArtifacts@1
-      condition: and(succeededOrFailed(), eq(variables['Agent.JobName'], 'Windows_NetCore_Record'))
+      condition: and(succeededOrFailed(), eq(variables['Record'], 'true'), eq(variables['Agent.JobName'], 'Windows_NetCore'))
       displayName: "Publish Test Recordings"
       inputs:
         pathToPublish: '$(Build.ArtifactStagingDirectory)/SessionRecords'

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -82,7 +82,7 @@ parameters:
   type: object
   default:
     - task: CopyFiles@2
-      condition: and(succeededOrFailed(), eq(variables['Record'], 'true'), eq(variables['Agent.JobName'], 'Windows_NetCore'))
+      condition: and(succeededOrFailed(), eq(variables.TestMode, 'Record'))
       displayName: "Copy Test Recordings"
       inputs:
         sourceFolder: '$(Build.SourcesDirectory)'
@@ -91,7 +91,7 @@ parameters:
         contents: 'sdk/$(ServiceDirectory)/**/SessionRecords/**/*.json'
         targetFolder: '$(Build.ArtifactStagingDirectory)/SessionRecords'
     - task: PublishBuildArtifacts@1
-      condition: and(succeededOrFailed(), eq(variables['Record'], 'true'), eq(variables['Agent.JobName'], 'Windows_NetCore'))
+      condition: and(succeededOrFailed(), eq(variables.TestMode, 'Record'))
       displayName: "Publish Test Recordings"
       inputs:
         pathToPublish: '$(Build.ArtifactStagingDirectory)/SessionRecords'

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -58,6 +58,7 @@ parameters:
     Windows_NetCore:
       OSVmImage: "windows-2019"
       TestTargetFramework: netcoreapp2.1
+      SupportsRecording: true
     Windows_NetCore_ProjectRefAzureClients:
       OSVmImage: "windows-2019"
       TestTargetFramework: netcoreapp2.1


### PR DESCRIPTION
Previously we used template expressions, which are rendered at compile time, in order to set the condition expression (https://github.com/azure/azure-sdk-for-net/blob/c6f9946dbb30ccbf11460e14655175cae50e0fc4/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml#L39). With recent changes, in order to support MaxParallel, we have switched to using a matrix strategy. This change meant that platforms were enumerated via the matrix definition, instead of an `${{ each platforms ...}}` loop in the job definition. As a result, the TestMode setting was then available as a variable instead of a parameter, like so:

```
- job:
  strategy:
    matrix: ${{ parameters.Platforms }}
```
which becomes:
```
- job:
  strategy:
    matrix:
      Windows_NetCore_Record:
        TestMode: Record
```

The pipelines evaluation logic does not have the matrix variables within a template in scope at the time it evaluates a job condition. I think this is because it is in the execution context for job orchestration, which is prior to matrix expansion. However, it DOES have them in scope at the time it evaluates a step condition (since it is the runtime execution context).

See https://developercommunity.visualstudio.com/content/problem/1145638/azure-devops-pipelines-variable-not-expanded-in-te.html and https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml#use-a-template-parameter-as-part-of-a-condition for some detail on this behavior.

Due to these constraints, I've moved the Record condition into the step condition, and instead of having a separate Windows_NetCore_Record platform, made it so that the Windows_NetCore platform will record and publish recordings when the Record variable is set for the pipeline run. A drawback to this change is that when running a pipeline with Record set to true, it will run the tests for all 6 platforms, instead of just the recording platform (however it will still only record for the intended platform). I don't think this is tradeoff is too bad since the recording will take the same amount of time as before, we'll just consume a few more agents from the queue for the test duration.

Example passing pipeline with Record set to true: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=625512&view=results