### PR TITLE
Map old configuration settings to new options type

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.netstandard2.0.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/api/Microsoft.Azure.WebJobs.Extensions.EventHubs.netstandard2.0.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 {
     public partial class EventHubOptions : Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter
     {
+        public const string LeaseContainerName = "azure-webjobs-eventhub";
         public EventHubOptions() { }
         public int BatchCheckpointFrequency { get { throw null; } set { } }
         public Azure.Messaging.EventHubs.Primitives.EventProcessorOptions EventProcessorOptions { get { throw null; } }
         public bool InvokeProcessorAfterReceiveTimeout { get { throw null; } set { } }
-        public string LeaseContainerName { get { throw null; } set { } }
         public int MaxBatchSize { get { throw null; } set { } }
         public void AddReceiver(string eventHubName, string receiverConnectionString) { }
         public void AddReceiver(string eventHubName, string receiverConnectionString, string storageConnectionString) { }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubClientFactory.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             }
 
             // Fall back to default if not explicitly registered
-            return new BlobContainerClient(storageConnectionString ?? _configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage), _options.LeaseContainerName);
+            return new BlobContainerClient(storageConnectionString ?? _configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage), _options.CheckpointContainer);
         }
 
         internal static string NormalizeConnectionString(string originalConnectionString, string eventHubName)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubExtensionConfigProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubExtensionConfigProvider.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             context.AddBindingRule<EventHubAttribute>()
                 .BindToInput(attribute => _clientFactory.GetEventHubProducerClient(attribute.EventHubName, attribute.Connection));
 
-            ExceptionHandler = (e =>
+            ExceptionHandler = e =>
             {
                 LogExceptionReceivedEvent(e, _loggerFactory);
-            });
+            };
         }
 
         internal static void LogExceptionReceivedEvent(ExceptionReceivedEventArgs e, ILoggerFactory loggerFactory)

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             InvokeProcessorAfterReceiveTimeout = false;
             EventProcessorOptions = new EventProcessorOptions()
             {
+                TrackLastEnqueuedEventProperties = false,
                 MaximumWaitTime = TimeSpan.FromMinutes(1),
                 PrefetchCount = 300,
                 DefaultStartingPosition = EventPosition.Earliest,

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubOptions.cs
@@ -21,9 +21,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs
         /// Name of the blob container that the EventHostProcessor instances uses to coordinate load balancing listening on an event hub.
         /// Each event hub gets its own blob prefix within the container.
         /// </summary>
-        public string LeaseContainerName { get; set; } = "azure-webjobs-eventhub";
-
-        private int _batchCheckpointFrequency = 1;
+        public const string LeaseContainerName = "azure-webjobs-eventhub";
 
         public EventHubOptions()
         {
@@ -36,6 +34,10 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 DefaultStartingPosition = EventPosition.Earliest,
             };
         }
+
+        public EventProcessorOptions EventProcessorOptions { get; }
+
+        private int _batchCheckpointFrequency = 1;
 
         /// <summary>
         /// Gets or sets the number of batches to process before creating an EventHub cursor checkpoint. Default 1.
@@ -67,15 +69,21 @@ namespace Microsoft.Azure.WebJobs.EventHubs
             {
                 if (value < 1)
                 {
-                    throw new ArgumentException("Batch checkpoint frequency must be larger than 0.");
+                    throw new ArgumentException("Batch size must be larger than 0.");
                 }
                 _maxBatchSize = value;
             }
         }
 
+        /// <summary>
+        /// Returns whether the function would be triggered when a receive timeout occurs.
+        /// </summary>
         public bool InvokeProcessorAfterReceiveTimeout { get; set; }
 
-        public EventProcessorOptions EventProcessorOptions { get; }
+        /// <summary>
+        /// Gets or sets the Azure Blobs container name that the event processor uses to coordinate load balancing listening on an event hub.
+        /// </summary>
+        internal string CheckpointContainer { get; set; } = LeaseContainerName;
 
         internal Action<ExceptionReceivedEventArgs> ExceptionHandler { get; set; }
 
