### PR TITLE
diable inheritdoc again while troubleshooting failures

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -55,7 +55,7 @@
     <GenerateAPIListing Condition="'$(IsShippingClientLibrary)' == 'true'">true</GenerateAPIListing>
     <UpdateSourceOnBuild Condition="'$(UpdateSourceOnBuild)' == ''">$(AZURE_DEV_UPDATESOURCESONBUILD)</UpdateSourceOnBuild>
     <PowerShellExe Condition="'$(PowerShellExe)' == ''">pwsh</PowerShellExe>
-    <InheritDocEnabled>true</InheritDocEnabled>
+    <InheritDocEnabled>false</InheritDocEnabled>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsShippingClientLibrary)' == 'true' and '$(TF_BUILD)' == 'true'">

--- a/sdk/attestation/Azure.Security.Attestation/src/AttestationAdministrationClient.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/AttestationAdministrationClient.cs
@@ -323,7 +323,6 @@ namespace Azure.Security.Attestation
             }
         }
 
-
         /// <summary>
         /// Retrieves the attesttion policy for the specified <see cref="AttestationType"/>.
         /// </summary>
@@ -446,6 +445,5 @@ namespace Azure.Security.Attestation
                 return _signers;
             }
         }
-
     }
 }

--- a/sdk/attestation/Azure.Security.Attestation/src/AttestationClient.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/AttestationClient.cs
@@ -23,7 +23,6 @@ namespace Azure.Security.Attestation
     /// </summary>
     public class AttestationClient
     {
-
         private readonly HttpPipeline _pipeline;
         private readonly ClientDiagnostics _clientDiagnostics;
         private readonly AttestationRestClient _restClient;

--- a/sdk/attestation/Azure.Security.Attestation/src/AttestationClient.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/AttestationClient.cs
@@ -390,7 +390,6 @@ namespace Azure.Security.Attestation
                     }
 
                     returnedCertificates.Add(new AttestationSigner(certificates.ToArray(), keyId));
-
                 }
 
                 return Task.FromResult(Response.FromValue((IReadOnlyList<AttestationSigner>)returnedCertificates, keys.GetRawResponse()));
@@ -414,7 +413,5 @@ namespace Azure.Security.Attestation
                 return _signers;
             }
         }
-
-
     }
 }

--- a/sdk/attestation/Azure.Security.Attestation/src/AttestationToken.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/AttestationToken.cs
@@ -42,7 +42,6 @@ namespace Azure.Security.Attestation
 
             _options.Converters.Add(new PolicyResultConverter());
             _options.Converters.Add(new AttestationResultConverter());
-
         }
 
         /// <summary>
@@ -50,7 +49,6 @@ namespace Azure.Security.Attestation
         /// </summary>
         protected AttestationToken()
         {
-
         }
 
         /// <summary>
@@ -152,6 +150,5 @@ namespace Azure.Security.Attestation
         {
             return _token ??  GetType().Name;
         }
-
     }
 }

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/AttestationResult.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/AttestationResult.cs
@@ -13,7 +13,6 @@ namespace Azure.Security.Attestation.Models
     [JsonConverter(typeof(AttestationResultConverter))]
     public partial class AttestationResult
     {
-
         internal AttestationResult()
         {
         }

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/AttestationResultConverter.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/AttestationResultConverter.cs
@@ -18,7 +18,6 @@ namespace Azure.Security.Attestation.Models
         /// <inheritdoc/>
         public override AttestationResult Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-
             string serializedJson = Utilities.SerializeJsonObject(ref reader, options);
 
             if (typeToConvert != typeof(AttestationResult))

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/AttestationSigner.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/AttestationSigner.cs
@@ -34,7 +34,6 @@ namespace Azure.Security.Attestation.Models
         /// </summary>
         public string CertificateKeyId { get; internal set; }
 
-
         internal static IReadOnlyList<AttestationSigner> FromJsonWebKeySet(JsonWebKeySet keys)
         {
             List<AttestationSigner> returnedCertificates = new List<AttestationSigner>();

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/JsonWebTokenHeader.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/JsonWebTokenHeader.cs
@@ -76,6 +76,5 @@ namespace Azure.Security.Attestation.Models
         /// </summary>
         [JsonPropertyName("crit")]
         public bool? Critical { get; set; }
-
     }
 }

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/PolicyCertificatesResult.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/PolicyCertificatesResult.cs
@@ -48,7 +48,6 @@ namespace Azure.Security.Attestation.Models
                     _certificateList = certificates;
                 }
                 return _certificateList;
-
             }
         }
 
@@ -59,5 +58,4 @@ namespace Azure.Security.Attestation.Models
         internal JsonWebKeySet InternalPolicyCertificates
         { get; private set; }
     }
