### PR TITLE
[TA] Update service version and some cleanup

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/api/Azure.AI.TextAnalytics.netstandard2.0.cs
@@ -536,13 +536,13 @@ namespace Azure.AI.TextAnalytics
     }
     public partial class TextAnalyticsClientOptions : Azure.Core.ClientOptions
     {
-        public TextAnalyticsClientOptions(Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion version = Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_2) { }
+        public TextAnalyticsClientOptions(Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion version = Azure.AI.TextAnalytics.TextAnalyticsClientOptions.ServiceVersion.V3_1_Preview_3) { }
         public string DefaultCountryHint { get { throw null; } set { } }
         public string DefaultLanguage { get { throw null; } set { } }
         public enum ServiceVersion
         {
             V3_0 = 1,
-            V3_1_Preview_2 = 2,
+            V3_1_Preview_3 = 2,
         }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClient.cs
@@ -7,9 +7,7 @@ using Azure.Core.Pipeline;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,12 +16,11 @@ namespace Azure.AI.TextAnalytics
     /// <summary>
     /// The client to use for interacting with the Azure Cognitive Service, Text Analytics.
     /// </summary>
-    public partial class TextAnalyticsClient
+    public class TextAnalyticsClient
     {
         private readonly Uri _baseUri;
         internal readonly TextAnalyticsRestClient _serviceRestClient;
         internal readonly ClientDiagnostics _clientDiagnostics;
-        private readonly string _apiVersion;
         private readonly TextAnalyticsClientOptions _options;
         private readonly string DefaultCognitiveScope = "https://cognitiveservices.azure.com/.default";
         private const string AuthorizationHeader = "Ocp-Apim-Subscription-Key";
@@ -68,7 +65,6 @@ namespace Azure.AI.TextAnalytics
             Argument.AssertNotNull(options, nameof(options));
 
             _baseUri = endpoint;
-            _apiVersion = options.GetVersionString();
             _clientDiagnostics = new ClientDiagnostics(options);
             _options = options;
 
@@ -108,7 +104,6 @@ namespace Azure.AI.TextAnalytics
             Argument.AssertNotNull(options, nameof(options));
 
             _baseUri = endpoint;
-            _apiVersion = options.GetVersionString();
             _clientDiagnostics = new ClientDiagnostics(options);
             _options = options;
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClientOptions.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/TextAnalyticsClientOptions.cs
@@ -16,7 +16,7 @@ namespace Azure.AI.TextAnalytics
         /// <summary>
         /// The latest service version supported by this client library.
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V3_1_Preview_2;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V3_1_Preview_3;
 
         /// <summary>
         /// The versions of the Text Analytics service supported by this client library.
@@ -30,9 +30,9 @@ namespace Azure.AI.TextAnalytics
             V3_0 = 1,
 
             /// <summary>
-            /// Version 3.1-preview.2
+            /// Version 3.1-preview.3
             /// </summary>
-            V3_1_Preview_2 = 2,
+            V3_1_Preview_3 = 2,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -74,9 +74,9 @@ namespace Azure.AI.TextAnalytics
             return Version switch
             {
                 ServiceVersion.V3_0 => "v3.0",
-                ServiceVersion.V3_1_Preview_2 => "v3.1-preview.2",
+                ServiceVersion.V3_1_Preview_3 => "v3.1-preview.3",
 
-                _ => throw new ArgumentException($"Version {Version.ToString()} not supported."),
+                _ => throw new ArgumentException($"Version {Version} not supported."),
             };
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17340

Because currently the SDK doesn't support multiple service versions, this change is just to maintain consistency between our documentation and our `TextAnalyticsClientOptions`. 
Eventually, when there is support for multiple service versions, then this will be more relevant.

Other changes:
- `TextAnalyticsClient` is no longer partial, so remove
- Remove `_apiVersion` as it is no longer needed (this was used before TA moved to codegen)