### PR TITLE
[Event Hubs Client] Credential Refresh Buffer Tweak

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpConnectionScope.cs
@@ -67,14 +67,14 @@ namespace Azure.Messaging.EventHubs.Amqp
         ///   than the expected expiration by this amount.
         /// </summary>
         ///
-        private static TimeSpan AuthorizationRefreshBuffer { get; } = TimeSpan.FromMinutes(5);
+        private static TimeSpan AuthorizationRefreshBuffer { get; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
         ///   The minimum amount of time for authorization to be refreshed; any calculations that
         ///   call for refreshing more frequently will be substituted with this value.
         /// </summary>
         ///
-        private static TimeSpan MinimumAuthorizationRefresh { get; } = TimeSpan.FromMinutes(4);
+        private static TimeSpan MinimumAuthorizationRefresh { get; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
         ///   The amount time to allow to refresh authorization of an AMQP link.


### PR DESCRIPTION
# Summary

The focus of these changes is to add more buffer when computing the time when a credential should be renewed.  We've recently begun to see the occasional credential expiration infrequently during nightly runs.  These tweaks will allow for a greater period clock skew by eagerly refreshing the token 10 minutes before the client believes it expires.  The minimum interval  for refreshing has also been reduced in order to guard against short lived credentials.

# Last Upstream Rebase

Friday, December 4, 8:23am (EST)

# References

- [Example nightly run failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=642510&view=ms.vss-test-web.build-test-results-tab&runId=15330400&resultId=100122&paneView=debug)