-
 }

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/PolicyResult.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/PolicyResult.cs
@@ -21,7 +21,6 @@ namespace Azure.Security.Attestation.Models
         /// </summary>
         public PolicyResult()
         {
-
         }
 
         /// <summary>
@@ -57,7 +56,6 @@ namespace Azure.Security.Attestation.Models
         /// JSON Web Token containing the policy retrieved.
         /// </summary>
         internal AttestationToken PolicyToken { get => new AttestationToken(BasePolicy); }
-
 
         [CodeGenMember("PolicyTokenHash")]
         internal string BasePolicyTokenHash { get; private set; }

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/PolicyResultConverter.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/PolicyResultConverter.cs
@@ -17,7 +17,6 @@ namespace Azure.Security.Attestation.Models
 
             using var document = JsonDocument.Parse(serializedReader);
             return PolicyResult.DeserializePolicyResult(document.RootElement);
-
         }
 
         public override void Write(Utf8JsonWriter writer, PolicyResult value, JsonSerializerOptions options)

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/StoredAttestationPolicy.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/StoredAttestationPolicy.cs
@@ -12,13 +12,11 @@ namespace Azure.Security.Attestation.Models
     /// </summary>
     public partial class StoredAttestationPolicy
     {
-
         /// <summary>
         /// Initializes a new instance of the <see cref="StoredAttestationPolicy"/> class.
         /// </summary>
         public StoredAttestationPolicy() : base()
         {
-
         }
         /// <summary>
         /// Gets or sets the attestation policy stored in the MAA.

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/TpmAttestationRequest.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/TpmAttestationRequest.cs
@@ -12,7 +12,6 @@ namespace Azure.Security.Attestation.Models
     /// </summary>
     public partial class TpmAttestationRequest
     {
-
         /// <summary>
         /// Attestation Response data. See  https://docs.microsoft.com/en-us/azure/attestation/virtualization-based-security-protocol for more details
         /// </summary>

--- a/sdk/attestation/Azure.Security.Attestation/src/Models/TpmAttestationResponse.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Models/TpmAttestationResponse.cs
@@ -12,7 +12,6 @@ namespace Azure.Security.Attestation.Models
     /// </summary>
     public partial class TpmAttestationResponse
     {
-
         /// <summary>
         /// Attestation Response data. See  https://docs.microsoft.com/en-us/azure/attestation/virtualization-based-security-protocol for more details
         /// </summary>

--- a/sdk/attestation/Azure.Security.Attestation/src/SecuredAttestationToken.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/SecuredAttestationToken.cs
@@ -94,7 +94,6 @@ namespace Azure.Security.Attestation
             var serializationOptions = new JsonSerializerOptions
             {
                 IgnoreNullValues = true,
-
             };
             byte[] jwtHeader = JsonSerializer.SerializeToUtf8Bytes<JsonWebTokenHeader>(header, serializationOptions);
             string encodedHeader = Base64Url.Encode(jwtHeader);

--- a/sdk/attestation/Azure.Security.Attestation/src/SecuredAttestationToken.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/SecuredAttestationToken.cs
@@ -38,9 +38,8 @@ namespace Azure.Security.Attestation
         {
         }
 
-
         /// <summary>
-        /// Creates a new attestation token based on the supplied body, certificateand private key.
+        /// Creates a new attestation token based on the supplied body, certificate, and private key.
         /// </summary>
         /// <param name="body"></param>
         /// <param name="signingKey"></param>

--- a/sdk/attestation/Azure.Security.Attestation/src/UnsecuredAttestationToken.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/UnsecuredAttestationToken.cs
@@ -56,7 +56,5 @@ namespace Azure.Security.Attestation
 
             return returnValue;
         }
-
-
     }
 }

--- a/sdk/attestation/Azure.Security.Attestation/src/Utilities.cs
+++ b/sdk/attestation/Azure.Security.Attestation/src/Utilities.cs
@@ -159,6 +159,5 @@ namespace Azure.Security.Attestation
             returnValue += "\"";
             return returnValue;
         }
-
     }
 }

--- a/sdk/attestation/Azure.Security.Attestation/tests/AttestationClientTestEnvironment.cs
+++ b/sdk/attestation/Azure.Security.Attestation/tests/AttestationClientTestEnvironment.cs
@@ -10,7 +10,6 @@ using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Identity;
 
