### PR TITLE
Get Scope From Headers

### DIFF
--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Customizations/ContainerRegistryCredentials.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Customizations/ContainerRegistryCredentials.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.ContainerRegistry
         private ContainerRegistryRefreshToken _acrRefresh;
         private AuthToken _aadAccess;
         private const string pattern = "\".+:.+:.+\"";  //Pattern to get the scope from headers
-        private static readonly Regex regex = new Regex(pattern);
+        private static readonly Regex scopeFromHeaderRegex = new Regex(pattern);
 
         #endregion
 
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.ContainerRegistry
         {
             if (headers == null)
             {
-                throw new ValidationException(ValidationRules.CannotBeNull, "headers");
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(headers));
             }
 
             string challengeHeader = "Www-Authenticate".ToLower();
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.ContainerRegistry
             else if(length > 2)
             {
                 string scopeContainedIn = keyValues[1];
-                return TrimDoubleQuotes(regex.Match(scopeContainedIn).Value);
+                return TrimDoubleQuotes(scopeFromHeaderRegex.Match(scopeContainedIn).Value);
             }
             else
             {

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Customizations/ContainerRegistryCredentials.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Customizations/ContainerRegistryCredentials.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.ContainerRegistry
 
         private async Task<string> GetScope(string operation, string method, string path)
         {
-            string methodOperationKey = $"{method}>{operation}";
+            string methodOperationKey = $"{method}>{operation}";         
 
             if (_acrScopes.TryGetValue(methodOperationKey, out string result))
             {
@@ -280,22 +280,26 @@ namespace Microsoft.Azure.ContainerRegistry
                 if (headerKVP.Key.ToLower() == challengeHeader)
                 {
                     headerValue = string.Join(",", headerKVP.Value);
+                    
                     break;
                 }
             }
-            
-            foreach (string part in headerValue.Split(','))
+
+            string scope = "";
+            int position = headerValue.IndexOf("scope=");
+            if (position > 0)
             {
-                string[] keyValues = part.Split(new char[] { '=' }, 2);
-                if (keyValues.Length != 2)
-                {
-                    throw new Exception($"{challengeHeader} has incorrect format, " +
-                        $"header key-value pair '{part}' does not have a value but in '{headerValue}'");
-                }
-                if (keyValues[0].ToLower().Trim() == "scope")
-                {
-                    return TrimDoubleQuotes(keyValues[1]);
-                } 
+                scope = headerValue.Substring(position);
+            }
+            else
+            {
+                throw new Exception($"Could not find a scope in the {headerValue}");
+            }
+
+            string[] keyValues = scope.Split(new char[] { '=' }, 2);
+            if (keyValues[0].ToLower().Trim() == "scope")
+            {
+                return TrimDoubleQuotes(keyValues[1]);
             }
 
             return null;

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ScopeTests/CreateAndGetManifest.json
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ScopeTests/CreateAndGetManifest.json
@@ -1,0 +1,399 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittestupdateable?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0dXBkYXRlYWJsZT9hcGktdmVyc2lvbj0yMDE3LTEwLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "4b2f076e-e85e-44e2-a51d-b0698a4b535e"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "x-ms-request-id": [
+          "ff5ddf6e-83e2-4d61-8b07-d5597e564858"
+        ],
+        "x-ms-correlation-request-id": [
+          "ff5ddf6e-83e2-4d61-8b07-d5597e564858"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201217T131400Z:ff5ddf6e-83e2-4d61-8b07-d5597e564858"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:13:59 GMT"
+        ],
+        "Content-Length": [
+          "489"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"type\": \"Microsoft.ContainerRegistry/registries\",\r\n  \"id\": \"/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittestupdateable\",\r\n  \"name\": \"azuresdkunittestupdateable\",\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"loginServer\": \"azuresdkunittestupdateable.azurecr.io\",\r\n    \"creationDate\": \"2019-08-06T23:24:57.9977962Z\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"adminUserEnabled\": true\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittestupdateable/listCredentials?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0dXBkYXRlYWJsZS9saXN0Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MjAxNy0xMC0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "96d8b360-2a05-45d0-8e1d-4cc1288e2467"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1196"
+        ],
+        "x-ms-request-id": [
+          "dc3907f6-a963-4c81-b775-0d2a8faa8ded"
+        ],
+        "x-ms-correlation-request-id": [
+          "dc3907f6-a963-4c81-b775-0d2a8faa8ded"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201217T131402Z:dc3907f6-a963-4c81-b775-0d2a8faa8ded"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:14:01 GMT"
+        ],
+        "Content-Length": [
+          "182"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"username\": \"azuresdkunittestupdateable\",\r\n  \"passwords\": [\r\n    {\r\n      \"name\": \"password\",\r\n      \"value\": \"tNqQ0+t2+k/2XYvJtnqBnfyzkP1HqhuR\"\r\n    },\r\n    {\r\n      \"name\": \"password2\",\r\n      \"value\": \"ZVjBq6OaAfkf800R2yU9/mpjuCyRQ4eO\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/v2/doundo%2Fbash/manifests/test-put",
+      "EncodedRequestUri": "L3YyL2RvdW5kbyUyRmJhc2gvbWFuaWZlc3RzL3Rlc3QtcHV0",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\r\n  \"config\": {\r\n    \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\r\n    \"size\": 5635,\r\n    \"digest\": \"sha256:16463e0c481e161aabb735437d30b3c9c7391c2747cc564bb927e843b73dcb39\"\r\n  },\r\n  \"layers\": [\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\r\n      \"size\": 2789742,\r\n      \"digest\": \"sha256:0503825856099e6adb39c8297af09547f69684b7016b7f3680ed801aa310baaa\"\r\n    },\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\r\n      \"size\": 3174556,\r\n      \"digest\": \"sha256:7bf5420b55e6bbefb64ddb4fbb98ef094866f3a3facda638a155715ab6002d9b\"\r\n    },\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\r\n      \"size\": 344,\r\n      \"digest\": \"sha256:1beb2aaf8cf93eacf658fa7f7f10f89ccec1838d1ac643a273345d4d0bc813a8\"\r\n    }\r\n  ],\r\n  \"schemaVersion\": 2\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "bd36006b-c30c-4a1e-90a0-9fc88749fb0c"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ],
+        "Content-Type": [
+          "application/vnd.docker.distribution.manifest.v2+json"
+        ],
+        "Content-Length": [
+          "920"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:14:05 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:e9bf142ca148d37d4d60b2735a26237b2cfc1bf3711d248fc837346182d64264"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "Location": [
+          "/v2/doundo/bash/manifests/sha256:e9bf142ca148d37d4d60b2735a26237b2cfc1bf3711d248fc837346182d64264"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "bd36006b-c30c-4a1e-90a0-9fc88749fb0c"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "947296ff-c8a6-4de4-b60b-76dfb728f4de"
+        ],
+        "X-Ms-Request-Id": [
+          "fd5d993f-7414-4edc-a4d6-54f96f33da92"
+        ],
+        "Content-Length": [
+          "0"
+        ]
+      },
+      "ResponseBody": "",
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/v2/doundo%2Fbash/manifests/test-put",
+      "EncodedRequestUri": "L3YyL2RvdW5kbyUyRmJhc2gvbWFuaWZlc3RzL3Rlc3QtcHV0",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "469b7e50-244e-4b3f-ace9-c3fc7feaaf34"
+        ],
+        "Accept": [
+          "application/vnd.docker.distribution.manifest.v2+json"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:14:05 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:e9bf142ca148d37d4d60b2735a26237b2cfc1bf3711d248fc837346182d64264"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "ETag": [
+          "\"sha256:e9bf142ca148d37d4d60b2735a26237b2cfc1bf3711d248fc837346182d64264\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "469b7e50-244e-4b3f-ace9-c3fc7feaaf34"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "c197228a-a736-4289-91b0-db74cef98751"
+        ],
+        "X-Ms-Request-Id": [
+          "46057cb8-a49b-4a12-867c-5ec14ee8b68b"
+        ],
+        "Content-Type": [
+          "application/vnd.docker.distribution.manifest.v2+json"
+        ],
+        "Content-Length": [
+          "920"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\r\n  \"config\": {\r\n    \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\r\n    \"size\": 5635,\r\n    \"digest\": \"sha256:16463e0c481e161aabb735437d30b3c9c7391c2747cc564bb927e843b73dcb39\"\r\n  },\r\n  \"layers\": [\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\r\n      \"size\": 2789742,\r\n      \"digest\": \"sha256:0503825856099e6adb39c8297af09547f69684b7016b7f3680ed801aa310baaa\"\r\n    },\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\r\n      \"size\": 3174556,\r\n      \"digest\": \"sha256:7bf5420b55e6bbefb64ddb4fbb98ef094866f3a3facda638a155715ab6002d9b\"\r\n    },\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.image.rootfs.diff.tar.gzip\",\r\n      \"size\": 344,\r\n      \"digest\": \"sha256:1beb2aaf8cf93eacf658fa7f7f10f89ccec1838d1ac643a273345d4d0bc813a8\"\r\n    }\r\n  ],\r\n  \"schemaVersion\": 2\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/acr/v1/doundo%2Fbash/_tags/test-put",
+      "EncodedRequestUri": "L2Fjci92MS9kb3VuZG8lMkZiYXNoL190YWdzL3Rlc3QtcHV0",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "a3373fc7-d004-429e-a3ec-f0479cdc217c"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:14:06 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "496c3e11-ef42-4853-9adc-225e51627f8b"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "400"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"registry\": \"azuresdkunittestupdateable.azurecr.io\",\r\n  \"imageName\": \"doundo/bash\",\r\n  \"tag\": {\r\n    \"name\": \"test-put\",\r\n    \"digest\": \"sha256:e9bf142ca148d37d4d60b2735a26237b2cfc1bf3711d248fc837346182d64264\",\r\n    \"createdTime\": \"2020-12-17T13:14:05.1357693Z\",\r\n    \"lastUpdateTime\": \"2020-12-17T13:14:05.1357693Z\",\r\n    \"signed\": false,\r\n    \"changeableAttributes\": {\r\n      \"deleteEnabled\": true,\r\n      \"writeEnabled\": true,\r\n      \"readEnabled\": true,\r\n      \"listEnabled\": true\r\n    }\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/v2/doundo%2Fbash/manifests/sha256%3Ae9bf142ca148d37d4d60b2735a26237b2cfc1bf3711d248fc837346182d64264",
+      "EncodedRequestUri": "L3YyL2RvdW5kbyUyRmJhc2gvbWFuaWZlc3RzL3NoYTI1NiUzQWU5YmYxNDJjYTE0OGQzN2Q0ZDYwYjI3MzVhMjYyMzdiMmNmYzFiZjM3MTFkMjQ4ZmM4MzczNDYxODJkNjQyNjQ=",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "6ea6724d-e44b-44b1-8c9e-9a549074b44c"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:14:06 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "6ea6724d-e44b-44b1-8c9e-9a549074b44c"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "d596b94e-8133-44d9-82fb-7b1c2df8700b"
+        ],
+        "X-Ms-Request-Id": [
+          "ea0fcb4d-0470-42f5-bfcc-ae1acc474342"
+        ],
+        "Content-Length": [
+          "0"
+        ]
+      },
+      "ResponseBody": "",
+      "StatusCode": 202
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "dfb63c8c-7c89-4ef8-af13-75c1d873c895"
+  }
+}

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ScopeTests/MoreScopeTests.json
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ScopeTests/MoreScopeTests.json
@@ -1,0 +1,134 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittestupdateable?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0dXBkYXRlYWJsZT9hcGktdmVyc2lvbj0yMDE3LTEwLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "d23ecbdb-7cf2-477a-b050-525eff65f330"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11999"
+        ],
+        "x-ms-request-id": [
+          "06c18753-5216-44d0-9085-71f1c44304c2"
+        ],
+        "x-ms-correlation-request-id": [
+          "06c18753-5216-44d0-9085-71f1c44304c2"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201217T131512Z:06c18753-5216-44d0-9085-71f1c44304c2"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:15:12 GMT"
+        ],
+        "Content-Length": [
+          "489"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"type\": \"Microsoft.ContainerRegistry/registries\",\r\n  \"id\": \"/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittestupdateable\",\r\n  \"name\": \"azuresdkunittestupdateable\",\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"loginServer\": \"azuresdkunittestupdateable.azurecr.io\",\r\n    \"creationDate\": \"2019-08-06T23:24:57.9977962Z\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"adminUserEnabled\": true\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittestupdateable/listCredentials?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0dXBkYXRlYWJsZS9saXN0Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MjAxNy0xMC0wMQ==",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "017ff709-5f7f-4f0f-859d-422467fdb4af"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-request-id": [
+          "45507a21-6abd-4b39-9238-00a444f6e94d"
+        ],
+        "x-ms-correlation-request-id": [
+          "45507a21-6abd-4b39-9238-00a444f6e94d"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201217T131513Z:45507a21-6abd-4b39-9238-00a444f6e94d"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Thu, 17 Dec 2020 13:15:13 GMT"
+        ],
+        "Content-Length": [
+          "182"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"username\": \"azuresdkunittestupdateable\",\r\n  \"passwords\": [\r\n    {\r\n      \"name\": \"password\",\r\n      \"value\": \"tNqQ0+t2+k/2XYvJtnqBnfyzkP1HqhuR\"\r\n    },\r\n    {\r\n      \"name\": \"password2\",\r\n      \"value\": \"ZVjBq6OaAfkf800R2yU9/mpjuCyRQ4eO\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "dfb63c8c-7c89-4ef8-af13-75c1d873c895"
+  }
+}

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ScopeTests.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ScopeTests.cs
@@ -89,7 +89,7 @@
             Assert.Equal(baseManifest.GetType(), actualManifest.GetType());
             Assert.Equal(baseManifest.SchemaVersion, actualManifest.SchemaVersion);
 
