### PR TITLE
Enable legacy checkpoint reading in WebJobs

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
@@ -28,9 +28,12 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
     ///
     public class BlobsCheckpointStoreTests
     {
-        private const string FullyQualifiedNamespace = "fqns";
-        private const string EventHubName = "name";
-        private const string ConsumerGroup = "group";
+        private const string FullyQualifiedNamespace = "FqNs";
+        private const string EventHubName = "Name";
+        private const string ConsumerGroup = "Group";
+        private const string FullyQualifiedNamespaceLowercase = "fqns";
+        private const string EventHubNameLowercase = "name";
+        private const string ConsumerGroupLowercase = "group";
         private const string MatchingEtag = "etag";
         private const string WrongEtag = "wrongEtag";
         private const string PartitionId = "1";
@@ -90,7 +93,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         {
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/{Guid.NewGuid().ToString()}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/ownership/{Guid.NewGuid().ToString()}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",
@@ -331,7 +334,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         {
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{Guid.NewGuid().ToString()}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/checkpoint/{Guid.NewGuid().ToString()}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",
@@ -364,7 +367,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{Guid.NewGuid().ToString()}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/checkpoint/{Guid.NewGuid().ToString()}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",
@@ -394,7 +397,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{Guid.NewGuid().ToString()}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/checkpoint/{Guid.NewGuid().ToString()}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",
@@ -422,7 +425,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{partitionId}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/checkpoint/{partitionId}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",
@@ -455,7 +458,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             string partitionId = Guid.NewGuid().ToString();
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{partitionId}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/checkpoint/{partitionId}",
                                             false,
                                             BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag), contentLength: 0),
                                             "snapshot",
@@ -465,14 +468,14 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                                                 {BlobMetadataKey.SequenceNumber, "960182"},
                                                 {BlobMetadataKey.Offset, "14"}
                                             }),
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/{partitionId}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/{partitionId}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot")
             };
 
             var containerClient = new MockBlobContainerClient() { Blobs = blobList };
-            containerClient.AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/{partitionId}", client =>
+            containerClient.AddBlobClient($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/{partitionId}", client =>
             {
                 client.Content = Encoding.UTF8.GetBytes("{" +
                                                             "\"PartitionId\":\"0\"," +
@@ -503,7 +506,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             string partitionId2 = Guid.NewGuid().ToString();
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{partitionId1}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/checkpoint/{partitionId1}",
                                             false,
                                             BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag), contentLength: 0),
                                             "snapshot",
@@ -717,7 +720,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{partitionId}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/checkpoint/{partitionId}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",
@@ -769,7 +772,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/{Guid.NewGuid().ToString()}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/ownership/{Guid.NewGuid().ToString()}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",
@@ -810,7 +813,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var blobList = new List<BlobItem>
             {
-                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/{Guid.NewGuid().ToString()}",
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespaceLowercase}/{EventHubNameLowercase}/{ConsumerGroupLowercase}/ownership/{Guid.NewGuid().ToString()}",
                                            false,
                                            BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
                                            "snapshot",

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
@@ -487,7 +487,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                                                             "}");
             });
 
-            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), readLegacyCheckpoints: true);
+            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), initializeWithLegacyCheckpoints: true);
             var checkpoints = await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
 
             Assert.That(checkpoints, Has.One.Items, "A single checkpoint should have been returned.");
@@ -535,7 +535,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                                                             "}");
             });
 
-            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), readLegacyCheckpoints: true);
+            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), initializeWithLegacyCheckpoints: true);
             var checkpoints = (await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken())).ToArray();
 
             Assert.That(checkpoints, Has.Exactly(2).Items, "Two checkpoints should have been returned.");
@@ -573,7 +573,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                                                             "}");
             });
 
-            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), readLegacyCheckpoints: true);
+            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), initializeWithLegacyCheckpoints: true);
             var checkpoints = await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
 
             Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
@@ -608,7 +608,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                                                         "}");
             });
 
-            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), readLegacyCheckpoints: true);
+            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), initializeWithLegacyCheckpoints: true);
             var checkpoints = await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
 
             Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
@@ -642,7 +642,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             });
 
             var mockLogger = new Mock<BlobEventStoreEventSource>();
-            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), readLegacyCheckpoints: true);
+            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), initializeWithLegacyCheckpoints: true);
 
             target.Logger = mockLogger.Object;
 
@@ -679,7 +679,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             });
 
             var mockLogger = new Mock<BlobEventStoreEventSource>();
-            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), readLegacyCheckpoints: true);
+            var target = new BlobsCheckpointStore(containerClient, new BasicRetryPolicy(new EventHubsRetryOptions()), initializeWithLegacyCheckpoints: true);
 
             target.Logger = mockLogger.Object;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
@@ -75,7 +75,7 @@ namespace Azure.Messaging.EventHubs.Processor
         ///   Indicates whether to read legacy checkpoints when no current version checkpoints are available.
         /// </summary>
         ///