-
 namespace Azure.Security.Attestation.Tests
 {
     public class AttestationClientTestEnvironment : TestEnvironment
@@ -33,7 +32,6 @@ namespace Azure.Security.Attestation.Tests
         // Policy management keys.
         public X509Certificate2 PolicyManagementCertificate => new X509Certificate2(Convert.FromBase64String(GetRecordedVariable("isolatedSigningCertificate")));
         public RSA PolicyManagementKey => GetRSACryptoServiceProvider("serializedIsolatedSigningKey");
-
 
         public string SharedEusTest => "https://sharedeus.eus.test.attest.azure.net";
         public string SharedUkSouth => "https://shareduks.uks.test.attest.azure.net";

--- a/sdk/attestation/Azure.Security.Attestation/tests/AttestationTests.cs
+++ b/sdk/attestation/Azure.Security.Attestation/tests/AttestationTests.cs
@@ -109,14 +109,12 @@ namespace Azure.Security.Attestation.Tests
         [RecordedTest]
         public async Task AttestSgxShared()
         {
-
             byte[] binaryQuote = Base64Url.Decode(_sgxQuote);
             byte[] binaryRuntimeData = Base64Url.Decode(_runtimeData);
 
             var client = GetSharedAttestationClient();
 
             IReadOnlyList<AttestationSigner> signingCertificates = (await client.GetSigningCertificatesAsync()).Value;
-
             {
                 // Collect quote and enclave held data from an SGX enclave.
 

--- a/sdk/attestation/Azure.Security.Attestation/tests/PolicyGetSetTests.cs
+++ b/sdk/attestation/Azure.Security.Attestation/tests/PolicyGetSetTests.cs
@@ -33,7 +33,6 @@ namespace Azure.Security.Attestation.Tests
             var policyRaw = Base64Url.Decode(result);
             var policy = System.Text.Encoding.UTF8.GetString(policyRaw);
             Assert.IsTrue(policy.StartsWith("version"));
-
         }
 
         [RecordedTest]
@@ -47,7 +46,6 @@ namespace Azure.Security.Attestation.Tests
             var policyRaw = Base64Url.Decode(result);
             var policy = System.Text.Encoding.UTF8.GetString(policyRaw);
             Assert.IsTrue(policy.StartsWith("version"));
-
         }
 
         [RecordedTest]
@@ -62,7 +60,6 @@ namespace Azure.Security.Attestation.Tests
             var policy = System.Text.Encoding.UTF8.GetString(policyRaw);
 
             Assert.IsTrue(policy.StartsWith("version"));
-
         }
 
         public const string disallowDebugging = "version=1.0;" +
@@ -130,7 +127,6 @@ namespace Azure.Security.Attestation.Tests
 
                 var policyRaw = Base64Url.Decode(result);
                 originalPolicy = System.Text.Encoding.UTF8.GetString(policyRaw);
-
             }
 
             byte[] disallowDebuggingHash;
@@ -209,7 +205,6 @@ namespace Azure.Security.Attestation.Tests
 
                 var policyRaw = Base64Url.Decode(result);
                 originalPolicy = System.Text.Encoding.UTF8.GetString(policyRaw);
-
             }
 
             X509Certificate2 x509Certificate;
@@ -270,7 +265,6 @@ namespace Azure.Security.Attestation.Tests
                 // And when we're done, policy should be reset to the original value.
                 Assert.AreEqual(originalPolicy, policy);
             }
-
         }
 
         [RecordedTest]
@@ -399,7 +393,6 @@ namespace Azure.Security.Attestation.Tests
                     }
                 }
                 Assert.IsFalse(foundAddedCertificate);
-
             }
         }
 

--- a/sdk/attestation/Azure.Security.Attestation/tests/PolicyGetSetTests.cs
+++ b/sdk/attestation/Azure.Security.Attestation/tests/PolicyGetSetTests.cs
@@ -114,7 +114,6 @@ namespace Azure.Security.Attestation.Tests
         [RecordedTest]
         public async Task SetPolicyUnsecuredAad()
         {
-
             var adminclient = GetAadAdministrationClient();
 
             // Reset the current attestation policy to a known state. Necessary if there were previous runs that failed.
@@ -137,7 +136,6 @@ namespace Azure.Security.Attestation.Tests
 
                 var shaHasher = SHA256Managed.Create();
                 disallowDebuggingHash = shaHasher.ComputeHash(Encoding.UTF8.GetBytes(policySetToken.ToString()));
-
 
                 Assert.AreEqual(200, policySetResult.GetRawResponse().Status);
                 Assert.AreEqual(PolicyModification.Updated, policySetResult.Value.PolicyResolution);
@@ -176,7 +174,6 @@ namespace Azure.Security.Attestation.Tests
         [RecordedTest]
         public async Task SetPolicyUnsecuredIsolated()
         {
-
             var adminclient = GetIsolatedAdministrationClient();
 
             byte[] disallowDebuggingHash;
@@ -191,7 +188,6 @@ namespace Azure.Security.Attestation.Tests
                 await Task.Yield();
             }
         }
