### PR TITLE
[FR] ConvertPrebuiltOutputToRecognizedForms moved to ClientCommon

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientCommon.cs
@@ -70,5 +70,15 @@ namespace Azure.AI.FormRecognizer
                 ? await diagnostics.CreateRequestFailedExceptionAsync(response, errorMessage, errorCode, errorInfo).ConfigureAwait(false)
                 : diagnostics.CreateRequestFailedException(response, errorMessage, errorCode, errorInfo);
         }
+
+        public static RecognizedFormCollection ConvertPrebuiltOutputToRecognizedForms(AnalyzeResult analyzeResult)
+        {
+            List<RecognizedForm> forms = new List<RecognizedForm>();
+            for (int i = 0; i < analyzeResult.DocumentResults.Count; i++)
+            {
+                forms.Add(new RecognizedForm(analyzeResult.DocumentResults[i], analyzeResult.PageResults, analyzeResult.ReadResults, default));
+            }
+            return new RecognizedFormCollection(forms);
+        }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeBusinessCardsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeBusinessCardsOperation.cs
@@ -181,7 +181,7 @@ namespace Azure.AI.FormRecognizer.Models
                     if (update.Value.Status == OperationStatus.Succeeded)
                     {
                         // We need to first assign a value and then mark the operation as completed to avoid a race condition with the getter in Value
-                        _value = ConvertToRecognizedForms(update.Value.AnalyzeResult);
+                        _value = ClientCommon.ConvertPrebuiltOutputToRecognizedForms(update.Value.AnalyzeResult);
                         _hasCompleted = true;
                     }
                     else if (update.Value.Status == OperationStatus.Failed)
@@ -201,16 +201,6 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             return GetRawResponse();
-        }
-
-        private static RecognizedFormCollection ConvertToRecognizedForms(AnalyzeResult analyzeResult)
-        {
-            List<RecognizedForm> businessCards = new List<RecognizedForm>();
-            for (int i = 0; i < analyzeResult.DocumentResults.Count; i++)
-            {
-                businessCards.Add(new RecognizedForm(analyzeResult.DocumentResults[i], analyzeResult.PageResults, analyzeResult.ReadResults, default));
-            }
-            return new RecognizedFormCollection(businessCards);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeInvoicesOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeInvoicesOperation.cs
@@ -181,7 +181,7 @@ namespace Azure.AI.FormRecognizer.Models
                     if (update.Value.Status == OperationStatus.Succeeded)
                     {
                         // We need to first assign a value and then mark the operation as completed to avoid a race condition with the getter in Value
-                        _value = ConvertToRecognizedForms(update.Value.AnalyzeResult);
+                        _value = ClientCommon.ConvertPrebuiltOutputToRecognizedForms(update.Value.AnalyzeResult);
                         _hasCompleted = true;
                     }
                     else if (update.Value.Status == OperationStatus.Failed)
@@ -201,16 +201,6 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             return GetRawResponse();
-        }
-
-        private static RecognizedFormCollection ConvertToRecognizedForms(AnalyzeResult analyzeResult)
-        {
-            List<RecognizedForm> invoices = new List<RecognizedForm>();
-            for (int i = 0; i < analyzeResult.DocumentResults.Count; i++)
-            {
-                invoices.Add(new RecognizedForm(analyzeResult.DocumentResults[i], analyzeResult.PageResults, analyzeResult.ReadResults, default));
-            }
-            return new RecognizedFormCollection(invoices);
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
@@ -181,7 +181,7 @@ namespace Azure.AI.FormRecognizer.Models
                     if (update.Value.Status == OperationStatus.Succeeded)
                     {
                         // We need to first assign a value and then mark the operation as completed to avoid a race condition with the getter in Value
-                        _value = ConvertToRecognizedForms(update.Value.AnalyzeResult);
+                        _value = ClientCommon.ConvertPrebuiltOutputToRecognizedForms(update.Value.AnalyzeResult);
                         _hasCompleted = true;
                     }
                     else if (update.Value.Status == OperationStatus.Failed)
@@ -201,16 +201,6 @@ namespace Azure.AI.FormRecognizer.Models
             }
 
             return GetRawResponse();
-        }
-
-        private static RecognizedFormCollection ConvertToRecognizedForms(AnalyzeResult analyzeResult)
-        {
-            List<RecognizedForm> receipts = new List<RecognizedForm>();
-            for (int i = 0; i < analyzeResult.DocumentResults.Count; i++)
-            {
-                receipts.Add(new RecognizedForm(analyzeResult.DocumentResults[i], analyzeResult.PageResults, analyzeResult.ReadResults, default));
-            }
-            return new RecognizedFormCollection(receipts);
         }
     }
 }


### PR DESCRIPTION
As part of the effort of removing duplicated code on the `Operation<T>` classes in FR, I am moving `ConvertPrebuiltOutputToRecognizedForms` to `ClientCommon`. Besides that, nothing else seems like transferable.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/10435