-        private bool ReadLegacyCheckpoints { get; }
+        private bool InitializeWithLegacyCheckpoints { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="BlobsCheckpointStore" /> class.
@@ -83,18 +83,18 @@ namespace Azure.Messaging.EventHubs.Processor
         ///
         /// <param name="blobContainerClient">The client used to interact with the Azure Blob Storage service.</param>
         /// <param name="retryPolicy">The retry policy to use as the basis for interacting with the Storage Blobs service.</param>
-        /// <param name="readLegacyCheckpoints">Indicates whether to read legacy checkpoint when no current version checkpoint is available for a partition.</param>
+        /// <param name="initializeWithLegacyCheckpoints">Indicates whether to read legacy checkpoint when no current version checkpoint is available for a partition.</param>
         ///
         public BlobsCheckpointStore(BlobContainerClient blobContainerClient,
                                     EventHubsRetryPolicy retryPolicy,
-                                    bool readLegacyCheckpoints = false)
+                                    bool initializeWithLegacyCheckpoints = false)
         {
             Argument.AssertNotNull(blobContainerClient, nameof(blobContainerClient));
             Argument.AssertNotNull(retryPolicy, nameof(retryPolicy));
 
             ContainerClient = blobContainerClient;
             RetryPolicy = retryPolicy;
-            ReadLegacyCheckpoints = readLegacyCheckpoints;
+            InitializeWithLegacyCheckpoints = initializeWithLegacyCheckpoints;
             BlobsCheckpointStoreCreated(nameof(BlobsCheckpointStore), blobContainerClient.AccountName, blobContainerClient.Name);
         }
 
@@ -410,7 +410,7 @@ namespace Azure.Messaging.EventHubs.Processor
             try
             {
                 checkpoints = await ApplyRetryPolicy(listCheckpointsAsync, cancellationToken).ConfigureAwait(false);
-                if (ReadLegacyCheckpoints)
+                if (InitializeWithLegacyCheckpoints)
                 {
                     checkpoints.AddRange(await ApplyRetryPolicy(ct => listLegacyCheckpointsAsync(checkpoints, ct), cancellationToken).ConfigureAwait(false));
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
@@ -344,7 +344,8 @@ namespace Azure.Messaging.EventHubs.Processor
 
             async Task<List<EventProcessorCheckpoint>> listLegacyCheckpointsAsync(List<EventProcessorCheckpoint> existingCheckpoints, CancellationToken listCheckpointsToken)
             {
-                var legacyPrefix = string.Format(CultureInfo.InvariantCulture, LegacyCheckpointPrefix, fullyQualifiedNamespace.ToLowerInvariant(), eventHubName.ToLowerInvariant(), consumerGroup.ToLowerInvariant());
+                // Legacy checkpoints are not normalized to lowercase
+                var legacyPrefix = string.Format(CultureInfo.InvariantCulture, LegacyCheckpointPrefix, fullyQualifiedNamespace, eventHubName, consumerGroup);
                 var checkpoints = new List<EventProcessorCheckpoint>();
 
                 await foreach (BlobItem blob in ContainerClient.GetBlobsAsync(prefix: legacyPrefix, cancellationToken: listCheckpointsToken).ConfigureAwait(false))

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/BlobsCheckpointStore.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Processor
         public BlobsCheckpointStore(BlobContainerClient blobContainerClient,
             EventHubsRetryPolicy retryPolicy,
             string functionId,
-            ILogger logger): this(blobContainerClient, retryPolicy)
+            ILogger logger): this(blobContainerClient, retryPolicy, readLegacyCheckpoints: true)
         {
             _functionId = functionId;
             _logger = logger;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/BlobsCheckpointStore.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Processor
         public BlobsCheckpointStore(BlobContainerClient blobContainerClient,
             EventHubsRetryPolicy retryPolicy,
             string functionId,
-            ILogger logger): this(blobContainerClient, retryPolicy, readLegacyCheckpoints: true)
+            ILogger logger): this(blobContainerClient, retryPolicy, initializeWithLegacyCheckpoints: true)
         {
             _functionId = functionId;
             _logger = logger;

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/BlobsCheckpointStoreTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                     {
                         Page<BlobItem>.FromValues(new[]
                         {
-                            BlobsModelFactory.BlobItem("testnamespace/testeventhubname/testconsumergroup/checkpoint/0", false, BlobsModelFactory.BlobItemProperties(false), metadata: new Dictionary<string, string>())
+                            BlobsModelFactory.BlobItem("testnamespace/testeventhubname/testconsumergroup/checkpoint/0", false, BlobsModelFactory.BlobItemProperties(false, contentLength: 0), metadata: new Dictionary<string, string>())
                         }, null, Mock.Of<Response>())
                     }));
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17034

Also include name casing in tests.