-            if (baseManifest.GetType() == typeof(V2Manifest))
+            if (baseManifest is V2Manifest)
             {
                 var baseManifestV2 = (V2Manifest)baseManifest;
                 var actualManifestV2 = (V2Manifest)baseManifest;
@@ -103,42 +103,6 @@
                 Assert.Equal(baseManifestV2.Config.Digest, actualManifestV2.Config.Digest);
                 Assert.Equal(baseManifestV2.Config.MediaType, actualManifestV2.Config.MediaType);
                 Assert.Equal(baseManifestV2.Config.Size, actualManifestV2.Config.Size);
-            }
-            if (baseManifest.GetType() == typeof(V1Manifest))
-            {
-                var baseManifestV1 = (V1Manifest)baseManifest;
-                var actualManifestV1 = (V1Manifest)baseManifest;
-                Assert.Equal(baseManifestV1.Architecture, actualManifestV1.Architecture);
-                Assert.Equal(baseManifestV1.Name, actualManifestV1.Name);
-                Assert.Equal(baseManifestV1.Tag, actualManifestV1.Tag);
-                Assert.Equal(baseManifestV1.FsLayers.Count, actualManifestV1.FsLayers.Count);
-
-                for (int i = 0; i < baseManifestV1.FsLayers.Count; i++)
-                {
-                    Assert.Equal(baseManifestV1.FsLayers[i].BlobSum, actualManifestV1.FsLayers[i].BlobSum);
-                }
-
-                Assert.Equal(baseManifestV1.History.Count, actualManifestV1.History.Count);
-                for (int i = 0; i < baseManifestV1.History.Count; i++)
-                {
-                    Assert.Equal(baseManifestV1.History[i].V1Compatibility, actualManifestV1.History[i].V1Compatibility);
-                }
-            }
-            if (baseManifest.GetType() == typeof(OCIManifest))
-            {
-                var baseManifestOCI = (OCIManifest)baseManifest;
-                var actualManifestOCI = (OCIManifest)baseManifest;
-                Assert.Equal(baseManifestOCI.Layers.Count, actualManifestOCI.Layers.Count);
-                for (int i = 0; i < baseManifestOCI.Layers.Count; i++)
-                {
-                    Assert.Equal(baseManifestOCI.Layers[i].Digest, actualManifestOCI.Layers[i].Digest);
-                    Assert.Equal(baseManifestOCI.Layers[i].MediaType, actualManifestOCI.Layers[i].MediaType);
-                    Assert.Equal(baseManifestOCI.Layers[i].Size, actualManifestOCI.Layers[i].Size);
-                    Assert.Equal(baseManifestOCI.Layers[i].Annotations, actualManifestOCI.Layers[i].Annotations);
-                }
-                Assert.Equal(baseManifestOCI.Config.Digest, actualManifestOCI.Config.Digest);
-                Assert.Equal(baseManifestOCI.Config.MediaType, actualManifestOCI.Config.MediaType);
-                Assert.Equal(baseManifestOCI.Config.Size, actualManifestOCI.Config.Size);
             }
         }
 

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ScopeTests.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ScopeTests.cs
@@ -1,0 +1,147 @@
+﻿namespace ContainerRegistry.Tests
+{
+    using Microsoft.Azure.ContainerRegistry;
+    using Microsoft.Azure.ContainerRegistry.Models;
+    using Microsoft.Azure.Management.ContainerRegistry;
+    using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class ScopeTests
+    {
+        [Fact]
+        public async Task CreateAndGetManifest()
+        {
+            using (var context = MockContext.Start(GetType(), nameof(CreateAndGetManifest)))
+            {
+                var tag = "test-put";
+                var client = await ACRTestUtil.GetACRClientAsync(context, ACRTestUtil.ManagedTestRegistryForChanges);
+                await client.Manifests.CreateAsync(ACRTestUtil.changeableRepository, tag, ExpectedV2ManifestProd);
+
+                var newManifest = (V2Manifest)await client.Manifests.GetAsync(ACRTestUtil.changeableRepository, tag, ACRTestUtil.MediatypeV2Manifest);
+                var tagAttributes = await client.Tag.GetAttributesAsync(ACRTestUtil.changeableRepository, tag);
+
+                VerifyManifest(ExpectedV2ManifestProd, newManifest);
+                await client.Manifests.DeleteAsync(ACRTestUtil.changeableRepository, tagAttributes.Attributes.Digest);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task MoreScopeTests(string headerValue, string expectedScope)
+        {
+            using (var context = MockContext.Start(GetType(), nameof(MoreScopeTests)))
+            {
+                var _httpRequest = new HttpRequestMessage();
+                _httpRequest.Headers.Add("Www-Authenticate", headerValue);
+
+                var client = await ACRTestUtil.GetCredentialsAsync(context, ACRTestUtil.ManagedTestRegistryForChanges);
+                string actualScope = client.GetScopeFromHeaders(_httpRequest.Headers);
+                Assert.Equal(expectedScope, actualScope);
+            }
+        }
+
+        public static IEnumerable<object[]> TestData()
+        {
+            yield return new object[] { "Bearer realm=\"https://myregistry.azurecr-test.io/oauth2/token\",service=\"myregistry.azurecr-test.io\",scope=\"foo:bar:baz,abc\",Basic xyz=123", "foo:bar:baz,abc"};
+            yield return new object[] { "Bearer realm=\"https://myregistry.azurecr-test.io/oauth2/token\",service=\"myregistry.azurecr-test.io\",scope=\"foo:bar:baz,abc\", Basic xyz=123", "foo:bar:baz,abc"};
+            yield return new object[] { "Bearer realm=\"https://myregistry.azurecr-test.io/oauth2/token\",service=\"myregistry.azurecr-test.io\",scope=\"foo:bar:baz,abc\"", "foo:bar:baz,abc" };
+            yield return new object[] { "Bearer realm=\"https://myregistry.azurecr-test.io/oauth2/token\",service=\"myregistry.azurecr-test.io\",scope=\"foo:bar:baz\"", "foo:bar:baz" };
+        }
+
+        private static readonly V2Manifest ExpectedV2ManifestProd = new V2Manifest()
+        {
+            SchemaVersion = 2,
+            MediaType = ACRTestUtil.MediatypeV2Manifest,
+            Config = new Descriptor
+            {
+                MediaType = ACRTestUtil.MediatypeV1Manifest,
+                Size = 5635,
+                Digest = "sha256:16463e0c481e161aabb735437d30b3c9c7391c2747cc564bb927e843b73dcb39"
+            },
+            Layers = new List<Descriptor>
+            {
+                new Descriptor
+                {
+                    MediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                    Size = 2789742,
+                    Digest = "sha256:0503825856099e6adb39c8297af09547f69684b7016b7f3680ed801aa310baaa"
+                },
+                new Descriptor
+                {
+                    MediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                    Size = 3174556,
+                    Digest = "sha256:7bf5420b55e6bbefb64ddb4fbb98ef094866f3a3facda638a155715ab6002d9b"
+                },
+                new Descriptor
+                {
+                    MediaType = "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                    Size = 344,
+                    Digest = "sha256:1beb2aaf8cf93eacf658fa7f7f10f89ccec1838d1ac643a273345d4d0bc813a8"
+                }
+            }
+        };
+
+        private void VerifyManifest(Manifest baseManifest, Manifest actualManifest)
+        {
+            Assert.Equal(baseManifest.GetType(), actualManifest.GetType());
+            Assert.Equal(baseManifest.SchemaVersion, actualManifest.SchemaVersion);
+
+            if (baseManifest.GetType() == typeof(V2Manifest))
+            {
+                var baseManifestV2 = (V2Manifest)baseManifest;
+                var actualManifestV2 = (V2Manifest)baseManifest;
+                Assert.Equal(baseManifestV2.Layers.Count, actualManifestV2.Layers.Count);
+                for (int i = 0; i < baseManifestV2.Layers.Count; i++)
+                {
+                    Assert.Equal(baseManifestV2.Layers[i].Digest, actualManifestV2.Layers[i].Digest);
+                    Assert.Equal(baseManifestV2.Layers[i].MediaType, actualManifestV2.Layers[i].MediaType);
+                    Assert.Equal(baseManifestV2.Layers[i].Size, actualManifestV2.Layers[i].Size);
+                }
+                Assert.Equal(baseManifestV2.Config.Digest, actualManifestV2.Config.Digest);
+                Assert.Equal(baseManifestV2.Config.MediaType, actualManifestV2.Config.MediaType);
+                Assert.Equal(baseManifestV2.Config.Size, actualManifestV2.Config.Size);
+            }
+            if (baseManifest.GetType() == typeof(V1Manifest))
+            {
+                var baseManifestV1 = (V1Manifest)baseManifest;
+                var actualManifestV1 = (V1Manifest)baseManifest;
+                Assert.Equal(baseManifestV1.Architecture, actualManifestV1.Architecture);
+                Assert.Equal(baseManifestV1.Name, actualManifestV1.Name);
+                Assert.Equal(baseManifestV1.Tag, actualManifestV1.Tag);
+                Assert.Equal(baseManifestV1.FsLayers.Count, actualManifestV1.FsLayers.Count);
+
+                for (int i = 0; i < baseManifestV1.FsLayers.Count; i++)
+                {
+                    Assert.Equal(baseManifestV1.FsLayers[i].BlobSum, actualManifestV1.FsLayers[i].BlobSum);
+                }
+
+                Assert.Equal(baseManifestV1.History.Count, actualManifestV1.History.Count);
+                for (int i = 0; i < baseManifestV1.History.Count; i++)
+                {
+                    Assert.Equal(baseManifestV1.History[i].V1Compatibility, actualManifestV1.History[i].V1Compatibility);
+                }
+            }
+            if (baseManifest.GetType() == typeof(OCIManifest))
+            {
+                var baseManifestOCI = (OCIManifest)baseManifest;
+                var actualManifestOCI = (OCIManifest)baseManifest;
+                Assert.Equal(baseManifestOCI.Layers.Count, actualManifestOCI.Layers.Count);
+                for (int i = 0; i < baseManifestOCI.Layers.Count; i++)
+                {
+                    Assert.Equal(baseManifestOCI.Layers[i].Digest, actualManifestOCI.Layers[i].Digest);
+                    Assert.Equal(baseManifestOCI.Layers[i].MediaType, actualManifestOCI.Layers[i].MediaType);
+                    Assert.Equal(baseManifestOCI.Layers[i].Size, actualManifestOCI.Layers[i].Size);
+                    Assert.Equal(baseManifestOCI.Layers[i].Annotations, actualManifestOCI.Layers[i].Annotations);
+                }
+                Assert.Equal(baseManifestOCI.Config.Digest, actualManifestOCI.Config.Digest);
+                Assert.Equal(baseManifestOCI.Config.MediaType, actualManifestOCI.Config.MediaType);
+                Assert.Equal(baseManifestOCI.Config.Size, actualManifestOCI.Config.Size);
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Issue Statement

When invoking a write API the client is sending the incorrect scope.

This issue is tracked at [Azure/acr](https://github.com/Azure/azure-sdk-for-net/issues/16511).

## Root Cause Analysis

In the GetScopeFromHeaders method .A split is done in the headerValue by a comma(,). This in turn excludes the push action from the scope since it has a comma before it.

## Resolution

The fix is to find the index of "scope=" in the string and get its substring.

## Tests
Manual tests have been done on a console app to verify the pull and push of a manifest Which was successful.
Automation Tests have also been done to check on more scope scenarios.