### PR TITLE
Enable track 2 mgmt projects by default

### DIFF
--- a/eng/CodeCoverage.targets
+++ b/eng/CodeCoverage.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <_IsCodeCoverable Condition="'$(IsClientLibrary)' == 'true' and '$(IsMgmtClientLibrary)' != 'true'">true</_IsCodeCoverable>
+    <!-- Conditions for which projects should be covered by default. -->
+    <_IsCodeCoverable Condition="'$(IsClientLibrary)' == 'true'">true</_IsCodeCoverable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(CollectCoverage)' == 'true' and '$(_IsCodeCoverable)' == 'true' and '$(IsTestProject)' == 'true' and '$(ExcludeFromCodeCoverage)' != 'true'">


### PR DESCRIPTION
Resolves #17090 - at least for re-enabling mgmt-plane. Still needs coverage improvement but that's being handled separately.