### PR TITLE
Fix to be able to CanGenerateSas and GenerateSas from clients generated GetClient

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.8.0-beta.1 (Unreleased)
-
+- Fixed bug where BlobContainerClient.GetBlobClient(), BlobContainerClient.GetParentServiceClient(), BlobServiceClient.GetContainerClient(), BlobBaseClient.WithClientSideEncryptionOptions(), BlobBaseClient.GetParentBlobContainerClient(), BlobBaseClient.WithSnapshot() and BlobBaseClient.WithVersion() created clients that could not generate a SAS from clients that could generate a SAS
 
 ## 12.7.0 (2020-11-10)
 - Includes all features from 12.7.0-preview.1

--- a/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.8.0-beta.1 (Unreleased)
-- Fixed bug where BlobContainerClient.GetBlobClient(), BlobContainerClient.GetParentServiceClient(), BlobServiceClient.GetContainerClient(), BlobBaseClient.WithClientSideEncryptionOptions(), BlobBaseClient.GetParentBlobContainerClient(), BlobBaseClient.WithSnapshot() and BlobBaseClient.WithVersion() created clients that could not generate a SAS from clients that could generate a SAS
+- Fixed bug where BlobContainerClient.GetBlobClient(), BlobContainerClient.GetParentServiceClient(), BlobServiceClient.GetBlobContainerClient(), BlobBaseClient.WithClientSideEncryptionOptions(), BlobBaseClient.GetParentBlobContainerClient(), BlobBaseClient.WithSnapshot() and BlobBaseClient.WithVersion() created clients that could not generate a SAS from clients that could generate a SAS
 
 ## 12.7.0 (2020-11-10)
 - Includes all features from 12.7.0-preview.1