@@ -260,7 +268,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 {
                     { nameof(EventProcessorOptions.TrackLastEnqueuedEventProperties), EventProcessorOptions.TrackLastEnqueuedEventProperties },
                     { nameof(EventProcessorOptions.PrefetchCount), EventProcessorOptions.PrefetchCount },
-                    { nameof(EventProcessorOptions.MaximumWaitTime), EventProcessorOptions.MaximumWaitTime }
+                    { nameof(EventProcessorOptions.MaximumWaitTime), EventProcessorOptions.MaximumWaitTime },
+                    { nameof(EventProcessorOptions.PartitionOwnershipExpirationInterval), EventProcessorOptions.PartitionOwnershipExpirationInterval },
+                    { nameof(EventProcessorOptions.LoadBalancingUpdateInterval), EventProcessorOptions.LoadBalancingUpdateInterval },
                 };
             }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.EventHubs;
 using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting
@@ -36,6 +37,41 @@ namespace Microsoft.Extensions.Hosting
             }
 
             builder.AddExtension<EventHubExtensionConfigProvider>()
+                .ConfigureOptions<EventHubOptions>((section, options) =>
+                {
+                    // Map old property names for backwards compatibility
+                    // do it before the binding so new property names take precedence
+                    options.InvokeProcessorAfterReceiveTimeout = section.GetValue(
+                        "EventProcessorOptions:InvokeProcessorAfterReceiveTimeout",
+                        options.InvokeProcessorAfterReceiveTimeout);
+
+                    var receiveTimeout = section.GetValue<TimeSpan?>(
+                        "EventProcessorOptions:ReceiveTimeout",
+                        null);
+
+                    if (receiveTimeout != null)
+                    {
+                        options.EventProcessorOptions.MaximumWaitTime = receiveTimeout.Value;
+                    }
+
+                    var leaseDuration = section.GetValue<TimeSpan?>(
+                        "PartitionManagerOptions:LeaseDuration",
+                        null);
+
+                    if (leaseDuration != null)
+                    {
+                        options.EventProcessorOptions.PartitionOwnershipExpirationInterval = leaseDuration.Value;
+                    }
+
+                    var renewInterval = section.GetValue<TimeSpan?>(
+                        "PartitionManagerOptions:RenewInterval",
+                        null);
+
+                    if (renewInterval != null)
+                    {
+                        options.EventProcessorOptions.LoadBalancingUpdateInterval = renewInterval.Value;
+                    }
+                })
                 .BindOptions<EventHubOptions>();
 
             builder.Services.AddAzureClientsCore();

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
@@ -45,6 +45,14 @@ namespace Microsoft.Extensions.Hosting
                         "EventProcessorOptions:InvokeProcessorAfterReceiveTimeout",
                         options.InvokeProcessorAfterReceiveTimeout);
 
+                    options.EventProcessorOptions.TrackLastEnqueuedEventProperties = section.GetValue(
+                        "EventProcessorOptions:EnableReceiverRuntimeMetric",
+                        options.EventProcessorOptions.TrackLastEnqueuedEventProperties);
+
+                    options.MaxBatchSize = section.GetValue(
+                        "EventProcessorOptions:MaxBatchSize",
+                        options.MaxBatchSize);
+
                     var receiveTimeout = section.GetValue<TimeSpan?>(
                         "EventProcessorOptions:ReceiveTimeout",
                         null);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -133,9 +133,11 @@ namespace Microsoft.Azure.WebJobs.EventHubs
 
             public async Task ProcessEventsAsync(EventProcessorHostPartition context, IEnumerable<EventData> messages)
             {
+                var events = messages.ToArray();
+
                 var triggerInput = new EventHubTriggerInput
                 {
-                    Events = messages.ToArray(),
+                    Events = events,
                     PartitionContext = context
                 };
 
@@ -191,9 +193,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 // so that is the responsibility of the user's function currently. E.g.
                 // the function should have try/catch handling around all event processing
                 // code, and capture/log/persist failed events, since they won't be retried.
-                if (messages.Any())
+                if (events.Any())
                 {
-                    await CheckpointAsync(messages.Last(), context).ConfigureAwait(false);
+                    await CheckpointAsync(events.Last(), context).ConfigureAwait(false);
                 }
             }
 

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Utility.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Utility.cs
@@ -42,42 +42,19 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                 throw new ArgumentNullException(nameof(ex));
             }
 
