### PR TITLE
Fix bug on create OCI Manifest

### DIFF
--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Customizations/ManifestConvertions.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Customizations/ManifestConvertions.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Azure.ContainerRegistry.Models
                 Name = v.Name,
                 Signatures = v.Signatures,
                 Tag = v.Tag,
-                SchemaVersion = v.SchemaVersion
+                SchemaVersion = v.SchemaVersion,
+                MediaType=v.MediaType             
             };
             return manifest;
         }
@@ -68,7 +69,8 @@ namespace Microsoft.Azure.ContainerRegistry.Models
             {
                 Manifests = v.Manifests,
                 SchemaVersion = v.SchemaVersion,
-                Annotations = v.Annotations
+                Annotations = v.Annotations,
+                MediaType=v.MediaType               
             };
             return manifest;
         }
@@ -86,7 +88,8 @@ namespace Microsoft.Azure.ContainerRegistry.Models
                 Layers = v.Layers,
                 SchemaVersion = v.SchemaVersion,
                 Config = v.Config,
-                Annotations = v.Annotations
+                Annotations = v.Annotations,
+                MediaType=v.MediaType
             };
             return manifest;
         }

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/ManifestsOperations.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/ManifestsOperations.cs
@@ -358,35 +358,31 @@ namespace Microsoft.Azure.ContainerRegistry
             // Serialize Request
             string _requestContent = null;
             if(payload != null)
-            {              
+            {
                 _requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(payload, Client.SerializationSettings);
                 _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
-                string mediaType = string.Empty;               
+                string mediaType = string.Empty;
                 switch (payload)
                 {
                     case V2Manifest v2Manifest:
                          mediaType = v2Manifest.MediaType;
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case V1Manifest v1Manifest:
                         mediaType = v1Manifest.MediaType;
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case ManifestList manifestList:
                         mediaType = manifestList.MediaType;
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case OCIManifest ociManifest:
                         mediaType = ociManifest.MediaType;
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case OCIIndex ociIndex:
                         mediaType = ociIndex.MediaType;
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     default:
                         throw new AcrErrorsException($"The manifest type is unknown: {payload}.");
                 }
+                _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
             }
             // Set Credentials
             if (Client.Credentials != null)

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/ManifestsOperations.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/ManifestsOperations.cs
@@ -358,10 +358,30 @@ namespace Microsoft.Azure.ContainerRegistry
             // Serialize Request
             string _requestContent = null;
             if(payload != null)
-            {
+            {              
                 _requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(payload, Client.SerializationSettings);
                 _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
-                _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/vnd.docker.distribution.manifest.v2+json");
+
+                switch (payload)
+                {
+                    case V2Manifest v2Manifest:
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(v2Manifest.MediaType);
+                        break;
+                    case V1Manifest v1Manifest:
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(v1Manifest.MediaType);
+                        break;
+                    case ManifestList manifestList:
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(manifestList.MediaType);
+                        break;
+                    case OCIManifest ociManifest:
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(ociManifest.MediaType);
+                        break;
+                    case OCIIndex ociIndex:
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(ociIndex.MediaType);
+                        break;
+                    default:
+                        throw new AcrErrorsException($"The requested mediaType could not be found in {payload}.");
+                }
             }
             // Set Credentials
             if (Client.Credentials != null)

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/ManifestsOperations.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/ManifestsOperations.cs
@@ -361,26 +361,31 @@ namespace Microsoft.Azure.ContainerRegistry
             {              
                 _requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(payload, Client.SerializationSettings);
                 _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
-
+                string mediaType = string.Empty;               
                 switch (payload)
                 {
                     case V2Manifest v2Manifest:
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(v2Manifest.MediaType);
+                         mediaType = v2Manifest.MediaType;
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case V1Manifest v1Manifest:
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(v1Manifest.MediaType);
+                        mediaType = v1Manifest.MediaType;
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case ManifestList manifestList:
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(manifestList.MediaType);
+                        mediaType = manifestList.MediaType;
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case OCIManifest ociManifest:
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(ociManifest.MediaType);
+                        mediaType = ociManifest.MediaType;
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     case OCIIndex ociIndex:
-                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(ociIndex.MediaType);
+                        mediaType = ociIndex.MediaType;
+                        _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
                         break;
                     default:
-                        throw new AcrErrorsException($"The requested mediaType could not be found in {payload}.");
+                        throw new AcrErrorsException($"The manifest type is unknown: {payload}.");
                 }
             }
             // Set Credentials

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/Models/OCIIndex.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/Models/OCIIndex.cs
@@ -33,9 +33,10 @@ namespace Microsoft.Azure.ContainerRegistry.Models
         /// </summary>
         /// <param name="schemaVersion">Schema version</param>
         /// <param name="manifests">List of OCI image layer information</param>
-        public OCIIndex(int? schemaVersion = default(int?), IList<ManifestListAttributes> manifests = default(IList<ManifestListAttributes>), Annotations annotations = default(Annotations))
+        public OCIIndex(int? schemaVersion = default(int?), string mediaType = default(string), IList<ManifestListAttributes> manifests = default(IList<ManifestListAttributes>), Annotations annotations = default(Annotations))
             : base(schemaVersion)
         {
+            MediaType = mediaType;
             Manifests = manifests;
             Annotations = annotations;
             CustomInit();
@@ -56,6 +57,12 @@ namespace Microsoft.Azure.ContainerRegistry.Models
         /// </summary>
         [JsonProperty(PropertyName = "annotations")]
         public Annotations Annotations { get; set; }
+
+        /// <summary>
+        /// Gets or sets media type for this Manifest
+        /// </summary>
+        [JsonProperty(PropertyName = "mediaType")]
+        public string MediaType { get; set; }
 
     }
 }

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/Models/OCIManifest.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/Models/OCIManifest.cs
@@ -34,9 +34,10 @@ namespace Microsoft.Azure.ContainerRegistry.Models
         /// <param name="schemaVersion">Schema version</param>
         /// <param name="config">V2 image config descriptor</param>
         /// <param name="layers">List of V2 image layer information</param>
-        public OCIManifest(int? schemaVersion = default(int?), Descriptor config = default(Descriptor), IList<Descriptor> layers = default(IList<Descriptor>), Annotations annotations = default(Annotations))
+        public OCIManifest(int? schemaVersion = default(int?), string mediaType = default(string), Descriptor config = default(Descriptor), IList<Descriptor> layers = default(IList<Descriptor>), Annotations annotations = default(Annotations))
             : base(schemaVersion)
         {
+            MediaType = mediaType;
             Config = config;
             Layers = layers;
             Annotations = annotations;
@@ -64,6 +65,12 @@ namespace Microsoft.Azure.ContainerRegistry.Models
         /// </summary>
         [JsonProperty(PropertyName = "annotations")]
         public Annotations Annotations { get; set; }
+        
+        /// <summary>
+        /// Gets or sets media type for this Manifest
+        /// </summary>
+        [JsonProperty(PropertyName = "mediaType")]
+        public string MediaType { get; set; }
 
     }
 }

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/Models/V1Manifest.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Generated/Models/V1Manifest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.ContainerRegistry.Models
         /// <param name="fsLayers">List of layer information</param>
         /// <param name="history">Image history</param>
         /// <param name="signatures">Image signature</param>
