### PR TITLE
Wrap client exception in an AggregateException

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
@@ -226,8 +226,15 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             {
                 return new ServiceBusCommunicationException(message, aggregateException);
             }
-
-            return aggregateException;
+            else if (aggregateException == exception)
+            {
+                // Wrap it in an AggregateException so that if the caller throws it, we preserve the original stack trace.
+                return new AggregateException(exception);
+            }
+            else
+            {
+                return aggregateException;
+            }
         }
 
         public static string GetTrackingId(this AmqpLink link)


### PR DESCRIPTION
GetClientException is used to wrap the input exceptions in certain cases.  In those cases where it doesn't and the caller throws the exception, the stacktrace gets truncated at the throw-site.  This change is to make sure the input exceptions are always wrapped, so that we preserve the original stacktrace.