### PR TITLE
Skip canary region for search weekly live tests

### DIFF
--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -6,5 +6,6 @@ extends:
     ServiceDirectory: search
     TimeoutInMinutes: 120
     MaxParallel: 2
+    UnsupportedClouds: Canary
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live


### PR DESCRIPTION
It looks like both euap regions are not supported for search services, so this change disables the Canary run that gets executed in the weekly live test runs.