### PR TITLE
EventGrid blob trigger support

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/Microsoft.Azure.WebJobs.Extensions.EventGrid.sln
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/Microsoft.Azure.WebJobs.Extensions.EventGrid.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30704.19
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests", "tests\Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.csproj", "{E58845C7-D3EF-41F8-9E02-C8F02C1DEFA5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.EventGrid", "src\Microsoft.Azure.WebJobs.Extensions.EventGrid.csproj", "{9322A9CD-ADC3-4BF3-B3AA-063A66585113}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E58845C7-D3EF-41F8-9E02-C8F02C1DEFA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E58845C7-D3EF-41F8-9E02-C8F02C1DEFA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E58845C7-D3EF-41F8-9E02-C8F02C1DEFA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E58845C7-D3EF-41F8-9E02-C8F02C1DEFA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9322A9CD-ADC3-4BF3-B3AA-063A66585113}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9322A9CD-ADC3-4BF3-B3AA-063A66585113}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9322A9CD-ADC3-4BF3-B3AA-063A66585113}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9322A9CD-ADC3-4BF3-B3AA-063A66585113}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D8FAA1CE-4C73-49FE-A59D-CCEBDAA223CE}
+	EndGlobalSection
+EndGlobal

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridExtensionConfigProvider.cs
@@ -32,18 +32,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         private ILogger _logger;
         private readonly ILoggerFactory _loggerFactory;
         private readonly Func<EventGridAttribute, IAsyncCollector<EventGridEvent>> _converter;
+        private readonly HttpRequestProcessor _httpRequestProcessor;
 
         // for end to end testing
-        internal EventGridExtensionConfigProvider(Func<EventGridAttribute, IAsyncCollector<EventGridEvent>> converter, ILoggerFactory loggerFactory)
+        internal EventGridExtensionConfigProvider(
+            Func<EventGridAttribute, IAsyncCollector<EventGridEvent>> converter,
+            HttpRequestProcessor httpRequestProcessor,
+            ILoggerFactory loggerFactory)
         {
             _converter = converter;
+            _httpRequestProcessor = httpRequestProcessor;
             _loggerFactory = loggerFactory;
         }
 
         // default constructor
-        public EventGridExtensionConfigProvider(ILoggerFactory loggerFactory)
+        public EventGridExtensionConfigProvider(HttpRequestProcessor httpRequestProcessor, ILoggerFactory loggerFactory)
         {
             _converter = (attr => new EventGridAsyncCollector(new EventGridPublisherClient(new Uri(attr.TopicEndpointUri), new AzureKeyCredential(attr.TopicKeySetting))));
+            _httpRequestProcessor = httpRequestProcessor;
             _loggerFactory = loggerFactory;
         }
 
@@ -122,90 +128,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 return new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent($"cannot find function: '{functionName}'") };
             }
 
-            IEnumerable<string> eventTypeHeaders = null;
-            string eventTypeHeader = null;
-            if (req.Headers.TryGetValues("aeg-event-type", out eventTypeHeaders))
-            {
-                eventTypeHeader = eventTypeHeaders.First();
-            }
+            return await _httpRequestProcessor.ProcessAsync(req, functionName, ProcessEventsAsync, CancellationToken.None).ConfigureAwait(false);
+        }
 
-            if (String.Equals(eventTypeHeader, "SubscriptionValidation", StringComparison.OrdinalIgnoreCase))
-            {
-                string jsonArray = await req.Content.ReadAsStringAsync().ConfigureAwait(false);
-                SubscriptionValidationEvent validationEvent = null;
-                List<JObject> events = JsonConvert.DeserializeObject<List<JObject>>(jsonArray);
-                // TODO remove unnecessary serialization
-                validationEvent = ((JObject)events[0]["data"]).ToObject<SubscriptionValidationEvent>();
-                SubscriptionValidationResponse validationResponse = new SubscriptionValidationResponse { ValidationResponse = validationEvent.ValidationCode };
-                var returnMessage = new HttpResponseMessage(HttpStatusCode.OK);
-                returnMessage.Content = new StringContent(JsonConvert.SerializeObject(validationResponse));
-                _logger.LogInformation($"perform handshake with eventGrid for function: {functionName}");
-                return returnMessage;
-            }
-            else if (String.Equals(eventTypeHeader, "Notification", StringComparison.OrdinalIgnoreCase))
-            {
-                JArray events = null;
-                string requestContent = await req.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var token = JToken.Parse(requestContent);
-                if (token.Type == JTokenType.Array)
-                {
-                    // eventgrid schema
-                    events = (JArray)token;
-                }
-                else if (token.Type == JTokenType.Object)
-                {
-                    // cloudevent schema
-                    events = new JArray
-                    {
-                        token
-                    };
-                }
+        private async Task<HttpResponseMessage> ProcessEventsAsync(JArray events, string functionName, CancellationToken cancellationToken)
+        {
+            List<Task<FunctionResult>> executions = new List<Task<FunctionResult>>();
 
-                List<Task<FunctionResult>> executions = new List<Task<FunctionResult>>();
-
-                // Single Dispatch
-                if (_listeners[functionName].SingleDispatch)
+            // Single Dispatch
+            if (_listeners[functionName].SingleDispatch)
+            {
+                foreach (var ev in events)
                 {
-                    foreach (var ev in events)
-                    {
-                        // assume each event is a JObject
-                        TriggeredFunctionData triggerData = new TriggeredFunctionData
-                        {
-                            TriggerValue = ev
-                        };
-                        executions.Add(_listeners[functionName].Executor.TryExecuteAsync(triggerData, CancellationToken.None));
-                    }
-                    await Task.WhenAll(executions).ConfigureAwait(false);
-                }
-                // Batch Dispatch
-                else
-                {
+                    // assume each event is a JObject
                     TriggeredFunctionData triggerData = new TriggeredFunctionData
                     {
-                        TriggerValue = events
+                        TriggerValue = ev
                     };
                     executions.Add(_listeners[functionName].Executor.TryExecuteAsync(triggerData, CancellationToken.None));
                 }
-
-                // FIXME without internal queuing, we are going to process all events in parallel
-                // and return 500 if there's at least one failure...which will cause EventGrid to resend the entire payload
-                foreach (var execution in executions)
-                {
-                    if (!execution.Result.Succeeded)
-                    {
-                        return new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(execution.Result.Exception.Message) };
-                    }
-                }
-
-                return new HttpResponseMessage(HttpStatusCode.Accepted);
+                await Task.WhenAll(executions).ConfigureAwait(false);
             }
-            else if (String.Equals(eventTypeHeader, "Unsubscribe", StringComparison.OrdinalIgnoreCase))
+            // Batch Dispatch
+            else
             {
-                // TODO disable function?
-                return new HttpResponseMessage(HttpStatusCode.Accepted);
+                TriggeredFunctionData triggerData = new TriggeredFunctionData
+                {
+                    TriggerValue = events
+                };
+                executions.Add(_listeners[functionName].Executor.TryExecuteAsync(triggerData, CancellationToken.None));
             }
 
-            return new HttpResponseMessage(HttpStatusCode.BadRequest);
+            // FIXME without internal queuing, we are going to process all events in parallel
+            // and return 500 if there's at least one failure...which will cause EventGrid to resend the entire payload
+            foreach (var execution in executions)
+            {
+                if (!execution.Result.Succeeded)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent(execution.Result.Exception.Message) };
+                }
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.Accepted);
         }
 
         private class JTokenToPocoConverter<T> : IConverter<JToken, T>

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridWebJobsBuilderExtensions.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/EventGridWebJobsBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
 {
@@ -21,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 throw new ArgumentNullException(nameof(builder));
             }
 
