### PR TITLE
[synapse] Trim resource name to 15 char limit in provisioning

### DIFF
--- a/sdk/synapse/test-resources.json
+++ b/sdk/synapse/test-resources.json
@@ -181,7 +181,7 @@
         "uniqueDataLakeStorageFilesystemName": "[concat(parameters('defaultDataLakeStorageFilesystemNamePrefix'), parameters('baseName'))]",
         "storageBlobDataContributorRoleID": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
         "defaultDataLakeStorageAccountUrl": "[concat('https://', variables('uniqueDataLakeStorageAccountName'), '.dfs.core.windows.net')]",
-        "uniqueSparkPoolName": "[concat(parameters('sparkPoolPrefix'), parameters('baseName'))]"
+        "uniqueSparkPoolName": "[take(concat(parameters('sparkPoolPrefix'), parameters('baseName')), 15)]"
     },
     "resources": [
         {


### PR DESCRIPTION
- Fixes https://github.com/Azure/azure-sdk-for-net/issues/17237