### PR TITLE
Fix template path for tests.yml

### DIFF
--- a/sdk/timeseriesinsights/tests.yml
+++ b/sdk/timeseriesinsights/tests.yml
@@ -5,4 +5,3 @@ extends:
   parameters:
     ServiceDirectory: timeseriesinsights
     Location: westus2
-    Clouds: Preview

--- a/sdk/timeseriesinsights/tests.yml
+++ b/sdk/timeseriesinsights/tests.yml
@@ -1,8 +1,9 @@
 trigger: none
 
 extends:
-  template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: timeseriesinsights
     Location: westus2
     SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+    Clouds: Preview

--- a/sdk/timeseriesinsights/tests.yml
+++ b/sdk/timeseriesinsights/tests.yml
@@ -5,5 +5,4 @@ extends:
   parameters:
     ServiceDirectory: timeseriesinsights
     Location: westus2
-    SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
     Clouds: Preview


### PR DESCRIPTION
There was a change in the pipeline template jobs that moved archetype-sdk-tests.yml to a different folder. This PR is to point to the proper path.