### PR TITLE
Skip .NET 5 installation on Windows

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,6 +1,7 @@
 steps:
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK'
+    condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
     inputs:
       useGlobalJson: true
       performMultiLevelLookup: true


### PR DESCRIPTION
The default image should now have the .NET 5 available.