### PR TITLE
Azure Monitor Exporter: new test to verify correlation ids using Activity + iLogger

### DIFF
--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
@@ -162,18 +162,17 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
 
             var transmitter = new MockTransmitter();
 
+            var azureMonitorExporterOptions = new AzureMonitorExporterOptions
+            {
+                ConnectionString = EmptyConnectionString,
+            };
+
             var processor1 = new BatchExportProcessor<Activity>(new AzureMonitorTraceExporter(
-                options: new AzureMonitorExporterOptions
-                {
-                    ConnectionString = EmptyConnectionString,
-                },
+                options: azureMonitorExporterOptions,
                 transmitter: transmitter));
 
             var processor2 = new BatchExportProcessor<LogRecord>(new AzureMonitorLogExporter(
-                options: new AzureMonitorExporterOptions
-                {
-                    ConnectionString = EmptyConnectionString,
-                },
+                options: azureMonitorExporterOptions,
                 transmitter: transmitter));
 
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
         private TelemetryItem RunActivityTest(Action<ActivitySource> testScenario)
         {
             // SETUP
-            var ActivitySourceName = "MyCompany.MyProduct.MyLibrary";
+            var ActivitySourceName = $"{nameof(TelemetryItemTests)}.{nameof(RunActivityTest)}";
             using var activitySource = new ActivitySource(ActivitySourceName);
 
             var mockTransmitter = new MockTransmitter();
@@ -157,7 +157,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
         public void VerifyLoggerWithActivity()
         {
             // SETUP
-            var ActivitySourceName = "MyCompany.MyProduct.MyLibrary";
+            var ActivitySourceName = $"{nameof(TelemetryItemTests)}.{nameof(VerifyLoggerWithActivity)}";
             using var activitySource = new ActivitySource(ActivitySourceName);
 
             var mockTransmitter = new MockTransmitter();

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
@@ -93,13 +93,13 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
             var ActivitySourceName = "MyCompany.MyProduct.MyLibrary";
             using var activitySource = new ActivitySource(ActivitySourceName);
 
-            var transmitter = new MockTransmitter();
+            var mockTransmitter = new MockTransmitter();
             var processor = new BatchExportProcessor<Activity>(new AzureMonitorTraceExporter(
                 options: new AzureMonitorExporterOptions
                 {
                     ConnectionString = EmptyConnectionString,
                 },
-                transmitter: transmitter));
+                transmitter: mockTransmitter));
 
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
@@ -113,26 +113,26 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
             // CLEANUP
             processor.ForceFlush();
 
-            Assert.True(transmitter.TelemetryItems.Any(), "test project did not capture telemetry");
-            return transmitter.TelemetryItems.Single();
+            Assert.True(mockTransmitter.TelemetryItems.Any(), "test project did not capture telemetry");
+            return mockTransmitter.TelemetryItems.Single();
         }
 
         private TelemetryItem RunLoggerTest(Action<ILogger<TelemetryItemTests>> testScenario)
         {
             // SETUP
-            var transmitter = new MockTransmitter();
+            var mockTransmitter = new MockTransmitter();
             var processor = new BatchExportProcessor<LogRecord>(new AzureMonitorLogExporter(
                 options: new AzureMonitorExporterOptions
                 {
                     ConnectionString = EmptyConnectionString,
                 },
-                transmitter: transmitter));
+                transmitter: mockTransmitter));
 
             var serviceCollection = new ServiceCollection().AddLogging(builder =>
             {
                 builder.SetMinimumLevel(LogLevel.Trace)
                     .AddOpenTelemetry(options => options
-                    .AddProcessor(processor));
+                        .AddProcessor(processor));
             });
 
             using var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -144,8 +144,8 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
             // CLEANUP
             processor.ForceFlush();
 
-            Assert.True(transmitter.TelemetryItems.Any(), "test project did not capture telemetry");
-            return transmitter.TelemetryItems.Single();
+            Assert.True(mockTransmitter.TelemetryItems.Any(), "test project did not capture telemetry");
+            return mockTransmitter.TelemetryItems.Single();
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
             var ActivitySourceName = "MyCompany.MyProduct.MyLibrary";
             using var activitySource = new ActivitySource(ActivitySourceName);
 
