### PR TITLE
Don't install NET5

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,13 +1,1 @@
-steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK'
-    condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
-    inputs:
-      useGlobalJson: true
-      performMultiLevelLookup: true
-  - task: UseDotNet@2
-    condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
-    displayName: 'Use .NET Core 2.1 runtime'
-    inputs:
-      packageType: runtime
-      version: "2.1.x"
+steps: []

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,1 +1,15 @@
+# All required SDKs/runtimes are available on DevOps agents
 steps: []
+# Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
+#steps:
+#  - task: UseDotNet@2
+#    displayName: 'Use .NET Core SDK'
+#    inputs:
+#      useGlobalJson: true
+#      performMultiLevelLookup: true
+#  - task: UseDotNet@2
+#    condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
+#    displayName: 'Use .NET Core 2.1 runtime'
+#    inputs:
+#      packageType: runtime
+#      version: "2.1.x"


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17118

.NET 5 is available, by default, on all agents now.

I'll keep the file so we don't have to re-discover all the places we need to install dotnet the next time.