### PR TITLE
Make storage mock clients able to generate sas

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -177,7 +177,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -470,7 +470,7 @@ namespace Azure.Storage.Blobs.Specialized
             return new BlobBaseClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -510,7 +510,7 @@ namespace Azure.Storage.Blobs.Specialized
             return new BlobBaseClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -4265,7 +4265,7 @@ namespace Azure.Storage.Blobs.Specialized
             }
             BlobUriBuilder sasUri = new BlobUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }
@@ -4297,7 +4297,7 @@ namespace Azure.Storage.Blobs.Specialized
                 _parentBlobContainerClient = new BlobContainerClient(
                     blobUriBuilder.ToUri(),
                     Pipeline,
-                    _storageSharedKeyCredential,
+                    SharedKeyCredential,
                     Version,
                     ClientDiagnostics,
                     CustomerProvidedKey,

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -156,10 +156,15 @@ namespace Azure.Storage.Blobs
         private readonly StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         #region ctor
         /// <summary>
@@ -420,7 +425,7 @@ namespace Azure.Storage.Blobs
             return new BlobBaseClient(
                 blobUriBuilder.ToUri(),
                 _pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -446,7 +451,7 @@ namespace Azure.Storage.Blobs
             return new BlobClient(
                 blobUriBuilder.ToUri(),
                 _pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -479,7 +484,7 @@ namespace Azure.Storage.Blobs
             return new BlockBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -511,7 +516,7 @@ namespace Azure.Storage.Blobs
             return new AppendBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -543,7 +548,7 @@ namespace Azure.Storage.Blobs
             return new PageBlobClient(
                 blobUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 CustomerProvidedKey,
@@ -3000,7 +3005,7 @@ namespace Azure.Storage.Blobs
             }
             BlobUriBuilder sasUri = new BlobUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }
@@ -3039,7 +3044,7 @@ namespace Azure.Storage.Blobs
                     ClientSideEncryption,
                     EncryptionScope,
                     Pipeline,
-                    _storageSharedKeyCredential);
+                    SharedKeyCredential);
             }
 
             return _parentBlobServiceClient;

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -130,13 +130,18 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS
         /// </summary>
-        private StorageSharedKeyCredential _storageSharedKeyCredential;
+        private readonly StorageSharedKeyCredential _storageSharedKeyCredential;
+
+        /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
 
         /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateAccountSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateAccountSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -1859,7 +1864,7 @@ namespace Azure.Storage.Blobs
                     nameof(AccountSasServices.Blobs));
             }
             UriBuilder sasUri = new UriBuilder(Uri);
-            sasUri.Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString();
+            sasUri.Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString();
             return sasUri.Uri;
         }
         #endregion

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobBaseClientTests.cs
@@ -5734,39 +5734,39 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName)
-            BlobBaseClient blob = new BlobBaseClient(
+            BlobBaseClient blob = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 GetNewContainerName(),
-                GetNewBlobName());
+                GetNewBlobName()));
             Assert.IsTrue(blob.CanGenerateSasUri);
 
             // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
-            BlobBaseClient blob2 = new BlobBaseClient(
+            BlobBaseClient blob2 = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 GetNewContainerName(),
                 GetNewBlobName(),
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(blob2.CanGenerateSasUri);
 
             // Act - BlobBaseClient(Uri blobContainerUri, BlobClientOptions options = default)
-            BlobBaseClient blob3 = new BlobBaseClient(
+            BlobBaseClient blob3 = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(blob3.CanGenerateSasUri);
 
             // Act - BlobBaseClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            BlobBaseClient blob4 = new BlobBaseClient(
+            BlobBaseClient blob4 = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(blob4.CanGenerateSasUri);
 
             // Act - BlobBaseClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            BlobBaseClient blob5 = new BlobBaseClient(
+            BlobBaseClient blob5 = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(blob5.CanGenerateSasUri);
         }
 
@@ -5781,43 +5781,43 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName)
-            BlobBaseClient blob = new BlobBaseClient(
+            BlobBaseClient blob = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 GetNewContainerName(),
-                GetNewBlobName());
+                GetNewBlobName()));
             BlobContainerClient container = blob.GetParentBlobContainerClient();
             Assert.IsTrue(container.CanGenerateSasUri);
 
             // Act - BlobBaseClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
-            BlobBaseClient blob2 = new BlobBaseClient(
+            BlobBaseClient blob2 = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 GetNewContainerName(),
                 GetNewBlobName(),
-                GetOptions());
+                GetOptions()));
             BlobContainerClient container2 = blob2.GetParentBlobContainerClient();
             Assert.IsTrue(container2.CanGenerateSasUri);
 
             // Act - BlobBaseClient(Uri blobContainerUri, BlobClientOptions options = default)
-            BlobBaseClient blob3 = new BlobBaseClient(
+            BlobBaseClient blob3 = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             BlobContainerClient container3 = blob3.GetParentBlobContainerClient();
             Assert.IsFalse(container3.CanGenerateSasUri);
 
             // Act - BlobBaseClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            BlobBaseClient blob4 = new BlobBaseClient(
+            BlobBaseClient blob4 = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             BlobContainerClient container4 = blob4.GetParentBlobContainerClient();
             Assert.IsTrue(container4.CanGenerateSasUri);
 
             // Act - BlobBaseClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            BlobBaseClient blob5 = new BlobBaseClient(
+            BlobBaseClient blob5 = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             BlobContainerClient container5 = blob5.GetParentBlobContainerClient();
             Assert.IsFalse(container5.CanGenerateSasUri);
         }
@@ -5833,10 +5833,10 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Create blob
-            BlobBaseClient blob = new BlobBaseClient(
+            BlobBaseClient blob = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 GetNewContainerName(),
-                GetNewBlobName());
+                GetNewBlobName()));
             Assert.IsTrue(blob.CanGenerateSasUri);
 
             // Act
@@ -5855,9 +5855,9 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Create blob
-            BlobBaseClient blob = new BlobBaseClient(
+            BlobBaseClient blob = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(blob.CanGenerateSasUri);
 
             // Act
@@ -5879,10 +5879,10 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Create blob
-            BlobBaseClient blob = new BlobBaseClient(
+            BlobBaseClient blob = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 GetNewContainerName(),
-                GetNewBlobName());
+                GetNewBlobName()));
             Assert.IsTrue(blob.CanGenerateSasUri);
 
             // Act
@@ -5901,9 +5901,9 @@ namespace Azure.Storage.Blobs.Test
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Create blob
-            BlobBaseClient blob = new BlobBaseClient(
+            BlobBaseClient blob = InstrumentClient(new BlobBaseClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(blob.CanGenerateSasUri);
 
             // Act
@@ -5927,11 +5927,11 @@ namespace Azure.Storage.Blobs.Test
             string blobName = GetNewBlobName();
             BlobSasPermissions permissions = BlobSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            BlobBaseClient blobClient = new BlobBaseClient(
+            BlobBaseClient blobClient = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 containerName,
                 blobName,
-                GetOptions());
+                GetOptions()));
 
             //Act
             Uri sasUri = blobClient.GenerateSasUri(permissions, expiresOn);
@@ -5964,11 +5964,11 @@ namespace Azure.Storage.Blobs.Test
             BlobSasPermissions permissions = BlobSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