-            if (IsConflictLeaseIdMismatchWithLeaseOperation(ex))
-            {
-                // For EventProcessorHost these exceptions can happen as part
-                // of normal partition balancing across instances, so we want to
-                // trace them, but not treat them as errors.
-                return LogLevel.Information;
-            }
-
             var ehex = ex as EventHubsException;
-            if (!(ex is OperationCanceledException) && (ehex == null || !ehex.IsTransient))
-            {
-                // any non-transient exceptions or unknown exception types
-                // we want to log as errors
-                return LogLevel.Error;
-            }
-            else
+            if (ex is OperationCanceledException ||
+                ehex?.IsTransient == true ||
+                ehex?.Reason == EventHubsException.FailureReason.ConsumerDisconnected)
             {
                 // transient messaging errors we log as info so we have a record
                 // of them, but we don't treat them as actual errors
                 return LogLevel.Information;
             }
-        }
 
-        public static bool IsConflictLeaseIdMismatchWithLeaseOperation(Exception ex)
-        {
-            RequestFailedException exception = ex as RequestFailedException;
-            if (exception == null)
-            {
-                return false;
-            }
-            if (exception.Status != 409)
-            {
-                return false;
-            }
-
-            return exception.ErrorCode == "LeaseIdMismatchWithLeaseOperation";
+            // any non-transient exceptions or unknown exception types
+            // we want to log as errors
+            return LogLevel.Error;
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubConfigurationTests.cs
@@ -4,32 +4,24 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Azure.Messaging.EventHubs;
-using Microsoft.Azure.EventHubs;
-using Microsoft.Azure.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.EventHubs.Processor;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.TestCommon;
-using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json.Linq;
-using Xunit;
-using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+using NUnit.Framework;
 
 namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
 {
     public class EventHubConfigurationTests
     {
-        private readonly ILoggerFactory _loggerFactory;
-        private readonly TestLoggerProvider _loggerProvider;
+        private ILoggerFactory _loggerFactory;
+        private TestLoggerProvider _loggerProvider;
         private readonly string _template = " An exception of type '{0}' was thrown. This exception type is typically a result of Event Hub processor rebalancing or a transient error and can be safely ignored.";
-        public EventHubConfigurationTests()
+
+        [SetUp]
+        public void SetUp()
         {
             _loggerFactory = new LoggerFactory();
 
@@ -37,22 +29,22 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             _loggerFactory.AddProvider(_loggerProvider);
         }
 
-        [Fact]
+        [Test]
         public void ConfigureOptions_AppliesValuesCorrectly()
         {
             EventHubOptions options = CreateOptions();
 
-            Assert.Equal(123, options.EventProcessorOptions.MaxBatchSize);
-            Assert.Equal(TimeSpan.FromSeconds(33), options.EventProcessorOptions.ReceiveTimeout);
-            Assert.Equal(true, options.EventProcessorOptions.EnableReceiverRuntimeMetric);
-            Assert.Equal(123, options.EventProcessorOptions.PrefetchCount);
-            Assert.Equal(true, options.EventProcessorOptions.InvokeProcessorAfterReceiveTimeout);
-            Assert.Equal(5, options.BatchCheckpointFrequency);
-            Assert.Equal(31, options.PartitionManagerOptions.LeaseDuration.TotalSeconds);
-            Assert.Equal(21, options.EventProcessorOptions.RenewInterval.TotalSeconds);
+            Assert.AreEqual(123, options.MaxBatchSize);
+            Assert.AreEqual(TimeSpan.FromSeconds(33), options.EventProcessorOptions.MaximumWaitTime);
+            Assert.AreEqual(true, options.EventProcessorOptions.TrackLastEnqueuedEventProperties);
+            Assert.AreEqual(123, options.EventProcessorOptions.PrefetchCount);
+            Assert.AreEqual(true, options.InvokeProcessorAfterReceiveTimeout);
+            Assert.AreEqual(5, options.BatchCheckpointFrequency);
+            Assert.AreEqual(31, options.EventProcessorOptions.PartitionOwnershipExpirationInterval.TotalSeconds);
+            Assert.AreEqual(21, options.EventProcessorOptions.LoadBalancingUpdateInterval.TotalSeconds);
         }
 
-        [Fact]
+        [Test]
         public void ConfigureOptions_Format_Returns_Expected()
         {
             EventHubOptions options = CreateOptions();
@@ -61,14 +53,14 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             JObject iObj = JObject.Parse(format);
             EventHubOptions result = iObj.ToObject<EventHubOptions>();
 
-            Assert.Equal(result.BatchCheckpointFrequency, 5);
-            Assert.Equal(result.EventProcessorOptions.EnableReceiverRuntimeMetric, true);
-            Assert.Equal(result.EventProcessorOptions.InvokeProcessorAfterReceiveTimeout, true);
-            Assert.Equal(result.EventProcessorOptions.MaxBatchSize, 123);
-            Assert.Equal(result.EventProcessorOptions.PrefetchCount, 123);
-            Assert.Equal(result.EventProcessorOptions.ReceiveTimeout, TimeSpan.FromSeconds(33));
-            Assert.Equal(result.PartitionManagerOptions.LeaseDuration, TimeSpan.FromSeconds(31));
-            Assert.Equal(result.PartitionManagerOptions.RenewInterval, TimeSpan.FromSeconds(21));
+            Assert.AreEqual(123, options.MaxBatchSize);
+            Assert.AreEqual(result.BatchCheckpointFrequency, 5);
+            Assert.AreEqual(result.EventProcessorOptions.TrackLastEnqueuedEventProperties, true);
+            Assert.AreEqual(result.InvokeProcessorAfterReceiveTimeout, true);
+            Assert.AreEqual(result.EventProcessorOptions.PrefetchCount, 123);
+            Assert.AreEqual(result.EventProcessorOptions.MaximumWaitTime, TimeSpan.FromSeconds(33));
+            Assert.AreEqual(result.EventProcessorOptions.PartitionOwnershipExpirationInterval, TimeSpan.FromSeconds(31));
+            Assert.AreEqual(result.EventProcessorOptions.LoadBalancingUpdateInterval, TimeSpan.FromSeconds(21));
         }
 
         private EventHubOptions CreateOptions()
@@ -83,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
                 { $"{extensionPath}:EventProcessorOptions:InvokeProcessorAfterReceiveTimeout", "true" },
                 { $"{extensionPath}:BatchCheckpointFrequency", "5" },
                 { $"{extensionPath}:PartitionManagerOptions:LeaseDuration", "00:00:31" },
-                { $"{extensionPath}:PartitionManagerOptions:RenewInterval", "00:00:21" }
+                { $"{extensionPath}:PartitionManagerOptions:RenewInterval", "00:00:21" },
             };
 
             return TestHelpers.GetConfiguredOptions<EventHubOptions>(b =>
@@ -92,144 +84,94 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             }, values);
         }
 