-
 
         public async Task SetPolicySecured(AttestationAdministrationClient adminClient, bool isIsolated)
         {
@@ -270,7 +266,6 @@ namespace Azure.Security.Attestation.Tests
         [RecordedTest]
         public async Task SetPolicySecuredAad()
         {
-
             var adminclient = GetAadAdministrationClient();
 
             await SetPolicySecured(adminclient, false);
@@ -279,18 +274,15 @@ namespace Azure.Security.Attestation.Tests
         [RecordedTest]
         public async Task SetPolicySecuredIsolated()
         {
-
             var adminclient = GetIsolatedAdministrationClient();
 
             await SetPolicySecured(adminclient, true);
         }
 
-
         [RecordedTest]
         public async Task GetPolicyManagementCertificatesIsolated()
         {
             var adminclient = GetIsolatedAdministrationClient();
-
             {
                 var certificateResult = await adminclient.GetPolicyManagementCertificatesAsync();
                 Assert.AreNotEqual(0, certificateResult.Value.GetPolicyCertificates().Count);
@@ -312,7 +304,6 @@ namespace Azure.Security.Attestation.Tests
         public async Task GetPolicyManagementCertificatesShared()
         {
             var adminclient = GetSharedAdministrationClient();
-
             {
                 var certificateResult = await adminclient.GetPolicyManagementCertificatesAsync();
                 Assert.AreEqual(0, certificateResult.Value.GetPolicyCertificates().Count);
@@ -326,7 +317,6 @@ namespace Azure.Security.Attestation.Tests
 
             var x509Certificate = TestEnvironment.PolicyManagementCertificate;
             var rsaKey = TestEnvironment.PolicyManagementKey;
-
             {
                 PolicyCertificateModification modification = new Models.PolicyCertificateModification(TestEnvironment.PolicyCertificate2);
                 var policySetToken = new SecuredAttestationToken(modification, rsaKey, x509Certificate);
@@ -372,7 +362,6 @@ namespace Azure.Security.Attestation.Tests
                 Assert.IsTrue(foundAddedCertificate);
             }
 
-
             {
                 PolicyCertificateModification modification = new Models.PolicyCertificateModification(TestEnvironment.PolicyCertificate2);
                 var policySetToken = new SecuredAttestationToken(modification, rsaKey, x509Certificate);
@@ -395,8 +384,6 @@ namespace Azure.Security.Attestation.Tests
                 Assert.IsFalse(foundAddedCertificate);
             }
         }
-
-
 
         private AttestationAdministrationClient GetSharedAdministrationClient()
         {

--- a/sdk/attestation/Azure.Security.Attestation/tests/Samples/AttestationServiceAttestationSamples.cs
+++ b/sdk/attestation/Azure.Security.Attestation/tests/Samples/AttestationServiceAttestationSamples.cs
@@ -140,7 +140,6 @@ namespace Azure.Security.Attestation.Tests.Samples
 
             var policyResult = await client.GetPolicyAsync(AttestationType.SgxEnclave);
             var result = policyResult.Value.AttestationPolicy;
-
         }
 
         [RecordedTest]
@@ -173,7 +172,6 @@ namespace Azure.Security.Attestation.Tests.Samples
                 AttestationType.SgxEnclave,
                 new SecuredAttestationToken(policyTokenSigner));
             return;
-
         }
         private AttestationClient GetAttestationClient()
         {

--- a/sdk/attestation/Azure.Security.Attestation/tests/Samples/AttestationServiceAttestationSamples.cs
+++ b/sdk/attestation/Azure.Security.Attestation/tests/Samples/AttestationServiceAttestationSamples.cs
@@ -104,8 +104,6 @@ namespace Azure.Security.Attestation.Tests.Samples
     "dOd2FRR1RjZHBhMEVDCklRQ1V0OFNHdnhLbWpwY00vejBXUDlEdm84aDJrNWR1MWlXRGRCa0FuKzBpaUE9" +
     "PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCgA";
 
-
-
         [RecordedTest]
         public async Task AttestingAnSgxEnclave()
         {
@@ -117,7 +115,6 @@ namespace Azure.Security.Attestation.Tests.Samples
             var client = GetAttestationClient();
 
             IReadOnlyList<AttestationSigner> signingCertificates = (await client.GetSigningCertificatesAsync()).Value;
-
             {
                 // Collect quote and enclave held data from OpenEnclave enclave.
 


### PR DESCRIPTION
I don't yet understand why, but suddenly CIs are failing with inheritdoc warnings after working when this was enabled again.

Will continue troubleshooting.