### PR TITLE
Make DedicatedHostGroup.properties.supportAutomaticPlacement default to false

### DIFF
--- a/eng/mgmt/mgmtmetadata/compute_resource-manager.txt
+++ b/eng/mgmt/mgmtmetadata/compute_resource-manager.txt
@@ -3,12 +3,12 @@ AutoRest installed successfully.
 Commencing code generation
 Generating CSharp code
 Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/compute/resource-manager/readme.md --csharp --version=v2 --reflect-api-versions --csharp-sdks-folder=D:\Azure\azure-sdk-for-net\sdk
-2020-10-12 03:40:00 PDT
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/compute/resource-manager/readme.md --csharp --version=v2 --reflect-api-versions --csharp-sdks-folder=E:\azure-sdk-for-net\sdk
+2020-11-29 04:50:45 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      3330966e764d615930452a561c2f91886414fb04
+Commit:      33b5733cc82028c9ce6e2c9ec9f28e7f763098f7
 AutoRest information
 Requested version: v2
 Bootstrapper version:    autorest@2.0.4413

--- a/sdk/compute/Microsoft.Azure.Management.Compute/src/Generated/Models/DedicatedHostGroup.cs
+++ b/sdk/compute/Microsoft.Azure.Management.Compute/src/Generated/Models/DedicatedHostGroup.cs
@@ -54,8 +54,8 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// machines or virtual machine scale sets can be placed automatically
         /// on the dedicated host group. Automatic placement means resources
         /// are allocated on dedicated hosts, that are chosen by Azure, under
-        /// the dedicated host group. The value is defaulted to 'true' when not
-        /// provided. &lt;br&gt;&lt;br&gt;Minimum api-version:
+        /// the dedicated host group. The value is defaulted to 'false' when
+        /// not provided. &lt;br&gt;&lt;br&gt;Minimum api-version:
         /// 2020-06-01.</param>
         /// <param name="zones">Availability Zone to use for this host group.
         /// Only single zone is supported. The zone can be assigned only during
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// scale sets can be placed automatically on the dedicated host group.
         /// Automatic placement means resources are allocated on dedicated
         /// hosts, that are chosen by Azure, under the dedicated host group.
-        /// The value is defaulted to 'true' when not provided.
+        /// The value is defaulted to 'false' when not provided.
         /// &amp;lt;br&amp;gt;&amp;lt;br&amp;gt;Minimum api-version:
         /// 2020-06-01.
         /// </summary>

--- a/sdk/compute/Microsoft.Azure.Management.Compute/src/Generated/Models/DedicatedHostGroupUpdate.cs
+++ b/sdk/compute/Microsoft.Azure.Management.Compute/src/Generated/Models/DedicatedHostGroupUpdate.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// machines or virtual machine scale sets can be placed automatically
         /// on the dedicated host group. Automatic placement means resources
         /// are allocated on dedicated hosts, that are chosen by Azure, under
-        /// the dedicated host group. The value is defaulted to 'true' when not
-        /// provided. &lt;br&gt;&lt;br&gt;Minimum api-version:
+        /// the dedicated host group. The value is defaulted to 'false' when
+        /// not provided. &lt;br&gt;&lt;br&gt;Minimum api-version:
         /// 2020-06-01.</param>
         /// <param name="zones">Availability Zone to use for this host group.
         /// Only single zone is supported. The zone can be assigned only during
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// scale sets can be placed automatically on the dedicated host group.
         /// Automatic placement means resources are allocated on dedicated
         /// hosts, that are chosen by Azure, under the dedicated host group.
-        /// The value is defaulted to 'true' when not provided.
+        /// The value is defaulted to 'false' when not provided.
         /// &amp;lt;br&amp;gt;&amp;lt;br&amp;gt;Minimum api-version:
         /// 2020-06-01.
         /// </summary>

--- a/sdk/compute/Microsoft.Azure.Management.Compute/src/Microsoft.Azure.Management.Compute.csproj
+++ b/sdk/compute/Microsoft.Azure.Management.Compute/src/Microsoft.Azure.Management.Compute.csproj
@@ -22,6 +22,7 @@
         5. Remove EncryptionAtRestWithPlatformKey in diskEncryptionSetType
         6. Remove maximum for PlatformFaultDomainCount of DedicatedHostGroup
         7. New API: RunCommand resource for VM and VMSS instance
+        8. Update the description for DedicatedHostGroup.supportAutomaticPlacement to mention that the property defaults to true.
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/sdk/compute/Microsoft.Azure.Management.Compute/src/Microsoft.Azure.Management.Compute.csproj
+++ b/sdk/compute/Microsoft.Azure.Management.Compute/src/Microsoft.Azure.Management.Compute.csproj
@@ -9,7 +9,7 @@
       Provides developers with libraries for the updated compute platform under Azure Resource manager to deploy virtual machine, virtual machine extensions and availability set management capabilities. Launch, restart, scale, capture and manage VMs, VM Extensions and more. Note: This client library is for Virtual Machines under Azure Resource Manager.
       Development of this library has shifted focus to the Azure Unified SDK. The future development will be focused on "Azure.ResourceManager.Compute" (https://www.nuget.org/packages/Azure.ResourceManager.Compute/). Please see the package changelog for more information.
     </Description>
-    <Version>41.0.0.0</Version>
+    <Version>42.0.0.0</Version>
     <AssemblyName>Microsoft.Azure.Management.Compute</AssemblyName>
     <PackageTags>management;virtual machine;compute;</PackageTags>
     <PackageReleaseNotes>

--- a/sdk/compute/Microsoft.Azure.Management.Compute/src/Properties/AssemblyInfo.cs
+++ b/sdk/compute/Microsoft.Azure.Management.Compute/src/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Compute Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Compute Resources.")]
 
-[assembly: AssemblyVersion("41.0.0.0")]
-[assembly: AssemblyFileVersion("41.0.0.0")]
+[assembly: AssemblyVersion("42.0.0.0")]
+[assembly: AssemblyFileVersion("42.0.0.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/11697

Dedicated host group automatic placement feature is currently in a limited public preview, available in a few regions for whitelisted subscriptions. It is planned to be GA'ed in some public regions in December. The initial plan was to default DedicatedHostGroup.properties.supportAutomaticPlacement to true, but recently we have agreed to default the value to false as we GA. Changing the default to false has already been made on the service side.

This PR updates only the description to the "supportAutomaticPlacement" property.