### PR TITLE
[EventGrid] Add a cross reference to the docs

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridSharedAccessSignatureCredential.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/EventGridSharedAccessSignatureCredential.cs
@@ -15,7 +15,8 @@ namespace Azure.Messaging.EventGrid
         /// <summary>
         /// Initializes a new instance of the <see cref="EventGridSharedAccessSignatureCredential"/> class.
         /// </summary>
-        /// <param name="signature">SAS token used for authentication</param>
+        /// <param name="signature">SAS token used for authentication. This token can be constructed using
+        /// <see cref="EventGridPublisherClient.BuildSharedAccessSignature"/>.</param>
         public EventGridSharedAccessSignatureCredential(string signature)
         {
             Signature = signature;


### PR DESCRIPTION
From our user studies we've seen cases where folks correctly find
`EventGridSharedAccessSignitureCredential` but don't figure out how to
construct one.

We already have pointers on some of the constructors for
`EventGridPublisherClient` that take `EventGridSharedAccessSignature`'s
but we can also add a reference on the type itself.