+            builder.Services.TryAddSingleton<HttpRequestProcessor>();
             builder.AddExtension<EventGridExtensionConfigProvider>();
             return builder;
         }

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/HttpRequestProcessor.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/HttpRequestProcessor.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
     {
         private readonly ILogger _logger;
 
-        public HttpRequestProcessor(ILoggerFactory loggerFactory)
+        public HttpRequestProcessor(ILogger<HttpRequestProcessor> logger)
         {
-            _logger = loggerFactory.CreateLogger<HttpRequestProcessor>();
+            _logger = logger;
         }
 
         internal async Task<HttpResponseMessage> ProcessAsync(HttpRequestMessage req, string functionName, Func<JArray, string, CancellationToken, Task<HttpResponseMessage>> eventsFunc, CancellationToken cancellationToken)

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/HttpRequestProcessor.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/src/TriggerBinding/HttpRequestProcessor.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
+{
+    internal class HttpRequestProcessor
+    {
+        private readonly ILogger _logger;
+
+        public HttpRequestProcessor(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<HttpRequestProcessor>();
+        }
+
+        internal async Task<HttpResponseMessage> ProcessAsync(HttpRequestMessage req, string functionName, Func<JArray, string, CancellationToken, Task<HttpResponseMessage>> eventsFunc, CancellationToken cancellationToken)
+        {
+            IEnumerable<string> eventTypeHeaders = null;
+            string eventTypeHeader = null;
+            if (req.Headers.TryGetValues("aeg-event-type", out eventTypeHeaders))
+            {
+                eventTypeHeader = eventTypeHeaders.First();
+            }
+
+            if (String.Equals(eventTypeHeader, "SubscriptionValidation", StringComparison.OrdinalIgnoreCase))
+            {
+                string jsonArray = await req.Content.ReadAsStringAsync().ConfigureAwait(false);
+                SubscriptionValidationEvent validationEvent = null;
+                List<JObject> events = JsonConvert.DeserializeObject<List<JObject>>(jsonArray);
+                // TODO remove unnecessary serialization
+                validationEvent = ((JObject)events[0]["data"]).ToObject<SubscriptionValidationEvent>();
+                SubscriptionValidationResponse validationResponse = new SubscriptionValidationResponse { ValidationResponse = validationEvent.ValidationCode };
+                var returnMessage = new HttpResponseMessage(HttpStatusCode.OK);
+                returnMessage.Content = new StringContent(JsonConvert.SerializeObject(validationResponse));
+                _logger.LogInformation($"perform handshake with eventGrid for function: {functionName}");
+                return returnMessage;
+            }
+            else if (String.Equals(eventTypeHeader, "Notification", StringComparison.OrdinalIgnoreCase))
+            {
+                JArray events = null;
+                string requestContent = await req.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var token = JToken.Parse(requestContent);
+                if (token.Type == JTokenType.Array)
+                {
+                    // eventgrid schema
+                    events = (JArray)token;
+                }
+                else if (token.Type == JTokenType.Object)
+                {
+                    // cloudevent schema
+                    events = new JArray
+                    {
+                        token
+                    };
+                }
+
+                return await eventsFunc(events, functionName, cancellationToken).ConfigureAwait(false);
+            }
+            else if (String.Equals(eventTypeHeader, "Unsubscribe", StringComparison.OrdinalIgnoreCase))
+            {
+                // TODO disable function?
+                return new HttpResponseMessage(HttpStatusCode.Accepted);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.BadRequest);
+        }
+    }
+}

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/JobhostEndToEnd.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/JobhostEndToEnd.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -205,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new TestLoggerProvider());
             // use moq eventgridclient for test extension
-            var customExtension = new EventGridExtensionConfigProvider(customConverter, new HttpRequestProcessor(loggerFactory), loggerFactory);
+            var customExtension = new EventGridExtensionConfigProvider(customConverter, new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), loggerFactory);
 
             var configuration = new Dictionary<string, string>
                 {

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/JobhostEndToEnd.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/JobhostEndToEnd.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new TestLoggerProvider());
             // use moq eventgridclient for test extension