-        public V1Manifest(int? schemaVersion = default(int?), string architecture = default(string), string name = default(string), string tag = default(string), IList<FsLayer> fsLayers = default(IList<FsLayer>), IList<History> history = default(IList<History>), IList<ImageSignature> signatures = default(IList<ImageSignature>))
+        public V1Manifest(int? schemaVersion = default(int?), string mediaType = default(string), string architecture = default(string), string name = default(string), string tag = default(string), IList<FsLayer> fsLayers = default(IList<FsLayer>), IList<History> history = default(IList<History>), IList<ImageSignature> signatures = default(IList<ImageSignature>))
             : base(schemaVersion)
         {
             Architecture = architecture;
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.ContainerRegistry.Models
             FsLayers = fsLayers;
             History = history;
             Signatures = signatures;
+            MediaType = mediaType;
             CustomInit();
         }
 
@@ -90,6 +91,12 @@ namespace Microsoft.Azure.ContainerRegistry.Models
         /// </summary>
         [JsonProperty(PropertyName = "signatures")]
         public IList<ImageSignature> Signatures { get; set; }
+
+        /// <summary>
+        /// Gets or sets media type for this Manifest
+        /// </summary>
+        [JsonProperty(PropertyName = "mediaType")]
+        public string MediaType { get; set; }
 
     }
 }

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ManifestTests/CreateManifestList.json
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ManifestTests/CreateManifestList.json
@@ -1,0 +1,280 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "514b0726-f8b3-43b4-bbc9-2d04bb3eea4c"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11999"
+        ],
+        "x-ms-request-id": [
+          "ef4793b7-0985-4bc9-ac8f-9dd57d94ef7f"
+        ],
+        "x-ms-correlation-request-id": [
+          "ef4793b7-0985-4bc9-ac8f-9dd57d94ef7f"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201207T102830Z:ef4793b7-0985-4bc9-ac8f-9dd57d94ef7f"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:29 GMT"
+        ],
+        "Content-Length": [
+          "459"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"type\": \"Microsoft.ContainerRegistry/registries\",\r\n  \"id\": \"/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest\",\r\n  \"name\": \"azuresdkunittest\",\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"loginServer\": \"azuresdkunittest.azurecr.io\",\r\n    \"creationDate\": \"2019-08-01T22:42:31.7178676Z\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"adminUserEnabled\": true\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest/listCredentials?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0L2xpc3RDcmVkZW50aWFscz9hcGktdmVyc2lvbj0yMDE3LTEwLTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "8a7fbb0a-aa0a-4117-a3e4-bd8ca3e3c947"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-request-id": [
+          "1dfbabd0-87e9-4b93-9d2b-876e7627e18b"
+        ],
+        "x-ms-correlation-request-id": [
+          "1dfbabd0-87e9-4b93-9d2b-876e7627e18b"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201207T102831Z:1dfbabd0-87e9-4b93-9d2b-876e7627e18b"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:31 GMT"
+        ],
+        "Content-Length": [
+          "172"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"username\": \"azuresdkunittest\",\r\n  \"passwords\": [\r\n    {\r\n      \"name\": \"password\",\r\n      \"value\": \"ccswPG/Y0OTXd3m8ZhBsnuZojLVSlql+\"\r\n    },\r\n    {\r\n      \"name\": \"password2\",\r\n      \"value\": \"9i/WBxz4VBOkFBq=2P8sTqC+hUG+5Oz7\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/v2/multi-hello-world/manifests/test-manifest-list",
+      "EncodedRequestUri": "L3YyL211bHRpLWhlbGxvLXdvcmxkL21hbmlmZXN0cy90ZXN0LW1hbmlmZXN0LWxpc3Q=",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\",\r\n  \"manifests\": [\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\r\n      \"size\": 528,\r\n      \"digest\": \"sha256:4b36b0347b2c6b02adc54a3d8e8143299e7c733b4dcadb95c1d4c8b6da720172\",\r\n      \"platform\": {\r\n        \"architecture\": \"amd64\",\r\n        \"os\": \"linux\"\r\n      }\r\n    },\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\r\n      \"size\": 838,\r\n      \"digest\": \"sha256:2542c76d5ba87f9923ebcc6711677a2167dedf33e382f61a97772ae35106274d\",\r\n      \"platform\": {\r\n        \"architecture\": \"amd64\",\r\n        \"os\": \"windows\",\r\n        \"os.version\": \"10.0.18362.295\"\r\n      }\r\n    }\r\n  ],\r\n  \"schemaVersion\": 2\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "62b8060a-f822-4116-ace3-234f4b7cb567"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ],
+        "Content-Type": [
+          "application/vnd.docker.distribution.manifest.list.v2+json"
+        ],
+        "Content-Length": [
+          "749"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:33 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:8269f937dbe108d31d320a91a2dacac5da6cc83ce6af8e915830b8158c9775c2"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "Location": [
+          "/v2/multi-hello-world/manifests/sha256:8269f937dbe108d31d320a91a2dacac5da6cc83ce6af8e915830b8158c9775c2"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "62b8060a-f822-4116-ace3-234f4b7cb567"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "61d7347b-ff86-48cb-ab80-3cadf29256a5"
+        ],
+        "X-Ms-Request-Id": [
+          "84b74dcc-85e3-4131-a816-83c0b92fdaed"
+        ],
+        "Content-Length": [
+          "0"
+        ]
+      },
+      "ResponseBody": "",
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/v2/multi-hello-world/manifests/test-manifest-list",
+      "EncodedRequestUri": "L3YyL211bHRpLWhlbGxvLXdvcmxkL21hbmlmZXN0cy90ZXN0LW1hbmlmZXN0LWxpc3Q=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "b54375a3-6618-4419-8d1e-8c1bf51c2da4"
+        ],
+        "Accept": [
+          "application/vnd.docker.distribution.manifest.list.v2+json"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:33 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:8269f937dbe108d31d320a91a2dacac5da6cc83ce6af8e915830b8158c9775c2"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "ETag": [
+          "\"sha256:8269f937dbe108d31d320a91a2dacac5da6cc83ce6af8e915830b8158c9775c2\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "b54375a3-6618-4419-8d1e-8c1bf51c2da4"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "08b49ae1-d4d6-4d30-b404-cb7ceccc9050"
+        ],
+        "X-Ms-Request-Id": [
+          "4349702b-f42f-4815-a0b1-7d3eacd1d448"
+        ],
+        "Content-Type": [
+          "application/vnd.docker.distribution.manifest.list.v2+json"
+        ],
+        "Content-Length": [
+          "749"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\",\r\n  \"manifests\": [\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\r\n      \"size\": 528,\r\n      \"digest\": \"sha256:4b36b0347b2c6b02adc54a3d8e8143299e7c733b4dcadb95c1d4c8b6da720172\",\r\n      \"platform\": {\r\n        \"architecture\": \"amd64\",\r\n        \"os\": \"linux\"\r\n      }\r\n    },\r\n    {\r\n      \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\r\n      \"size\": 838,\r\n      \"digest\": \"sha256:2542c76d5ba87f9923ebcc6711677a2167dedf33e382f61a97772ae35106274d\",\r\n      \"platform\": {\r\n        \"architecture\": \"amd64\",\r\n        \"os\": \"windows\",\r\n        \"os.version\": \"10.0.18362.295\"\r\n      }\r\n    }\r\n  ],\r\n  \"schemaVersion\": 2\r\n}",
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "dfb63c8c-7c89-4ef8-af13-75c1d873c895"
+  }
+}

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ManifestTests/CreateOCIIndex.json
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ManifestTests/CreateOCIIndex.json
@@ -1,0 +1,280 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "8e096094-522f-46d8-a128-8d0c11a318de"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11998"
+        ],
+        "x-ms-request-id": [
+          "58f818ef-74f4-4b0f-ac54-13cbcd145da8"
+        ],
+        "x-ms-correlation-request-id": [
+          "58f818ef-74f4-4b0f-ac54-13cbcd145da8"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201207T102808Z:58f818ef-74f4-4b0f-ac54-13cbcd145da8"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:07 GMT"
+        ],
+        "Content-Length": [
+          "459"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"type\": \"Microsoft.ContainerRegistry/registries\",\r\n  \"id\": \"/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest\",\r\n  \"name\": \"azuresdkunittest\",\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"loginServer\": \"azuresdkunittest.azurecr.io\",\r\n    \"creationDate\": \"2019-08-01T22:42:31.7178676Z\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"adminUserEnabled\": true\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest/listCredentials?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0L2xpc3RDcmVkZW50aWFscz9hcGktdmVyc2lvbj0yMDE3LTEwLTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "23bf3c51-ea68-425b-9d54-01878c86c52b"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
+        ],
+        "x-ms-request-id": [
+          "48beb30c-85d2-4483-8f4f-b9da95648a77"
+        ],
+        "x-ms-correlation-request-id": [
+          "48beb30c-85d2-4483-8f4f-b9da95648a77"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201207T102809Z:48beb30c-85d2-4483-8f4f-b9da95648a77"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:08 GMT"
+        ],
+        "Content-Length": [
+          "172"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"username\": \"azuresdkunittest\",\r\n  \"passwords\": [\r\n    {\r\n      \"name\": \"password\",\r\n      \"value\": \"ccswPG/Y0OTXd3m8ZhBsnuZojLVSlql+\"\r\n    },\r\n    {\r\n      \"name\": \"password2\",\r\n      \"value\": \"9i/WBxz4VBOkFBq=2P8sTqC+hUG+5Oz7\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/v2/multi-hello-world/manifests/oci-index-put",
+      "EncodedRequestUri": "L3YyL211bHRpLWhlbGxvLXdvcmxkL21hbmlmZXN0cy9vY2ktaW5kZXgtcHV0",
+      "RequestMethod": "PUT",
+      "RequestBody": "ew0KICAibWFuaWZlc3RzIjogWw0KICAgIHsNCiAgICAgICJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsDQogICAgICAic2l6ZSI6IDUyOCwNCiAgICAgICJkaWdlc3QiOiAic2hhMjU2OjRiMzZiMDM0N2IyYzZiMDJhZGM1NGEzZDhlODE0MzI5OWU3YzczM2I0ZGNhZGI5NWMxZDRjOGI2ZGE3MjAxNzIiLA0KICAgICAgInBsYXRmb3JtIjogew0KICAgICAgICAiYXJjaGl0ZWN0dXJlIjogImFtZDY0IiwNCiAgICAgICAgIm9zIjogImxpbnV4Ig0KICAgICAgfQ0KICAgIH0sDQogICAgew0KICAgICAgIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwNCiAgICAgICJzaXplIjogODM4LA0KICAgICAgImRpZ2VzdCI6ICJzaGEyNTY6MjU0MmM3NmQ1YmE4N2Y5OTIzZWJjYzY3MTE2NzdhMjE2N2RlZGYzM2UzODJmNjFhOTc3NzJhZTM1MTA2Mjc0ZCIsDQogICAgICAicGxhdGZvcm0iOiB7DQogICAgICAgICJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLA0KICAgICAgICAib3MiOiAid2luZG93cyIsDQogICAgICAgICJvcy52ZXJzaW9uIjogIjEwLjAuMTgzNjIuMjk1Ig0KICAgICAgfQ0KICAgIH0NCiAgXSwNCiAgImFubm90YXRpb25zIjogew0KICAgICJjb20uZXhhbXBsZS5rZXkxIjogInZhbHVlMSIsDQogICAgImNvbS5leGFtcGxlLmtleTIiOiAidmFsdWUyIg0KICB9LA0KICAibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuaW5kZXgudjEranNvbiIsDQogICJzY2hlbWFWZXJzaW9uIjogMg0KfQ==",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "54da0415-067e-4d1d-bcf1-334f92f38188"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ],
+        "Content-Type": [
+          "application/vnd.oci.image.index.v1+json"
+        ],
+        "Content-Length": [
+          "826"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:12 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:7995b7c61c453b2a2e5a8e64464fd2512befac28d700dc63106d3d8b918d2d1e"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "Location": [
+          "/v2/multi-hello-world/manifests/sha256:7995b7c61c453b2a2e5a8e64464fd2512befac28d700dc63106d3d8b918d2d1e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "54da0415-067e-4d1d-bcf1-334f92f38188"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "a73904f6-222f-4c46-9171-5ad83484e200"
+        ],
+        "X-Ms-Request-Id": [
+          "05dde8e4-07ba-4ceb-9b4c-fc50993b94f3"
+        ],
+        "Content-Length": [
+          "0"
+        ]
+      },
+      "ResponseBody": "",
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/v2/multi-hello-world/manifests/oci-index-put",
+      "EncodedRequestUri": "L3YyL211bHRpLWhlbGxvLXdvcmxkL21hbmlmZXN0cy9vY2ktaW5kZXgtcHV0",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "0e5658cf-be8c-4cc4-9752-92e617014444"
+        ],
+        "Accept": [
+          "application/vnd.oci.image.index.v1+json"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:13 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:7995b7c61c453b2a2e5a8e64464fd2512befac28d700dc63106d3d8b918d2d1e"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "ETag": [
+          "\"sha256:7995b7c61c453b2a2e5a8e64464fd2512befac28d700dc63106d3d8b918d2d1e\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "0e5658cf-be8c-4cc4-9752-92e617014444"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "6e7a392a-1690-4ec7-85fb-0c9c5526ffc7"
+        ],
+        "X-Ms-Request-Id": [
+          "4e526788-a479-4051-b9ad-d1029f7a01aa"
+        ],
+        "Content-Type": [
+          "application/vnd.oci.image.index.v1+json"
+        ],
+        "Content-Length": [
+          "826"
+        ]
+      },
+      "ResponseBody": "ew0KICAibWFuaWZlc3RzIjogWw0KICAgIHsNCiAgICAgICJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsDQogICAgICAic2l6ZSI6IDUyOCwNCiAgICAgICJkaWdlc3QiOiAic2hhMjU2OjRiMzZiMDM0N2IyYzZiMDJhZGM1NGEzZDhlODE0MzI5OWU3YzczM2I0ZGNhZGI5NWMxZDRjOGI2ZGE3MjAxNzIiLA0KICAgICAgInBsYXRmb3JtIjogew0KICAgICAgICAiYXJjaGl0ZWN0dXJlIjogImFtZDY0IiwNCiAgICAgICAgIm9zIjogImxpbnV4Ig0KICAgICAgfQ0KICAgIH0sDQogICAgew0KICAgICAgIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwNCiAgICAgICJzaXplIjogODM4LA0KICAgICAgImRpZ2VzdCI6ICJzaGEyNTY6MjU0MmM3NmQ1YmE4N2Y5OTIzZWJjYzY3MTE2NzdhMjE2N2RlZGYzM2UzODJmNjFhOTc3NzJhZTM1MTA2Mjc0ZCIsDQogICAgICAicGxhdGZvcm0iOiB7DQogICAgICAgICJhcmNoaXRlY3R1cmUiOiAiYW1kNjQiLA0KICAgICAgICAib3MiOiAid2luZG93cyIsDQogICAgICAgICJvcy52ZXJzaW9uIjogIjEwLjAuMTgzNjIuMjk1Ig0KICAgICAgfQ0KICAgIH0NCiAgXSwNCiAgImFubm90YXRpb25zIjogew0KICAgICJjb20uZXhhbXBsZS5rZXkxIjogInZhbHVlMSIsDQogICAgImNvbS5leGFtcGxlLmtleTIiOiAidmFsdWUyIg0KICB9LA0KICAibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuaW5kZXgudjEranNvbiIsDQogICJzY2hlbWFWZXJzaW9uIjogMg0KfQ==",
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "dfb63c8c-7c89-4ef8-af13-75c1d873c895"
+  }
+}

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ManifestTests/CreateOCIManifest.json
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/SessionRecords/ManifestTests/CreateOCIManifest.json
@@ -1,0 +1,280 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0P2FwaS12ZXJzaW9uPTIwMTctMTAtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "ad42abd9-e1fd-476b-ac5e-ebe6852d55dc"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11999"
+        ],
+        "x-ms-request-id": [
+          "c746eac9-cbab-480a-9a4c-b97ad94699ab"
+        ],
+        "x-ms-correlation-request-id": [
+          "c746eac9-cbab-480a-9a4c-b97ad94699ab"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201207T102838Z:c746eac9-cbab-480a-9a4c-b97ad94699ab"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:38 GMT"
+        ],
+        "Content-Length": [
+          "459"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"sku\": {\r\n    \"name\": \"Standard\",\r\n    \"tier\": \"Standard\"\r\n  },\r\n  \"type\": \"Microsoft.ContainerRegistry/registries\",\r\n  \"id\": \"/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest\",\r\n  \"name\": \"azuresdkunittest\",\r\n  \"location\": \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"loginServer\": \"azuresdkunittest.azurecr.io\",\r\n    \"creationDate\": \"2019-08-01T22:42:31.7178676Z\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"adminUserEnabled\": true\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/dfb63c8c-7c89-4ef8-af13-75c1d873c895/resourceGroups/ereyTest/providers/Microsoft.ContainerRegistry/registries/azuresdkunittest/listCredentials?api-version=2017-10-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvZGZiNjNjOGMtN2M4OS00ZWY4LWFmMTMtNzVjMWQ4NzNjODk1L3Jlc291cmNlR3JvdXBzL2VyZXlUZXN0L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ29udGFpbmVyUmVnaXN0cnkvcmVnaXN0cmllcy9henVyZXNka3VuaXR0ZXN0L2xpc3RDcmVkZW50aWFscz9hcGktdmVyc2lvbj0yMDE3LTEwLTAx",
+      "RequestMethod": "POST",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "16005494-0582-4135-b1bb-4b078a3e8af9"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.Management.ContainerRegistry.ContainerRegistryManagementClient/2.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Server": [
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-request-id": [
+          "1dbaccb8-307c-4a6b-80a5-8b94d6fa60d1"
+        ],
+        "x-ms-correlation-request-id": [
+          "1dbaccb8-307c-4a6b-80a5-8b94d6fa60d1"
+        ],
+        "x-ms-routing-request-id": [
+          "SOUTHAFRICANORTH:20201207T102839Z:1dbaccb8-307c-4a6b-80a5-8b94d6fa60d1"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:39 GMT"
+        ],
+        "Content-Length": [
+          "172"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"username\": \"azuresdkunittest\",\r\n  \"passwords\": [\r\n    {\r\n      \"name\": \"password\",\r\n      \"value\": \"ccswPG/Y0OTXd3m8ZhBsnuZojLVSlql+\"\r\n    },\r\n    {\r\n      \"name\": \"password2\",\r\n      \"value\": \"9i/WBxz4VBOkFBq=2P8sTqC+hUG+5Oz7\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/v2/oras/manifests/test-put-ociManifest",
+      "EncodedRequestUri": "L3YyL29yYXMvbWFuaWZlc3RzL3Rlc3QtcHV0LW9jaU1hbmlmZXN0",
+      "RequestMethod": "PUT",
+      "RequestBody": "ew0KICAiY29uZmlnIjogew0KICAgICJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5jb25maWcudjEranNvbiIsDQogICAgInNpemUiOiAyLA0KICAgICJkaWdlc3QiOiAic2hhMjU2OjQ0MTM2ZmEzNTViMzY3OGExMTQ2YWQxNmY3ZTg2NDllOTRmYjRmYzIxZmU3N2U4MzEwYzA2MGY2MWNhYWZmOGEiDQogIH0sDQogICJsYXllcnMiOiBbDQogICAgew0KICAgICAgIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLmxheWVyLnYxLnRhcitnemlwIiwNCiAgICAgICJzaXplIjogMjM2MDA0LA0KICAgICAgImRpZ2VzdCI6ICJzaGEyNTY6MmQxZmI3NmMxMGU4MDVjZjNkOGQxMzBhMjkyMWI4OTcyMWJjODM4Njc4NTVhYTQ2MDg4MTFmNTdjMDM1OTllYSIsDQogICAgICAiYW5ub3RhdGlvbnMiOiB7DQogICAgICAgICJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UudGl0bGUiOiAiLiIsDQogICAgICAgICJpby5kZWlzLm9yYXMuY29udGVudC5kaWdlc3QiOiAic2hhMjU2OmQ0ZDNiZGEzZTY0YmJjMWQ4NTUwYTZlZDhkMDkzMjRhMzlhNzVjODY4N2FiNWY2ZTA2YjJlOWJhZWUyOWEwMGMiLA0KICAgICAgICAiaW8uZGVpcy5vcmFzLmNvbnRlbnQudW5wYWNrIjogInRydWUiDQogICAgICB9DQogICAgfQ0KICBdLA0KICAibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UubWFuaWZlc3QudjEranNvbiIsDQogICJzY2hlbWFWZXJzaW9uIjogMg0KfQ==",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "aab07ed6-92d2-45ea-9dfb-73e7e165d04b"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ],
+        "Content-Type": [
+          "application/vnd.oci.image.manifest.v1+json"
+        ],
+        "Content-Length": [
+          "736"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:43 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:9406b396769770fa388f8933abc12bb933bf2abe40641eaaa11b9d9520057164"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "Location": [
+          "/v2/oras/manifests/sha256:9406b396769770fa388f8933abc12bb933bf2abe40641eaaa11b9d9520057164"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "aab07ed6-92d2-45ea-9dfb-73e7e165d04b"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "e0ea09f7-afb8-4d94-b53a-e76e85a2c432"
+        ],
+        "X-Ms-Request-Id": [
+          "21ffc211-cbe0-4fe3-9b41-5407f540a766"
+        ],
+        "Content-Length": [
+          "0"
+        ]
+      },
+      "ResponseBody": "",
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/v2/oras/manifests/test-put-ociManifest",
+      "EncodedRequestUri": "L3YyL29yYXMvbWFuaWZlc3RzL3Rlc3QtcHV0LW9jaU1hbmlmZXN0",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "daf3a674-fb06-4af5-96ce-d497796232fd"
+        ],
+        "Accept": [
+          "application/vnd.oci.image.manifest.v1+json"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.29321.03",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042.",
+          "Microsoft.Azure.ContainerRegistry.AzureContainerRegistryClient/1.0.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Server": [
+          "openresty"
+        ],
+        "Date": [
+          "Mon, 07 Dec 2020 10:28:43 GMT"
+        ],
+        "Connection": [
+          "keep-alive"
+        ],
+        "Access-Control-Expose-Headers": [
+          "Docker-Content-Digest",
+          "WWW-Authenticate",
+          "Link",
+          "X-Ms-Correlation-Request-Id"
+        ],
+        "Docker-Content-Digest": [
+          "sha256:9406b396769770fa388f8933abc12bb933bf2abe40641eaaa11b9d9520057164"
+        ],
+        "Docker-Distribution-Api-Version": [
+          "registry/2.0"
+        ],
+        "ETag": [
+          "\"sha256:9406b396769770fa388f8933abc12bb933bf2abe40641eaaa11b9d9520057164\""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains",
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Ms-Client-Request-Id": [
+          "daf3a674-fb06-4af5-96ce-d497796232fd"
+        ],
+        "X-Ms-Correlation-Request-Id": [
+          "954413a1-a987-48e9-a013-c0cff9378fb5"
+        ],
+        "X-Ms-Request-Id": [
+          "951df621-4983-4495-8961-22c06ab6d628"
+        ],
+        "Content-Type": [
+          "application/vnd.oci.image.manifest.v1+json"
+        ],
+        "Content-Length": [
+          "736"
+        ]
+      },
+      "ResponseBody": "ew0KICAiY29uZmlnIjogew0KICAgICJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLm9jaS5pbWFnZS5jb25maWcudjEranNvbiIsDQogICAgInNpemUiOiAyLA0KICAgICJkaWdlc3QiOiAic2hhMjU2OjQ0MTM2ZmEzNTViMzY3OGExMTQ2YWQxNmY3ZTg2NDllOTRmYjRmYzIxZmU3N2U4MzEwYzA2MGY2MWNhYWZmOGEiDQogIH0sDQogICJsYXllcnMiOiBbDQogICAgew0KICAgICAgIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLmxheWVyLnYxLnRhcitnemlwIiwNCiAgICAgICJzaXplIjogMjM2MDA0LA0KICAgICAgImRpZ2VzdCI6ICJzaGEyNTY6MmQxZmI3NmMxMGU4MDVjZjNkOGQxMzBhMjkyMWI4OTcyMWJjODM4Njc4NTVhYTQ2MDg4MTFmNTdjMDM1OTllYSIsDQogICAgICAiYW5ub3RhdGlvbnMiOiB7DQogICAgICAgICJvcmcub3BlbmNvbnRhaW5lcnMuaW1hZ2UudGl0bGUiOiAiLiIsDQogICAgICAgICJpby5kZWlzLm9yYXMuY29udGVudC5kaWdlc3QiOiAic2hhMjU2OmQ0ZDNiZGEzZTY0YmJjMWQ4NTUwYTZlZDhkMDkzMjRhMzlhNzVjODY4N2FiNWY2ZTA2YjJlOWJhZWUyOWEwMGMiLA0KICAgICAgICAiaW8uZGVpcy5vcmFzLmNvbnRlbnQudW5wYWNrIjogInRydWUiDQogICAgICB9DQogICAgfQ0KICBdLA0KICAibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UubWFuaWZlc3QudjEranNvbiIsDQogICJzY2hlbWFWZXJzaW9uIjogMg0KfQ==",
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "dfb63c8c-7c89-4ef8-af13-75c1d873c895"
+  }
+}

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ManifestTests.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ManifestTests.cs
@@ -78,6 +78,7 @@ namespace ContainerRegistry.Tests
         private static readonly V1Manifest ExpectedV1ManifestProd = new V1Manifest()
         {
             SchemaVersion = 1,
+            MediaType=ACRTestUtil.MediatypeV1Manifest,
             Architecture = "amd64",
             Name = ACRTestUtil.TestRepository,
             Tag = "latest",
@@ -191,6 +192,7 @@ namespace ContainerRegistry.Tests
 
         private static readonly OCIManifest ExpectedOCIManifestProd = new OCIManifest()
         {
+            MediaType=ACRTestUtil.MediatypeOCIManifest,
             Config = new Descriptor
             {
                 MediaType = "application/vnd.oci.image.config.v1+json",
@@ -302,6 +304,7 @@ namespace ContainerRegistry.Tests
 
         private static readonly OCIIndex ExpectedOCIIndex = new OCIIndex()
         {
+            MediaType = ACRTestUtil.MediatypeOCIIndex,
             Manifests = new List<ManifestListAttributes>
             {
                 new ManifestListAttributes
@@ -415,7 +418,7 @@ namespace ContainerRegistry.Tests
                 VerifyManifest(ExpectedOCIManifestProd, manifest);
             }
         }
-        
+
         [Fact]
         public async Task GetOCIIndex()
         {
@@ -427,7 +430,46 @@ namespace ContainerRegistry.Tests
                 VerifyManifest(ExpectedOCIIndex, manifest);
             }
         }
-        
+
+        [Fact]
+        public async Task CreateOCIManifest()
+        {
+            using (var context = MockContext.Start(GetType(), nameof(CreateOCIManifest)))
+            {
+                var tag = "test-put-ociManifest";
+                var client = await ACRTestUtil.GetACRClientAsync(context, ACRTestUtil.ManagedTestRegistry);
+                await client.Manifests.CreateAsync(ACRTestUtil.OCITestRepository, tag, ExpectedOCIManifestProd);
+                var manifest = (OCIManifest)await client.Manifests.GetAsync(ACRTestUtil.OCITestRepository, tag, ACRTestUtil.MediatypeOCIManifest);
+                VerifyManifest(ExpectedOCIManifestProd, manifest);
+            }
+        }
+
+        [Fact]
+        public async Task CreateOCIIndex()
+        {
+            using (var context = MockContext.Start(GetType(), nameof(CreateOCIIndex)))
+            {
+                var tag = "oci-index-put";
+                var client = await ACRTestUtil.GetACRClientAsync(context, ACRTestUtil.ManagedTestRegistry);               
+                await client.Manifests.CreateAsync(ACRTestUtil.ManifestListTestRepository, tag,ExpectedOCIIndex);
+                var manifest = (OCIIndex)await client.Manifests.GetAsync(ACRTestUtil.ManifestListTestRepository, tag, ACRTestUtil.MediatypeOCIIndex);
+                VerifyManifest(ExpectedOCIIndex, manifest);
+            }
+        }
+
+        [Fact]
+        public async Task CreateManifestList()
+        {
+            using (var context = MockContext.Start(GetType(), nameof(CreateManifestList)))
+            {
+                var tag = "test-manifest-list";
+                var client = await ACRTestUtil.GetACRClientAsync(context, ACRTestUtil.ManagedTestRegistry);
+                await client.Manifests.CreateAsync(ACRTestUtil.ManifestListTestRepository, tag, ExpectedManifestList);
+                var manifest = (ManifestList)await client.Manifests.GetAsync(ACRTestUtil.ManifestListTestRepository, tag, ACRTestUtil.MediatypeManifestList);
+                VerifyManifest(ExpectedManifestList, manifest);
+            }
+        }
+
         [Fact]
         public async Task GetManifestList()
         {
@@ -515,7 +557,7 @@ namespace ContainerRegistry.Tests
         {
             Assert.Equal(baseManifest.GetType(), actualManifest.GetType());
             Assert.Equal(baseManifest.SchemaVersion, actualManifest.SchemaVersion);
-
+            
             if (baseManifest.GetType() == typeof(V2Manifest))
             {
                 var baseManifestV2 = (V2Manifest)baseManifest;

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ManifestTests.cs
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Tests/ManifestTests.cs
@@ -78,7 +78,7 @@ namespace ContainerRegistry.Tests
         private static readonly V1Manifest ExpectedV1ManifestProd = new V1Manifest()
         {
             SchemaVersion = 1,
-            MediaType=ACRTestUtil.MediatypeV1Manifest,
+            MediaType = ACRTestUtil.MediatypeV1Manifest,
             Architecture = "amd64",
             Name = ACRTestUtil.TestRepository,
             Tag = "latest",
@@ -192,7 +192,7 @@ namespace ContainerRegistry.Tests
 
         private static readonly OCIManifest ExpectedOCIManifestProd = new OCIManifest()
         {
-            MediaType=ACRTestUtil.MediatypeOCIManifest,
+            MediaType = ACRTestUtil.MediatypeOCIManifest,
             Config = new Descriptor
             {
                 MediaType = "application/vnd.oci.image.config.v1+json",
@@ -556,8 +556,7 @@ namespace ContainerRegistry.Tests
         private void VerifyManifest(Manifest baseManifest, Manifest actualManifest)
         {
             Assert.Equal(baseManifest.GetType(), actualManifest.GetType());
-            Assert.Equal(baseManifest.SchemaVersion, actualManifest.SchemaVersion);
-            
+            Assert.Equal(baseManifest.SchemaVersion, actualManifest.SchemaVersion);           
             if (baseManifest.GetType() == typeof(V2Manifest))
             {
                 var baseManifestV2 = (V2Manifest)baseManifest;


### PR DESCRIPTION
# Unable to create OCI manifest in Azure Container Registry	

## Issue Statement

The SDK doesn't enable the client to create an OCI manifest.

This issue is tracked at [Azure/azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net/issues/17084).

## Root Cause Analysis

The MediaType used in the http request headers(content type) was that of a V2Manifest leaving out all the other MediaTypes for other types of manifests.

## Resolution

To fix the issue, the media type was added as a parameter in each of the manifest types and all of them were fetched in the _httpRequest.Content.Headers.ContentType.

## Tests
Automated tests were added to create the different manifests and they were all successful.