--- a/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs/api/Azure.Storage.Blobs.netstandard2.0.cs
@@ -32,6 +32,7 @@ namespace Azure.Storage.Blobs
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> UploadAsync(string path, Azure.Storage.Blobs.Models.BlobUploadOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> UploadAsync(string path, bool overwrite = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> UploadAsync(string path, System.Threading.CancellationToken cancellationToken) { throw null; }
+        protected internal virtual Azure.Storage.Blobs.BlobClient WithClientSideEncryptionOptionsCore(Azure.Storage.ClientSideEncryptionOptions clientSideEncryptionOptions) { throw null; }
         public new Azure.Storage.Blobs.BlobClient WithSnapshot(string snapshot) { throw null; }
         public new Azure.Storage.Blobs.BlobClient WithVersion(string versionId) { throw null; }
     }
@@ -93,6 +94,7 @@ namespace Azure.Storage.Blobs
         public virtual Azure.Response<Azure.Storage.Blobs.Models.BlobContainerAccessPolicy> GetAccessPolicy(Azure.Storage.Blobs.Models.BlobRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContainerAccessPolicy>> GetAccessPolicyAsync(Azure.Storage.Blobs.Models.BlobRequestConditions conditions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         protected internal virtual Azure.Storage.Blobs.Specialized.AppendBlobClient GetAppendBlobClientCore(string blobName) { throw null; }
+        protected internal virtual Azure.Storage.Blobs.Specialized.BlobBaseClient GetBlobBaseClientCore(string blobName) { throw null; }
         public virtual Azure.Storage.Blobs.BlobClient GetBlobClient(string blobName) { throw null; }
         protected internal virtual Azure.Storage.Blobs.Specialized.BlobLeaseClient GetBlobLeaseClientCore(string leaseId) { throw null; }
         public virtual Azure.Pageable<Azure.Storage.Blobs.Models.BlobItem> GetBlobs(Azure.Storage.Blobs.Models.BlobTraits traits = Azure.Storage.Blobs.Models.BlobTraits.None, Azure.Storage.Blobs.Models.BlobStates states = Azure.Storage.Blobs.Models.BlobStates.None, string prefix = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -189,12 +189,16 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="clientDiagnostics">Client diagnostics.</param>
         /// <param name="customerProvidedKey">Customer provided key.</param>
         /// <param name="encryptionScope">Encryption scope.</param>
         internal AppendBlobClient(
             Uri blobUri,
             HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
             BlobClientOptions.ServiceVersion version,
             ClientDiagnostics clientDiagnostics,
             CustomerProvidedKey? customerProvidedKey,
@@ -202,6 +206,7 @@ namespace Azure.Storage.Blobs.Specialized
             : base(
                   blobUri,
                   pipeline,
+                  storageSharedKeyCredential,
                   version,
                   clientDiagnostics,
                   customerProvidedKey,
@@ -244,6 +249,7 @@ namespace Azure.Storage.Blobs.Specialized
             return new AppendBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -272,6 +278,7 @@ namespace Azure.Storage.Blobs.Specialized
             return new AppendBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -339,6 +339,9 @@ namespace Azure.Storage.Blobs
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="clientDiagnostics"></param>
         /// <param name="customerProvidedKey">Customer provided key.</param>
         /// <param name="clientSideEncryption"></param>
@@ -346,6 +349,7 @@ namespace Azure.Storage.Blobs
         internal BlobContainerClient(
             Uri containerUri,
             HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
             BlobClientOptions.ServiceVersion version,
             ClientDiagnostics clientDiagnostics,
             CustomerProvidedKey? customerProvidedKey,
@@ -354,6 +358,7 @@ namespace Azure.Storage.Blobs
         {
             _uri = containerUri;
             _pipeline = pipeline;
+            _storageSharedKeyCredential = storageSharedKeyCredential;
             _version = version;
             _clientDiagnostics = clientDiagnostics;
             _customerProvidedKey = customerProvidedKey;
@@ -388,6 +393,7 @@ namespace Azure.Storage.Blobs
             return new BlobContainerClient(
                 containerUri,
                 pipeline,
+                null,
                 options.Version,
                 new ClientDiagnostics(options),
                 customerProvidedKey: null,
@@ -395,6 +401,32 @@ namespace Azure.Storage.Blobs
                 encryptionScope: null);
         }
         #endregion ctor
+
+        /// <summary>
+        /// Create a new <see cref="BlobBaseClient"/> object by appending
+        /// <paramref name="blobName"/> to the end of <see cref="Uri"/>.  The
+        /// new <see cref="BlobBaseClient"/> uses the same request policy
+        /// pipeline as the <see cref="BlobContainerClient"/>.
+        /// </summary>
+        /// <param name="blobName">The name of the blob.</param>
+        /// <returns>A new <see cref="BlobBaseClient"/> instance.</returns>
+        protected internal virtual BlobBaseClient GetBlobBaseClientCore(string blobName)
+        {
+            BlobUriBuilder blobUriBuilder = new BlobUriBuilder(Uri)
+            {
+                BlobName = blobName
+            };
+
+            return new BlobBaseClient(
+                blobUriBuilder.ToUri(),
+                _pipeline,
+                _storageSharedKeyCredential,
+                Version,
+                ClientDiagnostics,
+                CustomerProvidedKey,
+                ClientSideEncryption,
+                EncryptionScope);
+        }
 
         /// <summary>
         /// Create a new <see cref="BlobClient"/> object by appending
@@ -414,6 +446,7 @@ namespace Azure.Storage.Blobs
             return new BlobClient(
                 blobUriBuilder.ToUri(),
                 _pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -446,6 +479,7 @@ namespace Azure.Storage.Blobs
             return new BlockBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -477,6 +511,7 @@ namespace Azure.Storage.Blobs
             return new AppendBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -508,6 +543,7 @@ namespace Azure.Storage.Blobs
             return new PageBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -3002,7 +3038,8 @@ namespace Azure.Storage.Blobs
                     CustomerProvidedKey,
                     ClientSideEncryption,
                     EncryptionScope,
-                    Pipeline);
+                    Pipeline,
+                    _storageSharedKeyCredential);
             }
 
             return _parentBlobServiceClient;

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -330,7 +330,7 @@ namespace Azure.Storage.Blobs
             ClientSideEncryptionOptions clientSideEncryption,
             string encryptionScope,
             HttpPipeline pipeline,
-            StorageSharedKeyCredential storageSharedKeyCredential = default)
+            StorageSharedKeyCredential storageSharedKeyCredential)
         {
             _uri = serviceUri;
             _authenticationPolicy = authentication;
@@ -384,7 +384,8 @@ namespace Azure.Storage.Blobs
                 customerProvidedKey: null,
                 clientSideEncryption: null,
                 encryptionScope: null,
-                pipeline);
+                pipeline,
+                storageSharedKeyCredential: null);
         }
         #endregion ctors
 
@@ -401,7 +402,15 @@ namespace Azure.Storage.Blobs
         /// A <see cref="BlobContainerClient"/> for the desired container.
         /// </returns>
         public virtual BlobContainerClient GetBlobContainerClient(string blobContainerName) =>
-            new BlobContainerClient(Uri.AppendToPath(blobContainerName), Pipeline, Version, ClientDiagnostics, CustomerProvidedKey, ClientSideEncryption, EncryptionScope);
+            new BlobContainerClient(
+                Uri.AppendToPath(blobContainerName),
+                Pipeline,
+                _storageSharedKeyCredential,
+                Version,
+                ClientDiagnostics,
+                CustomerProvidedKey,
+                ClientSideEncryption,
+                EncryptionScope);
 
         #region protected static accessors for Azure.Storage.Blobs.Batch
         /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -270,6 +270,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="pipeline">
         /// The transport pipeline used to send every request.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
@@ -279,6 +282,7 @@ namespace Azure.Storage.Blobs.Specialized
         internal BlockBlobClient(
             Uri blobUri,
             HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
             BlobClientOptions.ServiceVersion version,
             ClientDiagnostics clientDiagnostics,
             CustomerProvidedKey? customerProvidedKey,
@@ -286,6 +290,7 @@ namespace Azure.Storage.Blobs.Specialized
             : base(
                   blobUri,
                   pipeline,
+                  storageSharedKeyCredential,
                   version,
                   clientDiagnostics,
                   customerProvidedKey,
@@ -316,7 +321,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </returns>
         protected static BlockBlobClient CreateClient(Uri blobUri, BlobClientOptions options, HttpPipeline pipeline)
         {
-            return new BlockBlobClient(blobUri, pipeline, options.Version, new ClientDiagnostics(options), null, null);
+            return new BlockBlobClient(blobUri, pipeline, null, options.Version, new ClientDiagnostics(options), null, null);
         }
 
         private static void AssertNoClientSideEncryption(BlobClientOptions options)
@@ -360,7 +365,7 @@ namespace Azure.Storage.Blobs.Specialized
         public new BlockBlobClient WithVersion(string versionId)
         {
             var builder = new BlobUriBuilder(Uri) { VersionId = versionId };
-            return new BlockBlobClient(builder.ToUri(), Pipeline, Version, ClientDiagnostics, CustomerProvidedKey, EncryptionScope);
+            return new BlockBlobClient(builder.ToUri(), Pipeline, SharedKeyCredential, Version, ClientDiagnostics, CustomerProvidedKey, EncryptionScope);
         }
 
         /// <summary>
@@ -374,7 +379,7 @@ namespace Azure.Storage.Blobs.Specialized
         {
             var builder = new BlobUriBuilder(Uri) { Snapshot = snapshot };
 
-            return new BlockBlobClient(builder.ToUri(), Pipeline, Version, ClientDiagnostics, CustomerProvidedKey, EncryptionScope);
+            return new BlockBlobClient(builder.ToUri(), Pipeline, SharedKeyCredential, Version, ClientDiagnostics, CustomerProvidedKey, EncryptionScope);
         }
 
         ///// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -185,6 +185,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// <param name="pipeline">
         /// The transport pipeline used to send every request.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
@@ -194,6 +197,7 @@ namespace Azure.Storage.Blobs.Specialized
         internal PageBlobClient(
             Uri blobUri,
             HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
             BlobClientOptions.ServiceVersion version,
             ClientDiagnostics clientDiagnostics,
             CustomerProvidedKey? customerProvidedKey,
@@ -201,6 +205,7 @@ namespace Azure.Storage.Blobs.Specialized
             : base(
                   blobUri,
                   pipeline,
+                  storageSharedKeyCredential,
                   version,
                   clientDiagnostics,
                   customerProvidedKey,
@@ -252,6 +257,7 @@ namespace Azure.Storage.Blobs.Specialized
             return new PageBlobClient(
                 builder.ToUri(),
                 Pipeline,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -272,7 +278,9 @@ namespace Azure.Storage.Blobs.Specialized
             };
 
             return new PageBlobClient(
-                builder.ToUri(), Pipeline,
+                builder.ToUri(),
+                Pipeline,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -2578,6 +2586,7 @@ namespace Azure.Storage.Blobs.Specialized
                     PageBlobClient pageBlobUri = new PageBlobClient(
                         sourceUri,
                         Pipeline,
+                        SharedKeyCredential,
                         Version,
                         ClientDiagnostics,
                         CustomerProvidedKey,

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -5771,6 +5771,150 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void CanGenerateSas_GetParentBlobContainerClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName)
+            BlobBaseClient blob = new BlobBaseClient(
+                connectionString,
+                GetNewContainerName(),
+                GetNewBlobName());
+            BlobContainerClient container = blob.GetParentBlobContainerClient();
+            Assert.IsTrue(container.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
+            BlobBaseClient blob2 = new BlobBaseClient(
+                connectionString,
+                GetNewContainerName(),
+                GetNewBlobName(),
+                GetOptions());
+            BlobContainerClient container2 = blob2.GetParentBlobContainerClient();
+            Assert.IsTrue(container2.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, BlobClientOptions options = default)
+            BlobBaseClient blob3 = new BlobBaseClient(
+                blobEndpoint,
+                GetOptions());
+            BlobContainerClient container3 = blob3.GetParentBlobContainerClient();
+            Assert.IsFalse(container3.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            BlobBaseClient blob4 = new BlobBaseClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            BlobContainerClient container4 = blob4.GetParentBlobContainerClient();
+            Assert.IsTrue(container4.CanGenerateSasUri);
+
+            // Act - BlobBaseClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            BlobBaseClient blob5 = new BlobBaseClient(
+                blobEndpoint,
+                tokenCredentials,
+                GetOptions());
+            BlobContainerClient container5 = blob5.GetParentBlobContainerClient();
+            Assert.IsFalse(container5.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_WithSnapshot_True()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Create blob
+            BlobBaseClient blob = new BlobBaseClient(
+                connectionString,
+                GetNewContainerName(),
+                GetNewBlobName());
+            Assert.IsTrue(blob.CanGenerateSasUri);
+
+            // Act
+            string snapshot = "2020-04-17T20:37:16.5129130Z";
+            BlobBaseClient snapshotBlob = blob.WithSnapshot(snapshot);
+
+            // Assert
+            Assert.IsTrue(snapshotBlob.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_WithSnapshot_False()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+
+            // Create blob
+            BlobBaseClient blob = new BlobBaseClient(
+                blobEndpoint,
+                GetOptions());
+            Assert.IsFalse(blob.CanGenerateSasUri);
+
+            // Act
+            string snapshot = "2020-04-17T20:37:16.5129130Z";
+            BlobBaseClient snapshotBlob = blob.WithSnapshot(snapshot);
+
+            // Assert
+            Assert.IsFalse(snapshotBlob.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_WithVersion_True()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Create blob
+            BlobBaseClient blob = new BlobBaseClient(
+                connectionString,
+                GetNewContainerName(),
+                GetNewBlobName());
+            Assert.IsTrue(blob.CanGenerateSasUri);
+
+            // Act
+            string version = "2020-04-17T21:55:48.6692074Z";
+            BlobBaseClient versionBlob = blob.WithVersion(version);
+
+            // Assert
+            Assert.IsTrue(versionBlob.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_WithVersion_False()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+
+            // Create blob
+            BlobBaseClient blob = new BlobBaseClient(
+                blobEndpoint,
+                GetOptions());
+            Assert.IsFalse(blob.CanGenerateSasUri);
+
+            // Act
+            string version = "2020-04-17T21:55:48.6692074Z";
+            BlobBaseClient versionBlob = blob.WithVersion(version);
+
+            // Assert
+            Assert.IsFalse(versionBlob.CanGenerateSasUri);
+        }
+
+        [Test]
         public void GenerateSas_RequiredParameters()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestExtensions.cs
@@ -28,6 +28,7 @@ namespace Azure.Storage
             new AppendBlobClient(
                 ToHttps(blob.Uri),
                 blob.Pipeline,
+                blob.SharedKeyCredential,
                 blob.Version,
                 blob.ClientDiagnostics,
                 customerProvidedKey,
@@ -40,6 +41,7 @@ namespace Azure.Storage
             new AppendBlobClient(
                 ToHttps(blob.Uri),
                 blob.Pipeline,
+                blob.SharedKeyCredential,
                 blob.Version,
                 blob.ClientDiagnostics,
                 null,
@@ -51,6 +53,7 @@ namespace Azure.Storage
             new BlockBlobClient(
                 ToHttps(blob.Uri),
                 blob.Pipeline,
+                blob.SharedKeyCredential,
                 blob.Version,
                 blob.ClientDiagnostics,
                 customerProvidedKey,
@@ -63,6 +66,7 @@ namespace Azure.Storage
             new BlockBlobClient(
                 ToHttps(blob.Uri),
                 blob.Pipeline,
+                blob.SharedKeyCredential,
                 blob.Version,
                 blob.ClientDiagnostics,
                 null,
@@ -74,6 +78,7 @@ namespace Azure.Storage
             new PageBlobClient(
                 ToHttps(blob.Uri),
                 blob.Pipeline,
+                blob.SharedKeyCredential,
                 blob.Version,
                 blob.ClientDiagnostics,
                 customerProvidedKey,
@@ -86,6 +91,7 @@ namespace Azure.Storage
             new PageBlobClient(
                 ToHttps(blob.Uri),
                 blob.Pipeline,
+                blob.SharedKeyCredential,
                 blob.Version,
                 blob.ClientDiagnostics,
                 null,

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -17,6 +17,7 @@ using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Tests;
 using Azure.Storage.Cryptography;
 using Azure.Storage.Cryptography.Models;
+using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using Moq;
 using NUnit.Framework;
@@ -720,6 +721,64 @@ namespace Azure.Storage.Blobs.Test
                 Assert.IsTrue(downloadResult.Value.Details.Metadata.ContainsKey(Constants.ClientSideEncryption.EncryptionDataKey));
                 Assert.AreNotEqual(firstDownloadEncryptionData, downloadResult.Value.Details.Metadata[Constants.ClientSideEncryption.EncryptionDataKey]);
             }
+        }
+
+        [Test]
+        public void CanGenerateSas_WithClientSideEncryptionOptions_True()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
+            {
+                KeyEncryptionKey = GetIKeyEncryptionKey().Object,
+                KeyResolver = GetIKeyEncryptionKeyResolver(default).Object,
+                KeyWrapAlgorithm = "bar"
+            };
+
+            // Create blob
+            BlobClient blob = new BlobClient(
+                connectionString,
+                GetNewContainerName(),
+                GetNewBlobName());
+            Assert.IsTrue(blob.CanGenerateSasUri);
+
+            // Act
+            BlobClient blobEncrypted = blob.WithClientSideEncryptionOptions(options);
+
+            // Assert
+            Assert.IsTrue(blobEncrypted.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_WithClientSideEncryptionOptions_False()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+
+            var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
+            {
+                KeyEncryptionKey = GetIKeyEncryptionKey().Object,
+                KeyResolver = GetIKeyEncryptionKeyResolver(default).Object,
+                KeyWrapAlgorithm = "bar"
+            };
+
+            // Create blob
+            BlobClient blob = new BlobClient(
+                blobEndpoint,
+                GetOptions());
+            Assert.IsFalse(blob.CanGenerateSasUri);
+
+            // Act
+            BlobClient blobEncrypted = blob.WithClientSideEncryptionOptions(options);
+
+            // Assert
+            Assert.IsFalse(blobEncrypted.CanGenerateSasUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -2642,6 +2642,106 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void CanGenerateSas_GetBlobClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - BlobContainerClient(string connectionString, string blobContainerName)
+            BlobContainerClient container = new BlobContainerClient(
+                connectionString,
+                GetNewContainerName());
+            BlobBaseClient blob = container.GetBlobBaseClient(GetNewBlobName());
+            Assert.IsTrue(blob.CanGenerateSasUri);
+
+            // Act - BlobContainerClient(string connectionString, string blobContainerName, BlobClientOptions options)
+            BlobContainerClient container2 = new BlobContainerClient(
+                connectionString,
+                GetNewContainerName(),
+                GetOptions());
+            BlobBaseClient blob2 = container2.GetBlobBaseClient(GetNewBlobName());
+            Assert.IsTrue(blob2.CanGenerateSasUri);
+
+            // Act - BlobContainerClient(Uri blobContainerUri, BlobClientOptions options = default)
+            BlobContainerClient container3 = new BlobContainerClient(
+                blobEndpoint,
+                GetOptions());
+            BlobBaseClient blob3 = container3.GetBlobBaseClient(GetNewBlobName());
+            Assert.IsFalse(blob3.CanGenerateSasUri);
+
+            // Act - BlobContainerClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            BlobContainerClient container4 = new BlobContainerClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            BlobBaseClient blob4 = container4.GetBlobBaseClient(GetNewBlobName());
+            Assert.IsTrue(blob4.CanGenerateSasUri);
+
+            // Act - BlobContainerClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            BlobContainerClient container5 = new BlobContainerClient(
+                blobEndpoint,
+                tokenCredentials,
+                GetOptions());
+            BlobBaseClient blob5 = container5.GetBlobBaseClient(GetNewBlobName());
+            Assert.IsFalse(blob5.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetParentServiceClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - BlobContainerClient(string connectionString, string blobContainerName)
+            BlobContainerClient container = new BlobContainerClient(
+                connectionString,
+                GetNewContainerName());
+            BlobServiceClient service = container.GetParentBlobServiceClient();
+            Assert.IsTrue(service.CanGenerateAccountSasUri);
+
+            // Act - BlobContainerClient(string connectionString, string blobContainerName, BlobClientOptions options)
+            BlobContainerClient container2 = new BlobContainerClient(
+                connectionString,
+                GetNewContainerName(),
+                GetOptions());
+            BlobServiceClient service2 = container2.GetParentBlobServiceClient();
+            Assert.IsTrue(service2.CanGenerateAccountSasUri);
+
+            // Act - BlobContainerClient(Uri blobContainerUri, BlobClientOptions options = default)
+            BlobContainerClient container3 = new BlobContainerClient(
+                blobEndpoint,
+                GetOptions());
+            BlobServiceClient service3 = container3.GetParentBlobServiceClient();
+            Assert.IsFalse(service3.CanGenerateAccountSasUri);
+
+            // Act - BlobContainerClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            BlobContainerClient container4 = new BlobContainerClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            BlobServiceClient service4 = container4.GetParentBlobServiceClient();
+            Assert.IsTrue(service4.CanGenerateAccountSasUri);
+
+            // Act - BlobContainerClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            BlobContainerClient container5 = new BlobContainerClient(
+                blobEndpoint,
+                tokenCredentials,
+                GetOptions());
+            BlobServiceClient service5 = container5.GetParentBlobServiceClient();
+            Assert.IsFalse(service5.CanGenerateAccountSasUri);
+        }
+
+        [Test]
         public void GenerateSas_RequiredParameters()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_GetParentBlobContainerClient.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_GetParentBlobContainerClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:05.7928538-08:00",
+    "RandomSeed": "715413478"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_GetParentBlobContainerClientAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_GetParentBlobContainerClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:24.1553069-08:00",
+    "RandomSeed": "1634359990"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_False.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_False.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:05.8564071-08:00",
+    "RandomSeed": "1952525841"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_FalseAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_FalseAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:24.2239393-08:00",
+    "RandomSeed": "2136049969"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_True.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_True.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:05.8592834-08:00",
+    "RandomSeed": "694572079"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_TrueAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithSnapshot_TrueAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:24.2271101-08:00",
+    "RandomSeed": "141063331"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_False.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_False.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:05.8618775-08:00",
+    "RandomSeed": "328222041"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_FalseAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_FalseAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:24.2296495-08:00",
+    "RandomSeed": "726324327"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_True.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_True.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:05.8643983-08:00",
+    "RandomSeed": "295604707"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_TrueAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobBaseClientTests/CanGenerateSas_WithVersion_TrueAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:24.2324148-08:00",
+    "RandomSeed": "1269038168"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_False.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_False.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T10:36:14.6498420-08:00",
+    "RandomSeed": "1782943879"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_FalseAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_FalseAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T10:36:14.8585940-08:00",
+    "RandomSeed": "418547543"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_True.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_True.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T10:28:23.1409850-08:00",
+    "RandomSeed": "1909558580"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_TrueAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_TrueAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T10:28:23.3511461-08:00",
+    "RandomSeed": "1828014544"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetBlobClient.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetBlobClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:43.5834391-08:00",
+    "RandomSeed": "1043428533"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetBlobClientAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetBlobClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:57.8000306-08:00",
+    "RandomSeed": "278310243"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetParentServiceClient.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetParentServiceClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:43.6459731-08:00",
+    "RandomSeed": "1312296080"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetParentServiceClientAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ContainerClientTests/CanGenerateSas_GetParentServiceClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:39:57.8729754-08:00",
+    "RandomSeed": "192293735"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetContainerClient.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetContainerClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:40:16.6277538-08:00",
+    "RandomSeed": "2047033499"
+  }
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetContainerClientAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetContainerClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-24T13:40:30.8692227-08:00",
+    "RandomSeed": "225733080"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.6.0-beta.1 (Unreleased)
-
+- Fixed bug where DataLakeServiceClient.GetFileSystemClient(), DataLakeFileSystemClient.GetFileClient(), DataLakeFileSystemClient.GetDirectoryClient(), DataLakeDirectoryClient.GetSubDirectoryClient() and DataLakeFileClient.GetFileClient() created clients that could not generate a SAS from clients that could generate a SAS
 
 ## 12.5.0 (2020-11-10)
 - Includes all features from 12.5.0-preview.1

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
@@ -206,12 +206,14 @@ namespace Azure.Storage.Files.DataLake
             Uri fileSystemUri,
             string directoryPath,
             HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
             DataLakeClientOptions.ServiceVersion version,
             ClientDiagnostics clientDiagnostics)
             : base(
                   fileSystemUri,
                   directoryPath,
                   pipeline,
+                  storageSharedKeyCredential,
                   version,
                   clientDiagnostics)
         {
@@ -231,6 +233,7 @@ namespace Azure.Storage.Files.DataLake
                 Uri,
                 $"{Path}/{fileName}",
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics);
 
@@ -247,6 +250,7 @@ namespace Azure.Storage.Files.DataLake
                 Uri,
                 $"{Path}/{subdirectoryName}",
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics);
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileClient.cs
@@ -223,12 +223,14 @@ namespace Azure.Storage.Files.DataLake
             Uri fileSystemUri,
             string filePath,
             HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
             DataLakeClientOptions.ServiceVersion version,
             ClientDiagnostics clientDiagnostics)
             : base(
                   fileSystemUri,
                   filePath,
                   pipeline,
+                  storageSharedKeyCredential,
                   version,
                   clientDiagnostics)
         {

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -298,6 +298,9 @@ namespace Azure.Storage.Files.DataLake
         /// <param name="pipeline">
         /// The transport pipeline used to send every request.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
@@ -305,13 +308,19 @@ namespace Azure.Storage.Files.DataLake
         /// The <see cref="ClientDiagnostics"/> instance used to create
         /// diagnostic scopes every request.
         /// </param>
-        internal DataLakeFileSystemClient(Uri fileSystemUri, HttpPipeline pipeline, DataLakeClientOptions.ServiceVersion version, ClientDiagnostics clientDiagnostics)
+        internal DataLakeFileSystemClient(
+            Uri fileSystemUri,
+            HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
+            DataLakeClientOptions.ServiceVersion version,
+            ClientDiagnostics clientDiagnostics)
         {
             DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(fileSystemUri);
             _uri = fileSystemUri;
             _blobUri = uriBuilder.ToBlobUri();
             _dfsUri = uriBuilder.ToDfsUri();
             _pipeline = pipeline;
+            _storageSharedKeyCredential = storageSharedKeyCredential;
             _version = version;
             _clientDiagnostics = clientDiagnostics;
             _containerClient = BlobContainerClientInternals.Create(_blobUri, pipeline, Version.AsBlobsVersion(), _clientDiagnostics);
@@ -360,6 +369,7 @@ namespace Azure.Storage.Files.DataLake
                 Uri,
                 directoryName,
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics);
             }
@@ -389,6 +399,7 @@ namespace Azure.Storage.Files.DataLake
                 Uri,
                 fileName,
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics);
 

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -324,7 +324,7 @@ namespace Azure.Storage.Files.DataLake
         /// A <see cref="DataLakeFileSystemClient"/> for the desired share.
         /// </returns>
         public virtual DataLakeFileSystemClient GetFileSystemClient(string fileSystemName)
-            => new DataLakeFileSystemClient(Uri.AppendToPath(fileSystemName), Pipeline, Version, ClientDiagnostics);
+            => new DataLakeFileSystemClient(Uri.AppendToPath(fileSystemName), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
 
         #region Get User Delegation Key
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -4867,6 +4867,70 @@ namespace Azure.Storage.Files.DataLake.Tests
         }
 
         [Test]
+        public void CanGenerateSas_GetFileClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+
+            // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
+            DataLakeDirectoryClient directory = new DataLakeDirectoryClient(
+                blobEndpoint,
+                GetOptions());
+            DataLakeFileClient file = directory.GetFileClient(GetNewFileName());
+            Assert.IsFalse(file.CanGenerateSasUri);
+
+            // Act - DataLakeDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, fileClientOptions options = default)
+            DataLakeDirectoryClient directory2 = new DataLakeDirectoryClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            DataLakeFileClient file2 = directory2.GetFileClient(GetNewFileName());
+            Assert.IsTrue(file2.CanGenerateSasUri);
+
+            // Act - DataLakeDirectoryClient(Uri blobContainerUri, TokenCredential credential, fileClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            DataLakeDirectoryClient directory3 = new DataLakeDirectoryClient(
+                blobEndpoint,
+                tokenCredentials,
+                GetOptions());
+            DataLakeFileClient file3 = directory3.GetFileClient(GetNewFileName());
+            Assert.IsFalse(file3.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetSubDirectoryClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+
+            // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
+            DataLakeDirectoryClient directory = new DataLakeDirectoryClient(
+                blobEndpoint,
+                GetOptions());
+            DataLakeDirectoryClient subdirectory = directory.GetSubDirectoryClient(GetNewDirectoryName());
+            Assert.IsFalse(subdirectory.CanGenerateSasUri);
+
+            // Act - DataLakeDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, fileClientOptions options = default)
+            DataLakeDirectoryClient directory2 = new DataLakeDirectoryClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            DataLakeDirectoryClient subdirectory2 = directory2.GetSubDirectoryClient(GetNewDirectoryName());
+            Assert.IsTrue(subdirectory2.CanGenerateSasUri);
+
+            // Act - DataLakeDirectoryClient(Uri blobContainerUri, TokenCredential credential, fileClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            DataLakeDirectoryClient directory3 = new DataLakeDirectoryClient(
+                blobEndpoint,
+                tokenCredentials,
+                GetOptions());
+            DataLakeDirectoryClient subdirectory3 = directory3.GetSubDirectoryClient(GetNewDirectoryName());
+            Assert.IsFalse(subdirectory3.CanGenerateSasUri);
+        }
+
+        [Test]
         public void GenerateSas_RequiredParameters()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -1975,25 +1975,95 @@ namespace Azure.Storage.Files.DataLake.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, BlobClientOptions options = default)
-            DataLakeFileSystemClient container3 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem = new DataLakeFileSystemClient(
                 blobEndpoint,
                 GetOptions());
-            Assert.IsFalse(container3.CanGenerateSasUri);
+            Assert.IsFalse(filesystem.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            DataLakeFileSystemClient container4 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem2 = new DataLakeFileSystemClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
                 GetOptions());
-            Assert.IsTrue(container4.CanGenerateSasUri);
+            Assert.IsTrue(filesystem2.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeFileSystemClient container5 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem3 = new DataLakeFileSystemClient(
                 blobEndpoint,
                 tokenCredentials,
                 GetOptions());
-            Assert.IsFalse(container5.CanGenerateSasUri);
+            Assert.IsFalse(filesystem3.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetFileClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - DataLakeFileSystemClient(Uri blobContainerUri, BlobClientOptions options = default)
+            DataLakeFileSystemClient filesystem = new DataLakeFileSystemClient(
+                blobEndpoint,
+                GetOptions());
+            DataLakeFileClient file = filesystem.GetFileClient(GetNewFileName());
+            Assert.IsFalse(file.CanGenerateSasUri);
+
+            // Act - DataLakeFileSystemClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            DataLakeFileSystemClient filesystem2 = new DataLakeFileSystemClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            DataLakeFileClient file2 = filesystem2.GetFileClient(GetNewFileName());
+            Assert.IsTrue(file2.CanGenerateSasUri);
+
+            // Act - DataLakeFileSystemClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            DataLakeFileSystemClient filesystem3 = new DataLakeFileSystemClient(
+                blobEndpoint,
+                tokenCredentials,
+                GetOptions());
+            DataLakeFileClient file3 = filesystem3.GetFileClient(GetNewFileName());
+            Assert.IsFalse(file3.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetDirectoryClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - DataLakeFileSystemClient(Uri blobContainerUri, BlobClientOptions options = default)
+            DataLakeFileSystemClient filesystem = new DataLakeFileSystemClient(
+                blobEndpoint,
+                GetOptions());
+            DataLakeDirectoryClient directory = filesystem.GetDirectoryClient(GetNewDirectoryName());
+            Assert.IsFalse(directory.CanGenerateSasUri);
+
+            // Act - DataLakeFileSystemClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            DataLakeFileSystemClient filesystem2 = new DataLakeFileSystemClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            DataLakeDirectoryClient directory2 = filesystem2.GetDirectoryClient(GetNewDirectoryName());
+            Assert.IsTrue(directory2.CanGenerateSasUri);
+
+            // Act - DataLakeFileSystemClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            DataLakeFileSystemClient filesystem3 = new DataLakeFileSystemClient(
+                blobEndpoint,
+                tokenCredentials,
+                GetOptions());
+            DataLakeDirectoryClient directory3 = filesystem3.GetDirectoryClient(GetNewDirectoryName());
+            Assert.IsFalse(directory3.CanGenerateSasUri);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -286,6 +286,40 @@ namespace Azure.Storage.Files.DataLake.Tests
         }
 
         [Test]
+        public void CanGenerateSas_GetFileSystemClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var uriEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (uriEndpoint, blobSecondaryEndpoint));
+
+            // Act - DataLakeServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
+            DataLakeServiceClient serviceClient = new DataLakeServiceClient(
+                uriEndpoint,
+                GetOptions());
+            DataLakeFileSystemClient fileSystemClient = serviceClient.GetFileSystemClient(GetNewFileSystemName());
+            Assert.IsFalse(fileSystemClient.CanGenerateSasUri);
+
+            // Act - DataLakeServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            DataLakeServiceClient serviceClient2 = new DataLakeServiceClient(
+                uriEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            DataLakeFileSystemClient fileSystemClient2 = serviceClient2.GetFileSystemClient(GetNewFileSystemName());
+            Assert.IsTrue(fileSystemClient2.CanGenerateSasUri);
+
+            // Act - DataLakeServiceClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
+            var tokenCredentials = new DefaultAzureCredential();
+            DataLakeServiceClient serviceClient3 = new DataLakeServiceClient(
+                uriEndpoint,
+                tokenCredentials,
+                GetOptions());
+            DataLakeFileSystemClient fileSystemClient3 = serviceClient3.GetFileSystemClient(GetNewFileSystemName());
+            Assert.IsFalse(fileSystemClient3.CanGenerateSasUri);
+        }
+
+        [Test]
         public void GenerateSas_RequiredParameters()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:04.6494434-08:00",
+    "RandomSeed": "209130536"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:18.7359509-08:00",
+    "RandomSeed": "2129166567"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubDirectoryClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubDirectoryClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:04.7090879-08:00",
+    "RandomSeed": "1015702674"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubDirectoryClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubDirectoryClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:18.8030736-08:00",
+    "RandomSeed": "811451308"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetDirectoryClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetDirectoryClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:38.6110352-08:00",
+    "RandomSeed": "2144647754"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetDirectoryClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetDirectoryClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:49.5003040-08:00",
+    "RandomSeed": "1840895128"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetFileClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetFileClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:38.6719793-08:00",
+    "RandomSeed": "710189255"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetFileClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/FileSystemClientTests/CanGenerateSas_GetFileClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:49:49.5585743-08:00",
+    "RandomSeed": "712856573"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetFileSystemClient.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetFileSystemClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:50:00.3058191-08:00",
+    "RandomSeed": "386561537"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetFileSystemClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetFileSystemClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-25T10:50:00.3646133-08:00",
+    "RandomSeed": "989414557"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.Shares/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.6.0-beta.1 (Unreleased)
-
+- Fixed bug where ShareServiceClient.GetShareClient(), ShareClient.GetDirectoryClient(), ShareClient.GetRootDirectoryClient(), ShareClient.WithSnapshot(), ShareDirectoryClient.GetSubDirectoryClient() and ShareDirectoryClient.GetFileClient() created clients that could not generate a SAS from clients that could generate a SAS
 
 ## 12.5.0 (2020-11-10)
 - Includes all features from 12.5.0-preview.1

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -258,6 +258,9 @@ namespace Azure.Storage.Files.Shares
         /// <param name="pipeline">
         /// The transport pipeline used to send every request.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
@@ -265,10 +268,16 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="ClientDiagnostics"/> instance used to create
         /// diagnostic scopes every request.
         /// </param>
-        internal ShareClient(Uri shareUri, HttpPipeline pipeline, ShareClientOptions.ServiceVersion version, ClientDiagnostics clientDiagnostics)
+        internal ShareClient(
+            Uri shareUri,
+            HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
+            ShareClientOptions.ServiceVersion version,
+            ClientDiagnostics clientDiagnostics)
         {
             _uri = shareUri;
             _pipeline = pipeline;
+            _storageSharedKeyCredential = storageSharedKeyCredential;
             _version = version;
             _clientDiagnostics = clientDiagnostics;
         }
@@ -295,7 +304,7 @@ namespace Azure.Storage.Files.Shares
         public virtual ShareClient WithSnapshot(string snapshot)
         {
             var p = new ShareUriBuilder(Uri) { Snapshot = snapshot };
-            return new ShareClient(p.ToUri(), Pipeline, Version, ClientDiagnostics);
+            return new ShareClient(p.ToUri(), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
         }
 
         /// <summary>
@@ -315,6 +324,7 @@ namespace Azure.Storage.Files.Shares
             return new ShareDirectoryClient(
                 shareUriBuilder.ToUri(),
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics);
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -302,6 +302,9 @@ namespace Azure.Storage.Files.Shares
         /// <param name="pipeline">
         /// The transport pipeline used to send every request.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
@@ -309,11 +312,17 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="ClientDiagnostics"/> instance used to create
         /// diagnostic scopes every request.
         /// </param>
-        internal ShareDirectoryClient(Uri directoryUri, HttpPipeline pipeline, ShareClientOptions.ServiceVersion version, ClientDiagnostics clientDiagnostics)
+        internal ShareDirectoryClient(
+            Uri directoryUri,
+            HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
+            ShareClientOptions.ServiceVersion version,
+            ClientDiagnostics clientDiagnostics)
         {
             _uri = directoryUri;
             _pipeline = pipeline;
             _version = version;
+            _storageSharedKeyCredential = storageSharedKeyCredential;
             _clientDiagnostics = clientDiagnostics;
         }
         #endregion ctors
@@ -339,7 +348,12 @@ namespace Azure.Storage.Files.Shares
         public virtual ShareDirectoryClient WithSnapshot(string snapshot)
         {
             var p = new ShareUriBuilder(Uri) { Snapshot = snapshot };
-            return new ShareDirectoryClient(p.ToUri(), Pipeline, Version, ClientDiagnostics);
+            return new ShareDirectoryClient(
+                p.ToUri(),
+                Pipeline,
+                _storageSharedKeyCredential,
+                Version,
+                ClientDiagnostics);
         }
 
         /// <summary>
@@ -357,6 +371,7 @@ namespace Azure.Storage.Files.Shares
             return new ShareFileClient(
                 shareUriBuilder.ToUri(),
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics);
         }
@@ -376,6 +391,7 @@ namespace Azure.Storage.Files.Shares
             return new ShareDirectoryClient(
                 shareUriBuilder.ToUri(),
                 Pipeline,
+                _storageSharedKeyCredential,
                 Version,
                 ClientDiagnostics);
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -312,6 +312,9 @@ namespace Azure.Storage.Files.Shares
         /// <param name="pipeline">
         /// The transport pipeline used to send every request.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
@@ -319,10 +322,16 @@ namespace Azure.Storage.Files.Shares
         /// The <see cref="ClientDiagnostics"/> instance used to create
         /// diagnostic scopes every request.
         /// </param>
-        internal ShareFileClient(Uri fileUri, HttpPipeline pipeline, ShareClientOptions.ServiceVersion version, ClientDiagnostics clientDiagnostics)
+        internal ShareFileClient(
+            Uri fileUri,
+            HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
+            ShareClientOptions.ServiceVersion version,
+            ClientDiagnostics clientDiagnostics)
         {
             _uri = fileUri;
             _pipeline = pipeline;
+            _storageSharedKeyCredential = storageSharedKeyCredential;
             _version = version;
             _clientDiagnostics = clientDiagnostics;
         }
@@ -349,7 +358,7 @@ namespace Azure.Storage.Files.Shares
         public virtual ShareFileClient WithSnapshot(string shareSnapshot)
         {
             var builder = new ShareUriBuilder(Uri) { Snapshot = shareSnapshot };
-            return new ShareFileClient(builder.ToUri(), Pipeline, Version, ClientDiagnostics);
+            return new ShareFileClient(builder.ToUri(), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -235,7 +235,7 @@ namespace Azure.Storage.Files.Shares
         /// A <see cref="ShareClient"/> for the desired share.
         /// </returns>
         public virtual ShareClient GetShareClient(string shareName) =>
-            new ShareClient(Uri.AppendToPath(shareName), Pipeline, Version, ClientDiagnostics);
+            new ShareClient(Uri.AppendToPath(shareName), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
 
         #region GetShares
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -9,12 +9,11 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Identity;
 using Azure.Storage.Files.Shares.Models;
-using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
 
-namespace Azure.Storage.Files.Shares.Test
+namespace Azure.Storage.Files.Shares.Tests
 {
     public class DirectoryClientTests : FileTestBase
     {
@@ -1154,6 +1153,92 @@ namespace Azure.Storage.Files.Shares.Test
                 constants.Sas.SharedKeyCredential,
                 GetOptions());
             Assert.IsTrue(directory4.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetFileClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName)
+            ShareDirectoryClient directory = new ShareDirectoryClient(
+                connectionString,
+                GetNewShareName(),
+                GetNewDirectoryName());
+            ShareFileClient file = directory.GetFileClient(GetNewFileName());
+            Assert.IsTrue(file.CanGenerateSasUri);
+
+            // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
+            ShareDirectoryClient directory2 = new ShareDirectoryClient(
+                connectionString,
+                GetNewShareName(),
+                GetNewDirectoryName(),
+                GetOptions());
+            ShareFileClient file2 = directory2.GetFileClient(GetNewFileName());
+            Assert.IsTrue(file2.CanGenerateSasUri);
+
+            // Act - ShareDirectoryClient(Uri blobContainerUri, BlobClientOptions options = default)
+            ShareDirectoryClient directory3 = new ShareDirectoryClient(
+                blobEndpoint,
+                GetOptions());
+            ShareFileClient file3 = directory3.GetFileClient(GetNewFileName());
+            Assert.IsFalse(file3.CanGenerateSasUri);
+
+            // Act - ShareDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            ShareDirectoryClient directory4 = new ShareDirectoryClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            ShareFileClient file4 = directory4.GetFileClient(GetNewFileName());
+            Assert.IsTrue(file4.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetSubdirectoryClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName)
+            ShareDirectoryClient directory = new ShareDirectoryClient(
+                connectionString,
+                GetNewShareName(),
+                GetNewDirectoryName());
+            ShareDirectoryClient subdirectory = directory.GetSubdirectoryClient(GetNewFileName());
+            Assert.IsTrue(subdirectory.CanGenerateSasUri);
+
+            // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
+            ShareDirectoryClient directory2 = new ShareDirectoryClient(
+                connectionString,
+                GetNewShareName(),
+                GetNewDirectoryName(),
+                GetOptions());
+            ShareDirectoryClient subdirectory2 = directory2.GetSubdirectoryClient(GetNewFileName());
+            Assert.IsTrue(subdirectory2.CanGenerateSasUri);
+
+            // Act - ShareDirectoryClient(Uri blobContainerUri, BlobClientOptions options = default)
+            ShareDirectoryClient directory3 = new ShareDirectoryClient(
+                blobEndpoint,
+                GetOptions());
+            ShareDirectoryClient subdirectory3 = directory3.GetSubdirectoryClient(GetNewFileName());
+            Assert.IsFalse(subdirectory3.CanGenerateSasUri);
+
+            // Act - ShareDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            ShareDirectoryClient directory4 = new ShareDirectoryClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            ShareDirectoryClient subdirectory4 = directory4.GetSubdirectoryClient(GetNewFileName());
+            Assert.IsTrue(subdirectory4.CanGenerateSasUri);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileSasBuilderTests.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
 using TestConstants = Azure.Storage.Test.TestConstants;
 
-namespace Azure.Storage.Files.Shares.Test
+namespace Azure.Storage.Files.Shares.Tests
 {
     public class FileSasBuilderTests : FileTestBase
     {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Net;
 using Azure.Core.TestFramework;
-using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
 
-namespace Azure.Storage.Files.Shares.Test
+namespace Azure.Storage.Files.Shares.Tests
 {
     public class FileUriBuilderTests : FileTestBase
     {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -7,12 +7,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Files.Shares.Models;
-using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
 using NUnit.Framework;
 
-namespace Azure.Storage.Files.Shares.Test
+namespace Azure.Storage.Files.Shares.Tests
 {
     public class ServiceClientTests : FileTestBase
     {
@@ -411,6 +410,45 @@ namespace Azure.Storage.Files.Shares.Test
                 constants.Sas.SharedKeyCredential,
                 GetOptions());
             Assert.IsTrue(share4.CanGenerateAccountSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetShareClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - ShareServiceClient(string connectionString)
+            ShareServiceClient service = new ShareServiceClient(
+                connectionString);
+            ShareClient share = service.GetShareClient(GetNewShareName());
+            Assert.IsTrue(share.CanGenerateSasUri);
+
+            // Act - ShareServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
+            ShareServiceClient service2 = new ShareServiceClient(
+                connectionString,
+                GetOptions());
+            ShareClient share2 = service2.GetShareClient(GetNewShareName());
+            Assert.IsTrue(share2.CanGenerateSasUri);
+
+            // Act - ShareServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
+            ShareServiceClient service3 = new ShareServiceClient(
+                blobEndpoint,
+                GetOptions());
+            ShareClient share3 = service3.GetShareClient(GetNewShareName());
+            Assert.IsFalse(share3.CanGenerateSasUri);
+
+            // Act - ShareServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            ShareServiceClient service4 = new ShareServiceClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            ShareClient share4 = service4.GetShareClient(GetNewShareName());
+            Assert.IsTrue(share4.CanGenerateSasUri);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:18.6679085-08:00",
+    "RandomSeed": "70017518"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetFileClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:18.7254882-08:00",
+    "RandomSeed": "1722183284"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubdirectoryClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubdirectoryClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:18.7186152-08:00",
+    "RandomSeed": "1221506342"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubdirectoryClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/DirectoryClientTests/CanGenerateSas_GetSubdirectoryClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:18.7277641-08:00",
+    "RandomSeed": "142652003"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetShareClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetShareClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:34.5755757-08:00",
+    "RandomSeed": "1751476515"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetShareClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetShareClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:34.6334943-08:00",
+    "RandomSeed": "1857881418"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetDirectoryClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetDirectoryClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:44.6016307-08:00",
+    "RandomSeed": "1496766426"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetDirectoryClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetDirectoryClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:44.6690119-08:00",
+    "RandomSeed": "2065789603"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetRootDirectoryClient.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetRootDirectoryClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:44.6605518-08:00",
+    "RandomSeed": "2045322264"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetRootDirectoryClientAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_GetRootDirectoryClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:21:44.6719737-08:00",
+    "RandomSeed": "5206209"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_False.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_False.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T17:01:24.3329824-08:00",
+    "RandomSeed": "2051206815"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_FalseAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_FalseAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T17:01:24.6131587-08:00",
+    "RandomSeed": "599376017"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_True.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_True.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T17:03:10.4173222-08:00",
+    "RandomSeed": "853145177"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_TrueAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/ShareClientTests/CanGenerateSas_WithSnapshot_TrueAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T17:03:10.5514063-08:00",
+    "RandomSeed": "127229778"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Storage.Files.Shares.Models;
-using Azure.Storage.Files.Shares.Tests;
 using Azure.Storage.Files.Shares.Specialized;
 using Azure.Storage.Sas;
 using Azure.Storage.Test;
@@ -17,7 +16,7 @@ using NUnit.Framework;
 using System.Threading;
 using Azure.Identity;
 
-namespace Azure.Storage.Files.Shares.Test
+namespace Azure.Storage.Files.Shares.Tests
 {
     public class ShareClientTests : FileTestBase
     {
@@ -2012,6 +2011,88 @@ namespace Azure.Storage.Files.Shares.Test
                 constants.Sas.SharedKeyCredential,
                 GetOptions());
             Assert.IsTrue(container4.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetRootDirectoryClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - ShareClient(string connectionString, string blobContainerName)
+            ShareClient share = new ShareClient(
+                connectionString,
+                GetNewShareName());
+            ShareDirectoryClient directory = share.GetRootDirectoryClient();
+            Assert.IsTrue(directory.CanGenerateSasUri);
+
+            // Act - ShareClient(string connectionString, string blobContainerName, BlobClientOptions options)
+            ShareClient share2 = new ShareClient(
+                connectionString,
+                GetNewShareName(),
+                GetOptions());
+            ShareDirectoryClient directory2 = share.GetRootDirectoryClient();
+            Assert.IsTrue(directory2.CanGenerateSasUri);
+
+            // Act - ShareClient(Uri blobContainerUri, BlobClientOptions options = default)
+            ShareClient share3 = new ShareClient(
+                blobEndpoint,
+                GetOptions());
+            ShareDirectoryClient directory3 = share3.GetRootDirectoryClient();
+            Assert.IsFalse(directory3.CanGenerateSasUri);
+
+            // Act - ShareClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            ShareClient share4 = new ShareClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            ShareDirectoryClient directory4 = share4.GetRootDirectoryClient();
+            Assert.IsTrue(directory4.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetDirectoryClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, fileStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - ShareClient(string connectionString, string blobContainerName)
+            ShareClient share = new ShareClient(
+                connectionString,
+                GetNewShareName());
+            ShareDirectoryClient directory = share.GetDirectoryClient(GetNewDirectoryName());
+            Assert.IsTrue(directory.CanGenerateSasUri);
+
+            // Act - ShareClient(string connectionString, string blobContainerName, BlobClientOptions options)
+            ShareClient share2 = new ShareClient(
+                connectionString,
+                GetNewShareName(),
+                GetOptions());
+            ShareDirectoryClient directory2 = share.GetDirectoryClient(GetNewDirectoryName());
+            Assert.IsTrue(directory2.CanGenerateSasUri);
+
+            // Act - ShareClient(Uri blobContainerUri, BlobClientOptions options = default)
+            ShareClient share3 = new ShareClient(
+                blobEndpoint,
+                GetOptions());
+            ShareDirectoryClient directory3 = share3.GetDirectoryClient(GetNewDirectoryName());
+            Assert.IsFalse(directory3.CanGenerateSasUri);
+
+            // Act - ShareClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            ShareClient share4 = new ShareClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            ShareDirectoryClient directory4 = share4.GetDirectoryClient(GetNewDirectoryName());
+            Assert.IsTrue(directory4.CanGenerateSasUri);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -2096,6 +2096,51 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [Test]
+        public void CanGenerateSas_WithSnapshot_False()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var shareEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+
+            // Create blob
+            ShareClient share = new ShareClient(
+                shareEndpoint,
+                GetOptions());
+            Assert.IsFalse(share.CanGenerateSasUri);
+
+            // Act
+            string snapshot = "2020-04-17T20:37:16.5129130Z";
+            ShareClient snapshotShare = share.WithSnapshot(snapshot);
+
+            // Assert
+            Assert.IsFalse(snapshotShare.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_WithSnapshot_True()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Create blob
+            ShareClient share = new ShareClient(
+                connectionString,
+                GetNewShareName());
+            Assert.IsTrue(share.CanGenerateSasUri);
+
+            // Act
+            string snapshot = "2020-04-17T20:37:16.5129130Z";
+            ShareClient snapshotShare = share.WithSnapshot(snapshot);
+
+            // Assert
+            Assert.IsTrue(snapshotShare.CanGenerateSasUri);
+        }
+
+        [Test]
         public void GenerateSas_RequiredParameters()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/UnitTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/UnitTests.cs
@@ -5,7 +5,7 @@ using Azure.Storage.Tests.Shared;
 using Azure.Storage.Files.Shares.Models;
 using NUnit.Framework;
 
-namespace Azure.Storage.Files.Shares.Test
+namespace Azure.Storage.Files.Shares.Tests
 {
     public class UnitTests
     {

--- a/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Queues/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.6.0-beta.1 (Unreleased)
-
+- Fixed bug where QueueServiceClient.GetQueueClient() and QueueClient.WithClientSideEncryptionOptions() created clients that could not generate a SAS from clients that could generate a SAS
 
 ## 12.5.0 (2020-11-10)
 - Includes all features from 12.5.0-preview.1

--- a/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Queues/api/Azure.Storage.Queues.netstandard2.0.cs
@@ -63,6 +63,7 @@ namespace Azure.Storage.Queues
         public virtual Azure.Response<Azure.Storage.Queues.Models.UpdateReceipt> UpdateMessage(string messageId, string popReceipt, string messageText = null, System.TimeSpan visibilityTimeout = default(System.TimeSpan), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Queues.Models.UpdateReceipt>> UpdateMessageAsync(string messageId, string popReceipt, System.BinaryData message, System.TimeSpan visibilityTimeout = default(System.TimeSpan), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Queues.Models.UpdateReceipt>> UpdateMessageAsync(string messageId, string popReceipt, string messageText = null, System.TimeSpan visibilityTimeout = default(System.TimeSpan), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected internal virtual Azure.Storage.Queues.QueueClient WithClientSideEncryptionOptionsCore(Azure.Storage.ClientSideEncryptionOptions clientSideEncryptionOptions) { throw null; }
     }
     public partial class QueueClientOptions : Azure.Core.ClientOptions
     {

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -333,6 +333,9 @@ namespace Azure.Storage.Queues
         /// <param name="pipeline">
         /// The transport pipeline used to send every request.
         /// </param>
+        /// <param name="storageSharedKeyCredential">
+        /// The shared key credential used to sign requests.
+        /// </param>
         /// <param name="version">
         /// The version of the service to use when sending requests.
         /// </param>
@@ -349,6 +352,7 @@ namespace Azure.Storage.Queues
         internal QueueClient(
             Uri queueUri,
             HttpPipeline pipeline,
+            StorageSharedKeyCredential storageSharedKeyCredential,
             QueueClientOptions.ServiceVersion version,
             ClientDiagnostics clientDiagnostics,
             ClientSideEncryptionOptions encryptionOptions,
@@ -357,6 +361,7 @@ namespace Azure.Storage.Queues
             _uri = queueUri;
             _messagesUri = queueUri.AppendToPath(Constants.Queue.MessagesUri);
             _pipeline = pipeline;
+            _storageSharedKeyCredential = storageSharedKeyCredential;
             _version = version;
             _clientDiagnostics = clientDiagnostics;
             _clientSideEncryption = QueueClientSideEncryptionOptions.CloneFrom(encryptionOptions);
@@ -376,6 +381,24 @@ namespace Azure.Storage.Queues
                 _name = builder.QueueName;
                 _accountName = builder.AccountName;
             }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="QueueClient"/> class, maintaining all the same
+        /// internals but specifying new <see cref="ClientSideEncryptionOptions"/>.
+        /// </summary>
+        /// <param name="clientSideEncryptionOptions">New encryption options. Setting this to <code>default</code> will clear client-side encryption.</param>
+        /// <returns>New instance with provided options and same internals otherwise.</returns>
+        protected internal virtual QueueClient WithClientSideEncryptionOptionsCore(ClientSideEncryptionOptions clientSideEncryptionOptions)
+        {
+            return new QueueClient(
+                Uri,
+                Pipeline,
+                _storageSharedKeyCredential,
+                Version,
+                ClientDiagnostics,
+                clientSideEncryptionOptions,
+                MessageEncoding);
         }
 
         #region Create
@@ -2718,12 +2741,6 @@ namespace Azure.Storage.Queues.Specialized
         /// <param name="clientSideEncryptionOptions">New encryption options. Setting this to <code>default</code> will clear client-side encryption.</param>
         /// <returns>New instance with provided options and same internals otherwise.</returns>
         public static QueueClient WithClientSideEncryptionOptions(this QueueClient client, ClientSideEncryptionOptions clientSideEncryptionOptions)
-            => new QueueClient(
-                client.Uri,
-                client.Pipeline,
-                client.Version,
-                client.ClientDiagnostics,
-                clientSideEncryptionOptions,
-                client.MessageEncoding);
+            => client.WithClientSideEncryptionOptionsCore(clientSideEncryptionOptions);
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -275,7 +275,7 @@ namespace Azure.Storage.Queues
         /// A <see cref="QueueClient"/> for the desired queue.
         /// </returns>
         public virtual QueueClient GetQueueClient(string queueName)
-            => new QueueClient(Uri.AppendToPath(queueName), Pipeline, Version, ClientDiagnostics, ClientSideEncryption, MessageEncoding);
+            => new QueueClient(Uri.AppendToPath(queueName), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics, ClientSideEncryption, MessageEncoding);
 
         #region GetQueues
         /// <summary>

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
@@ -18,6 +18,7 @@ using Azure.Storage.Queues.Models;
 using Azure.Storage.Queues.Specialized;
 using Azure.Storage.Queues.Specialized.Models;
 using Azure.Storage.Queues.Tests;
+using Azure.Storage.Test;
 using Moq;
 using NUnit.Framework;
 using static Moq.It;
@@ -732,6 +733,63 @@ namespace Azure.Storage.Queues.Test
                     }
                 }
             }
+        }
+
+        [Test]
+        public void CanGenerateSas_WithClientSideEncryptionOptions_True()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
+            {
+                KeyEncryptionKey = GetIKeyEncryptionKey().Object,
+                KeyResolver = GetIKeyEncryptionKeyResolver(default).Object,
+                KeyWrapAlgorithm = "bar"
+            };
+
+            // Create blob
+            QueueClient queue = new QueueClient(
+                connectionString,
+                GetNewQueueName());
+            Assert.IsTrue(queue.CanGenerateSasUri);
+
+            // Act
+            QueueClient queueEncrypted = queue.WithClientSideEncryptionOptions(options);
+
+            // Assert
+            Assert.IsTrue(queueEncrypted.CanGenerateSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_WithClientSideEncryptionOptions_False()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+
+            var options = new ClientSideEncryptionOptions(ClientSideEncryptionVersion.V1_0)
+            {
+                KeyEncryptionKey = GetIKeyEncryptionKey().Object,
+                KeyResolver = GetIKeyEncryptionKeyResolver(default).Object,
+                KeyWrapAlgorithm = "bar"
+            };
+
+            // Create blob
+            QueueClient queue = new QueueClient(
+                blobEndpoint,
+                GetOptions());
+            Assert.IsFalse(queue.CanGenerateSasUri);
+
+            // Act
+            QueueClient queueEncrypted = queue.WithClientSideEncryptionOptions(options);
+
+            // Assert
+            Assert.IsFalse(queueEncrypted.CanGenerateSasUri);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -341,28 +341,67 @@ namespace Azure.Storage.Queues.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - QueueServiceClient(string connectionString)
-            QueueServiceClient share = new QueueServiceClient(
+            QueueServiceClient serviceClient = new QueueServiceClient(
                 connectionString);
-            Assert.IsTrue(share.CanGenerateAccountSasUri);
+            Assert.IsTrue(serviceClient.CanGenerateAccountSasUri);
 
             // Act - QueueServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            QueueServiceClient share2 = new QueueServiceClient(
+            QueueServiceClient serviceClient2 = new QueueServiceClient(
                 connectionString,
                 GetOptions());
-            Assert.IsTrue(share2.CanGenerateAccountSasUri);
+            Assert.IsTrue(serviceClient2.CanGenerateAccountSasUri);
 
             // Act - QueueServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            QueueServiceClient share3 = new QueueServiceClient(
+            QueueServiceClient serviceClient3 = new QueueServiceClient(
                 blobEndpoint,
                 GetOptions());
-            Assert.IsFalse(share3.CanGenerateAccountSasUri);
+            Assert.IsFalse(serviceClient3.CanGenerateAccountSasUri);
 
             // Act - QueueServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            QueueServiceClient share4 = new QueueServiceClient(
+            QueueServiceClient serviceClient4 = new QueueServiceClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
                 GetOptions());
-            Assert.IsTrue(share4.CanGenerateAccountSasUri);
+            Assert.IsTrue(serviceClient4.CanGenerateAccountSasUri);
+        }
+
+        [Test]
+        public void CanGenerateSas_GetQueueClient()
+        {
+            // Arrange
+            var constants = new TestConstants(this);
+            var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
+            var blobSecondaryEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account + "-secondary");
+            var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, queueStorageUri: (blobEndpoint, blobSecondaryEndpoint));
+            string connectionString = storageConnectionString.ToString(true);
+
+            // Act - QueueServiceClient(string connectionString)
+            QueueServiceClient serviceClient = new QueueServiceClient(
+                connectionString);
+            QueueClient queueClient = serviceClient.GetQueueClient(GetNewQueueName());
+            Assert.IsTrue(queueClient.CanGenerateSasUri);
+
+            // Act - QueueServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
+            QueueServiceClient serviceClient2 = new QueueServiceClient(
+                connectionString,
+                GetOptions());
+            QueueClient queueClient2 = serviceClient2.GetQueueClient(GetNewQueueName());
+            Assert.IsTrue(queueClient2.CanGenerateSasUri);
+
+            // Act - QueueServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
+            QueueServiceClient serviceClient3 = new QueueServiceClient(
+                blobEndpoint,
+                GetOptions());
+            QueueClient queueClient3 = serviceClient3.GetQueueClient(GetNewQueueName());
+            Assert.IsFalse(queueClient3.CanGenerateSasUri);
+
+            // Act - QueueServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
+            QueueServiceClient serviceClient4 = new QueueServiceClient(
+                blobEndpoint,
+                constants.Sas.SharedKeyCredential,
+                GetOptions());
+            QueueClient queueClient4 = serviceClient4.GetQueueClient(GetNewQueueName());
+            Assert.IsTrue(queueClient4.CanGenerateSasUri);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_False.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_False.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-12-01T09:26:06.1626380-08:00",
+    "RandomSeed": "2050111808"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_FalseAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_FalseAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T10:39:11.5143802-08:00",
+    "RandomSeed": "1638354842"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_True.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_True.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-12-01T09:26:06.3382030-08:00",
+    "RandomSeed": "2033659194"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_TrueAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ClientSideEncryptionTests/CanGenerateSas_WithClientSideEncryptionOptions_TrueAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T10:39:11.6990506-08:00",
+    "RandomSeed": "125925766"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetQueueClient.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetQueueClient.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:40:21.9445475-08:00",
+    "RandomSeed": "755353916"
+  }
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetQueueClientAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/ServiceClientTests/CanGenerateSas_GetQueueClientAsync.json
@@ -1,0 +1,7 @@
+{
+  "Entries": [],
+  "Variables": {
+    "DateTimeOffsetNow": "2020-11-30T09:40:21.9965148-08:00",
+    "RandomSeed": "2024139133"
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-net/issues/16953

Also allows users to do CanGenerateSas and GenerateSas from clients generated from WIthSnapshot, WithVersion, WithClientSideEncryptionOptions

Related to https://github.com/Azure/azure-sdk-for-net/pull/15972