### PR TITLE
[Storage] Live tests - Wait for RBAC replication.

### DIFF
--- a/sdk/storage/test-resources-post.ps1
+++ b/sdk/storage/test-resources-post.ps1
@@ -174,4 +174,5 @@ Write-Verbose "Setting AZ_STORAGE_CONFIG_PATH environment variable used by Stora
 Write-Host "##vso[task.setvariable variable=AZ_STORAGE_CONFIG_PATH]$TestConfigurationPath"
 
 # Wait until RBAC replicates. It has 5min SLA. https://github.com/Azure/azure-sdk-for-net/issues/17384 to find better solution.
+Write-Verbose "Sleeping for 90 seconds to let RBAC replicate"
 Start-Sleep -s 90

--- a/sdk/storage/test-resources-post.ps1
+++ b/sdk/storage/test-resources-post.ps1
@@ -172,3 +172,6 @@ $content | Set-Content $TestConfigurationPath
 Write-Verbose "Setting AZ_STORAGE_CONFIG_PATH environment variable used by Storage Tests"
 # https://github.com/microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md#logging-commands
 Write-Host "##vso[task.setvariable variable=AZ_STORAGE_CONFIG_PATH]$TestConfigurationPath"
+
+# Wait until RBAC replicates. It has 5min SLA. https://github.com/Azure/azure-sdk-for-net/issues/17384 to find better solution.
+Start-Sleep -s 90


### PR DESCRIPTION
It may take up to 5 minutes for RBAC (AAD) role assignments to replicate. This makes live tests flaky.
The short term solution is to add "sleep" after test resources provisioning.

Long term solution to be found here https://github.com/Azure/azure-sdk-for-net/issues/17384