-            BlobBaseClient blobClient = new BlobBaseClient(
+            BlobBaseClient blobClient = InstrumentClient(new BlobBaseClient(
                 connectionString,
                 containerName,
                 blobName,
-                GetOptions());
+                GetOptions()));
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
             {
@@ -6007,10 +6007,10 @@ namespace Azure.Storage.Blobs.Test
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewContainerName() + "/" + blobName;
             BlobSasPermissions permissions = BlobSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            BlobBaseClient blobClient = new BlobBaseClient(
+            BlobBaseClient blobClient = InstrumentClient(new BlobBaseClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
             {
@@ -6044,10 +6044,10 @@ namespace Azure.Storage.Blobs.Test
             blobUriBuilder.Path += constants.Sas.Account + "/" + containerName + "/" + GetNewBlobName();
             BlobSasPermissions permissions = BlobSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            BlobBaseClient blobClient = new BlobBaseClient(
+            BlobBaseClient blobClient = InstrumentClient(new BlobBaseClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
             {
@@ -6084,10 +6084,10 @@ namespace Azure.Storage.Blobs.Test
             blobUriBuilder.Path += constants.Sas.Account + "/" + containerName + "/" + blobName;
             BlobSasPermissions permissions = BlobSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            BlobBaseClient blobClient = new BlobBaseClient(
+            BlobBaseClient blobClient = InstrumentClient(new BlobBaseClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
             {
@@ -6125,10 +6125,10 @@ namespace Azure.Storage.Blobs.Test
             blobUriBuilder.Path += constants.Sas.Account + "/" + containerName + "/" + blobName;
             BlobSasPermissions permissions = BlobSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            BlobBaseClient blobClient = new BlobBaseClient(
+            BlobBaseClient blobClient = InstrumentClient(new BlobBaseClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ClientSideEncryptionTests.cs
@@ -741,10 +741,10 @@ namespace Azure.Storage.Blobs.Test
             };
 
             // Create blob
-            BlobClient blob = new BlobClient(
+            BlobClient blob = InstrumentClient(new BlobClient(
                 connectionString,
                 GetNewContainerName(),
-                GetNewBlobName());
+                GetNewBlobName()));
             Assert.IsTrue(blob.CanGenerateSasUri);
 
             // Act
@@ -769,9 +769,9 @@ namespace Azure.Storage.Blobs.Test
             };
 
             // Create blob
-            BlobClient blob = new BlobClient(
+            BlobClient blob = InstrumentClient(new BlobClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(blob.CanGenerateSasUri);
 
             // Act

--- a/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ContainerClientTests.cs
@@ -2607,37 +2607,37 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - BlobContainerClient(string connectionString, string blobContainerName)
-            BlobContainerClient container = new BlobContainerClient(
+            BlobContainerClient container = InstrumentClient(new BlobContainerClient(
                 connectionString,
-                GetNewContainerName());
+                GetNewContainerName()));
             Assert.IsTrue(container.CanGenerateSasUri);
 
             // Act - BlobContainerClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            BlobContainerClient container2 = new BlobContainerClient(
+            BlobContainerClient container2 = InstrumentClient(new BlobContainerClient(
                 connectionString,
                 GetNewContainerName(),
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container2.CanGenerateSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, BlobClientOptions options = default)
-            BlobContainerClient container3 = new BlobContainerClient(
+            BlobContainerClient container3 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(container3.CanGenerateSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            BlobContainerClient container4 = new BlobContainerClient(
+            BlobContainerClient container4 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container4.CanGenerateSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            BlobContainerClient container5 = new BlobContainerClient(
+            BlobContainerClient container5 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(container5.CanGenerateSasUri);
         }
 
@@ -2652,41 +2652,41 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - BlobContainerClient(string connectionString, string blobContainerName)
-            BlobContainerClient container = new BlobContainerClient(
+            BlobContainerClient container = InstrumentClient(new BlobContainerClient(
                 connectionString,
-                GetNewContainerName());
+                GetNewContainerName()));
             BlobBaseClient blob = container.GetBlobBaseClient(GetNewBlobName());
             Assert.IsTrue(blob.CanGenerateSasUri);
 
             // Act - BlobContainerClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            BlobContainerClient container2 = new BlobContainerClient(
+            BlobContainerClient container2 = InstrumentClient(new BlobContainerClient(
                 connectionString,
                 GetNewContainerName(),
-                GetOptions());
+                GetOptions()));
             BlobBaseClient blob2 = container2.GetBlobBaseClient(GetNewBlobName());
             Assert.IsTrue(blob2.CanGenerateSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, BlobClientOptions options = default)
-            BlobContainerClient container3 = new BlobContainerClient(
+            BlobContainerClient container3 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             BlobBaseClient blob3 = container3.GetBlobBaseClient(GetNewBlobName());
             Assert.IsFalse(blob3.CanGenerateSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            BlobContainerClient container4 = new BlobContainerClient(
+            BlobContainerClient container4 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             BlobBaseClient blob4 = container4.GetBlobBaseClient(GetNewBlobName());
             Assert.IsTrue(blob4.CanGenerateSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            BlobContainerClient container5 = new BlobContainerClient(
+            BlobContainerClient container5 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             BlobBaseClient blob5 = container5.GetBlobBaseClient(GetNewBlobName());
             Assert.IsFalse(blob5.CanGenerateSasUri);
         }
@@ -2702,41 +2702,41 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - BlobContainerClient(string connectionString, string blobContainerName)
-            BlobContainerClient container = new BlobContainerClient(
+            BlobContainerClient container = InstrumentClient(new BlobContainerClient(
                 connectionString,
-                GetNewContainerName());
+                GetNewContainerName()));
             BlobServiceClient service = container.GetParentBlobServiceClient();
             Assert.IsTrue(service.CanGenerateAccountSasUri);
 
             // Act - BlobContainerClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            BlobContainerClient container2 = new BlobContainerClient(
+            BlobContainerClient container2 = InstrumentClient(new BlobContainerClient(
                 connectionString,
                 GetNewContainerName(),
-                GetOptions());
+                GetOptions()));
             BlobServiceClient service2 = container2.GetParentBlobServiceClient();
             Assert.IsTrue(service2.CanGenerateAccountSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, BlobClientOptions options = default)
-            BlobContainerClient container3 = new BlobContainerClient(
+            BlobContainerClient container3 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             BlobServiceClient service3 = container3.GetParentBlobServiceClient();
             Assert.IsFalse(service3.CanGenerateAccountSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            BlobContainerClient container4 = new BlobContainerClient(
+            BlobContainerClient container4 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             BlobServiceClient service4 = container4.GetParentBlobServiceClient();
             Assert.IsTrue(service4.CanGenerateAccountSasUri);
 
             // Act - BlobContainerClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            BlobContainerClient container5 = new BlobContainerClient(
+            BlobContainerClient container5 = InstrumentClient(new BlobContainerClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             BlobServiceClient service5 = container5.GetParentBlobServiceClient();
             Assert.IsFalse(service5.CanGenerateAccountSasUri);
         }
@@ -2753,7 +2753,7 @@ namespace Azure.Storage.Blobs.Test
             string containerName = GetNewContainerName();
             BlobContainerSasPermissions permissions = BlobContainerSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            BlobContainerClient containerClient = new BlobContainerClient(connectionString, containerName, GetOptions());
+            BlobContainerClient containerClient = InstrumentClient(new BlobContainerClient(connectionString, containerName, GetOptions()));
 
             //Act
             Uri sasUri = containerClient.GenerateSasUri(permissions, expiresOn);
@@ -2783,7 +2783,7 @@ namespace Azure.Storage.Blobs.Test
             BlobContainerSasPermissions permissions = BlobContainerSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             BlobContainerClient containerClient =
-                new BlobContainerClient(connectionString, containerName, GetOptions());
+                InstrumentClient(new BlobContainerClient(connectionString, containerName, GetOptions()));
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
             {
@@ -2816,10 +2816,10 @@ namespace Azure.Storage.Blobs.Test
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewContainerName();
             BlobSasPermissions permissions = BlobSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            BlobContainerClient containerClient = new BlobContainerClient(
+            BlobContainerClient containerClient = InstrumentClient(new BlobContainerClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             BlobSasBuilder sasBuilder = new BlobSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/ServiceClientTests.cs
@@ -724,35 +724,35 @@ namespace Azure.Storage.Blobs.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - BlobServiceClient(string connectionString)
-            BlobServiceClient container = new BlobServiceClient(
-                connectionString);
+            BlobServiceClient container = InstrumentClient(new BlobServiceClient(
+                connectionString));
             Assert.IsTrue(container.CanGenerateAccountSasUri);
 
             // Act - BlobServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            BlobServiceClient container2 = new BlobServiceClient(
+            BlobServiceClient container2 = InstrumentClient(new BlobServiceClient(
                 connectionString,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container2.CanGenerateAccountSasUri);
 
             // Act - BlobServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            BlobServiceClient container3 = new BlobServiceClient(
+            BlobServiceClient container3 = InstrumentClient(new BlobServiceClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(container3.CanGenerateAccountSasUri);
 
             // Act - BlobServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            BlobServiceClient container4 = new BlobServiceClient(
+            BlobServiceClient container4 = InstrumentClient(new BlobServiceClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container4.CanGenerateAccountSasUri);
 
             // Act - BlobServiceClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            BlobServiceClient container5 = new BlobServiceClient(
+            BlobServiceClient container5 = InstrumentClient(new BlobServiceClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(container5.CanGenerateAccountSasUri);
         }
 
@@ -768,39 +768,39 @@ namespace Azure.Storage.Blobs.Test
 
             // Check if we're passing the SharedKeyCredential correctly to the containerClient
             // Act - BlobServiceClient(string connectionString)
-            BlobServiceClient serviceClient = new BlobServiceClient(
-                connectionString);
+            BlobServiceClient serviceClient = InstrumentClient(new BlobServiceClient(
+                connectionString));
             BlobContainerClient containerClient = serviceClient.GetBlobContainerClient(GetNewContainerName());
             Assert.IsTrue(containerClient.CanGenerateSasUri);
 
             // Act - BlobServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            BlobServiceClient serviceClient2 = new BlobServiceClient(
+            BlobServiceClient serviceClient2 = InstrumentClient(new BlobServiceClient(
                 connectionString,
-                GetOptions());
+                GetOptions()));
             BlobContainerClient containerClient2 = serviceClient2.GetBlobContainerClient(GetNewContainerName());
             Assert.IsTrue(containerClient2.CanGenerateSasUri);
 
             // Act - BlobServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            BlobServiceClient serviceClient3 = new BlobServiceClient(
+            BlobServiceClient serviceClient3 = InstrumentClient(new BlobServiceClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             BlobContainerClient containerClient3 = serviceClient3.GetBlobContainerClient(GetNewContainerName());
             Assert.IsFalse(containerClient3.CanGenerateSasUri);
 
             // Act - BlobServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            BlobServiceClient serviceClient4 = new BlobServiceClient(
+            BlobServiceClient serviceClient4 = InstrumentClient(new BlobServiceClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             BlobContainerClient containerClient4 = serviceClient4.GetBlobContainerClient(GetNewContainerName());
             Assert.IsTrue(containerClient4.CanGenerateSasUri);
 
             // Act - BlobServiceClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            BlobServiceClient serviceClient5 = new BlobServiceClient(
+            BlobServiceClient serviceClient5 = InstrumentClient(new BlobServiceClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             BlobContainerClient containerClient5 = serviceClient5.GetBlobContainerClient(GetNewContainerName());
             Assert.IsFalse(containerClient5.CanGenerateSasUri);
         }
@@ -817,7 +817,7 @@ namespace Azure.Storage.Blobs.Test
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            BlobServiceClient serviceClient = new BlobServiceClient(connectionString, GetOptions());
+            BlobServiceClient serviceClient = InstrumentClient(new BlobServiceClient(connectionString, GetOptions()));
 
             // Act
             Uri sasUri = serviceClient.GenerateAccountSasUri(
@@ -844,7 +844,7 @@ namespace Azure.Storage.Blobs.Test
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasServices services = AccountSasServices.Blobs;
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            BlobServiceClient serviceClient = new BlobServiceClient(connectionString, GetOptions());
+            BlobServiceClient serviceClient = InstrumentClient(new BlobServiceClient(connectionString, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {
@@ -873,7 +873,7 @@ namespace Azure.Storage.Blobs.Test
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasServices services = AccountSasServices.Files; // Wrong Service
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            BlobServiceClient serviceClient = new BlobServiceClient(connectionString, GetOptions());
+            BlobServiceClient serviceClient = InstrumentClient(new BlobServiceClient(connectionString, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeDirectoryClient.cs
@@ -233,7 +233,7 @@ namespace Azure.Storage.Files.DataLake
                 Uri,
                 $"{Path}/{fileName}",
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics);
 
@@ -250,7 +250,7 @@ namespace Azure.Storage.Files.DataLake
                 Uri,
                 $"{Path}/{subdirectoryName}",
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics);
 
@@ -2378,7 +2378,7 @@ namespace Azure.Storage.Files.DataLake
             }
             DataLakeUriBuilder sasUri = new DataLakeUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeFileSystemClient.cs
@@ -129,10 +129,15 @@ namespace Azure.Storage.Files.DataLake
         private readonly StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -2384,7 +2389,7 @@ namespace Azure.Storage.Files.DataLake
             }
             DataLakeUriBuilder sasUri = new DataLakeUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -179,13 +179,18 @@ namespace Azure.Storage.Files.DataLake
         /// <summary>
         /// The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS
         /// </summary>
-        internal readonly StorageSharedKeyCredential _storageSharedKeyCredential;
+        private readonly StorageSharedKeyCredential _storageSharedKeyCredential;
+
+        /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
 
         /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -1698,7 +1703,7 @@ namespace Azure.Storage.Files.DataLake
                     }
 
                     // Build destPathClient
-                    DataLakePathClient destPathClient = new DataLakePathClient(destUriBuilder.ToUri(), Pipeline, _storageSharedKeyCredential);
+                    DataLakePathClient destPathClient = new DataLakePathClient(destUriBuilder.ToUri(), Pipeline, SharedKeyCredential);
 
                     Response<PathCreateResult> response = await DataLakeRestClient.Path.CreateAsync(
                         clientDiagnostics: _clientDiagnostics,
@@ -3328,7 +3333,7 @@ namespace Azure.Storage.Files.DataLake
             }
             DataLakeUriBuilder sasUri = new DataLakeUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeServiceClient.cs
@@ -102,10 +102,15 @@ namespace Azure.Storage.Files.DataLake
         private StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateAccountSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateAccountSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -324,7 +329,7 @@ namespace Azure.Storage.Files.DataLake
         /// A <see cref="DataLakeFileSystemClient"/> for the desired share.
         /// </returns>
         public virtual DataLakeFileSystemClient GetFileSystemClient(string fileSystemName)
-            => new DataLakeFileSystemClient(Uri.AppendToPath(fileSystemName), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
+            => new DataLakeFileSystemClient(Uri.AppendToPath(fileSystemName), Pipeline, SharedKeyCredential, Version, ClientDiagnostics);
 
         #region Get User Delegation Key
         /// <summary>
@@ -838,7 +843,7 @@ namespace Azure.Storage.Files.DataLake
                     nameof(AccountSasServices.Blobs));
             }
             DataLakeUriBuilder sasUri = new DataLakeUriBuilder(Uri);
-            sasUri.Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString();
+            sasUri.Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString();
             return sasUri.ToUri();
         }
         #endregion

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -4845,24 +4845,24 @@ namespace Azure.Storage.Files.DataLake.Tests
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
-            DataLakeDirectoryClient directory = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(directory.CanGenerateSasUri);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, fileClientOptions options = default)
-            DataLakeDirectoryClient directory2 = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory2 = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(directory2.CanGenerateSasUri);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, TokenCredential credential, fileClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeDirectoryClient directory3 = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory3 = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(directory3.CanGenerateSasUri);
         }
 
@@ -4874,26 +4874,26 @@ namespace Azure.Storage.Files.DataLake.Tests
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
-            DataLakeDirectoryClient directory = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             DataLakeFileClient file = directory.GetFileClient(GetNewFileName());
             Assert.IsFalse(file.CanGenerateSasUri);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, fileClientOptions options = default)
-            DataLakeDirectoryClient directory2 = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory2 = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             DataLakeFileClient file2 = directory2.GetFileClient(GetNewFileName());
             Assert.IsTrue(file2.CanGenerateSasUri);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, TokenCredential credential, fileClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeDirectoryClient directory3 = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory3 = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             DataLakeFileClient file3 = directory3.GetFileClient(GetNewFileName());
             Assert.IsFalse(file3.CanGenerateSasUri);
         }
@@ -4906,26 +4906,26 @@ namespace Azure.Storage.Files.DataLake.Tests
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, fileClientOptions options = default)
-            DataLakeDirectoryClient directory = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             DataLakeDirectoryClient subdirectory = directory.GetSubDirectoryClient(GetNewDirectoryName());
             Assert.IsFalse(subdirectory.CanGenerateSasUri);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, fileClientOptions options = default)
-            DataLakeDirectoryClient directory2 = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory2 = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             DataLakeDirectoryClient subdirectory2 = directory2.GetSubDirectoryClient(GetNewDirectoryName());
             Assert.IsTrue(subdirectory2.CanGenerateSasUri);
 
             // Act - DataLakeDirectoryClient(Uri blobContainerUri, TokenCredential credential, fileClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeDirectoryClient directory3 = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directory3 = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             DataLakeDirectoryClient subdirectory3 = directory3.GetSubDirectoryClient(GetNewDirectoryName());
             Assert.IsFalse(subdirectory3.CanGenerateSasUri);
         }
@@ -4940,10 +4940,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "/" + fileSystemName + "/" + path);
-            DataLakeDirectoryClient directoryClient = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient directoryClient = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             // Act
             Uri sasUri = directoryClient.GenerateSasUri(permissions, expiresOn);
@@ -4970,10 +4970,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "/" + fileSystemName + "/" + path);
-            DataLakeDirectoryClient fileClient = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient fileClient = InstrumentClient(new DataLakeDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -5010,10 +5010,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewFileSystemName() + "/" + directoryName;
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            DataLakeDirectoryClient fileClient = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient fileClient = InstrumentClient(new DataLakeDirectoryClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -5046,10 +5046,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             blobUriBuilder.Path += constants.Sas.Account + "/" + fileSystemName + "/" + GetNewDirectoryName();
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            DataLakeDirectoryClient containerClient = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient containerClient = InstrumentClient(new DataLakeDirectoryClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -5083,10 +5083,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             blobUriBuilder.Path += constants.Sas.Account + "/" + fileSystemName + "/" + directoryName;
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            DataLakeDirectoryClient containerClient = new DataLakeDirectoryClient(
+            DataLakeDirectoryClient containerClient = InstrumentClient(new DataLakeDirectoryClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileClientTests.cs
@@ -4713,24 +4713,24 @@ namespace Azure.Storage.Files.DataLake.Tests
             var blobEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Act - DataLakeFileClient(Uri blobContainerUri, fileClientOptions options = default)
-            DataLakeFileClient file = new DataLakeFileClient(
+            DataLakeFileClient file = InstrumentClient(new DataLakeFileClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(file.CanGenerateSasUri);
 
             // Act - DataLakeFileClient(Uri blobContainerUri, StorageSharedKeyCredential credential, fileClientOptions options = default)
-            DataLakeFileClient file2 = new DataLakeFileClient(
+            DataLakeFileClient file2 = InstrumentClient(new DataLakeFileClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(file2.CanGenerateSasUri);
 
             // Act - DataLakeFileClient(Uri blobContainerUri, TokenCredential credential, fileClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeFileClient file3 = new DataLakeFileClient(
+            DataLakeFileClient file3 = InstrumentClient(new DataLakeFileClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(file3.CanGenerateSasUri);
         }
 
@@ -4744,10 +4744,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "/" + fileSystemName + "/" + path);
-            DataLakeFileClient fileClient = new DataLakeFileClient(
+            DataLakeFileClient fileClient = InstrumentClient(new DataLakeFileClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             // Act
             Uri sasUri = fileClient.GenerateSasUri(permissions, expiresOn);
@@ -4773,10 +4773,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "/" + fileSystemName + "/" + path);
-            DataLakeFileClient fileClient = new DataLakeFileClient(
+            DataLakeFileClient fileClient = InstrumentClient(new DataLakeFileClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -4811,10 +4811,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewFileSystemName() + "/" + path;
-            DataLakeFileClient fileClient = new DataLakeFileClient(
+            DataLakeFileClient fileClient = InstrumentClient(new DataLakeFileClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -4846,10 +4846,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             blobUriBuilder.Path += constants.Sas.Account + "/" + fileSystemName + "/" + GetNewFileName();
-            DataLakeFileClient fileClient = new DataLakeFileClient(
+            DataLakeFileClient fileClient = InstrumentClient(new DataLakeFileClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -4882,10 +4882,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             blobUriBuilder.Path += constants.Sas.Account + "/" + fileSystemName + "/" + fileName;
 
-            DataLakeFileClient fileClient = new DataLakeFileClient(
+            DataLakeFileClient fileClient = InstrumentClient(new DataLakeFileClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/FileSystemClientTests.cs
@@ -1975,24 +1975,24 @@ namespace Azure.Storage.Files.DataLake.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, BlobClientOptions options = default)
-            DataLakeFileSystemClient filesystem = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(filesystem.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            DataLakeFileSystemClient filesystem2 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem2 = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(filesystem2.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeFileSystemClient filesystem3 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem3 = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(filesystem3.CanGenerateSasUri);
         }
 
@@ -2007,26 +2007,26 @@ namespace Azure.Storage.Files.DataLake.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, BlobClientOptions options = default)
-            DataLakeFileSystemClient filesystem = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             DataLakeFileClient file = filesystem.GetFileClient(GetNewFileName());
             Assert.IsFalse(file.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            DataLakeFileSystemClient filesystem2 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem2 = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             DataLakeFileClient file2 = filesystem2.GetFileClient(GetNewFileName());
             Assert.IsTrue(file2.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeFileSystemClient filesystem3 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem3 = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             DataLakeFileClient file3 = filesystem3.GetFileClient(GetNewFileName());
             Assert.IsFalse(file3.CanGenerateSasUri);
         }
@@ -2042,26 +2042,26 @@ namespace Azure.Storage.Files.DataLake.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, BlobClientOptions options = default)
-            DataLakeFileSystemClient filesystem = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             DataLakeDirectoryClient directory = filesystem.GetDirectoryClient(GetNewDirectoryName());
             Assert.IsFalse(directory.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            DataLakeFileSystemClient filesystem2 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem2 = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             DataLakeDirectoryClient directory2 = filesystem2.GetDirectoryClient(GetNewDirectoryName());
             Assert.IsTrue(directory2.CanGenerateSasUri);
 
             // Act - DataLakeFileSystemClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeFileSystemClient filesystem3 = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient filesystem3 = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             DataLakeDirectoryClient directory3 = filesystem3.GetDirectoryClient(GetNewDirectoryName());
             Assert.IsFalse(directory3.CanGenerateSasUri);
         }
@@ -2079,10 +2079,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
             string connectionString = storageConnectionString.ToString(true);
-            DataLakeFileSystemClient fileSystemClient = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient fileSystemClient = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             // Act
             Uri sasUri = fileSystemClient.GenerateSasUri(permissions, expiresOn);
@@ -2110,10 +2110,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "/" + fileSystemName);
             var blobSecondaryEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "-secondary");
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (blobEndpoint, blobSecondaryEndpoint));
-            DataLakeFileSystemClient fileSystemClient = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient fileSystemClient = InstrumentClient(new DataLakeFileSystemClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -2145,10 +2145,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewFileSystemName();
             DataLakeFileSystemSasPermissions permissions = DataLakeFileSystemSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            DataLakeFileSystemClient fileSystemClient = new DataLakeFileSystemClient(
+            DataLakeFileSystemClient fileSystemClient = InstrumentClient(new DataLakeFileSystemClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/PathClientTests.cs
@@ -131,24 +131,24 @@ namespace Azure.Storage.Files.DataLake.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - DataLakePathClient(Uri blobContainerUri, BlobClientOptions options = default)
-            DataLakePathClient blob3 = new DataLakePathClient(
+            DataLakePathClient blob3 = InstrumentClient(new DataLakePathClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(blob3.CanGenerateSasUri);
 
             // Act - DataLakePathClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            DataLakePathClient blob4 = new DataLakePathClient(
+            DataLakePathClient blob4 = InstrumentClient(new DataLakePathClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(blob4.CanGenerateSasUri);
 
             // Act - DataLakePathClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakePathClient blob5 = new DataLakePathClient(
+            DataLakePathClient blob5 = InstrumentClient(new DataLakePathClient(
                 blobEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(blob5.CanGenerateSasUri);
         }
 
@@ -162,10 +162,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "/" + fileSystemName + "/" + path);
-            DataLakePathClient pathClient = new DataLakePathClient(
+            DataLakePathClient pathClient = InstrumentClient(new DataLakePathClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             // Act
             Uri sasUri = pathClient.GenerateSasUri(permissions, expiresOn);
@@ -193,10 +193,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
             var blobEndpoint = new Uri("http://127.0.0.1/" + constants.Sas.Account + "/" + fileSystemName + "/" + path);
-            DataLakePathClient pathClient = new DataLakePathClient(
+            DataLakePathClient pathClient = InstrumentClient(new DataLakePathClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -231,10 +231,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewFileSystemName() + "/" + path;
-            DataLakePathClient pathClient = new DataLakePathClient(
+            DataLakePathClient pathClient = InstrumentClient(new DataLakePathClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -266,10 +266,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             blobUriBuilder.Path += constants.Sas.Account + "/" + fileSystemName + "/" + GetNewFileName();
-            DataLakePathClient containerClient = new DataLakePathClient(
+            DataLakePathClient containerClient = InstrumentClient(new DataLakePathClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {
@@ -301,10 +301,10 @@ namespace Azure.Storage.Files.DataLake.Tests
             DataLakeSasPermissions permissions = DataLakeSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             blobUriBuilder.Path += constants.Sas.Account + "/" + fileSystemName + "/" + fileName;
-            DataLakePathClient containerClient = new DataLakePathClient(
+            DataLakePathClient containerClient = InstrumentClient(new DataLakePathClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             DataLakeSasBuilder sasBuilder = new DataLakeSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/ServiceClientTests.cs
@@ -264,24 +264,24 @@ namespace Azure.Storage.Files.DataLake.Tests
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (uriEndpoint, blobSecondaryEndpoint));
 
             // Act - DataLakeServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            DataLakeServiceClient serviceClient = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient = InstrumentClient(new DataLakeServiceClient(
                 uriEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(serviceClient.CanGenerateAccountSasUri);
 
             // Act - DataLakeServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            DataLakeServiceClient serviceClient2 = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient2 = InstrumentClient(new DataLakeServiceClient(
                 uriEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(serviceClient2.CanGenerateAccountSasUri);
 
             // Act - DataLakeServiceClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeServiceClient serviceClient3 = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient3 = InstrumentClient(new DataLakeServiceClient(
                 uriEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(serviceClient3.CanGenerateAccountSasUri);
         }
 
@@ -295,26 +295,26 @@ namespace Azure.Storage.Files.DataLake.Tests
             var storageConnectionString = new StorageConnectionString(constants.Sas.SharedKeyCredential, blobStorageUri: (uriEndpoint, blobSecondaryEndpoint));
 
             // Act - DataLakeServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            DataLakeServiceClient serviceClient = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient = InstrumentClient(new DataLakeServiceClient(
                 uriEndpoint,
-                GetOptions());
+                GetOptions()));
             DataLakeFileSystemClient fileSystemClient = serviceClient.GetFileSystemClient(GetNewFileSystemName());
             Assert.IsFalse(fileSystemClient.CanGenerateSasUri);
 
             // Act - DataLakeServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            DataLakeServiceClient serviceClient2 = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient2 = InstrumentClient(new DataLakeServiceClient(
                 uriEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             DataLakeFileSystemClient fileSystemClient2 = serviceClient2.GetFileSystemClient(GetNewFileSystemName());
             Assert.IsTrue(fileSystemClient2.CanGenerateSasUri);
 
             // Act - DataLakeServiceClient(Uri blobContainerUri, TokenCredential credential, BlobClientOptions options = default)
             var tokenCredentials = new DefaultAzureCredential();
-            DataLakeServiceClient serviceClient3 = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient3 = InstrumentClient(new DataLakeServiceClient(
                 uriEndpoint,
                 tokenCredentials,
-                GetOptions());
+                GetOptions()));
             DataLakeFileSystemClient fileSystemClient3 = serviceClient3.GetFileSystemClient(GetNewFileSystemName());
             Assert.IsFalse(fileSystemClient3.CanGenerateSasUri);
         }
@@ -331,9 +331,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             AccountSasPermissions permissions = AccountSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            DataLakeServiceClient serviceClient = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient = InstrumentClient(new DataLakeServiceClient(
                 blobEndpoint,
-                constants.Sas.SharedKeyCredential, GetOptions());
+                constants.Sas.SharedKeyCredential, GetOptions()));
 
             // Act
             Uri sasUri = serviceClient.GenerateAccountSasUri(
@@ -364,9 +364,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
             AccountSasServices services = AccountSasServices.Blobs;
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            DataLakeServiceClient serviceClient = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient = InstrumentClient(new DataLakeServiceClient(
                 blobEndpoint,
-                constants.Sas.SharedKeyCredential, GetOptions());
+                constants.Sas.SharedKeyCredential, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {
@@ -398,9 +398,9 @@ namespace Azure.Storage.Files.DataLake.Tests
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasServices services = AccountSasServices.Files; // Wrong Service
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            DataLakeServiceClient serviceClient = new DataLakeServiceClient(
+            DataLakeServiceClient serviceClient = InstrumentClient(new DataLakeServiceClient(
                 blobEndpoint,
-                constants.Sas.SharedKeyCredential, GetOptions());
+                constants.Sas.SharedKeyCredential, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareClient.cs
@@ -107,10 +107,15 @@ namespace Azure.Storage.Files.Shares
         private readonly StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -304,7 +309,7 @@ namespace Azure.Storage.Files.Shares
         public virtual ShareClient WithSnapshot(string snapshot)
         {
             var p = new ShareUriBuilder(Uri) { Snapshot = snapshot };
-            return new ShareClient(p.ToUri(), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
+            return new ShareClient(p.ToUri(), Pipeline, SharedKeyCredential, Version, ClientDiagnostics);
         }
 
         /// <summary>
@@ -324,7 +329,7 @@ namespace Azure.Storage.Files.Shares
             return new ShareDirectoryClient(
                 shareUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics);
         }
@@ -3252,7 +3257,7 @@ namespace Azure.Storage.Files.Shares
             }
             ShareUriBuilder sasUri = new ShareUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareDirectoryClient.cs
@@ -138,10 +138,15 @@ namespace Azure.Storage.Files.Shares
         internal readonly StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -351,7 +356,7 @@ namespace Azure.Storage.Files.Shares
             return new ShareDirectoryClient(
                 p.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics);
         }
@@ -371,7 +376,7 @@ namespace Azure.Storage.Files.Shares
             return new ShareFileClient(
                 shareUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics);
         }
@@ -391,7 +396,7 @@ namespace Azure.Storage.Files.Shares
             return new ShareDirectoryClient(
                 shareUriBuilder.ToUri(),
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics);
         }
@@ -2725,7 +2730,7 @@ namespace Azure.Storage.Files.Shares
             }
             ShareUriBuilder sasUri = new ShareUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareFileClient.cs
@@ -144,10 +144,15 @@ namespace Azure.Storage.Files.Shares
         internal readonly StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         //const string fileType = "file";
 
@@ -358,7 +363,7 @@ namespace Azure.Storage.Files.Shares
         public virtual ShareFileClient WithSnapshot(string shareSnapshot)
         {
             var builder = new ShareUriBuilder(Uri) { Snapshot = shareSnapshot };
-            return new ShareFileClient(builder.ToUri(), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
+            return new ShareFileClient(builder.ToUri(), Pipeline, SharedKeyCredential, Version, ClientDiagnostics);
         }
 
         /// <summary>
@@ -5293,7 +5298,7 @@ namespace Azure.Storage.Files.Shares
             }
             ShareUriBuilder sasUri = new ShareUriBuilder(Uri)
             {
-                Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString()
+                Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString()
             };
             return sasUri.ToUri();
         }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareServiceClient.cs
@@ -91,10 +91,15 @@ namespace Azure.Storage.Files.Shares
         private StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateAccountSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateAccountSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -235,7 +240,7 @@ namespace Azure.Storage.Files.Shares
         /// A <see cref="ShareClient"/> for the desired share.
         /// </returns>
         public virtual ShareClient GetShareClient(string shareName) =>
-            new ShareClient(Uri.AppendToPath(shareName), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics);
+            new ShareClient(Uri.AppendToPath(shareName), Pipeline, SharedKeyCredential, Version, ClientDiagnostics);
 
         #region GetShares
         /// <summary>
@@ -1245,7 +1250,7 @@ namespace Azure.Storage.Files.Shares
                     nameof(AccountSasServices.Files));
             }
             UriBuilder sasUri = new UriBuilder(Uri);
-            sasUri.Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString();
+            sasUri.Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString();
             return sasUri.Uri;
         }
         #endregion

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/DirectoryClientTests.cs
@@ -1127,31 +1127,31 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName)
-            ShareDirectoryClient directory = new ShareDirectoryClient(
+            ShareDirectoryClient directory = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 GetNewShareName(),
-                GetNewDirectoryName());
+                GetNewDirectoryName()));
             Assert.IsTrue(directory.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
-            ShareDirectoryClient directory2 = new ShareDirectoryClient(
+            ShareDirectoryClient directory2 = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 GetNewShareName(),
                 GetNewDirectoryName(),
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(directory2.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareDirectoryClient directory3 = new ShareDirectoryClient(
+            ShareDirectoryClient directory3 = InstrumentClient(new ShareDirectoryClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(directory3.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareDirectoryClient directory4 = new ShareDirectoryClient(
+            ShareDirectoryClient directory4 = InstrumentClient(new ShareDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(directory4.CanGenerateSasUri);
         }
 
@@ -1166,34 +1166,34 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName)
-            ShareDirectoryClient directory = new ShareDirectoryClient(
+            ShareDirectoryClient directory = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 GetNewShareName(),
-                GetNewDirectoryName());
+                GetNewDirectoryName()));
             ShareFileClient file = directory.GetFileClient(GetNewFileName());
             Assert.IsTrue(file.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
-            ShareDirectoryClient directory2 = new ShareDirectoryClient(
+            ShareDirectoryClient directory2 = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 GetNewShareName(),
                 GetNewDirectoryName(),
-                GetOptions());
+                GetOptions()));
             ShareFileClient file2 = directory2.GetFileClient(GetNewFileName());
             Assert.IsTrue(file2.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareDirectoryClient directory3 = new ShareDirectoryClient(
+            ShareDirectoryClient directory3 = InstrumentClient(new ShareDirectoryClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             ShareFileClient file3 = directory3.GetFileClient(GetNewFileName());
             Assert.IsFalse(file3.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareDirectoryClient directory4 = new ShareDirectoryClient(
+            ShareDirectoryClient directory4 = InstrumentClient(new ShareDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             ShareFileClient file4 = directory4.GetFileClient(GetNewFileName());
             Assert.IsTrue(file4.CanGenerateSasUri);
         }
@@ -1209,34 +1209,34 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName)
-            ShareDirectoryClient directory = new ShareDirectoryClient(
+            ShareDirectoryClient directory = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 GetNewShareName(),
-                GetNewDirectoryName());
+                GetNewDirectoryName()));
             ShareDirectoryClient subdirectory = directory.GetSubdirectoryClient(GetNewFileName());
             Assert.IsTrue(subdirectory.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
-            ShareDirectoryClient directory2 = new ShareDirectoryClient(
+            ShareDirectoryClient directory2 = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 GetNewShareName(),
                 GetNewDirectoryName(),
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient subdirectory2 = directory2.GetSubdirectoryClient(GetNewFileName());
             Assert.IsTrue(subdirectory2.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareDirectoryClient directory3 = new ShareDirectoryClient(
+            ShareDirectoryClient directory3 = InstrumentClient(new ShareDirectoryClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient subdirectory3 = directory3.GetSubdirectoryClient(GetNewFileName());
             Assert.IsFalse(subdirectory3.CanGenerateSasUri);
 
             // Act - ShareDirectoryClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareDirectoryClient directory4 = new ShareDirectoryClient(
+            ShareDirectoryClient directory4 = InstrumentClient(new ShareDirectoryClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient subdirectory4 = directory4.GetSubdirectoryClient(GetNewFileName());
             Assert.IsTrue(subdirectory4.CanGenerateSasUri);
         }
@@ -1254,11 +1254,11 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
             string shareName = GetNewShareName();
             string directoryName = GetNewDirectoryName();
-            ShareDirectoryClient directoryClient = new ShareDirectoryClient(
+            ShareDirectoryClient directoryClient = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 shareName,
                 directoryName,
-                GetOptions());
+                GetOptions()));
 
             // Act
             Uri sasUri = directoryClient.GenerateSasUri(permissions, expiresOn);
@@ -1292,11 +1292,11 @@ namespace Azure.Storage.Files.Shares.Tests
             string shareName = GetNewShareName();
             string directoryName = GetNewDirectoryName();
 
-            ShareDirectoryClient directoryClient = new ShareDirectoryClient(
+            ShareDirectoryClient directoryClient = InstrumentClient(new ShareDirectoryClient(
                 connectionString,
                 shareName,
                 directoryName,
-                GetOptions());
+                GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(permissions, expiresOn)
             {
@@ -1333,10 +1333,10 @@ namespace Azure.Storage.Files.Shares.Tests
             UriBuilder blobUriBuilder = new UriBuilder(blobEndpoint);
             string directoryName = GetNewDirectoryName();
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewShareName() + "/" + directoryName;
-            ShareDirectoryClient directoryClient = new ShareDirectoryClient(
+            ShareDirectoryClient directoryClient = InstrumentClient(new ShareDirectoryClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(ShareFileSasPermissions.All, Recording.UtcNow.AddHours(+1))
             {
@@ -1366,10 +1366,10 @@ namespace Azure.Storage.Files.Shares.Tests
             UriBuilder blobUriBuilder = new UriBuilder(blobEndpoint);
             string shareName = GetNewShareName();
             blobUriBuilder.Path += constants.Sas.Account + "/" + shareName + "/" + GetNewDirectoryName();
-            ShareDirectoryClient directoryClient = new ShareDirectoryClient(
+            ShareDirectoryClient directoryClient = InstrumentClient(new ShareDirectoryClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(ShareFileSasPermissions.All, Recording.UtcNow.AddHours(+1))
             {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileClientTests.cs
@@ -3977,31 +3977,31 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareDirectoryClient(string connectionString, string blobContainerName, string blobName)
-            ShareFileClient directory = new ShareFileClient(
+            ShareFileClient directory = InstrumentClient(new ShareFileClient(
                 connectionString,
                 GetNewShareName(),
-                GetNewDirectoryName());
+                GetNewDirectoryName()));
             Assert.IsTrue(directory.CanGenerateSasUri);
 
             // Act - ShareFileClient(string connectionString, string blobContainerName, string blobName, BlobClientOptions options)
-            ShareFileClient directory2 = new ShareFileClient(
+            ShareFileClient directory2 = InstrumentClient(new ShareFileClient(
                 connectionString,
                 GetNewShareName(),
                 GetNewDirectoryName(),
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(directory2.CanGenerateSasUri);
 
             // Act - ShareFileClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareFileClient directory3 = new ShareFileClient(
+            ShareFileClient directory3 = InstrumentClient(new ShareFileClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(directory3.CanGenerateSasUri);
 
             // Act - ShareFileClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareFileClient directory4 = new ShareFileClient(
+            ShareFileClient directory4 = InstrumentClient(new ShareFileClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(directory4.CanGenerateSasUri);
         }
 
@@ -4018,11 +4018,11 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
             string shareName = GetNewShareName();
             string fileName = GetNewFileName();
-            ShareFileClient fileClient = new ShareFileClient(
+            ShareFileClient fileClient = InstrumentClient(new ShareFileClient(
                 connectionString,
                 shareName,
                 fileName,
-                GetOptions());
+                GetOptions()));
 
             // Act
             Uri sasUri = fileClient.GenerateSasUri(permissions, expiresOn);
@@ -4056,11 +4056,11 @@ namespace Azure.Storage.Files.Shares.Tests
             string shareName = GetNewShareName();
             string fileName = GetNewFileName();
 
-            ShareFileClient directoryClient = new ShareFileClient(
+            ShareFileClient directoryClient = InstrumentClient(new ShareFileClient(
                 connectionString,
                 shareName,
                 fileName,
-                GetOptions());
+                GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(permissions, expiresOn)
             {
@@ -4097,10 +4097,10 @@ namespace Azure.Storage.Files.Shares.Tests
             UriBuilder uriBuilder = new UriBuilder(blobEndpoint);
             string fileName = GetNewFileName();
             uriBuilder.Path += constants.Sas.Account + "/" + GetNewShareName() + "/" + fileName;
-            ShareFileClient fileClient = new ShareFileClient(
+            ShareFileClient fileClient = InstrumentClient(new ShareFileClient(
                 uriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(ShareFileSasPermissions.All, Recording.UtcNow.AddHours(+1))
             {
@@ -4130,10 +4130,10 @@ namespace Azure.Storage.Files.Shares.Tests
             string shareName = GetNewShareName();
             UriBuilder blobUriBuilder = new UriBuilder(blobEndpoint);
             blobUriBuilder.Path += constants.Sas.Account + "/" + shareName + "/" + GetNewFileName();
-            ShareFileClient containerClient = new ShareFileClient(
+            ShareFileClient containerClient = InstrumentClient(new ShareFileClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(ShareFileSasPermissions.All, Recording.UtcNow.AddHours(+1))
             {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ServiceClientTests.cs
@@ -388,27 +388,27 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareServiceClient(string connectionString)
-            ShareServiceClient share = new ShareServiceClient(
-                connectionString);
+            ShareServiceClient share = InstrumentClient(new ShareServiceClient(
+                connectionString));
             Assert.IsTrue(share.CanGenerateAccountSasUri);
 
             // Act - ShareServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            ShareServiceClient share2 = new ShareServiceClient(
+            ShareServiceClient share2 = InstrumentClient(new ShareServiceClient(
                 connectionString,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(share2.CanGenerateAccountSasUri);
 
             // Act - ShareServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareServiceClient share3 = new ShareServiceClient(
+            ShareServiceClient share3 = InstrumentClient(new ShareServiceClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(share3.CanGenerateAccountSasUri);
 
             // Act - ShareServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareServiceClient share4 = new ShareServiceClient(
+            ShareServiceClient share4 = InstrumentClient(new ShareServiceClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(share4.CanGenerateAccountSasUri);
         }
 
@@ -423,30 +423,30 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareServiceClient(string connectionString)
-            ShareServiceClient service = new ShareServiceClient(
-                connectionString);
+            ShareServiceClient service = InstrumentClient(new ShareServiceClient(
+                connectionString));
             ShareClient share = service.GetShareClient(GetNewShareName());
             Assert.IsTrue(share.CanGenerateSasUri);
 
             // Act - ShareServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            ShareServiceClient service2 = new ShareServiceClient(
+            ShareServiceClient service2 = InstrumentClient(new ShareServiceClient(
                 connectionString,
-                GetOptions());
+                GetOptions()));
             ShareClient share2 = service2.GetShareClient(GetNewShareName());
             Assert.IsTrue(share2.CanGenerateSasUri);
 
             // Act - ShareServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareServiceClient service3 = new ShareServiceClient(
+            ShareServiceClient service3 = InstrumentClient(new ShareServiceClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             ShareClient share3 = service3.GetShareClient(GetNewShareName());
             Assert.IsFalse(share3.CanGenerateSasUri);
 
             // Act - ShareServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareServiceClient service4 = new ShareServiceClient(
+            ShareServiceClient service4 = InstrumentClient(new ShareServiceClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             ShareClient share4 = service4.GetShareClient(GetNewShareName());
             Assert.IsTrue(share4.CanGenerateSasUri);
         }
@@ -463,7 +463,7 @@ namespace Azure.Storage.Files.Shares.Tests
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            ShareServiceClient serviceClient = new ShareServiceClient(connectionString, GetOptions());
+            ShareServiceClient serviceClient = InstrumentClient(new ShareServiceClient(connectionString, GetOptions()));
 
             // Act
             Uri sasUri = serviceClient.GenerateAccountSasUri(
@@ -493,7 +493,7 @@ namespace Azure.Storage.Files.Shares.Tests
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
             AccountSasServices services = AccountSasServices.Files;
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            ShareServiceClient serviceClient = new ShareServiceClient(connectionString, GetOptions());
+            ShareServiceClient serviceClient = InstrumentClient(new ShareServiceClient(connectionString, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {
@@ -525,7 +525,7 @@ namespace Azure.Storage.Files.Shares.Tests
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasServices services = AccountSasServices.Blobs; // Wrong Service
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            ShareServiceClient serviceClient = new ShareServiceClient(connectionString, GetOptions());
+            ShareServiceClient serviceClient = InstrumentClient(new ShareServiceClient(connectionString, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/ShareClientTests.cs
@@ -1987,29 +1987,29 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareClient(string connectionString, string blobContainerName)
-            ShareClient container = new ShareClient(
+            ShareClient container = InstrumentClient(new ShareClient(
                 connectionString,
-                GetNewShareName());
+                GetNewShareName()));
             Assert.IsTrue(container.CanGenerateSasUri);
 
             // Act - ShareClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            ShareClient container2 = new ShareClient(
+            ShareClient container2 = InstrumentClient(new ShareClient(
                 connectionString,
                 GetNewShareName(),
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container2.CanGenerateSasUri);
 
             // Act - ShareClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareClient container3 = new ShareClient(
+            ShareClient container3 = InstrumentClient(new ShareClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(container3.CanGenerateSasUri);
 
             // Act - ShareClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareClient container4 = new ShareClient(
+            ShareClient container4 = InstrumentClient(new ShareClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container4.CanGenerateSasUri);
         }
 
@@ -2024,32 +2024,32 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareClient(string connectionString, string blobContainerName)
-            ShareClient share = new ShareClient(
+            ShareClient share = InstrumentClient(new ShareClient(
                 connectionString,
-                GetNewShareName());
+                GetNewShareName()));
             ShareDirectoryClient directory = share.GetRootDirectoryClient();
             Assert.IsTrue(directory.CanGenerateSasUri);
 
             // Act - ShareClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            ShareClient share2 = new ShareClient(
+            ShareClient share2 = InstrumentClient(new ShareClient(
                 connectionString,
                 GetNewShareName(),
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient directory2 = share.GetRootDirectoryClient();
             Assert.IsTrue(directory2.CanGenerateSasUri);
 
             // Act - ShareClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareClient share3 = new ShareClient(
+            ShareClient share3 = InstrumentClient(new ShareClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient directory3 = share3.GetRootDirectoryClient();
             Assert.IsFalse(directory3.CanGenerateSasUri);
 
             // Act - ShareClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareClient share4 = new ShareClient(
+            ShareClient share4 = InstrumentClient(new ShareClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient directory4 = share4.GetRootDirectoryClient();
             Assert.IsTrue(directory4.CanGenerateSasUri);
         }
@@ -2065,32 +2065,32 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - ShareClient(string connectionString, string blobContainerName)
-            ShareClient share = new ShareClient(
+            ShareClient share = InstrumentClient(new ShareClient(
                 connectionString,
-                GetNewShareName());
+                GetNewShareName()));
             ShareDirectoryClient directory = share.GetDirectoryClient(GetNewDirectoryName());
             Assert.IsTrue(directory.CanGenerateSasUri);
 
             // Act - ShareClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            ShareClient share2 = new ShareClient(
+            ShareClient share2 = InstrumentClient(new ShareClient(
                 connectionString,
                 GetNewShareName(),
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient directory2 = share.GetDirectoryClient(GetNewDirectoryName());
             Assert.IsTrue(directory2.CanGenerateSasUri);
 
             // Act - ShareClient(Uri blobContainerUri, BlobClientOptions options = default)
-            ShareClient share3 = new ShareClient(
+            ShareClient share3 = InstrumentClient(new ShareClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient directory3 = share3.GetDirectoryClient(GetNewDirectoryName());
             Assert.IsFalse(directory3.CanGenerateSasUri);
 
             // Act - ShareClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            ShareClient share4 = new ShareClient(
+            ShareClient share4 = InstrumentClient(new ShareClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             ShareDirectoryClient directory4 = share4.GetDirectoryClient(GetNewDirectoryName());
             Assert.IsTrue(directory4.CanGenerateSasUri);
         }
@@ -2103,9 +2103,9 @@ namespace Azure.Storage.Files.Shares.Tests
             var shareEndpoint = new Uri("https://127.0.0.1/" + constants.Sas.Account);
 
             // Create blob
-            ShareClient share = new ShareClient(
+            ShareClient share = InstrumentClient(new ShareClient(
                 shareEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(share.CanGenerateSasUri);
 
             // Act
@@ -2127,9 +2127,9 @@ namespace Azure.Storage.Files.Shares.Tests
             string connectionString = storageConnectionString.ToString(true);
 
             // Create blob
-            ShareClient share = new ShareClient(
+            ShareClient share = InstrumentClient(new ShareClient(
                 connectionString,
-                GetNewShareName());
+                GetNewShareName()));
             Assert.IsTrue(share.CanGenerateSasUri);
 
             // Act
@@ -2152,7 +2152,7 @@ namespace Azure.Storage.Files.Shares.Tests
             string shareName = GetNewShareName();
             ShareSasPermissions permissions = ShareSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            ShareClient shareClient = new ShareClient(connectionString, shareName, GetOptions());
+            ShareClient shareClient = InstrumentClient(new ShareClient(connectionString, shareName, GetOptions()));
 
             // Act
             Uri sasUri = shareClient.GenerateSasUri(permissions, expiresOn);
@@ -2182,7 +2182,7 @@ namespace Azure.Storage.Files.Shares.Tests
             ShareSasPermissions permissions = ShareSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
-            ShareClient shareClient = new ShareClient(connectionString, shareName, GetOptions());
+            ShareClient shareClient = InstrumentClient(new ShareClient(connectionString, shareName, GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(permissions, expiresOn)
             {
@@ -2217,10 +2217,10 @@ namespace Azure.Storage.Files.Shares.Tests
             ShareSasPermissions permissions = ShareSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewShareName();
-            ShareClient shareCLient = new ShareClient(
+            ShareClient shareCLient = InstrumentClient(new ShareClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             ShareSasBuilder sasBuilder = new ShareSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -144,10 +144,15 @@ namespace Azure.Storage.Queues
         private StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -394,7 +399,7 @@ namespace Azure.Storage.Queues
             return new QueueClient(
                 Uri,
                 Pipeline,
-                _storageSharedKeyCredential,
+                SharedKeyCredential,
                 Version,
                 ClientDiagnostics,
                 clientSideEncryptionOptions,
@@ -2697,7 +2702,7 @@ namespace Azure.Storage.Queues
                     nameof(Name));
             }
             QueueUriBuilder sasUri = new QueueUriBuilder(Uri);
-            sasUri.Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString();
+            sasUri.Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString();
             return sasUri.ToUri();
         }
         #endregion

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -102,10 +102,15 @@ namespace Azure.Storage.Queues
         private StorageSharedKeyCredential _storageSharedKeyCredential;
 
         /// <summary>
+        /// Gets the The <see cref="StorageSharedKeyCredential"/> used to authenticate and generate SAS.
+        /// </summary>
+        internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential;
+
+        /// <summary>
         /// Determines whether the client is able to generate a SAS.
         /// If the client is authenticated with a <see cref="StorageSharedKeyCredential"/>.
         /// </summary>
-        public bool CanGenerateAccountSasUri => _storageSharedKeyCredential != null;
+        public bool CanGenerateAccountSasUri => SharedKeyCredential != null;
 
         #region ctors
         /// <summary>
@@ -275,7 +280,7 @@ namespace Azure.Storage.Queues
         /// A <see cref="QueueClient"/> for the desired queue.
         /// </returns>
         public virtual QueueClient GetQueueClient(string queueName)
-            => new QueueClient(Uri.AppendToPath(queueName), Pipeline, _storageSharedKeyCredential, Version, ClientDiagnostics, ClientSideEncryption, MessageEncoding);
+            => new QueueClient(Uri.AppendToPath(queueName), Pipeline, SharedKeyCredential, Version, ClientDiagnostics, ClientSideEncryption, MessageEncoding);
 
         #region GetQueues
         /// <summary>
@@ -902,7 +907,7 @@ namespace Azure.Storage.Queues
                     nameof(AccountSasServices.Queues));
             }
             QueueUriBuilder sasUri = new QueueUriBuilder(Uri);
-            sasUri.Query = builder.ToSasQueryParameters(_storageSharedKeyCredential).ToString();
+            sasUri.Query = builder.ToSasQueryParameters(SharedKeyCredential).ToString();
             return sasUri.ToUri();
         }
         #endregion

--- a/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ClientSideEncryptionTests.cs
@@ -780,9 +780,9 @@ namespace Azure.Storage.Queues.Test
             };
 
             // Create blob
-            QueueClient queue = new QueueClient(
+            QueueClient queue = InstrumentClient(new QueueClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(queue.CanGenerateSasUri);
 
             // Act

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueClientTests.cs
@@ -1349,29 +1349,29 @@ namespace Azure.Storage.Queues.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - QueueClient(string connectionString, string blobContainerName)
-            QueueClient container = new QueueClient(
+            QueueClient container = InstrumentClient(new QueueClient(
                 connectionString,
-                GetNewQueueName());
+                GetNewQueueName()));
             Assert.IsTrue(container.CanGenerateSasUri);
 
             // Act - QueueClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            QueueClient container2 = new QueueClient(
+            QueueClient container2 = InstrumentClient(new QueueClient(
                 connectionString,
                 GetNewQueueName(),
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container2.CanGenerateSasUri);
 
             // Act - QueueClient(Uri blobContainerUri, BlobClientOptions options = default)
-            QueueClient container3 = new QueueClient(
+            QueueClient container3 = InstrumentClient(new QueueClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(container3.CanGenerateSasUri);
 
             // Act - QueueClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            QueueClient container4 = new QueueClient(
+            QueueClient container4 = InstrumentClient(new QueueClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(container4.CanGenerateSasUri);
         }
 
@@ -1387,7 +1387,7 @@ namespace Azure.Storage.Queues.Test
             string queueName = GetNewQueueName();
             QueueSasPermissions permissions = QueueSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            QueueClient queueClient = new QueueClient(connectionString, queueName, GetOptions());
+            QueueClient queueClient = InstrumentClient(new QueueClient(connectionString, queueName, GetOptions()));
 
             // Act
             Uri sasUri =  queueClient.GenerateSasUri(permissions, expiresOn);
@@ -1417,7 +1417,7 @@ namespace Azure.Storage.Queues.Test
             QueueSasPermissions permissions = QueueSasPermissions.Read;
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            QueueClient queueClient = new QueueClient(connectionString, queueName, GetOptions());
+            QueueClient queueClient = InstrumentClient(new QueueClient(connectionString, queueName, GetOptions()));
 
             QueueSasBuilder sasBuilder = new QueueSasBuilder(permissions, expiresOn)
             {
@@ -1452,10 +1452,10 @@ namespace Azure.Storage.Queues.Test
             blobUriBuilder.Path += constants.Sas.Account + "/" + GetNewQueueName();
             QueueSasPermissions permissions = QueueSasPermissions.Read;
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
-            QueueClient queueClient = new QueueClient(
+            QueueClient queueClient = InstrumentClient(new QueueClient(
                 blobUriBuilder.Uri,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
 
             QueueSasBuilder sasBuilder = new QueueSasBuilder(permissions, expiresOn)
             {

--- a/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/ServiceClientTests.cs
@@ -341,27 +341,27 @@ namespace Azure.Storage.Queues.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - QueueServiceClient(string connectionString)
-            QueueServiceClient serviceClient = new QueueServiceClient(
-                connectionString);
+            QueueServiceClient serviceClient = InstrumentClient(new QueueServiceClient(
+                connectionString));
             Assert.IsTrue(serviceClient.CanGenerateAccountSasUri);
 
             // Act - QueueServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            QueueServiceClient serviceClient2 = new QueueServiceClient(
+            QueueServiceClient serviceClient2 = InstrumentClient(new QueueServiceClient(
                 connectionString,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(serviceClient2.CanGenerateAccountSasUri);
 
             // Act - QueueServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            QueueServiceClient serviceClient3 = new QueueServiceClient(
+            QueueServiceClient serviceClient3 = InstrumentClient(new QueueServiceClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             Assert.IsFalse(serviceClient3.CanGenerateAccountSasUri);
 
             // Act - QueueServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            QueueServiceClient serviceClient4 = new QueueServiceClient(
+            QueueServiceClient serviceClient4 = InstrumentClient(new QueueServiceClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             Assert.IsTrue(serviceClient4.CanGenerateAccountSasUri);
         }
 
@@ -376,30 +376,30 @@ namespace Azure.Storage.Queues.Test
             string connectionString = storageConnectionString.ToString(true);
 
             // Act - QueueServiceClient(string connectionString)
-            QueueServiceClient serviceClient = new QueueServiceClient(
-                connectionString);
+            QueueServiceClient serviceClient = InstrumentClient(new QueueServiceClient(
+                connectionString));
             QueueClient queueClient = serviceClient.GetQueueClient(GetNewQueueName());
             Assert.IsTrue(queueClient.CanGenerateSasUri);
 
             // Act - QueueServiceClient(string connectionString, string blobContainerName, BlobClientOptions options)
-            QueueServiceClient serviceClient2 = new QueueServiceClient(
+            QueueServiceClient serviceClient2 = InstrumentClient(new QueueServiceClient(
                 connectionString,
-                GetOptions());
+                GetOptions()));
             QueueClient queueClient2 = serviceClient2.GetQueueClient(GetNewQueueName());
             Assert.IsTrue(queueClient2.CanGenerateSasUri);
 
             // Act - QueueServiceClient(Uri blobContainerUri, BlobClientOptions options = default)
-            QueueServiceClient serviceClient3 = new QueueServiceClient(
+            QueueServiceClient serviceClient3 = InstrumentClient(new QueueServiceClient(
                 blobEndpoint,
-                GetOptions());
+                GetOptions()));
             QueueClient queueClient3 = serviceClient3.GetQueueClient(GetNewQueueName());
             Assert.IsFalse(queueClient3.CanGenerateSasUri);
 
             // Act - QueueServiceClient(Uri blobContainerUri, StorageSharedKeyCredential credential, BlobClientOptions options = default)
-            QueueServiceClient serviceClient4 = new QueueServiceClient(
+            QueueServiceClient serviceClient4 = InstrumentClient(new QueueServiceClient(
                 blobEndpoint,
                 constants.Sas.SharedKeyCredential,
-                GetOptions());
+                GetOptions()));
             QueueClient queueClient4 = serviceClient4.GetQueueClient(GetNewQueueName());
             Assert.IsTrue(queueClient4.CanGenerateSasUri);
         }
@@ -416,7 +416,7 @@ namespace Azure.Storage.Queues.Test
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasPermissions permissions = AccountSasPermissions.Read | AccountSasPermissions.Write;
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            QueueServiceClient serviceClient = new QueueServiceClient(connectionString, GetOptions());
+            QueueServiceClient serviceClient = InstrumentClient(new QueueServiceClient(connectionString, GetOptions()));
 
             // Act
             Uri sasUri = serviceClient.GenerateAccountSasUri(
@@ -446,7 +446,7 @@ namespace Azure.Storage.Queues.Test
             DateTimeOffset startsOn = Recording.UtcNow.AddHours(-1);
             AccountSasServices services = AccountSasServices.Queues;
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            QueueServiceClient serviceClient = new QueueServiceClient(connectionString, GetOptions());
+            QueueServiceClient serviceClient = InstrumentClient(new QueueServiceClient(connectionString, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {
@@ -480,7 +480,7 @@ namespace Azure.Storage.Queues.Test
             DateTimeOffset expiresOn = Recording.UtcNow.AddHours(+1);
             AccountSasServices services = AccountSasServices.Blobs; // Wrong Service
             AccountSasResourceTypes resourceTypes = AccountSasResourceTypes.All;
-            QueueServiceClient serviceClient = new QueueServiceClient(connectionString, GetOptions());
+            QueueServiceClient serviceClient = InstrumentClient(new QueueServiceClient(connectionString, GetOptions()));
 
             AccountSasBuilder sasBuilder = new AccountSasBuilder(permissions, expiresOn, services, resourceTypes)
             {


### PR DESCRIPTION
Creating
`internal virtual StorageSharedKeyCredential SharedKeyCredential => _storageSharedKeyCredential`
then replacing references using `_storageSharedKeyCredential` and using the new property `SharedKeyCredential` instead.

Updating tests to use mock clients