### PR TITLE
[Event Hubs Client] Enable Idempotent Producer Tests

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/IdempotentPublishingLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/IdempotentPublishingLiveTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.EventHubs.Tests
     ///   incur costs for the associated Azure subscription.
     /// </remarks>
     ///
-    [TestFixture(Ignore="Idempotent Publishing is not yet available in the public cloud.")]
+    [TestFixture]
     [Category(TestCategory.Live)]
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public class IdempotentPublishingLiveTests


### PR DESCRIPTION
# Summary

The focus of these changes is to enable the Live tests for the Idempotent Producer feature now that the service team has confirmed that it has rolled out to all Azure clouds in our test matrix.

# Last Upstream Rebase

Thursday, December 3, 4:18pm (EST)