-            var transmitter = new MockTransmitter();
+            var mockTransmitter = new MockTransmitter();
 
             var azureMonitorExporterOptions = new AzureMonitorExporterOptions
             {
@@ -169,11 +169,11 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
 
             var processor1 = new BatchExportProcessor<Activity>(new AzureMonitorTraceExporter(
                 options: azureMonitorExporterOptions,
-                transmitter: transmitter));
+                transmitter: mockTransmitter));
 
             var processor2 = new BatchExportProcessor<LogRecord>(new AzureMonitorLogExporter(
                 options: azureMonitorExporterOptions,
-                transmitter: transmitter));
+                transmitter: mockTransmitter));
 
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
@@ -185,7 +185,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
             {
                 builder.SetMinimumLevel(LogLevel.Trace)
                     .AddOpenTelemetry(options => options
-                    .AddProcessor(processor2));
+                        .AddProcessor(processor2));
             });
 
             using var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -204,11 +204,11 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
             processor2.ForceFlush();
 
             // VERIFY
-            Assert.True(transmitter.TelemetryItems.Any(), "test project did not capture telemetry");
-            Assert.Equal(2, transmitter.TelemetryItems.Count);
+            Assert.True(mockTransmitter.TelemetryItems.Any(), "test project did not capture telemetry");
+            Assert.Equal(2, mockTransmitter.TelemetryItems.Count);
 
-            var logTelemetry = transmitter.TelemetryItems.Single(x => x.Name == "Message");
-            var activityTelemetry = transmitter.TelemetryItems.Single(x => x.Name == "Request");
+            var logTelemetry = mockTransmitter.TelemetryItems.Single(x => x.Name == "Message");
+            var activityTelemetry = mockTransmitter.TelemetryItems.Single(x => x.Name == "Request");
 
             var activityId = ((RequestData)activityTelemetry.Data.BaseData).Id;
             var operationId = activityTelemetry.Tags["ai.operation.id"];

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
@@ -76,7 +76,9 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
         {
             var message = "Hello World!";
 
+            var activity = new Activity("test activity").Start();
             var telemetryItem = this.RunLoggerTest(x => x.Log(logLevel: logLevel, message: message));
+            activity.Stop();
 
             VerifyTelemetryItem.VerifyEvent(
                 telemetryItem: telemetryItem,
@@ -84,6 +86,8 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
                 {
                     Message = message,
                     SeverityLevel = expectedSeverityLevel,
+                    SpanId = activity.SpanId.ToHexString(),
+                    TraceId = activity.TraceId.ToHexString(),
                 });
         }
 

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TelemetryItemTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
                 },
                 transmitter: transmitter));
 
-            Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(ActivitySourceName)
                 .AddProcessor(processor)
@@ -176,7 +176,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests
                 },
                 transmitter: transmitter));
 
-            Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(ActivitySourceName)
                 .AddProcessor(processor1)

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TestFramework/ExpectedTelemetryItemValues.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TestFramework/ExpectedTelemetryItemValues.cs
@@ -13,5 +13,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests.TestFr
         public string Message;
         public Dictionary<string, string> CustomProperties;
         public SeverityLevel SeverityLevel;
+        public string SpanId;
+        public string TraceId;
     }
 }

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TestFramework/VerifyTelemetryItem.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests/TestFramework/VerifyTelemetryItem.cs
@@ -12,7 +12,6 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests.TestFr
 {
     internal static class VerifyTelemetryItem
     {
-
         public static void Verify(TelemetryItem telemetryItem, ActivityKind activityKind, ExpectedTelemetryItemValues expectedVars)
         {
             switch (activityKind)
@@ -59,6 +58,8 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor.Integration.Tests.TestFr
             var data = (MessageData)telemetryItem.Data.BaseData;
             Assert.Equal(expectedVars.Message, data.Message);
             Assert.Equal(expectedVars.SeverityLevel, data.SeverityLevel);
+            Assert.Equal(expectedVars.SpanId, telemetryItem.Tags["ai.operation.parentId"]);
+            Assert.Equal(expectedVars.TraceId, telemetryItem.Tags["ai.operation.id"]);
         }
     }
 }


### PR DESCRIPTION
continuation of other PR (#17117).

This test sets up both ActivitySource and iLogger and verifies that the correlation ids are set on both.