### PR TITLE
[Storage] Bump network timeout, add progress logging.

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobTestBase.cs
@@ -75,7 +75,7 @@ namespace Azure.Storage.Test.Shared
                     MaxRetries = Storage.Constants.MaxReliabilityRetries,
                     Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
                     MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60),
-                    NetworkTimeout = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 100 : 200),
+                    NetworkTimeout = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 100 : 400),
                 },
                 Transport = GetTransport()
             };

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlockBlobClientTests.cs
@@ -2107,9 +2107,14 @@ namespace Azure.Storage.Blobs.Test
             long blobSize = Constants.Blob.Block.Pre_2019_12_12_MaxUploadBytes - 1;
             var data = GetRandomBuffer(blobSize);
             using Stream stream = new MemoryStream(data);
+            var dateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fff";
+            var progressHandler = new Progress<long>(n =>
+            {
+                TestContext.Out.WriteLine($"{DateTime.Now.ToString(dateTimeFormat)} sent {n} bytes");
+            });
 
             // Act
-            await blob.UploadAsync(content: stream);
+            await blob.UploadAsync(content: stream, progressHandler: progressHandler);
 
             // Assert
             Response<BlockList> blockListResponse = await blob.GetBlockListAsync();

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeTestBase.cs
@@ -70,7 +70,7 @@ namespace Azure.Storage.Files.DataLake.Tests
                     MaxRetries = Constants.MaxReliabilityRetries,
                     Delay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.01 : 1),
                     MaxDelay = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0.1 : 60),
-                    NetworkTimeout = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 100 : 200),
+                    NetworkTimeout = TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 100 : 400),
                 },
                 Transport = GetTransport()
             };


### PR DESCRIPTION
- Bump network timeout to 400s to see if it's enough for worst case agent-network-storage account combo
- add progress logging to flaky tests to see if it hangs.