-        [Fact]
-        public void Initialize_PerformsExpectedRegistrations()
-        {
-            var host = new HostBuilder()
-                .ConfigureDefaultTestHost(builder =>
-                {
-                    builder.AddEventHubs();
-                })
-                .ConfigureServices(c =>
-                {
-                    c.AddSingleton<INameResolver>(new RandomNameResolver());
-                })
-                .Build();
-
-            IExtensionRegistry extensions = host.Services.GetService<IExtensionRegistry>();
-
-            // ensure the EventHubTriggerAttributeBindingProvider was registered
-            var triggerBindingProviders = extensions.GetExtensions<ITriggerBindingProvider>().ToArray();
-            EventHubTriggerAttributeBindingProvider triggerBindingProvider = triggerBindingProviders.OfType<EventHubTriggerAttributeBindingProvider>().Single();
-            Assert.NotNull(triggerBindingProvider);
-
-            // ensure the EventProcessorOptions ExceptionReceived event is wired up
-            var options = host.Services.GetService<IOptions<EventHubOptions>>().Value;
-            var eventProcessorOptions = options.EventProcessorOptions;
-            var ex = new EventHubsException(false, "Kaboom!");
-            var ctor = typeof(ExceptionReceivedEventArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
-            var args = (ExceptionReceivedEventArgs)ctor.Invoke(new object[] { "TestHostName", "TestPartitionId", ex, "TestAction" });
-            var handler = (Action<ExceptionReceivedEventArgs>)eventProcessorOptions.GetType().GetField("exceptionHandler", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(eventProcessorOptions);
-            handler.Method.Invoke(handler.Target, new object[] { args });
-
-            string expectedMessage = "EventProcessorHost error (Action='TestAction', HostName='TestHostName', PartitionId='TestPartitionId').";
-            var logMessage = host.GetTestLoggerProvider().GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Error, logMessage.Level);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
-            Assert.Same(ex, logMessage.Exception);
-        }
-
-        [Fact]
+        [Test]
         public void LogExceptionReceivedEvent_NonTransientEvent_LoggedAsError()
         {
-            var ex = new EventHubsException(false);
-            Assert.False(ex.IsTransient);
-            var ctor = typeof(ExceptionReceivedEventArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
-            var e = (ExceptionReceivedEventArgs)ctor.Invoke(new object[] { "TestHostName", "TestPartitionId", ex, "TestAction" });
+            var ex = new EventHubsException(false, "");
+            var e = new ExceptionReceivedEventArgs("TestHostName", "TestAction", "TestPartitionId", ex);
             EventHubExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
 
             string expectedMessage = "EventProcessorHost error (Action='TestAction', HostName='TestHostName', PartitionId='TestPartitionId').";
             var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Error, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
+
+            Assert.False(ex.IsTransient);
+            Assert.AreEqual(LogLevel.Error, logMessage.Level);
+            Assert.AreSame(ex, logMessage.Exception);
+            Assert.AreEqual(expectedMessage, logMessage.FormattedMessage);
         }
 
-        [Fact]
+        [Test]
         public void LogExceptionReceivedEvent_TransientEvent_LoggedAsVerbose()
         {
-            var ex = new EventHubsException(true);
-            Assert.True(ex.IsTransient);
-            var ctor = typeof(ExceptionReceivedEventArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
-            var e = (ExceptionReceivedEventArgs)ctor.Invoke(new object[] { "TestHostName", "TestPartitionId", ex, "TestAction" });
+            var ex = new EventHubsException(true, "");
+            var e = new ExceptionReceivedEventArgs("TestHostName", "TestAction", "TestPartitionId", ex);
             EventHubExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
 
             string expectedMessage = "EventProcessorHost error (Action='TestAction', HostName='TestHostName', PartitionId='TestPartitionId').";
             var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Information, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage + string.Format(_template, typeof(EventHubsException).Name), logMessage.FormattedMessage);
+
+            Assert.True(ex.IsTransient);
+            Assert.AreEqual(LogLevel.Information, logMessage.Level);
+            Assert.AreSame(ex, logMessage.Exception);
+            Assert.AreEqual(expectedMessage + string.Format(_template, typeof(EventHubsException).Name), logMessage.FormattedMessage);
         }
 
-        [Fact]
+        [Test]
         public void LogExceptionReceivedEvent_OperationCanceledException_LoggedAsVerbose()
         {
             var ex = new OperationCanceledException("Testing");
-            var ctor = typeof(ExceptionReceivedEventArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
-            var e = (ExceptionReceivedEventArgs)ctor.Invoke(new object[] { "TestHostName", "TestPartitionId", ex, "TestAction" });
+            var e = new ExceptionReceivedEventArgs("TestHostName", "TestAction", "TestPartitionId", ex);
             EventHubExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
 
             string expectedMessage = "EventProcessorHost error (Action='TestAction', HostName='TestHostName', PartitionId='TestPartitionId').";
             var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Information, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage + string.Format(_template, typeof(OperationCanceledException).Name), logMessage.FormattedMessage);
+            Assert.AreEqual(LogLevel.Information, logMessage.Level);
+            Assert.AreSame(ex, logMessage.Exception);
+            Assert.AreEqual(expectedMessage + string.Format(_template, typeof(OperationCanceledException).Name), logMessage.FormattedMessage);
         }
 
-        [Fact]
+        [Test]
         public void LogExceptionReceivedEvent_NonMessagingException_LoggedAsError()
         {
             var ex = new MissingMethodException("What method??");
-            var ctor = typeof(ExceptionReceivedEventArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
-            var e = (ExceptionReceivedEventArgs)ctor.Invoke(new object[] { "TestHostName", "TestPartitionId", ex, "TestAction" });
+            var e = new ExceptionReceivedEventArgs("TestHostName", "TestAction", "TestPartitionId", ex);
             EventHubExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
 
             string expectedMessage = "EventProcessorHost error (Action='TestAction', HostName='TestHostName', PartitionId='TestPartitionId').";
             var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Error, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage, logMessage.FormattedMessage);
+            Assert.AreEqual(LogLevel.Error, logMessage.Level);
+            Assert.AreSame(ex, logMessage.Exception);
+            Assert.AreEqual(expectedMessage, logMessage.FormattedMessage);
         }
 
-        [Fact]
+        [Test]
         public void LogExceptionReceivedEvent_PartitionExceptions_LoggedAsInfo()
         {
-            var ctor = typeof(ReceiverDisconnectedException).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(string) }, null);
-            var ex = (ReceiverDisconnectedException)ctor.Invoke(new object[] { "New receiver with higher epoch of '30402' is created hence current receiver with epoch '30402' is getting disconnected." });
-            ctor = typeof(ExceptionReceivedEventArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
-            var e = (ExceptionReceivedEventArgs)ctor.Invoke(new object[] { "TestHostName", "TestPartitionId", ex, "TestAction" });
+            var ex = new EventHubsException(false, "New receiver with higher epoch of '30402' is created hence current receiver with epoch '30402' is getting disconnected.", EventHubsException.FailureReason.ConsumerDisconnected);
+            var e = new ExceptionReceivedEventArgs("TestHostName", "TestAction", "TestPartitionId", ex);
             EventHubExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
 
             string expectedMessage = "EventProcessorHost error (Action='TestAction', HostName='TestHostName', PartitionId='TestPartitionId').";
             var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Information, logMessage.Level);
-            Assert.Same(ex, logMessage.Exception);
-            Assert.Equal(expectedMessage + string.Format(_template, typeof(ReceiverDisconnectedException).Name), logMessage.FormattedMessage);
+            Assert.AreEqual(LogLevel.Information, logMessage.Level);
+            Assert.AreSame(ex, logMessage.Exception);
+            Assert.AreEqual(expectedMessage + string.Format(_template, typeof(EventHubsException).Name), logMessage.FormattedMessage);
         }
 
