### PR TITLE
Fix publishing bug in EventHubs samples

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample01_HelloWorld.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/Sample01_HelloWorld.md
@@ -39,7 +39,7 @@ try
             // decision would have to be made as to whether the event should
             // be dropped or published on its own.
 
-            return;
+            break;
         }
     }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample01_HelloWorldLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Snippets/Sample01_HelloWorldLiveTests.cs
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                         // decision would have to be made as to whether the event should
                         // be dropped or published on its own.
 
-                        return;
+                        break;
                     }
                 }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample01_HelloWorld.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample01_HelloWorld.md
@@ -45,7 +45,7 @@ try
             // decision would have to be made as to whether the event should
             // be dropped or published on its own.
 
-            return;
+            break;
         }
     }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample01_HelloWorldLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Snippets/Sample01_HelloWorldLiveTests.cs
@@ -104,7 +104,7 @@ namespace Azure.Messaging.EventHubs.Tests.Snippets
                         // decision would have to be made as to whether the event should
                         // be dropped or published on its own.
 
-                        return;
+                        break;
                     }
                 }
 


### PR DESCRIPTION
- Events are never published since sample calls `return` instead of `break`