-            var customExtension = new EventGridExtensionConfigProvider(customConverter, loggerFactory);
+            var customExtension = new EventGridExtensionConfigProvider(customConverter, new HttpRequestProcessor(loggerFactory), loggerFactory);
 
             var configuration = new Dictionary<string, string>
                 {

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task TestUnsubscribe()
         {
-            var ext = new EventGridExtensionConfigProvider(NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task TestDispatch()
         {
-            var ext = new EventGridExtensionConfigProvider(NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         public async Task TestCloudEvent()
         {
             // individual elements
-            var ext = new EventGridExtensionConfigProvider(NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task WrongFunctionNameTest()
         {
-            var ext = new EventGridExtensionConfigProvider(NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg2>(ext);
             await host.StartAsync(); // add listener
 
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task ExecutionFailureTest()
         {
-            var ext = new EventGridExtensionConfigProvider(NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg2>(ext);
             await host.StartAsync(); // add listener
 

--- a/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
+++ b/sdk/eventgrid/Microsoft.Azure.WebJobs.Extensions.EventGrid/tests/TestListener.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Newtonsoft.Json.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task TestUnsubscribe()
         {
-            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
@@ -46,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task TestDispatch()
         {
-            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         public async Task TestCloudEvent()
         {
             // individual elements
-            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg1>(ext);
             await host.StartAsync(); // add listener
 
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task WrongFunctionNameTest()
         {
-            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg2>(ext);
             await host.StartAsync(); // add listener
 
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
         [Test]
         public async Task ExecutionFailureTest()
         {
-            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance), NullLoggerFactory.Instance);
+            var ext = new EventGridExtensionConfigProvider(new HttpRequestProcessor(NullLoggerFactory.Instance.CreateLogger<HttpRequestProcessor>()), NullLoggerFactory.Instance);
             var host = TestHelpers.NewHost<MyProg2>(ext);
             await host.StartAsync(); // add listener
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Azure.WebJobs
         public BlobTriggerAttribute(string blobPath) { }
         public string BlobPath { get { throw null; } }
         public string Connection { get { throw null; } set { } }
+        public Microsoft.Azure.WebJobs.BlobTriggerSource Source { get { throw null; } set { } }
+    }
+    public enum BlobTriggerSource
+    {
+        LogsAndContainerScan = 0,
+        EventGrid = 1,
     }
 }
 namespace Microsoft.Azure.WebJobs.Extensions.Storage

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobTriggerAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobTriggerAttribute.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Azure.WebJobs
     {
         private readonly string _blobPath;
 
+        // LogsAndContainerScan is default kind as it does not require additional actions to set up a blob trigger
+        private BlobTriggerSource _blobTriggerSource = BlobTriggerSource.LogsAndContainerScan;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobTriggerAttribute"/> class.
         /// </summary>
@@ -64,6 +67,15 @@ namespace Microsoft.Azure.WebJobs
         public string BlobPath
         {
             get { return _blobPath; }
+        }
+
+        /// <summary>
+        /// Returns a bool value that indicates whether EventGrid is used.
+        /// </summary>
+        public BlobTriggerSource Source
+        {
+            get { return _blobTriggerSource; }
+            set { _blobTriggerSource = value; }
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobTriggerSource.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobTriggerSource.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Provides blob trigger kinds to detect changes.
+    /// </summary>
+    public enum BlobTriggerSource
+    {
+        /// <summary>
+        /// Polling works as a hybrid between inspecting logs and running periodic container scans. Blobs are scanned in groups of 10,000 at a time with a continuation token used between intervals.
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/storage-analytics-log-format">Storage Analytics logs</see>
+        /// </summary>
+        LogsAndContainerScan,
+        /// <summary>
+        /// Polling is relied on EventGrid.
+        /// <see href="https://docs.microsoft.com/en-us/azure/event-grid/event-schema-blob-storage">Azure Blob Storage as an Event Grid source</see>
+        /// </summary>
+        EventGrid
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobQueueTriggerExecutor.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobQueueTriggerExecutor.cs
@@ -18,6 +18,7 @@ using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Protocols;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using System.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
 {
@@ -29,16 +30,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         private readonly IBlobCausalityReader _causalityReader;
         private readonly IBlobWrittenWatcher _blobWrittenWatcher;
         private readonly ConcurrentDictionary<string, BlobQueueRegistration> _registrations;
+        private readonly BlobTriggerSource _blobTriggerSource;
         private readonly ILogger<BlobListener> _logger;
 
-        public BlobQueueTriggerExecutor(IBlobWrittenWatcher blobWrittenWatcher, ILogger<BlobListener> logger)
-            : this(BlobCausalityReader.Instance, blobWrittenWatcher, logger)
+        public BlobQueueTriggerExecutor(BlobTriggerSource blobTriggerSource, IBlobWrittenWatcher blobWrittenWatcher, ILogger<BlobListener> logger)
+            : this(BlobCausalityReader.Instance, blobTriggerSource, blobWrittenWatcher, logger)
         {
         }
 
-        public BlobQueueTriggerExecutor(IBlobCausalityReader causalityReader, IBlobWrittenWatcher blobWrittenWatcher, ILogger<BlobListener> logger)
+        public BlobQueueTriggerExecutor(IBlobCausalityReader causalityReader, BlobTriggerSource blobTriggerSource, IBlobWrittenWatcher blobWrittenWatcher, ILogger<BlobListener> logger)
         {
             _causalityReader = causalityReader;
+            _blobTriggerSource = blobTriggerSource;
             _blobWrittenWatcher = blobWrittenWatcher;
             _registrations = new ConcurrentDictionary<string, BlobQueueRegistration>();
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -99,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             string possibleETag = blobProperties.ETag.ToString();
 
             // If the blob still exists but the ETag is different, delete the message but do a fast path notification.
-            if (!string.Equals(message.ETag, possibleETag, StringComparison.Ordinal))
+            if (_blobTriggerSource == BlobTriggerSource.LogsAndContainerScan && !string.Equals(message.ETag, possibleETag, StringComparison.Ordinal))
             {
                 _blobWrittenWatcher.Notify(new Extensions.Storage.Blobs.BlobWithContainer<BlobBaseClient>(container, blob));
                 return successResult;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerExecutor.Logger.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerExecutor.Logger.cs
@@ -12,32 +12,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         {
             // Keep these events in 100-199 range.
 
-            private static readonly Action<ILogger<BlobListener>, string, string, string, string, BlobTriggerSource, Exception> _blobDoesNotMatchPattern =
-               LoggerMessage.Define<string, string, string, string, BlobTriggerSource>(LogLevel.Debug, new EventId(100, nameof(BlobDoesNotMatchPattern)),
+            private static readonly Action<ILogger<BlobListener>, string, string, string, string, BlobTriggerScanSource, Exception> _blobDoesNotMatchPattern =
+               LoggerMessage.Define<string, string, string, string, BlobTriggerScanSource>(LogLevel.Debug, new EventId(100, nameof(BlobDoesNotMatchPattern)),
                    "Blob '{blobName}' will be skipped for function '{functionName}' because it does not match the pattern '{pattern}'. PollId: '{pollId}'. Source: '{triggerSource}'.");
 
-            private static readonly Action<ILogger<BlobListener>, string, string, string, BlobTriggerSource, Exception> _blobHasNoETag =
-                LoggerMessage.Define<string, string, string, BlobTriggerSource>(LogLevel.Debug, new EventId(101, nameof(BlobHasNoETag)),
+            private static readonly Action<ILogger<BlobListener>, string, string, string, BlobTriggerScanSource, Exception> _blobHasNoETag =
+                LoggerMessage.Define<string, string, string, BlobTriggerScanSource>(LogLevel.Debug, new EventId(101, nameof(BlobHasNoETag)),
                     "Blob '{blobName}' will be skipped for function '{functionName}' because its ETag cannot be found. The blob may have been deleted. PollId: '{pollId}'. Source: '{triggerSource}'.");
 
-            private static readonly Action<ILogger<BlobListener>, string, string, string, string, BlobTriggerSource, Exception> _blobAlreadyProcessed =
-                LoggerMessage.Define<string, string, string, string, BlobTriggerSource>(LogLevel.Debug, new EventId(102, nameof(BlobAlreadyProcessed)),
+            private static readonly Action<ILogger<BlobListener>, string, string, string, string, BlobTriggerScanSource, Exception> _blobAlreadyProcessed =
+                LoggerMessage.Define<string, string, string, string, BlobTriggerScanSource>(LogLevel.Debug, new EventId(102, nameof(BlobAlreadyProcessed)),
                     "Blob '{blobName}' will be skipped for function '{functionName}' because this blob with ETag '{eTag}' has already been processed. PollId: '{pollId}'. Source: '{triggerSource}'.");
 
-            private static readonly Action<ILogger<BlobListener>, string, string, string, string, string, BlobTriggerSource, Exception> _blobMessageEnqueued =
-                LoggerMessage.Define<string, string, string, string, string, BlobTriggerSource>(LogLevel.Debug, new EventId(103, nameof(BlobMessageEnqueued)),
+            private static readonly Action<ILogger<BlobListener>, string, string, string, string, string, BlobTriggerScanSource, Exception> _blobMessageEnqueued =
+                LoggerMessage.Define<string, string, string, string, string, BlobTriggerScanSource>(LogLevel.Debug, new EventId(103, nameof(BlobMessageEnqueued)),
                     "Blob '{blobName}' is ready for processing by function '{functionName}'. A message with id '{messageId}' has been added to queue '{queueName}'. This message will be dequeued and processed by the BlobTrigger. PollId: '{pollId}'. Source: '{triggerSource}'.");
 
-            public static void BlobDoesNotMatchPattern(ILogger<BlobListener> logger, string functionName, string blobName, string pattern, string pollId, BlobTriggerSource triggerSource) =>
+            public static void BlobDoesNotMatchPattern(ILogger<BlobListener> logger, string functionName, string blobName, string pattern, string pollId, BlobTriggerScanSource triggerSource) =>
                 _blobDoesNotMatchPattern(logger, blobName, functionName, pattern, pollId, triggerSource, null);
 
-            public static void BlobHasNoETag(ILogger<BlobListener> logger, string functionName, string blobName, string pollId, BlobTriggerSource triggerSource) =>
+            public static void BlobHasNoETag(ILogger<BlobListener> logger, string functionName, string blobName, string pollId, BlobTriggerScanSource triggerSource) =>
                 _blobHasNoETag(logger, blobName, functionName, pollId, triggerSource, null);
 
-            public static void BlobAlreadyProcessed(ILogger<BlobListener> logger, string functionName, string blobName, string eTag, string pollId, BlobTriggerSource triggerSource) =>
+            public static void BlobAlreadyProcessed(ILogger<BlobListener> logger, string functionName, string blobName, string eTag, string pollId, BlobTriggerScanSource triggerSource) =>
                 _blobAlreadyProcessed(logger, blobName, functionName, eTag, pollId, triggerSource, null);
 
-            public static void BlobMessageEnqueued(ILogger<BlobListener> logger, string functionName, string blobName, string queueMessageId, string queueName, string pollId, BlobTriggerSource triggerSource) =>
+            public static void BlobMessageEnqueued(ILogger<BlobListener> logger, string functionName, string blobName, string queueMessageId, string queueName, string pollId, BlobTriggerScanSource triggerSource) =>
                 _blobMessageEnqueued(logger, blobName, functionName, queueMessageId, queueName, pollId, triggerSource, null);
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerExecutor.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerExecutor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         public async Task<FunctionResult> ExecuteAsync(BlobTriggerExecutorContext context, CancellationToken cancellationToken)
         {
             BlobBaseClient value = context.Blob.BlobClient;
-            BlobTriggerSource triggerSource = context.TriggerSource;
+            BlobTriggerScanSource triggerSource = context.TriggerSource;
             string pollId = context.PollId;
 
             // Avoid unnecessary network calls for non-matches. First, check to see if the blob matches this trigger.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerExecutorContext.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerExecutorContext.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         /// </summary>
         public string PollId { get; set; }
 
-        public BlobTriggerSource TriggerSource { get; set; }
+        public BlobTriggerScanSource TriggerSource { get; set; }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerQueueWriter.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerQueueWriter.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Protocols;
 using Newtonsoft.Json;
 using QueueClient = Azure.Storage.Queues.QueueClient;
@@ -14,22 +15,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
 {
     internal class BlobTriggerQueueWriter : IBlobTriggerQueueWriter
     {
-        private readonly QueueClient _queue;
-        private readonly IMessageEnqueuedWatcher _watcher;
-
-        public BlobTriggerQueueWriter(QueueClient queue, IMessageEnqueuedWatcher watcher)
+        public BlobTriggerQueueWriter(QueueClient queueClient, SharedQueueWatcher wsharedQueueWatcher)
         {
-            _queue = queue;
-            Debug.Assert(watcher != null);
-            _watcher = watcher;
+            QueueClient = queueClient;
+            SharedQueueWatcher = wsharedQueueWatcher;
         }
+
+        public QueueClient QueueClient { get; }
+
+        public SharedQueueWatcher SharedQueueWatcher { get; }
 
         public async Task<(string QueueName, string MessageId)> EnqueueAsync(BlobTriggerMessage message, CancellationToken cancellationToken)
         {
             string contents = JsonConvert.SerializeObject(message, JsonSerialization.Settings);
-            var receipt = await _queue.AddMessageAndCreateIfNotExistsAsync(BinaryData.FromString(contents), cancellationToken).ConfigureAwait(false);
-            _watcher.Notify(_queue.Name);
-            return (QueueName: _queue.Name, MessageId: receipt.MessageId);
+            var receipt = await QueueClient.AddMessageAndCreateIfNotExistsAsync(BinaryData.FromString(contents), cancellationToken).ConfigureAwait(false);
+            SharedQueueWatcher.Notify(QueueClient.Name);
+            return (QueueName: QueueClient.Name, MessageId: receipt.MessageId);
         }
     }
 }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerQueueWriterFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerQueueWriterFactory.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
+using Microsoft.Azure.WebJobs.Host.Executors;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
+{
+    internal class BlobTriggerQueueWriterFactory
+    {
+        private readonly IHostIdProvider _hostIdProvider;
+        private readonly QueueServiceClientProvider _queueServiceClientProvider;
+        private readonly SharedQueueWatcher _sharedQueueWatcher;
+
+        public BlobTriggerQueueWriterFactory(IHostIdProvider hostIdProvider, QueueServiceClientProvider queueServiceClientProvider, SharedQueueWatcher sharedQueueWatcher)
+        {
+            _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
+            _queueServiceClientProvider = queueServiceClientProvider ?? throw new ArgumentNullException(nameof(queueServiceClientProvider));
+            _sharedQueueWatcher = sharedQueueWatcher ?? throw new ArgumentNullException(nameof(sharedQueueWatcher));
+        }
+
+        public async Task<BlobTriggerQueueWriter> CreateAsync(CancellationToken cancellationToken)
+        {
+            string hostId = await _hostIdProvider.GetHostIdAsync(cancellationToken).ConfigureAwait(false);
+            string hostBlobTriggerQueueName = HostQueueNames.GetHostBlobTriggerQueueName(hostId);
+            var hostBlobTriggerQueue = _queueServiceClientProvider.GetHost().GetQueueClient(hostBlobTriggerQueueName);
+
+            return new BlobTriggerQueueWriter(hostBlobTriggerQueue, _sharedQueueWatcher);
+        }
+    }
+}

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerScanSource.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/BlobTriggerScanSource.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
 {
-    internal enum BlobTriggerSource
+    internal enum BlobTriggerScanSource
     {
         ContainerScan,
         LogScan

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/PollLogsStrategy.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/PollLogsStrategy.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 {
                     Blob = blob,
                     PollId = pollId,
-                    TriggerSource = BlobTriggerSource.LogScan
+                    TriggerSource = BlobTriggerScanSource.LogScan
                 };
 
                 FunctionResult result = await registration.ExecuteAsync(context, cancellationToken).ConfigureAwait(false);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanBlobScanLogHybridPollingStrategy.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 {
                     Blob = blob,
                     PollId = clientRequestId,
-                    TriggerSource = BlobTriggerSource.ContainerScan
+                    TriggerSource = BlobTriggerScanSource.ContainerScan
                 };
 
                 FunctionResult result = await registration.ExecuteAsync(context, cancellationToken).ConfigureAwait(false);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanContainersStrategy.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/ScanContainersStrategy.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
                 {
                     Blob = blob,
                     PollId = null,
-                    TriggerSource = BlobTriggerSource.ContainerScan
+                    TriggerSource = BlobTriggerScanSource.ContainerScan
                 };
 
                 FunctionResult result = await registration.ExecuteAsync(context, cancellationToken).ConfigureAwait(false);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/SharedBlobQueueListenerFactory.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Listeners/SharedBlobQueueListenerFactory.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         private readonly FunctionDescriptor _functionDescriptor;
         private readonly QueueServiceClient _hostQueueServiceClient;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly BlobTriggerSource _blobTriggerSource;
 
         public SharedBlobQueueListenerFactory(
             QueueServiceClient hostQueueServiceClient,
@@ -41,7 +42,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             IWebJobsExceptionHandler exceptionHandler,
             ILoggerFactory loggerFactory,
             IBlobWrittenWatcher blobWrittenWatcher,
-            FunctionDescriptor functionDescriptor)
+            FunctionDescriptor functionDescriptor,
+            BlobTriggerSource blobTriggerSource)
         {
             _hostQueueServiceClient = hostQueueServiceClient ?? throw new ArgumentNullException(nameof(hostQueueServiceClient));
             _sharedQueueWatcher = sharedQueueWatcher ?? throw new ArgumentNullException(nameof(sharedQueueWatcher));
@@ -49,14 +51,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             _blobsOptions = blobsOptions ?? throw new ArgumentNullException(nameof(blobsOptions));
             _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
             _loggerFactory = loggerFactory;
-            _blobWrittenWatcher = blobWrittenWatcher ?? throw new ArgumentNullException(nameof(blobWrittenWatcher));
+            _blobWrittenWatcher = blobWrittenWatcher;
             _functionDescriptor = functionDescriptor;
+            _blobTriggerSource = blobTriggerSource;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
         public SharedBlobQueueListener Create()
         {
-            BlobQueueTriggerExecutor triggerExecutor = new BlobQueueTriggerExecutor(_blobWrittenWatcher, _loggerFactory.CreateLogger<BlobListener>());
+            BlobQueueTriggerExecutor triggerExecutor = new BlobQueueTriggerExecutor(_blobTriggerSource, _blobWrittenWatcher, _loggerFactory.CreateLogger<BlobListener>());
 
             // The poison queue to use for a given poison blob lives in the same
             // storage account as the triggering blob by default. In multi-storage account scenarios

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.csproj
@@ -18,6 +18,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\TriggerBinding\HttpRequestProcessor.cs" Link="EventGrid\HttpRequestProcessor.cs" />
+    <Compile Include="..\..\..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\TriggerBinding\SubscriptionValidationEvent.cs" Link="EventGrid\SubscriptionValidationEvent.cs" />
+    <Compile Include="..\..\..\eventgrid\Microsoft.Azure.WebJobs.Extensions.EventGrid\src\TriggerBinding\SubscriptionValidationResponse.cs" Link="EventGrid\SubscriptionValidationResponse.cs" />
+  </ItemGroup>
+ 
+  <ItemGroup>
     <ProjectReference Include="..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\..\Azure.Storage.Queues\src\Azure.Storage.Queues.csproj" />
   </ItemGroup>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageBlobsWebJobsBuilderExtensions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/StorageBlobsWebJobsBuilderExtensions.cs
@@ -3,8 +3,10 @@
 
 using System;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Blobs;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Config;
+using Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Triggers;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
@@ -41,6 +43,8 @@ namespace Microsoft.Extensions.Hosting
 
             builder.Services.TryAddSingleton<BlobServiceClientProvider>();
             builder.Services.TryAddSingleton<QueueServiceClientProvider>();
+            builder.Services.TryAddSingleton<HttpRequestProcessor>();
+            builder.Services.TryAddSingleton<BlobTriggerQueueWriterFactory>();
 
             builder.Services.TryAddSingleton<IContextSetter<IBlobWrittenWatcher>>((p) => new ContextAccessor<IBlobWrittenWatcher>());
             builder.Services.TryAddSingleton((p) => p.GetService<IContextSetter<IBlobWrittenWatcher>>() as IContextGetter<IBlobWrittenWatcher>);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobListenerTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobListenerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         {
             var queueListener = new QueueListener();
             var watcherMock = new Mock<IBlobWrittenWatcher>(MockBehavior.Strict);
-            var executor = new BlobQueueTriggerExecutor(watcherMock.Object, NullLogger<BlobListener>.Instance);
+            var executor = new BlobQueueTriggerExecutor(BlobTriggerSource.LogsAndContainerScan, watcherMock.Object, NullLogger<BlobListener>.Instance);
             var sharedBlobQueueListener = new SharedBlobQueueListener(queueListener, executor);
             var sharedListenerMock = new Mock<ISharedListener>(MockBehavior.Strict);
             var blobListener1 = new BlobListener(sharedBlobQueueListener);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobQueueTriggerExecutorTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobQueueTriggerExecutorTests.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
         private BlobQueueTriggerExecutor CreateProductUnderTest(
              IBlobCausalityReader causalityReader, IBlobWrittenWatcher blobWrittenWatcher)
         {
-            return new BlobQueueTriggerExecutor(causalityReader, blobWrittenWatcher, _logger);
+            return new BlobQueueTriggerExecutor(causalityReader, BlobTriggerSource.LogsAndContainerScan, blobWrittenWatcher, _logger);
         }
 
         private static IBlobCausalityReader CreateStubCausalityReader()

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobTriggerExecutorTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/tests/Listeners/BlobTriggerExecutorTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             var context = new BlobTriggerExecutorContext
             {
                 Blob = new BlobWithContainer<BlobBaseClient>(otherContainer, blob),
-                TriggerSource = BlobTriggerSource.ContainerScan
+                TriggerSource = BlobTriggerScanSource.ContainerScan
             };
 
             // Act
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             Assert.AreEqual(containerName + "/{name}", logMessage.GetStateValue<string>("pattern"));
             Assert.AreEqual(blob.Name, logMessage.GetStateValue<string>("blobName"));
             Assert.Null(logMessage.GetStateValue<string>("pollId"));
-            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerSource>("triggerSource"));
+            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerScanSource>("triggerSource"));
             Assert.True(!string.IsNullOrWhiteSpace(logMessage.GetStateValue<string>("{OriginalFormat}")));
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             Assert.AreEqual(context.Blob.BlobClient.Name, logMessage.GetStateValue<string>("blobName"));
             Assert.AreEqual("FunctionIdLogName", logMessage.GetStateValue<string>("functionName"));
             Assert.AreEqual(context.PollId, logMessage.GetStateValue<string>("pollId"));
-            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerSource>("triggerSource"));
+            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerScanSource>("triggerSource"));
             Assert.True(!string.IsNullOrWhiteSpace(logMessage.GetStateValue<string>("{OriginalFormat}")));
         }
 
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             Assert.AreEqual(context.Blob.BlobClient.Name, logMessage.GetStateValue<string>("blobName"));
             Assert.AreEqual(expectedETag, logMessage.GetStateValue<string>("eTag"));
             Assert.AreEqual(context.PollId, logMessage.GetStateValue<string>("pollId"));
-            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerSource>("triggerSource"));
+            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerScanSource>("triggerSource"));
             Assert.True(!string.IsNullOrWhiteSpace(logMessage.GetStateValue<string>("{OriginalFormat}")));
         }
 
@@ -426,7 +426,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             Assert.AreEqual("testQueueName", logMessage.GetStateValue<string>("queueName"));
             Assert.AreEqual("testMessageId", logMessage.GetStateValue<string>("messageId"));
             Assert.AreEqual(context.PollId, logMessage.GetStateValue<string>("pollId"));
-            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerSource>("triggerSource"));
+            Assert.AreEqual(context.TriggerSource, logMessage.GetStateValue<BlobTriggerScanSource>("triggerSource"));
             Assert.True(!string.IsNullOrWhiteSpace(logMessage.GetStateValue<string>("{OriginalFormat}")));
         }
 
@@ -436,7 +436,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Listeners
             {
                 Blob = CreateBlobReference(ContainerName, "blob", createBlob),
                 PollId = TestClientRequestId,
-                TriggerSource = BlobTriggerSource.ContainerScan
+                TriggerSource = BlobTriggerScanSource.ContainerScan
             };
         }
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/EventGridBlobTriggerEndToEndTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Scenario.Tests/tests/EventGridBlobTriggerEndToEndTests.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.TestFramework;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+
+using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Storage.ScenarioTests
+{
+    public class EventGridBlobTriggerEndToEndTests : LiveTestBase<WebJobsTestEnvironment>
+    {
+        private const string TestArtifactPrefix = "e2etests";
+        private const string EventGridContainerName = TestArtifactPrefix + "eventgrid-%rnd%";
+        private const string TestBlobName = "test";
+        private readonly string _resolvedContainerName;
+
+        private readonly BlobContainerClient _testContainer;
+        private readonly BlobServiceClient _blobServiceClient;
+        private readonly RandomNameResolver _nameResolver;
+
+        private const string RegistrationRequest =
+ @"[{
+  ""id"": ""09473e51-90aa-4a7b-88f1-039ea0d7ee64"",
+  ""topic"": ""/subscriptions/[subId]/resourceGroups/EventGrid/providers/Microsoft.Storage/StorageAccounts/alrodegtest"",
+  ""subject"": """",
+  ""data"": {
+    ""validationCode"": ""F83B17BA-898A-4309-8F89-8BB2B3A06D02"",
+    ""validationUrl"": ""https://[region].eventgrid.azure.net:553/eventsubscriptions/eg1/validate?id=F83B17BA-898A-4309-8F89-8BB2B3A06D02&t=2020-12-08T02:28:30.6463986Z&apiVersion=2020-04-01-preview&token=AEvNcDi9Gonj83RQEK4owr6zXA31QPzppkc7BwlvBeI%3d""
+  },
+  ""eventType"": ""Microsoft.EventGrid.SubscriptionValidationEvent"",
+  ""eventTime"": ""2020-12-08T02:28:30.6463986Z"",
+  ""metadataVersion"": ""1"",
+  ""dataVersion"": ""2""
+}]";
+
+        private const string NotificationRequest =
+@"[{
+    ""topic"":""/subscriptions/[subId]/resourceGroups/EventGrid/providers/Microsoft.Storage/storageAccounts/alrodegtest"",
+    ""subject"":""/blobServices/default/containers/sample-workitems/blobs/blob.txt"",
+    ""eventType"":""Microsoft.Storage.BlobCreated"",
+    ""id"":""e5c50ef5-f01e-0017-048b-d20b04066601"",
+    ""data"":{
+    ""api"":""PutBlob"",
+    ""clientRequestId"":""8dd38cbd-67e6-473e-a64c-e4d715ed0a52"",
+    ""requestId"":""e5c50ef5-f01e-0017-048b-d20b04000000"",
+    ""eTag"":""0x8D8A0A2FA6E70FF"",
+    ""contentType"":""application/octet-stream"",
+    ""contentLength"":1,
+    ""blobType"":""BlockBlob"",
+    ""url"":""https://test.blob.core.windows.net/[blobPathPlaceHolder]"",
+    ""sequencer"":""000000000000000000000000000089AE00000000018dd658"",
+    ""storageDiagnostics"":{
+    ""batchId"":""aea96df5-b006-0006-008b-d291b0000000""
+    }
+    },
+    ""dataVersion"":"""",
+    ""metadataVersion"":""1"",
+    ""eventTime"":""2020-12-15T02:41:51.9623179Z""
+    }
+]";
+
+        public EventGridBlobTriggerEndToEndTests()
+        {
+            _nameResolver = new RandomNameResolver();
+
+            // pull from a default host
+            var host = new HostBuilder()
+                .ConfigureDefaultTestHost(b =>
+                {
+                    b.AddAzureStorageBlobs().AddAzureStorageQueues();
+                })
+                .Build();
+            _blobServiceClient = new BlobServiceClient(TestEnvironment.PrimaryStorageAccountConnectionString);
+            _resolvedContainerName = _nameResolver.ResolveInString(EventGridContainerName);
+            _testContainer = _blobServiceClient.GetBlobContainerClient(_resolvedContainerName);
+            Assert.False(_testContainer.ExistsAsync().Result);
+            _testContainer.CreateAsync().Wait();
+        }
+
+        public IHostBuilder NewBuilder<TProgram>(TProgram program, Action<IWebJobsBuilder> configure = null)
+        {
+            var activator = new FakeActivator();
+            activator.Add(program);
+
+            return new HostBuilder()
+                .ConfigureDefaultTestHost<TProgram>(b =>
+                {
+                    IWebJobsBuilder builder = b.AddAzureStorageBlobs().AddAzureStorageQueues();
+                    var ss = builder.Services.BuildServiceProvider();
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IJobActivator>(activator);
+                    services.AddSingleton<INameResolver>(_nameResolver);
+                });
+        }
+
+        [Test]
+        public async Task EventGridRequest_Subscription_Succeeded()
+        {
+            var prog = new EventGrid_Program();
+            var host = NewBuilder(prog).Build();
+
+            using (host)
+            {
+                host.Start();
+                HttpResponseMessage response = await SendEventGridRequest(host, RegistrationRequest, "SubscriptionValidation");
+                Assert.True(response.StatusCode == HttpStatusCode.OK);
+            }
+        }
+
+        [Test]
+        public async Task EventGridRequest_Notification_Succeeded()
+        {
+            var blob = _testContainer.GetBlockBlobClient(TestBlobName);
+            await blob.UploadTextAsync("0");
+
+            var prog = new EventGrid_Program();
+            var host = NewBuilder(prog).Build();
+
+            using (prog._completedEvent = new ManualResetEvent(initialState: false))
+            using (host)
+            {
+                host.Start();
+                HttpResponseMessage response = await SendEventGridRequest(host, NotificationRequest.Replace("[blobPathPlaceHolder]", _resolvedContainerName + "/" + TestBlobName), "Notification");
+                Assert.True(response.StatusCode == HttpStatusCode.Accepted);
+                Assert.True(prog._completedEvent.WaitOne(TimeSpan.FromSeconds(60)));
+            }
+        }
+
+        [Test]
+        public async Task PageBlob_NotSupported()
+        {
+            var prog = new EventGrid_PageBlob();
+            var host = NewBuilder(prog).Build();
+
+            using (host)
+            {
+                host.Start();
+                await Task.Delay(5000); // Wait util all logs a re populated
+                var log = host.GetTestLoggerProvider().GetAllLogMessages()
+                    .FirstOrDefault(x => x.Level == Microsoft.Extensions.Logging.LogLevel.Error && x.FormattedMessage == $"PageBlobClient is not supported with {nameof(BlobTriggerSource.EventGrid)}");
+                Assert.IsNotNull(log);
+            }
+        }
+
+        private async Task<HttpResponseMessage> SendEventGridRequest(IHost host, string content, string eventType)
+        {
+            var configProvidersEnumerator = host.Services.GetServices(typeof(IExtensionConfigProvider)).GetEnumerator();
+            while (configProvidersEnumerator.MoveNext())
+            {
+                if (configProvidersEnumerator.Current is IAsyncConverter<HttpRequestMessage, HttpResponseMessage> convertor)
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://test?functionName=EventGridBlobTrigger");
+                    request.Content = new StringContent(content);
+                    request.Headers.Add("Aeg-Event-Type", eventType);
+                    return await convertor.ConvertAsync(request, CancellationToken.None);
+                }
+            }
+
+            throw new Exception("IAsyncConverter was not found");
+        }
+
+        public class EventGrid_Program
+        {
+            public ManualResetEvent _completedEvent;
+
+            [FunctionName("EventGridBlobTrigger")]
+            public void EventGridBlobTrigger(
+                [BlobTrigger(EventGridContainerName + "/{name}", Source = BlobTriggerSource.EventGrid)] string input)
+            {
+                _completedEvent.Set();
+            }
+        }
+
+        public class EventGrid_PageBlob
+        {
+            [FunctionName("EventGridBlobTrigger")]
+            public void EventGridBlobTrigger(
+                [BlobTrigger(EventGridContainerName + "/{name}", Source = BlobTriggerSource.EventGrid)] PageBlobClient input)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Current Blob trigger logic relies on [pulling](https://github.com/Azure/azure-webjobs-sdk/pull/2438) azure storage diagnostic logs. This approach gives us high latencies, bad performance and fragile behavior overall. Using EventGrid subscription is much more reliable approach and it will give approximately 2-3 times better performance.

The overall flow for EventGrid Blob trigger: 
1. A blob uploaded to azure storage.
2. EventGrid subscription detects the blob change and sends a HTTP request to the blob extension HTTP endpoint.
3. Blob extension receives the HTTP request, parses it and put a new message to the internal storage queue with the blob information and function name. Regular Blob trigger uses the same internal queue. 
4. Internal storage queue listener reads the new queue message, creates CloudBlob and executes the function code. 

Steps to test locally:
1. Create a function app with blob trigger in VS.
2. Add new nuget source: https://www.myget.org/F/azure-appservice/api/v3/index.json
3. Replace the storage extension package with `Azure.WebJobs.Extensions.Storage.Blobs.5.0.0-alpha.20201120.1`
4. Add `"UseEventGrid = true`" to trigger definition
`public static void Run([BlobTrigger("samples-workitems/{name}", UseEventGrid = true)]Stream myBlob, string name, ILogger log)`
5. Start ngrok http -host-header=localhost 7071
https://docs.microsoft.com/en-us/azure/azure-functions/functions-debug-event-grid-trigger-local
6. Start the function app VS project.
7. Open portal and create an EventGrid subscription with WebHook endpoint:
https://83f2d199d6f4.ngrok.io/runtime/webhooks/blobs?functionName=Function1
Note: EventGrid subscription fires on all containers/blobs in the storage account. Maybe you want to add some EventGrid subscription filters.
Note: If you deploy the function app to azure the EventGrid subscription endpoint will be:
https://[functionAppName].azurewebsites.net/runtime/webhooks/blobs?functionName=Function1&code=[blobExtensionKey]
BlobExtensionKey is generated automatically and available on the azure portal.
8. Add a blob to blob storage and verify the trigger is fired.

The plan is to provide the EventGrid Blob trigger in beta as is, write documentation and collect customers feedback.