-        [Fact]
+        [Test]
         public void LogExceptionReceivedEvent_AggregateExceptions_LoggedAsInfo()
         {
-            var ctor = typeof(AggregateException).GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, new Type[] { typeof(IEnumerable<Exception>) }, null);
-            var request = new RequestResult()
-            {
-                HttpStatusCode = 409
-            };
-            var information = new StorageExtendedErrorInformation();
-            typeof(StorageExtendedErrorInformation).GetProperty("ErrorCode").SetValue(information, "LeaseIdMismatchWithLeaseOperation");
-            typeof(RequestResult).GetProperty("ExtendedErrorInformation").SetValue(request, information);
-            var storageException = new StorageException(request, "The lease ID specified did not match the lease ID for the blob.", null);
+            var oce = new OperationCanceledException("Testing");
 
-            var ex = (AggregateException)ctor.Invoke(new object[] { new Exception[] { storageException } });
-            ctor = typeof(ExceptionReceivedEventArgs).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance).Single();
-            var e = (ExceptionReceivedEventArgs)ctor.Invoke(new object[] { "TestHostName", "TestPartitionId", ex, "TestAction" });
+            var ex = new AggregateException(new Exception[] { oce });
+            var e = new ExceptionReceivedEventArgs("TestHostName", "TestAction", "TestPartitionId", ex);
             EventHubExtensionConfigProvider.LogExceptionReceivedEvent(e, _loggerFactory);
 
             string expectedMessage = "EventProcessorHost error (Action='TestAction', HostName='TestHostName', PartitionId='TestPartitionId').";
             var logMessage = _loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal(LogLevel.Information, logMessage.Level);
