### PR TITLE
[FR] Update service version, TODO cleanup, and add missing xxOperation tests

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/api/Azure.AI.FormRecognizer.netstandard2.0.cs
@@ -44,11 +44,12 @@ namespace Azure.AI.FormRecognizer
     }
     public partial class FormRecognizerClientOptions : Azure.Core.ClientOptions
     {
-        public FormRecognizerClientOptions(Azure.AI.FormRecognizer.FormRecognizerClientOptions.ServiceVersion version = Azure.AI.FormRecognizer.FormRecognizerClientOptions.ServiceVersion.V2_0) { }
+        public FormRecognizerClientOptions(Azure.AI.FormRecognizer.FormRecognizerClientOptions.ServiceVersion version = Azure.AI.FormRecognizer.FormRecognizerClientOptions.ServiceVersion.V2_1_Preview_2) { }
         public Azure.AI.FormRecognizer.FormRecognizerClientOptions.ServiceVersion Version { get { throw null; } }
         public enum ServiceVersion
         {
             V2_0 = 1,
+            V2_1_Preview_2 = 2,
         }
     }
     public static partial class OperationExtensions

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -86,6 +86,12 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="client">The client used to check for completion.</param>
         public CopyModelOperation(string operationId, string targetModelId, FormTrainingClient client)
         {
+            // We can't check if `targetModelId` is empty because it will create a breaking change for
+            // released version 3.0.0 of the SDK which works if value is == `string.Empty`.
+            Argument.AssertNotNull(targetModelId, nameof(targetModelId));
+            Argument.AssertNotNullOrEmpty(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
+
             _serviceClient = client.ServiceClient;
             _diagnostics = client.Diagnostics;
             _targetModelId = targetModelId;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CopyModelOperation.cs
@@ -86,9 +86,6 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="client">The client used to check for completion.</param>
         public CopyModelOperation(string operationId, string targetModelId, FormTrainingClient client)
         {
-            // We can't check if `targetModelId` is empty because it will create a breaking change for
-            // released version 3.0.0 of the SDK which works if value is == `string.Empty`.
-            Argument.AssertNotNull(targetModelId, nameof(targetModelId));
             Argument.AssertNotNullOrEmpty(operationId, nameof(operationId));
             Argument.AssertNotNull(client, nameof(client));
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CreateCustomFormModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CreateCustomFormModelOperation.cs
@@ -123,9 +123,6 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="client">The client used to check for completion.</param>
         public CreateCustomFormModelOperation(string operationId, FormTrainingClient client)
         {
-            // We can't check if `operationId` is empty because it will create a breaking change for
-            // released version 3.0.0 of the SDK which throws a FormatException.
-            Argument.AssertNotNull(operationId, nameof(operationId));
             Argument.AssertNotNull(client, nameof(client));
 
             Id = operationId;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CreateCustomFormModelOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/CreateCustomFormModelOperation.cs
@@ -123,6 +123,11 @@ namespace Azure.AI.FormRecognizer.Training
         /// <param name="client">The client used to check for completion.</param>
         public CreateCustomFormModelOperation(string operationId, FormTrainingClient client)
         {
+            // We can't check if `operationId` is empty because it will create a breaking change for
+            // released version 3.0.0 of the SDK which throws a FormatException.
+            Argument.AssertNotNull(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
+
             Id = operationId;
             _diagnostics = client.Diagnostics;
             _serviceClient = client.ServiceClient;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormField.cs
@@ -53,7 +53,6 @@ namespace Azure.AI.FormRecognizer.Models
             {
                 IReadOnlyList<FormElement> fieldElements = ConvertTextReferences(fieldValue.Elements, readResults);
 
-                // TODO: FormEnum<T> ?
                 FieldBoundingBox boundingBox = new FieldBoundingBox(fieldValue.BoundingBox);
 
                 ValueData = new FieldData(boundingBox, fieldValue.Page.Value, fieldValue.Text, fieldElements);
@@ -120,9 +119,6 @@ namespace Azure.AI.FormRecognizer.Models
 
         private static FormElement ResolveTextReference(IReadOnlyList<ReadResult> readResults, string reference)
         {
-            // TODO: Add additional validations here.
-            // https://github.com/Azure/azure-sdk-for-net/issues/10363
-
             // Example: the following should result in PageIndex = 3, LineIndex = 7, WordIndex = 12
             // "#/analyzeResult/readResults/3/lines/7/words/12" from DocumentResult
             // "#/readResults/3/lines/7/words/12" from PageResult

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.AI.FormRecognizer
     /// </summary>
     public class FormRecognizerClientOptions : ClientOptions
     {
-        internal const ServiceVersion LatestVersion = ServiceVersion.V2_0;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V2_1_Preview_2;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FormRecognizerClientOptions"/> class which allows
@@ -35,7 +35,12 @@ namespace Azure.AI.FormRecognizer
             /// The V2.0 of the service.
             /// </summary>
 #pragma warning disable CA1707 // Identifiers should not contain underscores
-            V2_0 = 1
+            V2_0 = 1,
+
+            /// <summary>
+            /// Version 3.1-preview.2
+            /// </summary>
+            V2_1_Preview_2 = 2,
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -49,6 +54,7 @@ namespace Azure.AI.FormRecognizer
             return version switch
             {
                 ServiceVersion.V2_0 => "v2.0",
+                ServiceVersion.V2_1_Preview_2 => "v2.1-preview.2",
                 _ => throw new NotSupportedException($"The service version {version} is not supported."),
             };
         }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormRecognizerClientOptions.cs
@@ -38,7 +38,7 @@ namespace Azure.AI.FormRecognizer
             V2_0 = 1,
 
             /// <summary>
-            /// Version 3.1-preview.2
+            /// Version 2.1-preview.2
             /// </summary>
             V2_1_Preview_2 = 2,
 #pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/FormTable.cs
@@ -62,10 +62,6 @@ namespace Azure.AI.FormRecognizer.Models
         /// <summary> Bounding box of the table. </summary>
         public FieldBoundingBox BoundingBox { get; }
 
-        // TODO: implement table indexer
-        // TODO: Handling column-span?
-        // https://github.com/Azure/azure-sdk-for-net/issues/9975
-
         /// <summary>
         /// </summary>
 #pragma warning disable CA1822 // Mark as static

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeBusinessCardsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeBusinessCardsOperation.cs
@@ -85,7 +85,8 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeBusinessCardsOperation(string operationId, FormRecognizerClient client)
         {
-            // TODO: Add argument validation here.
+            Argument.AssertNotNullOrEmpty(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
 
             Id = operationId;
             _serviceClient = client.ServiceClient;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
@@ -77,9 +77,6 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeContentOperation(string operationId, FormRecognizerClient client)
         {
-            // We can't check if `operationId` is empty because it will create a breaking change for
-            // released version 3.0.0 of the SDK which throws a FormatException.
-            Argument.AssertNotNull(operationId, nameof(operationId));
             Argument.AssertNotNull(client, nameof(client));
 
             Id = operationId;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeContentOperation.cs
@@ -77,7 +77,10 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeContentOperation(string operationId, FormRecognizerClient client)
         {
-            // TODO: Add argument validation here.
+            // We can't check if `operationId` is empty because it will create a breaking change for
+            // released version 3.0.0 of the SDK which throws a FormatException.
+            Argument.AssertNotNull(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
 
             Id = operationId;
             _serviceClient = client.ServiceClient;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -208,8 +208,6 @@ namespace Azure.AI.FormRecognizer.Models
                         ? await _serviceClient.GetAnalyzeFormResultAsync(new Guid(_modelId), new Guid(_resultId), cancellationToken).ConfigureAwait(false)
                         : _serviceClient.GetAnalyzeFormResult(new Guid(_modelId), new Guid(_resultId), cancellationToken);
 
-                    // TODO: Add reasonable null checks.
-
                     _response = update.GetRawResponse();
 
                     if (update.Value.Status == OperationStatus.Succeeded)

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeCustomFormsOperation.cs
@@ -145,6 +145,9 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeCustomFormsOperation(string operationId, FormRecognizerClient client)
         {
+            Argument.AssertNotNullOrEmpty(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
+
             _serviceClient = client.ServiceClient;
             _diagnostics = client.Diagnostics;
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeInvoicesOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeInvoicesOperation.cs
@@ -85,7 +85,8 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeInvoicesOperation(string operationId, FormRecognizerClient client)
         {
-            // TODO: Add argument validation here.
+            Argument.AssertNotNullOrEmpty(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
 
             Id = operationId;
             _serviceClient = client.ServiceClient;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
@@ -85,7 +85,10 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeReceiptsOperation(string operationId, FormRecognizerClient client)
         {
-            // TODO: Add argument validation here.
+            // We can't check if `operationId` is empty because it will create a breaking change for
+            // released version 3.0.0 of the SDK which throws a FormatException.
+            Argument.AssertNotNull(operationId, nameof(operationId));
+            Argument.AssertNotNull(client, nameof(client));
 
             Id = operationId;
             _serviceClient = client.ServiceClient;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizeReceiptsOperation.cs
@@ -85,9 +85,6 @@ namespace Azure.AI.FormRecognizer.Models
         /// <param name="client">The client used to check for completion.</param>
         public RecognizeReceiptsOperation(string operationId, FormRecognizerClient client)
         {
-            // We can't check if `operationId` is empty because it will create a breaking change for
-            // released version 3.0.0 of the SDK which throws a FormatException.
-            Argument.AssertNotNull(operationId, nameof(operationId));
             Argument.AssertNotNull(client, nameof(client));
 
             Id = operationId;

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedForm.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/RecognizedForm.cs
@@ -32,9 +32,6 @@ namespace Azure.AI.FormRecognizer.Models
             // Recognized form from a model trained with labels.
             FormType = documentResult.DocType;
 
-            // TODO: validate that PageRange.Length == 2.
-            // https://github.com/Azure/azure-sdk-for-net/issues/10547
-
             PageRange = new FormPageRange(documentResult.PageRange[0], documentResult.PageRange[1]);
 
             // documentResult.Fields is required and not null, according to the swagger file, but it's not

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.AI.FormRecognizer.Models;
 using Azure.AI.FormRecognizer.Training;
@@ -117,6 +118,26 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false);
 
             var sameOperation = new TrainingOperation(operation.Id, client);
+            await sameOperation.WaitForCompletionAsync(PollingInterval);
+
+            Assert.IsTrue(sameOperation.HasValue);
+            Assert.AreEqual(CustomFormModelStatus.Ready, sameOperation.Value.Status);
+        }
+
+        [Test]
+        public async Task CreateComposedModelOperationCanPollFromNewObject()
+        {
+            // Skip instrumenting here because the internal service client passed to the operation object would be made null otherwise,
+            // making the test fail.
+
+            var client = CreateFormTrainingClient(skipInstrumenting: true);
+
+            await using var trainedModelA = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
+            await using var trainedModelB = await CreateDisposableTrainedModelAsync(useTrainingLabels: true);
+
+            var operation = await client.StartCreateComposedModelAsync(new List<string> { trainedModelA.ModelId, trainedModelB.ModelId });
+
+            var sameOperation = new CreateComposedModelOperation(operation.Id, client);
             await sameOperation.WaitForCompletionAsync(PollingInterval);
 
             Assert.IsTrue(sameOperation.HasValue);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsMockTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsMockTests.cs
@@ -82,11 +82,7 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         {
             FormRecognizerClient client = CreateFormRecognizerClient();
 
-            Assert.Throws<ArgumentNullException>(() => new RecognizeContentOperation(null, client));
             Assert.Throws<ArgumentNullException>(() => new RecognizeContentOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
-
-            var operation = new RecognizeContentOperation(string.Empty, client);
-            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
         }
 
         [Test]
@@ -114,11 +110,7 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         {
             FormRecognizerClient client = CreateFormRecognizerClient();
 
-            Assert.Throws<ArgumentNullException>(() => new RecognizeReceiptsOperation(null, client));
             Assert.Throws<ArgumentNullException>(() => new RecognizeReceiptsOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
-
-            var operation = new RecognizeReceiptsOperation(string.Empty, client);
-            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
         }
 
         [Test]
@@ -242,11 +234,7 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         {
             FormTrainingClient client = CreateFormTrainingClient();
 
-            Assert.Throws<ArgumentNullException>(() => new TrainingOperation(null, client));
             Assert.Throws<ArgumentNullException>(() => new TrainingOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
-
-            var operation = new TrainingOperation(string.Empty, client);
-            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
         }
 
         [Test]
@@ -280,11 +268,7 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         {
             FormTrainingClient client = CreateFormTrainingClient();
 
-            Assert.Throws<ArgumentNullException>(() => new CreateComposedModelOperation(null, client));
             Assert.Throws<ArgumentNullException>(() => new CreateComposedModelOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
-
-            var operation = new CreateComposedModelOperation(string.Empty, client);
-            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
         }
 
         [Test]
@@ -316,7 +300,6 @@ namespace Azure.AI.FormRecognizer.Tests.Models
 
             Assert.Throws<ArgumentNullException>(() => new CopyModelOperation(null, targetId, client));
             Assert.Throws<ArgumentException>(() => new CopyModelOperation(string.Empty, targetId, client));
-            Assert.Throws<ArgumentNullException>(() => new CopyModelOperation(operationId, null, client));
             Assert.Throws<ArgumentNullException>(() => new CopyModelOperation(operationId, targetId, null));
         }
     }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsMockTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsMockTests.cs
@@ -78,6 +78,18 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         }
 
         [Test]
+        public void RecognizeContentOperationRequiredParameters()
+        {
+            FormRecognizerClient client = CreateFormRecognizerClient();
+
+            Assert.Throws<ArgumentNullException>(() => new RecognizeContentOperation(null, client));
+            Assert.Throws<ArgumentNullException>(() => new RecognizeContentOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
+
+            var operation = new RecognizeContentOperation(string.Empty, client);
+            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
+        }
+
+        [Test]
         public async Task RecognizeReceiptsOperationCreatesDiagnosticScopeOnUpdate()
         {
             using var testListener = new ClientDiagnosticListener(DiagnosticNamespace);
@@ -98,6 +110,38 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         }
 
         [Test]
+        public void RecognizeReceiptsOperationRequiredParameters()
+        {
+            FormRecognizerClient client = CreateFormRecognizerClient();
+
+            Assert.Throws<ArgumentNullException>(() => new RecognizeReceiptsOperation(null, client));
+            Assert.Throws<ArgumentNullException>(() => new RecognizeReceiptsOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
+
+            var operation = new RecognizeReceiptsOperation(string.Empty, client);
+            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
+        }
+
+        [Test]
+        public void RecognizeBusinessCardsOperationRequiredParameters()
+        {
+            FormRecognizerClient client = CreateFormRecognizerClient();
+
+            Assert.Throws<ArgumentNullException>(() => new RecognizeBusinessCardsOperation(null, client));
+            Assert.Throws<ArgumentException>(() => new RecognizeBusinessCardsOperation(string.Empty, client));
+            Assert.Throws<ArgumentNullException>(() => new RecognizeBusinessCardsOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
+        }
+
+        [Test]
+        public void RecognizeInvoicesOperationRequiredParameters()
+        {
+            FormRecognizerClient client = CreateFormRecognizerClient();
+
+            Assert.Throws<ArgumentNullException>(() => new RecognizeInvoicesOperation(null, client));
+            Assert.Throws<ArgumentException>(() => new RecognizeInvoicesOperation(string.Empty, client));
+            Assert.Throws<ArgumentNullException>(() => new RecognizeInvoicesOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
+        }
+
+        [Test]
         public async Task RecognizeCustomFormsOperationCreatesDiagnosticScopeOnUpdate()
         {
             using var testListener = new ClientDiagnosticListener(DiagnosticNamespace);
@@ -115,6 +159,16 @@ namespace Azure.AI.FormRecognizer.Tests.Models
             await operation.UpdateStatusAsync();
 
             testListener.AssertScope($"{nameof(RecognizeCustomFormsOperation)}.{nameof(RecognizeCustomFormsOperation.UpdateStatus)}");
+        }
+
+        [Test]
+        public void RecognizeCustomFormsOperationRequiredParameters()
+        {
+            FormRecognizerClient client = CreateFormRecognizerClient();
+
+            Assert.Throws<ArgumentNullException>(() => new RecognizeCustomFormsOperation(null, client));
+            Assert.Throws<ArgumentException>(() => new RecognizeCustomFormsOperation(string.Empty, client));
+            Assert.Throws<ArgumentNullException>(() => new RecognizeCustomFormsOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
         }
 
         [Test]
@@ -144,6 +198,30 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         }
 
         [Test]
+        public void TrainingOperationRequiredParameters()
+        {
+            FormTrainingClient client = CreateFormTrainingClient();
+
+            Assert.Throws<ArgumentNullException>(() => new TrainingOperation(null, client));
+            Assert.Throws<ArgumentNullException>(() => new TrainingOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
+
+            var operation = new TrainingOperation(string.Empty, client);
+            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
+        }
+
+        [Test]
+        public void CreateComposedModelOperationRequiredParameters()
+        {
+            FormTrainingClient client = CreateFormTrainingClient();
+
+            Assert.Throws<ArgumentNullException>(() => new CreateComposedModelOperation(null, client));
+            Assert.Throws<ArgumentNullException>(() => new CreateComposedModelOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
+
+            var operation = new CreateComposedModelOperation(string.Empty, client);
+            Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
+        }
+
+        [Test]
         public async Task CopyModelOperationCreatesDiagnosticScopeOnUpdate()
         {
             using var testListener = new ClientDiagnosticListener(DiagnosticNamespace);
@@ -161,6 +239,19 @@ namespace Azure.AI.FormRecognizer.Tests.Models
             await operation.UpdateStatusAsync();
 
             testListener.AssertScope($"{nameof(CopyModelOperation)}.{nameof(CopyModelOperation.UpdateStatus)}");
+        }
+
+        [Test]
+        public void CopyModelOperationRequiredParameters()
+        {
+            FormTrainingClient client = CreateFormTrainingClient();
+            string operationId = "00000000-0000-0000-0000-000000000000/copyresults/00000000-0000-0000-0000-000000000000";
+            string targetId = "00000000-0000-0000-0000-000000000000";
+
+            Assert.Throws<ArgumentNullException>(() => new CopyModelOperation(null, targetId, client));
+            Assert.Throws<ArgumentException>(() => new CopyModelOperation(string.Empty, targetId, client));
+            Assert.Throws<ArgumentNullException>(() => new CopyModelOperation(operationId, null, client));
+            Assert.Throws<ArgumentNullException>(() => new CopyModelOperation(operationId, targetId, null));
         }
     }
 }

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsMockTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsMockTests.cs
@@ -122,6 +122,26 @@ namespace Azure.AI.FormRecognizer.Tests.Models
         }
 
         [Test]
+        public async Task RecognizeBusinessCardsOperationCreatesDiagnosticScopeOnUpdate()
+        {
+            using var testListener = new ClientDiagnosticListener(DiagnosticNamespace);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes("{}"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var options = new FormRecognizerClientOptions() { Transport = mockTransport };
+            var client = CreateFormRecognizerClient(options);
+
+            var operation = new RecognizeBusinessCardsOperation("00000000-0000-0000-0000-000000000000", client);
+
+            await operation.UpdateStatusAsync();
+
+            testListener.AssertScope($"{nameof(RecognizeBusinessCardsOperation)}.{nameof(RecognizeBusinessCardsOperation.UpdateStatus)}");
+        }
+
+        [Test]
         public void RecognizeBusinessCardsOperationRequiredParameters()
         {
             FormRecognizerClient client = CreateFormRecognizerClient();
@@ -129,6 +149,26 @@ namespace Azure.AI.FormRecognizer.Tests.Models
             Assert.Throws<ArgumentNullException>(() => new RecognizeBusinessCardsOperation(null, client));
             Assert.Throws<ArgumentException>(() => new RecognizeBusinessCardsOperation(string.Empty, client));
             Assert.Throws<ArgumentNullException>(() => new RecognizeBusinessCardsOperation("00000000 - 0000 - 0000 - 0000 - 000000000000", null));
+        }
+
+        [Test]
+        public async Task RecognizeInvoicesOperationCreatesDiagnosticScopeOnUpdate()
+        {
+            using var testListener = new ClientDiagnosticListener(DiagnosticNamespace);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes("{}"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var options = new FormRecognizerClientOptions() { Transport = mockTransport };
+            var client = CreateFormRecognizerClient(options);
+
+            var operation = new RecognizeInvoicesOperation("00000000-0000-0000-0000-000000000000", client);
+
+            await operation.UpdateStatusAsync();
+
+            testListener.AssertScope($"{nameof(RecognizeInvoicesOperation)}.{nameof(RecognizeInvoicesOperation.UpdateStatus)}");
         }
 
         [Test]
@@ -207,6 +247,32 @@ namespace Azure.AI.FormRecognizer.Tests.Models
 
             var operation = new TrainingOperation(string.Empty, client);
             Assert.ThrowsAsync<FormatException>(async () => await operation.UpdateStatusAsync());
+        }
+
+        [Test]
+        public async Task CreateComposedModelOperationCreatesDiagnosticScopeOnUpdate()
+        {
+            using var testListener = new ClientDiagnosticListener(DiagnosticNamespace);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(@"
+                {
+                    ""modelInfo"": {
+                        ""status"": ""creating"",
+                        ""modelId"": ""00000000-0000-0000-0000-000000000000""
+                    }
+                }"));
+
+            var mockResponse = new MockResponse(200);
+            mockResponse.ContentStream = stream;
+
+            var mockTransport = new MockTransport(new[] { mockResponse, mockResponse });
+            var options = new FormRecognizerClientOptions() { Transport = mockTransport };
+            var client = CreateFormTrainingClient(options);
+
+            var operation = new CreateComposedModelOperation("00000000-0000-0000-0000-000000000000", client);
+
+            await operation.UpdateStatusAsync();
+
+            testListener.AssertScope($"{nameof(CreateCustomFormModelOperation)}.{nameof(CreateCustomFormModelOperation.UpdateStatus)}");
         }
 
         [Test]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/OperationsLiveTests/CreateComposedModelOperationCanPollFromNewObject.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/OperationsLiveTests/CreateComposedModelOperationCanPollFromNewObject.json
@@ -1,0 +1,769 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "42",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a6a3aec9cee79545b9f34e8e3dbbad7e-8d712e9c1582b64f-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1a3127b1905aa32b14f1dea82702f0e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "source": "Sanitized",
+        "useLabelFile": true
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "6dde7fbd-7a8b-4574-87f0-07c58edf6bd0",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:52:43 GMT",
+        "Location": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/3aea173e-38fc-485d-843d-b684c5cc43c0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "156"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/3aea173e-38fc-485d-843d-b684c5cc43c0?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "92e65b09fa6acfa7ab70f569a3105a18",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e7a0de47-93b1-4ce5-8994-325a9d09a752",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "47"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "3aea173e-38fc-485d-843d-b684c5cc43c0",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:43Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:43Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/3aea173e-38fc-485d-843d-b684c5cc43c0?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "14110df4c6a1faf61959485c18718a3d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2fbaa655-bd27-487d-af03-f0beafda950d",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "3aea173e-38fc-485d-843d-b684c5cc43c0",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:43Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:43Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/3aea173e-38fc-485d-843d-b684c5cc43c0?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "eba6bd419f55b6a880626ee99bc10004",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b6365d5b-8362-45d4-b380-62ab3278950e",
+        "Content-Length": "1218",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "53"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "3aea173e-38fc-485d-843d-b684c5cc43c0",
+          "attributes": {
+            "isComposed": false
+          },
+          "status": "ready",
+          "createdDateTime": "2020-12-07T19:52:43Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:46Z"
+        },
+        "trainResult": {
+          "averageModelAccuracy": 0.96,
+          "trainingDocuments": [
+            {
+              "documentName": "Form_1.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_2.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_3.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_4.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_5.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            }
+          ],
+          "fields": [
+            {
+              "fieldName": "CompanyAddress",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "CompanyName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "CompanyPhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "DatedAs",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Email",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Merchant",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PurchaseOrderNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Quantity",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Signature",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Subtotal",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Tax",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Total",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "VendorName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Website",
+              "accuracy": 1.0
+            }
+          ],
+          "errors": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "42",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2b31e46088d4c445b3dbae5ff04cdbcb-3d567de251262649-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1ab3c596dcf1424764eb7911b24bb63a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "source": "Sanitized",
+        "useLabelFile": true
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "bbc9efe5-959a-4044-898b-2daf6998b2e9",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:52:45 GMT",
+        "Location": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/6c885ace-bc6b-49b6-8f27-2057b75c76c5",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "72"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/6c885ace-bc6b-49b6-8f27-2057b75c76c5?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e528b8e66f6955c3655a943e580c5e57",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4f251a01-3b96-4954-9d73-aecca1898832",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "6c885ace-bc6b-49b6-8f27-2057b75c76c5",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:46Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:46Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/6c885ace-bc6b-49b6-8f27-2057b75c76c5?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "52c5445870bd654b7663876925960435",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3f905bdb-b6c8-4594-8869-fa7c249dbe1d",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "6c885ace-bc6b-49b6-8f27-2057b75c76c5",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:46Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:46Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/6c885ace-bc6b-49b6-8f27-2057b75c76c5?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e30333ab1b99279a025eb5964709ea57",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4659652c-515d-420f-98eb-3f8abf1a80f2",
+        "Content-Length": "1218",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "6c885ace-bc6b-49b6-8f27-2057b75c76c5",
+          "attributes": {
+            "isComposed": false
+          },
+          "status": "ready",
+          "createdDateTime": "2020-12-07T19:52:46Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:48Z"
+        },
+        "trainResult": {
+          "averageModelAccuracy": 0.96,
+          "trainingDocuments": [
+            {
+              "documentName": "Form_1.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_2.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_3.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_4.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_5.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            }
+          ],
+          "fields": [
+            {
+              "fieldName": "CompanyAddress",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "CompanyName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "CompanyPhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "DatedAs",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Email",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Merchant",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PurchaseOrderNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Quantity",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Signature",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Subtotal",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Tax",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Total",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "VendorName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Website",
+              "accuracy": 1.0
+            }
+          ],
+          "errors": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/compose",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "92",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "6eb8228d6485757d6cc36f05e85a2fce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "modelIds": [
+          "3aea173e-38fc-485d-843d-b684c5cc43c0",
+          "6c885ace-bc6b-49b6-8f27-2057b75c76c5"
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "35fc36cc-f1e3-403d-94f5-143f86dfb349",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:52:49 GMT",
+        "Location": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/d7756ef1-8722-476e-82b6-9d7711750941",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "103"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/d7756ef1-8722-476e-82b6-9d7711750941?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "24935f557b093dbda99d505ebbb51d6d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6b0d3e1d-9971-459d-8873-bcfb08856f32",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "d7756ef1-8722-476e-82b6-9d7711750941",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:49Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:49Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/d7756ef1-8722-476e-82b6-9d7711750941?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "03dc2f7996de47afb68e76d6ac953fa8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "05ff0759-045a-40ce-9b59-e589caa31601",
+        "Content-Length": "2329",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "34"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "d7756ef1-8722-476e-82b6-9d7711750941",
+          "attributes": {
+            "isComposed": true
+          },
+          "status": "ready",
+          "createdDateTime": "2020-12-07T19:52:49Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:49Z"
+        },
+        "composedTrainResults": [
+          {
+            "averageModelAccuracy": 0.96,
+            "trainingDocuments": [
+              {
+                "documentName": "Form_1.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_2.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_3.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_4.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_5.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              }
+            ],
+            "fields": [
+              {
+                "fieldName": "CompanyAddress",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "CompanyName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "CompanyPhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "DatedAs",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Email",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Merchant",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PurchaseOrderNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Quantity",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Signature",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Subtotal",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Tax",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Total",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "VendorName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Website",
+                "accuracy": 1.0
+              }
+            ],
+            "modelId": "3aea173e-38fc-485d-843d-b684c5cc43c0",
+            "errors": []
+          },
+          {
+            "averageModelAccuracy": 0.96,
+            "trainingDocuments": [
+              {
+                "documentName": "Form_1.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_2.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_3.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_4.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_5.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              }
+            ],
+            "fields": [
+              {
+                "fieldName": "CompanyAddress",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "CompanyName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "CompanyPhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "DatedAs",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Email",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Merchant",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PurchaseOrderNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Quantity",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Signature",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Subtotal",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Tax",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Total",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "VendorName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Website",
+                "accuracy": 1.0
+              }
+            ],
+            "modelId": "6c885ace-bc6b-49b6-8f27-2057b75c76c5",
+            "errors": []
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/6c885ace-bc6b-49b6-8f27-2057b75c76c5",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5d711766ec9a8548af4849b2058554c9-0c831689636f8440-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e840e62fc575114e647ac5e7141ebab7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d9b333f1-5f43-47b4-a677-3716922e75e2",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:52:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "31"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/3aea173e-38fc-485d-843d-b684c5cc43c0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b4da898ad127244a81fdf6241208166e-cd7c546e2591fe4e-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b88b02a52c7dbff0af4c6e7b04e79113",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "96b0fd78-b365-47dd-99db-ba9bae020fbb",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:52:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "31"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "FORM_RECOGNIZER_API_KEY": "Sanitized",
+    "FORM_RECOGNIZER_BLOB_CONTAINER_SAS_URL": "https://sanitized.blob.core.windows.net",
+    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
+    "RandomSeed": "824177279"
+  }
+}

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/OperationsLiveTests/CreateComposedModelOperationCanPollFromNewObjectAsync.json
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/SessionRecords/OperationsLiveTests/CreateComposedModelOperationCanPollFromNewObjectAsync.json
@@ -1,0 +1,2359 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "42",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-bc994278bbb54d4eb5eafcf776cadfb0-6049649b0811e140-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8410e2ef73484d5a7a0594f87b64fd11",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "source": "Sanitized",
+        "useLabelFile": true
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "054c74a5-3dd1-420c-a27a-12c2cea99e68",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:52:51 GMT",
+        "Location": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/629eaa15-0dcf-4f80-b0e7-7b23387e302d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "66"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/629eaa15-0dcf-4f80-b0e7-7b23387e302d?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1334655a1ec072085637c58372f63f4b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f7ac4c1b-d71d-4e3d-9efe-f02a730875a6",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "54"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "629eaa15-0dcf-4f80-b0e7-7b23387e302d",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:51Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:51Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/629eaa15-0dcf-4f80-b0e7-7b23387e302d?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "840a8e6d7eb0daedc7bdda2673c0b43f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2703c780-8cc8-4abe-b237-36dda2c59e06",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "629eaa15-0dcf-4f80-b0e7-7b23387e302d",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:51Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:51Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/629eaa15-0dcf-4f80-b0e7-7b23387e302d?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "368bf457306ad0a8da9e2d11aed6db84",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e51ff41f-cc9a-44af-ac97-7e340e8a65ce",
+        "Content-Length": "1218",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "629eaa15-0dcf-4f80-b0e7-7b23387e302d",
+          "attributes": {
+            "isComposed": false
+          },
+          "status": "ready",
+          "createdDateTime": "2020-12-07T19:52:51Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:52Z"
+        },
+        "trainResult": {
+          "averageModelAccuracy": 0.96,
+          "trainingDocuments": [
+            {
+              "documentName": "Form_1.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_2.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_3.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_4.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_5.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            }
+          ],
+          "fields": [
+            {
+              "fieldName": "CompanyAddress",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "CompanyName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "CompanyPhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "DatedAs",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Email",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Merchant",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PurchaseOrderNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Quantity",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Signature",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Subtotal",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Tax",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Total",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "VendorName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Website",
+              "accuracy": 1.0
+            }
+          ],
+          "errors": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "42",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-83cfda09087cb845964320a16812150a-b58a03c66e0a8846-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ed8a48c6785adc6078594b0244e1fe95",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "source": "Sanitized",
+        "useLabelFile": true
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "cc1220c6-ab19-4c2b-99af-d228c01132e5",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:52:53 GMT",
+        "Location": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "64"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7d2b8682096a3de1e539aa1250dc2cf0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "906da7d9-11e8-4502-b487-58b4109b01aa",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "2b6055e1c636dfe493aebe10e5a58cf8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "71340d4b-0a19-41c6-82a4-1b6478bd6719",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "288f989f5dabbd19674d0821cd4d8c9b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "90bb8d55-42b8-4282-8134-95a13480ab0a",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ee215a2dd380bb5fa14be9bb4bd05840",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "89a45097-ec00-4c66-8c30-d9e391a989f7",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b773b1ac034c83453ca3c4e8bec31146",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3d06af1f-51dd-45f9-976d-cb1648c011bb",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8ae322229d84cc7839d3875f735e7196",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3e38f99a-5307-4a7c-93bf-5cd52fae6f92",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:52:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1b74c7f5d4da294f159db2dd0e76fddd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bc3a8687-d221-4ee1-85fe-774c31d8a9fb",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "2999a339cded0fbc39a67e797ce510de",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "dbf31228-ef26-4ed3-bb3b-10669ef7ae54",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f7f32d31f64f4d6bd2b974e7ea9abdc2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0644fa94-40e8-4da5-ae8d-33ba0a003133",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d025a9d648c427a90b64e23356d5ad2f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "646ecb9e-6fc6-44ee-aae0-c2cba67f404a",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e1abd48c0683438e374c563358d4249e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cf07d8ad-6f3a-453b-9722-21f902c6288b",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "30"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d3a2bbe83fbfe81984cbebea1437f6fd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f6c3366a-26c0-4257-afd3-12dced02033c",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "96"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "155a450cdcefd03f1ae29878f275ce36",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ac584d8a-2855-4a9e-b9be-3c2cf78c9308",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "27"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9a4b433fd9324d6fbbc25db71aa42fff",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "39629c84-39a3-4043-8a70-2b053fee5294",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "36"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "132758550e7a0caf7bd2b8dda6a1f50e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f04d5560-f692-46d4-801c-eeb7ccf558e6",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "24"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "d0aab4fc5bec32cad50d5a2d7f88b576",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "35dd2f94-dcc5-4f6b-9cc4-7875016519c8",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "38"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9a2299b2bb4e31bc943f1f602092a61a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3082e81c-5f50-4d18-8358-b30412bf0973",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "75"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "66ba4ecc5ef9f9138ef53d6db4828cf3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "522b1f07-bc51-4743-9a8e-ef9380ca17e9",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "22"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "0d2b421d5b7e41c0f8793cad3c6a1143",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "70a63a2f-5421-44f8-aa4d-c92d1d6ea95c",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "316040664fcd537c86290b597d4f7c12",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cfab98f0-057b-42b3-97ce-08325b07f260",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "36"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "de432bb29866709c8d796e802165bc23",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "35fc6338-aa62-4782-a1b8-5afc9042a31c",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "25"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7306fae35b21cd25c6d787544f67c3a9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4a119a9f-6548-4f1d-b8ec-ba2a1e93b4f7",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "53"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "11fa2afc3327cedca4efa354e1fb3220",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6430e786-af8e-493c-adef-b6e422a2761d",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8275e86c084857f00575178f10472126",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "89910c35-6976-4ff5-b76d-5d678646a50f",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "26"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f783c4b5ab6ab0fc1e38cf32b8d1ebca",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fed7f501-9e0f-4ad0-9f04-29930e00217b",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "22"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "67e867a541f1f3603aa30bb11b4cbd5d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "35c8eee5-e754-43f8-8f79-a195ac897ef3",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "20"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1c9e7cce3b78c0b5ecc5641039be9e34",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "eb9ada8a-b81f-4bac-a141-a22dcd7e8566",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "a9ea4d89b95e7434648fbcc6a04a94d1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8f041ea6-a95c-436a-89e3-114c41789c9b",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "3b64727acf326952b1287a2cdc50ba7c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "726593e6-5c0c-4507-af96-d06a494dec13",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "24"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ce28d705146114fe482ab8e87eef20a2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0f6ed753-0d00-46e0-872e-e284079a71af",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c69593316359ba01fb80f8363e089813",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8feb9853-7a11-475f-bc09-d5a281e5fbba",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "23"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c8c140d4c621656f734ff2071769ebc1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ed3952dd-940a-4588-83e8-522216afff93",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "153"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "48fbd807f4baa122d66dd3e11cc8d53f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "35611c93-fb02-4a13-a3c8-7a725a06c84d",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:30 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "3e13a492572d6b80232f520a70f9a391",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c99bff9c-ae26-4ce5-99d4-020a3f978d8f",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "36"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "662e36954f0de0591d1ff2b3f28e49ab",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ea5b63c9-9d64-4aa6-aee6-c6333e2f06d4",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "22"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7275b27aad56b093588f258aa11830dc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f0f0bded-4875-4639-83a7-67ed0a40e8ce",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "22"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e64b42ca6f9943324b32200e65cc7895",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a9151e57-8640-4be6-a8a7-712339054ffd",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "32"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "bd8fa7e63083e83aa27e0d7d2ace3f05",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a65d7d4b-b677-47d8-a0f6-96407e8571a9",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b0e915ee63420b11803227238c854a8c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "bbfb7394-30c5-41f8-b42d-90e46bceea87",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f9a49017738999580763441b61b5187d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4af51dd9-2a8f-4050-a55c-95f284485094",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "4f1f1bf3c7e2835296833d5109175c1c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6d38799e-b0d8-45aa-84cd-938108dfebae",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "90"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9a65813345297b7cbd4fa9df1ef6aacb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "95efe05e-703b-474d-9589-b6dcf007ab1a",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7030a919fb6650a93d216305360790ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6580734f-55ac-47b4-91cc-6967623418dd",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "dfe728077e4fad549fa392931d7264a0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0377eb54-9ef2-460d-9578-9e812361f512",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:43 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "15"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5f3872d9ebe638b5d8155c07e27745b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e587868b-bfb3-4ab1-b53d-46132669fab9",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "f6d8b9bfca0e9a7b5582d0c2691532cb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c7dac0f2-57b0-41da-925e-bff84d4f701a",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "15"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "c32bc2bd30cf1b0972af0739224cca28",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "94de5fb2-9ae4-48f2-a62d-43b5ff359e78",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "64d4dc5e6d990f92f69d09641af2cec2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8d0f2bf8-19bf-48dc-b611-3b0ccb45f7d6",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "1f4a90e3814b8ee6b0bc845ec3417809",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "90df8bfa-5900-4052-8407-9c23750e0448",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "18"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "8c64a8b7cd415031301bcd3126a50080",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3e78ebd2-9dff-4f88-8095-b0bea823e521",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:49 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "27"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "915644e0ab02dcdcf545b3dce8334cb4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8cad1b98-850f-4093-b8db-a7632f74376b",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "16"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "72ac0025418d15815ef9ef30b4b4670b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fd0ec459-b4c0-4614-a960-a64469cc9047",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "19"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "7f7d04bce6eb0c07cb8797fb195467fd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0d96a083-1be2-4721-bb7d-2306d376ded2",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "17"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "260c18cf8ef89ff2c2403308bbac2840",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0dfe202a-0c62-4d55-9adf-49140f5869b9",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "23"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "e420a8decdb53fc8f89fa605aa85fb09",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7b113111-b80b-4b87-a98c-d4aa8af073b6",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "43"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:52:54Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "9b60f19240a82d1212debcabb2ff511f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3ac8ec79-05d9-415e-afd3-bcc3de8a8682",
+        "Content-Length": "1218",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+          "attributes": {
+            "isComposed": false
+          },
+          "status": "ready",
+          "createdDateTime": "2020-12-07T19:52:54Z",
+          "lastUpdatedDateTime": "2020-12-07T19:53:56Z"
+        },
+        "trainResult": {
+          "averageModelAccuracy": 0.96,
+          "trainingDocuments": [
+            {
+              "documentName": "Form_1.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_2.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_3.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_4.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            },
+            {
+              "documentName": "Form_5.jpg",
+              "pages": 1,
+              "status": "succeeded"
+            }
+          ],
+          "fields": [
+            {
+              "fieldName": "CompanyAddress",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "CompanyName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "CompanyPhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "DatedAs",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Email",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Merchant",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PhoneNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "PurchaseOrderNumber",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Quantity",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Signature",
+              "accuracy": 0.8
+            },
+            {
+              "fieldName": "Subtotal",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Tax",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Total",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "VendorName",
+              "accuracy": 1.0
+            },
+            {
+              "fieldName": "Website",
+              "accuracy": 1.0
+            }
+          ],
+          "errors": []
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/compose",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Content-Length": "92",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "711d565f823402484fcd2d59e8ecf43c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "modelIds": [
+          "629eaa15-0dcf-4f80-b0e7-7b23387e302d",
+          "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c"
+        ]
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "c07e32bc-828c-4d50-be43-3a4bb0c40013",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:53:56 GMT",
+        "Location": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/81102910-82ad-4e94-b5f8-aebbcbb647d9",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "188"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/81102910-82ad-4e94-b5f8-aebbcbb647d9?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "ca7529448d4b9d9895f3d2d6101d8cf9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "ad4075ed-4972-4dea-b7c6-2e87c24b2376",
+        "Content-Length": "170",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "21"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "81102910-82ad-4e94-b5f8-aebbcbb647d9",
+          "status": "creating",
+          "createdDateTime": "2020-12-07T19:53:57Z",
+          "lastUpdatedDateTime": "2020-12-07T19:53:57Z"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/81102910-82ad-4e94-b5f8-aebbcbb647d9?includeKeys=true",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "54a6864e8a680fd5a95e4bdb13b94425",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c4c5a744-1077-4423-b5bc-013923d0698d",
+        "Content-Length": "2329",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Mon, 07 Dec 2020 19:53:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "30"
+      },
+      "ResponseBody": {
+        "modelInfo": {
+          "modelId": "81102910-82ad-4e94-b5f8-aebbcbb647d9",
+          "attributes": {
+            "isComposed": true
+          },
+          "status": "ready",
+          "createdDateTime": "2020-12-07T19:53:57Z",
+          "lastUpdatedDateTime": "2020-12-07T19:53:57Z"
+        },
+        "composedTrainResults": [
+          {
+            "averageModelAccuracy": 0.96,
+            "trainingDocuments": [
+              {
+                "documentName": "Form_1.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_2.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_3.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_4.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_5.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              }
+            ],
+            "fields": [
+              {
+                "fieldName": "CompanyAddress",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "CompanyName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "CompanyPhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "DatedAs",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Email",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Merchant",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PurchaseOrderNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Quantity",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Signature",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Subtotal",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Tax",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Total",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "VendorName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Website",
+                "accuracy": 1.0
+              }
+            ],
+            "modelId": "629eaa15-0dcf-4f80-b0e7-7b23387e302d",
+            "errors": []
+          },
+          {
+            "averageModelAccuracy": 0.96,
+            "trainingDocuments": [
+              {
+                "documentName": "Form_1.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_2.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_3.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_4.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              },
+              {
+                "documentName": "Form_5.jpg",
+                "pages": 1,
+                "status": "succeeded"
+              }
+            ],
+            "fields": [
+              {
+                "fieldName": "CompanyAddress",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "CompanyName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "CompanyPhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "DatedAs",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Email",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Merchant",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PhoneNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "PurchaseOrderNumber",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Quantity",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Signature",
+                "accuracy": 0.8
+              },
+              {
+                "fieldName": "Subtotal",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Tax",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Total",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "VendorName",
+                "accuracy": 1.0
+              },
+              {
+                "fieldName": "Website",
+                "accuracy": 1.0
+              }
+            ],
+            "modelId": "5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+            "errors": []
+          }
+        ]
+      }
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/5e2145b0-fbe7-4a85-8e09-26f99ccfed4c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-baafd857ff35754586ac2f2ae6415ea7-900935f05a5a554e-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "89677fea8689d2d4be80db40b071f132",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "44d5e023-ef4d-422f-98fd-9c418f4d6428",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:53:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "35"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://mariari-canada-central.cognitiveservices.azure.com/formrecognizer/v2.1-preview.2/custom/models/629eaa15-0dcf-4f80-b0e7-7b23387e302d",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-544d320f23c1fb40bd94d160fb72bf55-51bba3cecd0cdb48-00",
+        "User-Agent": "azsdk-net-AI.FormRecognizer/3.1.0-alpha.20201207.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "610b3440a045b9d4536620ec41bc8adc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "4d83b7cd-0b4f-419c-95c3-b6e79bbe788c",
+        "Content-Length": "0",
+        "Date": "Mon, 07 Dec 2020 19:53:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "61"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "FORM_RECOGNIZER_API_KEY": "Sanitized",
+    "FORM_RECOGNIZER_BLOB_CONTAINER_SAS_URL": "https://sanitized.blob.core.windows.net",
+    "FORM_RECOGNIZER_ENDPOINT": "https://mariari-canada-central.cognitiveservices.azure.com/",
+    "RandomSeed": "1112571338"
+  }
+}


### PR DESCRIPTION
- Updates service version of FR to `2.1-preview.2` Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17339
- Add missing `xxOperation` tests. Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17344
- Remove solved or unnecessary TODOs in the code
- Add parameter validation to `xxOperation` classes.
~~Note that in order to avoid breaking changes some `string` parameters couldn't be validated for empty values mostly because current behavior throws a `FormatException` and new behavior will throw a `ArgumentException`.
After talking with architects, I am going to make a separate PR to make those breaking changes and will discuss in next arch board for FR ( issue: https://github.com/Azure/azure-sdk-for-net/issues/17383 ).~~
Note not all validations are added as some create breaking changes and need to be discussed in an arch board meeting. Issue tracking all scenarios is https://github.com/Azure/azure-sdk-for-net/issues/17383