### PR TITLE
[Event Hubs Client] Sample ReadMe Updates

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/samples/README.md
@@ -40,7 +40,7 @@ To quickly create a basic set of resources in Azure and to receive a connection 
 Install the Azure Event Hubs client library for .NET with [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-dotnet add package Azure.Messaging.EventHubs.Processor
+dotnet add package Azure.Messaging.EventHubs.Processor --version 5.3.0-beta.4
 ```
 
 ### Authenticate the client

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/README.md
@@ -40,7 +40,7 @@ To quickly create a basic set of Event Hubs resources in Azure and to receive a 
 Install the Azure Event Hubs client library for .NET with [NuGet](https://www.nuget.org/):
 
 ```PowerShell
-dotnet add package Azure.Messaging.EventHubs
+dotnet add package Azure.Messaging.EventHubs --version 5.3.0-beta.4
 ```
 
 ### Authenticate the client


### PR DESCRIPTION
# Summary

The focus of these changes is to fix the instructions for adding packages since there are references to API changes from the beta in the sample code.

# Last Upstream Rebase

Thursday, December 3, 4:18pm (EST)

# Related Issues

- [[BUG] EventHub .NET Sample. Wrong instructions in README (#17263)](https://github.com/azure/azure-sdk-for-net/issues/17263)