-            Assert.Same(storageException, logMessage.Exception);
-            Assert.Equal(expectedMessage + string.Format(_template, typeof(WindowsAzure.Storage.StorageException).Name), logMessage.FormattedMessage);
+            Assert.AreEqual(LogLevel.Information, logMessage.Level);
+            Assert.AreSame(oce, logMessage.Exception);
+            Assert.AreEqual(expectedMessage + string.Format(_template, typeof(OperationCanceledException).Name), logMessage.FormattedMessage);
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubEndToEndTests.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.Host.EndToEndTests
                     // Speedup shutdown
                     services.Configure<EventHubOptions>(options =>
                     {
-                        options.LeaseContainerName = _storageScope.ContainerName;
+                        options.CheckpointContainer = _storageScope.ContainerName;
                         options.EventProcessorOptions.MaximumWaitTime = TimeSpan.FromSeconds(5);
                     });
                 })

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/EventHubTests.cs
@@ -214,10 +214,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             var eventProcessorOptions = options.EventProcessorOptions;
             Assert.AreEqual(200, eventProcessorOptions.PrefetchCount);
             Assert.AreEqual(5, options.BatchCheckpointFrequency);
-            // TODO: https://github.com/Azure/azure-sdk-for-net/issues/16636
-            // Assert.AreEqual(100, eventProcessorOptions.MaxBatchSize);
-            // Assert.AreEqual(31, options.PartitionManagerOptions.LeaseDuration.TotalSeconds);
-            // Assert.AreEqual(21, options.PartitionManagerOptions.RenewInterval.TotalSeconds);
+            Assert.AreEqual(100, options.MaxBatchSize);
+            Assert.AreEqual(31, options.EventProcessorOptions.PartitionOwnershipExpirationInterval.TotalSeconds);
+            Assert.AreEqual(21, options.EventProcessorOptions.LoadBalancingUpdateInterval.TotalSeconds);
         }
 
         internal static EventProcessorHostPartition GetPartitionContext(string partitionId = "0", string eventHubPath = "path",

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
@@ -29,8 +29,6 @@
     <Compile Include="..\..\..\extensions\Microsoft.Azure.WebJobs.Extensions.Clients\tests\shared\**\*.cs" />
     <Compile Include="../../Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs" />
     <Compile Include="../../Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs" />
-    <!-- TODO: https://github.com/Azure/azure-sdk-for-net/issues/16635 -->
-    <Compile Remove="EventHubConfigurationTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
@@ -41,8 +41,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
 
         public AzuriteFixture()
         {
-            for (int i = 0; i < 150; i++)
-            {
             // This is to force newer protocol on machines with older .NET Framework. Otherwise tests don't connect to Azurite with unsigned cert.
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
@@ -129,8 +127,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
             }
             account.BlobsPort = blobsPort;
             account.QueuesPort = queuesPort;
-            process.Kill();
-            }
         }
 
         private int ParseAzuritePort(string outputLine)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
 
         public AzuriteFixture()
         {
+            for (int i = 0; i < 150; i++)
+            {
             // This is to force newer protocol on machines with older .NET Framework. Otherwise tests don't connect to Azurite with unsigned cert.
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
@@ -127,6 +129,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
             }
             account.BlobsPort = blobsPort;
             account.QueuesPort = queuesPort;
+            process.Kill();
+            }
         }
 
         private int ParseAzuritePort(string outputLine)


### PR DESCRIPTION
To make sure existing applications are not broken.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/16635 
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/16636

These are the mappings:

<table>
<tr>
	<td> Old name
	<td> New name
<tr>
	<td> EventProcessorOptions:InvokeProcessorAfterReceiveTimeout
	<td> InvokeProcessorAfterReceiveTimeout
<tr>
	<td> EventProcessorOptions:EnableReceiverRuntimeMetric
	<td> EventProcessorOptions:TrackLastEnqueuedEventProperties
<tr>
	<td> EventProcessorOptions:MaxBatchSize
	<td> MaxBatchSize
<tr>
	<td> EventProcessorOptions:ReceiveTimeout
	<td> EventProcessorOptions:MaximumWaitTime
<tr>
	<td> PartitionManagerOptions:LeaseDuration
	<td> EventProcessorOptions:PartitionOwnershipExpirationInterval
<tr>
	<td> PartitionManagerOptions:RenewInterval
	<td> EventProcessorOptions:LoadBalancingUpdateInterval
</table>

cc @paulbatum @mattchenderson