### PR TITLE
[New-TestResources.ps1] Set $SERVICE$_PRINCIPAL_ID as default variable from TestApplicationOid

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -428,6 +428,7 @@ try {
         $deploymentOutputs = @{
             "$($serviceDirectoryPrefix)CLIENT_ID" = $TestApplicationId;
             "$($serviceDirectoryPrefix)CLIENT_SECRET" = $TestApplicationSecret;
+            "$($serviceDirectoryPrefix)PRINCIPAL_ID" = $TestApplicationOid;
             "$($serviceDirectoryPrefix)TENANT_ID" = $context.Tenant.Id;
             "$($serviceDirectoryPrefix)SUBSCRIPTION_ID" =  $context.Subscription.Id;
             "$($serviceDirectoryPrefix)RESOURCE_GROUP" = $resourceGroup.ResourceGroupName;


### PR DESCRIPTION
- Some tests, such as [synapse here](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/synapse/Azure.Analytics.Synapse.Shared/tests/SynapseTestEnvironment.cs#L18) want a AZURE_SYNAPSE_PRINCIPAL_ID.
- It was suggested on Teams that this makes sense as a default variable from New-TestResources