### PR TITLE
[TA] Clean up samples

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -74,8 +74,7 @@ With the value of the endpoint and an `AzureKeyCredential`, you can create the [
 ```C# Snippet:CreateTextAnalyticsClient
 string endpoint = "<endpoint>";
 string apiKey = "<apiKey>";
-var credential = new AzureKeyCredential(apiKey);
-var client = new TextAnalyticsClient(new Uri(endpoint), credential);
+var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
 #### Create TextAnalyticsClient with Azure Active Directory Credential
@@ -139,11 +138,25 @@ The following section provides several code snippets using the `client` [created
 Run a Text Analytics predictive model to determine the language that the passed-in document or batch of documents are written in.
 
 ```C# Snippet:DetectLanguage
-string document = "Este documento está en español.";
+string document = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                    cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                    También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                    para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                    La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                    dialectos y algunos idiomas regionales o culturales.";
 
-DetectedLanguage language = client.DetectLanguage(document);
+try
+{
+    Response<DetectedLanguage> response = client.DetectLanguage(document);
 
-Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+    DetectedLanguage language = response.Value;
+    Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
+}
 ```
 For samples on using the production recommended option `DetectLanguageBatch` see [here][detect_language_sample].
 
@@ -153,14 +166,26 @@ Please refer to the service documentation for a conceptual discussion of [langua
 Run a Text Analytics predictive model to identify the positive, negative, neutral or mixed sentiment contained in the passed-in document or batch of documents.
 
 ```C# Snippet:AnalyzeSentiment
-string document = "That was the best day of my life!";
+string document = @"I had the best day of my life. I decided to go sky-diving and it
+                    made me appreciate my whole life so much more.
+                    I developed a deep-connection with my instructor as well, and I
+                    feel as if I've made a life-long friend in her.";
 
-DocumentSentiment docSentiment = client.AnalyzeSentiment(document);
+try
+{
+    Response<DocumentSentiment> response = client.AnalyzeSentiment(document);
+    DocumentSentiment docSentiment = response.Value;
 
-Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
-Console.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
-Console.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
-Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+    Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
+    Console.WriteLine($"  Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
+    Console.WriteLine($"  Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
+    Console.WriteLine($"  Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
+}
 ```
 For samples on using the production recommended option `AnalyzeSentimentBatch` see [here][analyze_sentiment_sample].
 
@@ -172,14 +197,27 @@ Please refer to the service documentation for a conceptual discussion of [sentim
 Run a model to identify a collection of significant phrases found in the passed-in document or batch of documents.
 
 ```C# Snippet:ExtractKeyPhrases
-string document = "My cat might need to see a veterinarian.";
+string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
+                    little sister thinks it is funny, I a worried it has the cold that I got last week.
+                    We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
+                    will be covered by the cat's insurance.
+                    It might be good to not let it sleep in my room for a while.";
 
-KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
-
-Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
-foreach (string keyPhrase in keyPhrases)
+try
 {
-    Console.WriteLine(keyPhrase);
+    Response<KeyPhraseCollection> response = client.ExtractKeyPhrases(document);
+    KeyPhraseCollection keyPhrases = response.Value;
+
+    Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
+    foreach (string keyPhrase in keyPhrases)
+    {
+        Console.WriteLine($"  {keyPhrase}");
+    }
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 For samples on using the production recommended option `ExtractKeyPhrasesBatch` see [here][extract_key_phrases_sample].
@@ -190,15 +228,34 @@ Please refer to the service documentation for a conceptual discussion of [key ph
 Run a predictive model to identify a collection of named entities in the passed-in document or batch of documents and categorize those entities into categories such as person, location, or organization.  For more information on available categories, see [Text Analytics Named Entity Categories][named_entities_categories].
 
 ```C# Snippet:RecognizeEntities
-string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+string document = @"We love this trail and make the trip every year. The views are breathtaking and well
+                    worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                    We tried again today and it was amazing. Everyone in my family liked the trail although
+                    it was too challenging for the less athletic among us.
+                    Not necessarily recommended for small children.
+                    A hotel close to the trail offers services for childcare in case you want that.";
 
-CategorizedEntityCollection entities = client.RecognizeEntities(document);
-
-Console.WriteLine($"Recognized {entities.Count} entities:");
-foreach (CategorizedEntity entity in entities)
+try
 {
-    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-    Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+    Response<CategorizedEntityCollection> response = client.RecognizeEntities(document);
+    CategorizedEntityCollection entitiesInDocument = response.Value;
+
+    Console.WriteLine($"Recognized {entitiesInDocument.Count} entities:");
+    foreach (CategorizedEntity entity in entitiesInDocument)
+    {
+        Console.WriteLine($"  Text: {entity.Text}");
+        Console.WriteLine($"  Offset: {entity.Offset}");
+        Console.WriteLine($"  Category: {entity.Category}");
+        if (!string.IsNullOrEmpty(entity.SubCategory))
+            Console.WriteLine($"  SubCategory: {entity.SubCategory}");
+        Console.WriteLine($"  Confidence score: {entity.ConfidenceScore}");
+        Console.WriteLine("");
+    }
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 For samples on using the production recommended option `RecognizeEntitiesBatch` see [here][recognize_entities_sample].
@@ -209,22 +266,32 @@ Please refer to the service documentation for a conceptual discussion of [named 
 Run a predictive model to identify a collection of entities containing Personally Identifiable Information found in the passed-in document or batch of documents, and categorize those entities into categories such as US social security number, drivers license number, or credit card number.
 
 ```C# Snippet:RecognizePiiEntities
-string document = "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.";
+string document = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                    Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                    They are originally from Brazil and have document ID number 998.214.865-68";
 
-PiiEntityCollection entities = client.RecognizePiiEntities(document).Value;
-
-Console.WriteLine($"Redacted Text: {entities.RedactedText}");
-if (entities.Count > 0)
+try
 {
-    Console.WriteLine($"Recognized {entities.Count} PII entit{(entities.Count > 1 ? "ies" : "y")}:");
+    Response<PiiEntityCollection> response = client.RecognizePiiEntities(document);
+    PiiEntityCollection entities = response.Value;
+
+    Console.WriteLine($"Redacted Text: {entities.RedactedText}");
+    Console.WriteLine("");
+    Console.WriteLine($"Recognized {entities.Count} PII entities:");
     foreach (PiiEntity entity in entities)
     {
-        Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+        Console.WriteLine($"  Text: {entity.Text}");
+        Console.WriteLine($"  Category: {entity.Category}");
+        if (!string.IsNullOrEmpty(entity.SubCategory))
+            Console.WriteLine($"  SubCategory: {entity.SubCategory}");
+        Console.WriteLine($"  Confidence score: {entity.ConfidenceScore}");
+        Console.WriteLine("");
     }
 }
-else
+catch (RequestFailedException exception)
 {
-    Console.WriteLine("No entities were found.");
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 
@@ -236,19 +303,38 @@ Please refer to the service documentation for supported [PII entity types][pii_e
 Run a predictive model to identify a collection of entities found in the passed-in document or batch of documents, and include information linking the entities to their corresponding entries in a well-known knowledge base.
 
 ```C# Snippet:RecognizeLinkedEntities
-string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+string document = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                    Steve Ballmer, eventually became CEO after Bill Gates as well. Steve Ballmer eventually stepped
+                    down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                    Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                    headquartered in Redmond";
 
-LinkedEntityCollection linkedEntities = client.RecognizeLinkedEntities(document);
-
-Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
-foreach (LinkedEntity linkedEntity in linkedEntities)
+try
 {
-    Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
-    foreach (LinkedEntityMatch match in linkedEntity.Matches)
+    Response<LinkedEntityCollection> response = client.RecognizeLinkedEntities(document);
+    LinkedEntityCollection linkedEntities = response.Value;
+
+    Console.WriteLine($"Recognized {linkedEntities.Count} entities:");
+    foreach (LinkedEntity linkedEntity in linkedEntities)
     {
-        Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
-        Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+        Console.WriteLine($"  Name: {linkedEntity.Name}");
+        Console.WriteLine($"  Language: {linkedEntity.Language}");
+        Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+        Console.WriteLine($"  URL: {linkedEntity.Url}");
+        Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+        foreach (LinkedEntityMatch match in linkedEntity.Matches)
+        {
+            Console.WriteLine($"    Match Text: {match.Text}");
+            Console.WriteLine($"    Offset: {match.Offset}");
+            Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+        }
+        Console.WriteLine("");
     }
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 For samples on using the production recommended option `RecognizeLinkedEntitiesBatch` see [here][recognize_linked_entities_sample].
@@ -259,26 +345,59 @@ Please refer to the service documentation for a conceptual discussion of [entity
 Run a Text Analytics predictive model to determine the language that the passed-in document or batch of documents are written in.
 
 ```C# Snippet:DetectLanguageAsync
-string document = "Este documento está en español.";
+string document = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                    cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                    También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                    para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                    La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                    dialectos y algunos idiomas regionales o culturales.";
 
-DetectedLanguage language = await client.DetectLanguageAsync(document);
+try
+{
+    Response<DetectedLanguage> response = await client.DetectLanguageAsync(document);
 
-Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+    DetectedLanguage language = response.Value;
+    Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
+}
 ```
 
 ### Recognize Entities Asynchronously
 Run a predictive model to identify a collection of named entities in the passed-in document or batch of documents and categorize those entities into categories such as person, location, or organization.  For more information on available categories, see [Text Analytics Named Entity Categories][named_entities_categories].
 
 ```C# Snippet:RecognizeEntitiesAsync
-string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+string document = @"We love this trail and make the trip every year. The views are breathtaking and well
+                    worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                    We tried again today and it was amazing. Everyone in my family liked the trail although
+                    it was too challenging for the less athletic among us.
+                    Not necessarily recommended for small children.
+                    A hotel close to the trail offers services for childcare in case you want that.";
 
-CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document);
-
-Console.WriteLine($"Recognized {entities.Count} entities:");
-foreach (CategorizedEntity entity in entities)
+try
 {
-    Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-    Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+    Response<CategorizedEntityCollection> response = await client.RecognizeEntitiesAsync(document);
+    CategorizedEntityCollection entitiesInDocument = response.Value;
+
+    Console.WriteLine($"Recognized {entitiesInDocument.Count} entities:");
+    foreach (CategorizedEntity entity in entitiesInDocument)
+    {
+        Console.WriteLine($"    Text: {entity.Text}");
+        Console.WriteLine($"    Offset: {entity.Offset}");
+        Console.WriteLine($"    Category: {entity.Category}");
+        if (!string.IsNullOrEmpty(entity.SubCategory))
+            Console.WriteLine($"    SubCategory: {entity.SubCategory}");
+        Console.WriteLine($"    Confidence score: {entity.ConfidenceScore}");
+        Console.WriteLine("");
+    }
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/README.md
@@ -198,7 +198,7 @@ Run a model to identify a collection of significant phrases found in the passed-
 
 ```C# Snippet:ExtractKeyPhrases
 string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
-                    little sister thinks it is funny, I a worried it has the cold that I got last week.
+                    little sister thinks it is funny, I am worried it has the cold that I got last week.
                     We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
                     will be covered by the cat's insurance.
                     It might be good to not let it sleep in my room for a while.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample1_DetectLanguage.md
@@ -8,7 +8,9 @@ To create a new `TextAnalyticsClient` to detect the language a document is writt
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample1CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
@@ -17,11 +19,25 @@ var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(a
 To detect the language of a single document, use the `DetectLanguage` method.  The detected language the document is written in will be returned in the `DetectedLanguage` object, which contains the language and the confidence that the service's prediction is correct.
 
 ```C# Snippet:DetectLanguage
-string document = "Este documento está en español.";
+string document = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                    cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                    También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                    para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                    La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                    dialectos y algunos idiomas regionales o culturales.";
 
-DetectedLanguage language = client.DetectLanguage(document);
+try
+{
+    Response<DetectedLanguage> response = client.DetectLanguage(document);
 
-Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+    DetectedLanguage language = response.Value;
+    Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
+}
 ```
 
 ## Detecting the language of multiple documents
@@ -29,33 +45,146 @@ Console.WriteLine($"Detected language {language.Name} with confidence score {lan
 To detect the language of a collection of documents in the same language, use `DetectLanguageBatch` on an `IEnumerable` of strings.  The results are returned as a `DetectLanguageResultCollection`.
 
 ```C# Snippet:TextAnalyticsSample1DetectLanguagesConvenience
-DetectLanguageResultCollection results = client.DetectLanguageBatch(documents);
+string documentA = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                    cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                    También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                    para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                    La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                    dialectos y algunos idiomas regionales o culturales.";
+
+string documentB = @"This document is written in a language different than Spanish. It's objective is to demonstrate
+                    how to call the Detect Language method from the Microsoft Azure Text Analytics service.
+                    It also shows how to access the information returned from the service. This capability is useful
+                    for content stores that collect arbitrary text, where language is unknown.
+                    The Language Detection feature can detect a wide range of languages, variants, dialects, and some
+                    regional or cultural languages.";
+
+string documentC = @"Ce document est rédigé dans une langue différente de l'espagnol. Son objectif est de montrer comment
+                    appeler la méthode Detect Language à partir du service Microsoft Azure Text Analytics.
+                    Il montre également comment accéder aux informations renvoyées par le service. Cette capacité est
+                    utile pour les magasins de contenu qui collectent du texte arbitraire dont la langue est inconnue.
+                    La fonctionnalité Détection de langue peut détecter une grande variété de langues, de variantes,
+                    de dialectes, et certaines langues régionales ou de culture.";
+
+string documentD = string.Empty;
+
+var documents = new List<string>
+{
+    documentA,
+    documentB,
+    documentC,
+    documentD
+};
+
+Response<DetectLanguageResultCollection> response = client.DetectLanguageBatch(documents);
+DetectLanguageResultCollection documentsLanguage = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{documentsLanguage.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (DetectLanguageResult documentLanguage in documentsLanguage)
+{
+    Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+    Console.WriteLine("");
+    if (documentLanguage.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error code: {documentLanguage.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {documentLanguage.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"  Detected language: {documentLanguage.PrimaryLanguage.Name}");
+        Console.WriteLine($"  Confidence score: {documentLanguage.PrimaryLanguage.ConfidenceScore}");
+    }
+    Console.WriteLine("");
+}
 ```
 
 To detect the languages of a collection of documents in different language, call `DetectLanguages` on an `IEnumerable` of `DetectLanguageInput` objects, setting the `CountryHint` on each document.
 
 ```C# Snippet:TextAnalyticsSample1DetectLanguageBatch
+string documentA = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                    cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                    También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                    para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                    La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                    dialectos y algunos idiomas regionales o culturales.";
+
+string documentB = @"This document is written in a language different than Spanish. It's objective is to demonstrate
+                    how to call the Detect Language method from the Microsoft Azure Text Analytics service.
+                    It also shows how to access the information returned from the service. This capability is useful
+                    for content stores that collect arbitrary text, where language is unknown.
+                    The Language Detection feature can detect a wide range of languages, variants, dialects, and some
+                    regional or cultural languages.";
+
+string documentC = @"Ce document est rédigé dans une langue différente de l'espagnol. Son objectif est de montrer comment
+                    appeler la méthode Detect Language à partir du service Microsoft Azure Text Analytics.
+                    Il montre également comment accéder aux informations renvoyées par le service. Cette capacité est
+                    utile pour les magasins de contenu qui collectent du texte arbitraire dont la langue est inconnue.
+                    La fonctionnalité Détection de langue peut détecter une grande variété de langues, de variantes,
+                    de dialectes, et certaines langues régionales ou de culture.";
+
 var documents = new List<DetectLanguageInput>
 {
-    new DetectLanguageInput("1", "Hello world")
+    new DetectLanguageInput("1", documentA)
+    {
+         CountryHint = "es",
+    },
+    new DetectLanguageInput("2", documentB)
     {
          CountryHint = "us",
     },
-    new DetectLanguageInput("2", "Bonjour tout le monde")
+    new DetectLanguageInput("3", documentC)
     {
          CountryHint = "fr",
-    },
-    new DetectLanguageInput("3", "Hola mundo")
-    {
-         CountryHint = "es",
     },
     new DetectLanguageInput("4", ":) :( :D")
     {
          CountryHint = DetectLanguageInput.None,
-    }
+    },
+    new DetectLanguageInput("5", "")
 };
 
-DetectLanguageResultCollection results = client.DetectLanguageBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+
+Response<DetectLanguageResultCollection> response = client.DetectLanguageBatch(documents, options);
+DetectLanguageResultCollection documentsLanguage = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{documentsLanguage.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (DetectLanguageResult documentLanguage in documentsLanguage)
+{
+    DetectLanguageInput document = documents[i++];
+
+    Console.WriteLine($"On document (Id={document.Id}, CountryHint=\"{document.CountryHint}\"):");
+
+    if (documentLanguage.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error code: {documentLanguage.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {documentLanguage.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"  Detected language: {documentLanguage.PrimaryLanguage.Name}");
+        Console.WriteLine($"  Confidence score: {documentLanguage.PrimaryLanguage.ConfidenceScore}");
+
+        Console.WriteLine($"  Document statistics:");
+        Console.WriteLine($"    Character count: {documentLanguage.Statistics.CharacterCount}");
+        Console.WriteLine($"    Transaction count: {documentLanguage.Statistics.TransactionCount}");
+    }
+    Console.WriteLine("");
+}
+
+Console.WriteLine($"Batch operation statistics:");
+Console.WriteLine($"  Document count: {documentsLanguage.Statistics.DocumentCount}");
+Console.WriteLine($"  Valid document count: {documentsLanguage.Statistics.ValidDocumentCount}");
+Console.WriteLine($"  Invalid document count: {documentsLanguage.Statistics.InvalidDocumentCount}");
+Console.WriteLine($"  Transaction count: {documentsLanguage.Statistics.TransactionCount}");
 ```
 
 To see the full example source files, see:

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.md
@@ -11,7 +11,9 @@ To create a new `TextAnalyticsClient`, you need a Text Analytics endpoint and cr
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample1CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
@@ -20,18 +22,34 @@ var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(a
 To get a deeper analysis into which are the aspects that people considered good or bad, we will need to include the `AdditionalSentimentAnalyses.OpinionMining` type into the `AnalyzeSentimentOptions`.
 
 ```C# Snippet:TAAnalyzeSentimentWithOpinionMining
+string reviewA = @"The food and service were unacceptable, but the concierge were nice.
+                 After talking to them about the quality of the food and the process
+                 to get room service they refunded the money we spent at the restaurant
+                 and gave us a voucher for near by restaurants.";
+
+string reviewB = @"The rooms were beautiful. The AC was good and quiet, which was key for
+                us as outside it was 100F and our baby was getting uncomfortable because of the heat.
+                The breakfast was good too with good options and good servicing times.
+                The thing we didn't like was that the toilet in our bathroom was smelly.
+                It could have been that the toilet was not cleaned before we arrived.
+                Either way it was very uncomfortable.
+                Once we notified the staff, they came and cleaned it and left candles.";
+
+string reviewC = @"Nice rooms! I had a great unobstructed view of the Microsoft campus
+                but bathrooms were old and the toilet was dirty when we arrived. 
+                It was close to bus stops and groceries stores. If you want to be close to
+                campus I will recommend it, otherwise, might be better to stay in a cleaner one.";
+
 var documents = new List<string>
 {
-    "The food and service were unacceptable, but the concierge were nice.",
-    "The rooms were beautiful. The AC was good and quiet.",
-    "The breakfast was good, but the toilet was smelly.",
-    "Loved this hotel - good breakfast - nice shuttle service - clean rooms.",
-    "I had a great unobstructed view of the Microsoft campus.",
-    "Nice rooms but bathrooms were old and the toilet was dirty when we arrived.",
-    "We changed rooms as the toilet smelled."
+    reviewA,
+    reviewB,
+    reviewC
 };
 
-AnalyzeSentimentResultCollection reviews = client.AnalyzeSentimentBatch(documents, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+var options = new AnalyzeSentimentOptions() { IncludeOpinionMining = true };
+Response<AnalyzeSentimentResultCollection> response = client.AnalyzeSentimentBatch(documents, options: options);
+AnalyzeSentimentResultCollection reviews = response.Value;
 
 Dictionary<string, int> complaints = GetComplaints(reviews);
 
@@ -53,8 +71,6 @@ Alert! major complaint is *toilet*
    food, 1
    service, 1
    toilet, 3
-   bathrooms, 1
-   rooms, 1
 ```
 
 ## Define method `GetComplaints`

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.md
@@ -25,7 +25,7 @@ To get a deeper analysis into which are the aspects that people considered good 
 string reviewA = @"The food and service were unacceptable, but the concierge were nice.
                  After talking to them about the quality of the food and the process
                  to get room service they refunded the money we spent at the restaurant
-                 and gave us a voucher for near by restaurants.";
+                 and gave us a voucher for nearby restaurants.";
 
 string reviewB = @"The rooms were beautiful. The AC was good and quiet, which was key for
                 us as outside it was 100F and our baby was getting uncomfortable because of the heat.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -8,7 +8,9 @@ To create a new `TextAnalyticsClient` to analyze the sentiment in a document, yo
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample2CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
@@ -17,14 +19,26 @@ var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(a
 To analyze the sentiment of a document, use the `AnalyzeSentiment` method.  The returned `DocumentSentiment` describes the sentiment of the document, as well as a collection of `Sentences` indicating the sentiment of each individual sentence.
 
 ```C# Snippet:AnalyzeSentiment
-string document = "That was the best day of my life!";
+string document = @"I had the best day of my life. I decided to go sky-diving and it
+                    made me appreciate my whole life so much more.
+                    I developed a deep-connection with my instructor as well, and I
+                    feel as if I've made a life-long friend in her.";
 
-DocumentSentiment docSentiment = client.AnalyzeSentiment(document);
+try
+{
+    Response<DocumentSentiment> response = client.AnalyzeSentiment(document);
+    DocumentSentiment docSentiment = response.Value;
 
-Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
-Console.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
-Console.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
-Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+    Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
+    Console.WriteLine($"  Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
+    Console.WriteLine($"  Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
+    Console.WriteLine($"  Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
+}
 ```
 
 ## Analyzing the sentiment of multiple documents
@@ -32,33 +46,164 @@ Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScore
 To analyze the sentiment of a collection of documents in the same language, call `AnalyzeSentimentBatch` on an `IEnumerable` of strings.  The results are returned as a `AnalyzeSentimentResultCollection`.
 
 ```C# Snippet:TextAnalyticsSample2AnalyzeSentimentConvenience
-AnalyzeSentimentResultCollection results = client.AnalyzeSentimentBatch(documents);
+string documentA = @"The food and service were unacceptable, but the concierge were nice.
+                    After talking to them about the quality of the food and the process
+                    to get room service they refunded the money we spent at the restaurant and
+                    gave us a voucher for near by restaurants.";
+
+string documentB = @"Nice rooms! I had a great unobstructed view of the Microsoft campus but bathrooms
+                    were old and the toilet was dirty when we arrived. It was close to bus stops and
+                    groceries stores.
+                    If you want to be close to campus I will recommend it, otherwise, might be
+                    better to stay in a cleaner one";
+
+string documentC = @"The rooms were beautiful. The AC was good and quiet, which was key for us as outside
+                    it was 100F and our baby was getting uncomfortable because of the heat. The breakfast
+                    was good too with good options and good servicing times.
+                    The thing we didn't like was that the toilet in our bathroom was smelly.
+                    It could have been that the toilet was not cleaned before we arrived.";
+
+string documentD = string.Empty;
+
+var documents = new List<string>
+{
+    documentA,
+    documentB,
+    documentC,
+    documentD
+};
+
+Response<AnalyzeSentimentResultCollection> response = client.AnalyzeSentimentBatch(documents);
+AnalyzeSentimentResultCollection sentimentPerDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{sentimentPerDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (AnalyzeSentimentResult sentimentInDocument in sentimentPerDocuments)
+{
+    Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+    Console.WriteLine("");
+
+    if (sentimentInDocument.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error: {sentimentInDocument.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {sentimentInDocument.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"Document sentiment is {sentimentInDocument.DocumentSentiment.Sentiment}, with confidence scores: ");
+        Console.WriteLine($"  Positive confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Positive}.");
+        Console.WriteLine($"  Neutral confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Neutral}.");
+        Console.WriteLine($"  Negative confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Negative}.");
+        Console.WriteLine("");
+        Console.WriteLine($"  Sentence sentiment results:");
+
+        foreach (SentenceSentiment sentimentInSentence in sentimentInDocument.DocumentSentiment.Sentences)
+        {
+            Console.WriteLine($"  For sentence: \"{sentimentInSentence.Text}\"");
+            Console.WriteLine($"  Sentiment is {sentimentInSentence.Sentiment}, with confidence scores: ");
+            Console.WriteLine($"    Positive confidence score: {sentimentInSentence.ConfidenceScores.Positive}.");
+            Console.WriteLine($"    Neutral confidence score: {sentimentInSentence.ConfidenceScores.Neutral}.");
+            Console.WriteLine($"    Negative confidence score: {sentimentInSentence.ConfidenceScores.Negative}.");
+            Console.WriteLine("");
+        }
+    }
+    Console.WriteLine("");
+}
 ```
 
 To analyze the sentiment of a collection of documents in different languages, call `AnalyzeSentimentBatch` on an `IEnumerable` of `TextDocumentInput` objects, setting the `Language` on each document.
 
 ```C# Snippet:TextAnalyticsSample2AnalyzeSentimentBatch
+string documentA = @"The food and service were unacceptable, but the concierge were nice.
+                    After talking to them about the quality of the food and the process
+                    to get room service they refunded the money we spent at the restaurant and
+                    gave us a voucher for near by restaurants.";
+
+string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                    sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                    La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                    El próximo año volveremos.";
+
+string documentC = @"The rooms were beautiful. The AC was good and quiet, which was key for us as outside
+                    it was 100F and our baby was getting uncomfortable because of the heat. The breakfast
+                    was good too with good options and good servicing times.
+                    The thing we didn't like was that the toilet in our bathroom was smelly.
+                    It could have been that the toilet was not cleaned before we arrived.
+                    Either way it was very uncomfortable. Once we notified the staff, they came and cleaned
+                    it and left candles.";
+
 var documents = new List<TextDocumentInput>
 {
-    new TextDocumentInput("1", "That was the best day of my life!")
+    new TextDocumentInput("1", documentA)
     {
          Language = "en",
     },
-    new TextDocumentInput("2", "This food is very bad. Everyone who ate with us got sick.")
+    new TextDocumentInput("2", documentB)
+    {
+         Language = "es",
+    },
+    new TextDocumentInput("3", documentC)
     {
          Language = "en",
     },
-    new TextDocumentInput("3", "I'm not sure how I feel about this product.")
-    {
-         Language = "en",
-    },
-    new TextDocumentInput("4", "Pike Place Market is my favorite Seattle attraction.  We had so much fun there.")
-    {
-         Language = "en",
-    }
+    new TextDocumentInput("4", string.Empty)
 };
 
-AnalyzeSentimentResultCollection results = client.AnalyzeSentimentBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+var options = new AnalyzeSentimentOptions { IncludeStatistics = true };
+
+Response<AnalyzeSentimentResultCollection> response = client.AnalyzeSentimentBatch(documents, options);
+AnalyzeSentimentResultCollection sentimentPerDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{sentimentPerDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (AnalyzeSentimentResult sentimentInDocument in sentimentPerDocuments)
+{
+    TextDocumentInput document = documents[i++];
+
+    Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
+
+    if (sentimentInDocument.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error: {sentimentInDocument.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {sentimentInDocument.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"Document sentiment is {sentimentInDocument.DocumentSentiment.Sentiment}, with confidence scores: ");
+        Console.WriteLine($"  Positive confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Positive}.");
+        Console.WriteLine($"  Neutral confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Neutral}.");
+        Console.WriteLine($"  Negative confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Negative}.");
+        Console.WriteLine("");
+        Console.WriteLine($"  Sentence sentiment results:");
+
+        foreach (SentenceSentiment sentimentInSentence in sentimentInDocument.DocumentSentiment.Sentences)
+        {
+            Console.WriteLine($"  For sentence: \"{sentimentInSentence.Text}\"");
+            Console.WriteLine($"  Sentiment is {sentimentInSentence.Sentiment}, with confidence scores: ");
+            Console.WriteLine($"    Positive confidence score: {sentimentInSentence.ConfidenceScores.Positive}.");
+            Console.WriteLine($"    Neutral confidence score: {sentimentInSentence.ConfidenceScores.Neutral}.");
+            Console.WriteLine($"    Negative confidence score: {sentimentInSentence.ConfidenceScores.Negative}.");
+            Console.WriteLine("");
+        }
+
+        Console.WriteLine($"  Document statistics:");
+        Console.WriteLine($"    Character count: {sentimentInDocument.Statistics.CharacterCount}");
+        Console.WriteLine($"    Transaction count: {sentimentInDocument.Statistics.TransactionCount}");
+    }
+    Console.WriteLine("");
+}
+
+Console.WriteLine($"Batch operation statistics:");
+Console.WriteLine($"  Document count: {sentimentPerDocuments.Statistics.DocumentCount}");
+Console.WriteLine($"  Valid document count: {sentimentPerDocuments.Statistics.ValidDocumentCount}");
+Console.WriteLine($"  Invalid document count: {sentimentPerDocuments.Statistics.InvalidDocumentCount}");
+Console.WriteLine($"  Transaction count: {sentimentPerDocuments.Statistics.TransactionCount}");
 ```
 
 To see the full example source files, see:

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample2_AnalyzeSentiment.md
@@ -49,7 +49,7 @@ To analyze the sentiment of a collection of documents in the same language, call
 string documentA = @"The food and service were unacceptable, but the concierge were nice.
                     After talking to them about the quality of the food and the process
                     to get room service they refunded the money we spent at the restaurant and
-                    gave us a voucher for near by restaurants.";
+                    gave us a voucher for nearby restaurants.";
 
 string documentB = @"Nice rooms! I had a great unobstructed view of the Microsoft campus but bathrooms
                     were old and the toilet was dirty when we arrived. It was close to bus stops and
@@ -120,7 +120,7 @@ To analyze the sentiment of a collection of documents in different languages, ca
 string documentA = @"The food and service were unacceptable, but the concierge were nice.
                     After talking to them about the quality of the food and the process
                     to get room service they refunded the money we spent at the restaurant and
-                    gave us a voucher for near by restaurants.";
+                    gave us a voucher for nearby restaurants.";
 
 string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
                     sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -20,7 +20,7 @@ To extract key phrases from a document, use the `ExtractKeyPhrases` method.  The
 
 ```C# Snippet:ExtractKeyPhrases
 string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
-                    little sister thinks it is funny, I a worried it has the cold that I got last week.
+                    little sister thinks it is funny, I am worried it has the cold that I got last week.
                     We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
                     will be covered by the cat's insurance.
                     It might be good to not let it sleep in my room for a while.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample3_ExtractKeyPhrases.md
@@ -8,7 +8,9 @@ To create a new `TextAnalyticsClient` to extract key phrases from a document, yo
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample3CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
@@ -17,14 +19,27 @@ var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(a
 To extract key phrases from a document, use the `ExtractKeyPhrases` method.  The returned value the collection of `KeyPhrases` that were extracted from the document.
 
 ```C# Snippet:ExtractKeyPhrases
-string document = "My cat might need to see a veterinarian.";
+string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
+                    little sister thinks it is funny, I a worried it has the cold that I got last week.
+                    We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
+                    will be covered by the cat's insurance.
+                    It might be good to not let it sleep in my room for a while.";
 
-KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
-
-Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
-foreach (string keyPhrase in keyPhrases)
+try
 {
-    Console.WriteLine(keyPhrase);
+    Response<KeyPhraseCollection> response = client.ExtractKeyPhrases(document);
+    KeyPhraseCollection keyPhrases = response.Value;
+
+    Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
+    foreach (string keyPhrase in keyPhrases)
+    {
+        Console.WriteLine($"  {keyPhrase}");
+    }
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 
@@ -33,29 +48,144 @@ foreach (string keyPhrase in keyPhrases)
 To extract key phrases from multiple documents, call `ExtractKeyPhrasesBatch` on an `IEnumerable` of strings.  The results are returned as a `ExtractKeyPhrasesResultCollection`.
 
 ```C# Snippet:TextAnalyticsSample3ExtractKeyPhrasesConvenience
-ExtractKeyPhrasesResultCollection results = client.ExtractKeyPhrasesBatch(documents);
+string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                    worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                    We tried again today and it was amazing. Everyone in my family liked the trail although
+                    it was too challenging for the less athletic among us.
+                    Not necessarily recommended for small children.
+                    A hotel close to the trail offers services for childcare in case you want that.";
+
+string documentB = @"Last week we stayed at Hotel Foo to celebrate our anniversary. The staff knew about
+                    our anniversary so they helped me organize a little surprise for my partner.
+                    The room was clean and with the decoration I requested. It was perfect!";
+
+string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                    They had great amenities that included an indoor pool, a spa, and a bar.
+                    The spa offered couples massages which were really good. 
+                    The spa was clean and felt very peaceful. Overall the whole experience was great.
+                    We will definitely come back.";
+
+string documentD = string.Empty;
+
+var documents = new List<string>
+{
+    documentA,
+    documentB,
+    documentC,
+    documentD
+};
+
+Response<ExtractKeyPhrasesResultCollection> response = client.ExtractKeyPhrasesBatch(documents);
+ExtractKeyPhrasesResultCollection keyPhrasesInDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{keyPhrasesInDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (ExtractKeyPhrasesResult keyPhrases in keyPhrasesInDocuments)
+{
+    Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+    Console.WriteLine("");
+
+    if (keyPhrases.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error: {keyPhrases.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {keyPhrases.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"  Extracted the following {keyPhrases.KeyPhrases.Count()} key phrases:");
+
+        foreach (string keyPhrase in keyPhrases.KeyPhrases)
+        {
+            Console.WriteLine($"    {keyPhrase}");
+        }
+    }
+    Console.WriteLine("");
+}
 ```
 
 To extract key phrases from a collection of documents in different languages, call `ExtractKeyPhrasesBatch` on an `IEnumerable` of `TextDocumentInput` objects, setting the `Language` on each document.
 
 ```C# Snippet:TextAnalyticsSample3ExtractKeyPhrasesBatch
+string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                    worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                    We tried again today and it was amazing. Everyone in my family liked the trail although
+                    it was too challenging for the less athletic among us.
+                    Not necessarily recommended for small children.
+                    A hotel close to the trail offers services for childcare in case you want that.";
+
+string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                    sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                    La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                    El próximo año volveremos.";
+
+string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                    They had great amenities that included an indoor pool, a spa, and a bar.
+                    The spa offered couples massages which were really good. 
+                    The spa was clean and felt very peaceful. Overall the whole experience was great.
+                    We will definitely come back.";
+
 var documents = new List<TextDocumentInput>
 {
-    new TextDocumentInput("1", "Microsoft was founded by Bill Gates and Paul Allen.")
+    new TextDocumentInput("1", documentA)
     {
          Language = "en",
     },
-    new TextDocumentInput("2", "Text Analytics is one of the Azure Cognitive Services.")
+    new TextDocumentInput("2", documentB)
+    {
+         Language = "es",
+    },
+    new TextDocumentInput("3", documentC)
     {
          Language = "en",
     },
-    new TextDocumentInput("3", "My cat might need to see a veterinarian.")
-    {
-         Language = "en",
-    }
+    new TextDocumentInput("4", string.Empty)
 };
 
-ExtractKeyPhrasesResultCollection results = client.ExtractKeyPhrasesBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+Response<ExtractKeyPhrasesResultCollection> response = client.ExtractKeyPhrasesBatch(documents, options);
+ExtractKeyPhrasesResultCollection keyPhrasesInDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{keyPhrasesInDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (ExtractKeyPhrasesResult keyPhrases in keyPhrasesInDocuments)
+{
+    TextDocumentInput document = documents[i++];
+
+    Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
+
+    if (keyPhrases.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error: {keyPhrases.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {keyPhrases.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"  Extracted the following {keyPhrases.KeyPhrases.Count()} key phrases:");
+
+        foreach (string keyPhrase in keyPhrases.KeyPhrases)
+        {
+            Console.WriteLine($"    {keyPhrase}");
+        }
+
+        Console.WriteLine($"  Document statistics:");
+        Console.WriteLine($"    Character count: {keyPhrases.Statistics.CharacterCount}");
+        Console.WriteLine($"    Transaction count: {keyPhrases.Statistics.TransactionCount}");
+    }
+    Console.WriteLine("");
+}
+
+Console.WriteLine($"Batch operation statistics:");
+Console.WriteLine($"  Document count: {keyPhrasesInDocuments.Statistics.DocumentCount}");
+Console.WriteLine($"  Valid document count: {keyPhrasesInDocuments.Statistics.ValidDocumentCount}");
+Console.WriteLine($"  Invalid document count: {keyPhrasesInDocuments.Statistics.InvalidDocumentCount}");
+Console.WriteLine($"  Transaction count: {keyPhrasesInDocuments.Statistics.TransactionCount}");
+Console.WriteLine("");
 ```
 
 To see the full example source files, see:

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample5_RecognizePiiEntities.md
@@ -7,7 +7,9 @@ To create a new `TextAnalyticsClient` to recognize Personally Identifiable Infor
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample5CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
@@ -16,22 +18,32 @@ var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(a
 To recognize Personally Identifiable Information in a document, use the `RecognizePiiEntities` method.  The returned value is the collection of `PiiEntity` containing Personally Identifiable Information that were recognized in the document.
 
 ```C# Snippet:RecognizePiiEntities
-string document = "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.";
+string document = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                    Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                    They are originally from Brazil and have document ID number 998.214.865-68";
 
-PiiEntityCollection entities = client.RecognizePiiEntities(document).Value;
-
-Console.WriteLine($"Redacted Text: {entities.RedactedText}");
-if (entities.Count > 0)
+try
 {
-    Console.WriteLine($"Recognized {entities.Count} PII entit{(entities.Count > 1 ? "ies" : "y")}:");
+    Response<PiiEntityCollection> response = client.RecognizePiiEntities(document);
+    PiiEntityCollection entities = response.Value;
+
+    Console.WriteLine($"Redacted Text: {entities.RedactedText}");
+    Console.WriteLine("");
+    Console.WriteLine($"Recognized {entities.Count} PII entities:");
     foreach (PiiEntity entity in entities)
     {
-        Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+        Console.WriteLine($"  Text: {entity.Text}");
+        Console.WriteLine($"  Category: {entity.Category}");
+        if (!string.IsNullOrEmpty(entity.SubCategory))
+            Console.WriteLine($"  SubCategory: {entity.SubCategory}");
+        Console.WriteLine($"  Confidence score: {entity.ConfidenceScore}");
+        Console.WriteLine("");
     }
 }
-else
+catch (RequestFailedException exception)
 {
-    Console.WriteLine("No entities were found.");
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 
@@ -40,25 +52,140 @@ else
 To recognize Personally Identifiable Information in multiple documents, call `RecognizePiiEntitiesBatch` on an `IEnumerable` of strings.  The results are returned as a `RecognizePiiEntitiesResultCollection`.
 
 ```C# Snippet:TextAnalyticsSample5RecognizePiiEntitiesConvenience
-RecognizePiiEntitiesResultCollection results = client.RecognizePiiEntitiesBatch(documents);
+string documentA = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                    Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                    They are originally from Brazil and have document ID number 998.214.865-68";
+
+string documentB = @"Yesterday, Dan Doe was asking where they could find the ABA number. I explained
+                    that it is the first 9 digits in the lower left hand corner of their personal check.
+                    After looking at their account they confirmed the number was 111000025";
+
+string documentC = string.Empty;
+
+var documents = new List<string>
+{
+    documentA,
+    documentB,
+    documentC
+};
+
+Response<RecognizePiiEntitiesResultCollection> response = client.RecognizePiiEntitiesBatch(documents);
+RecognizePiiEntitiesResultCollection entititesPerDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"PII Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (RecognizePiiEntitiesResult piiEntititesInDocument in entititesPerDocuments)
+{
+    Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+    Console.WriteLine("");
+
+    if (piiEntititesInDocument.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error code: {piiEntititesInDocument.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {piiEntititesInDocument.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"  Redacted Text: {piiEntititesInDocument.Entities.RedactedText}");
+        Console.WriteLine("");
+        Console.WriteLine($"  Recognized {piiEntititesInDocument.Entities.Count} PII entities:");
+        foreach (PiiEntity piiEntity in piiEntititesInDocument.Entities)
+        {
+            Console.WriteLine($"    Text: {piiEntity.Text}");
+            Console.WriteLine($"    Category: {piiEntity.Category}");
+            if (!string.IsNullOrEmpty(piiEntity.SubCategory))
+                Console.WriteLine($"    SubCategory: {piiEntity.SubCategory}");
+            Console.WriteLine($"    Confidence score: {piiEntity.ConfidenceScore}");
+            Console.WriteLine("");
+        }
+    }
+    Console.WriteLine("");
+}
 ```
 
 To recognize Personally Identifiable Information in a collection of documents in different languages, call `RecognizePiiEntitiesBatch` on an `IEnumerable` of `TextDocumentInput` objects, setting the `Language` on each document.
 
 ```C# Snippet:TextAnalyticsSample5RecognizePiiEntitiesBatch
+string documentA = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                    Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                    They are originally from Brazil and have document ID number 998.214.865-68";
+
+string documentB = @"Hoy recibí una llamada al medio día del usuario Juanito Perez, quien preguntaba
+                    cómo acceder a su nuevo correo electrónico. Este trabaja en Microsoft y su correo es
+                    juanito.perez@contoso.com. El usuario accedió a compartir su número para futuras comunicaciones.
+                    El número es 800-102-1101";
+
+string documentC = @"Yesterday, Dan Doe was asking where they could find the ABA number. I explained
+                    that it is the first 9 digits in the lower left hand corner of their personal check.
+                    After looking at their account they confirmed the number was 111000025";
+
 var documents = new List<TextDocumentInput>
 {
-    new TextDocumentInput("1", "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.")
+    new TextDocumentInput("1", documentA)
     {
          Language = "en",
     },
-    new TextDocumentInput("2", "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.")
+    new TextDocumentInput("2", documentB)
+    {
+         Language = "es",
+    },
+    new TextDocumentInput("3", documentC)
     {
          Language = "en",
     }
 };
 
-RecognizePiiEntitiesResultCollection results = client.RecognizePiiEntitiesBatch(documents, new RecognizePiiEntitiesOptions { IncludeStatistics = true });
+var options = new RecognizePiiEntitiesOptions { IncludeStatistics = true };
+Response<RecognizePiiEntitiesResultCollection> response = client.RecognizePiiEntitiesBatch(documents, options);
+RecognizePiiEntitiesResultCollection entititesPerDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"PII Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (RecognizePiiEntitiesResult piiEntititesInDocument in entititesPerDocuments)
+{
+    TextDocumentInput document = documents[i++];
+
+    Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
+
+    if (piiEntititesInDocument.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error code: {piiEntititesInDocument.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {piiEntititesInDocument.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"  Redacted Text: {piiEntititesInDocument.Entities.RedactedText}");
+        Console.WriteLine("");
+        Console.WriteLine($"  Recognized {piiEntititesInDocument.Entities.Count} PII entities:");
+        foreach (PiiEntity piiEntity in piiEntititesInDocument.Entities)
+        {
+            Console.WriteLine($"    Text: {piiEntity.Text}");
+            Console.WriteLine($"    Category: {piiEntity.Category}");
+            if (!string.IsNullOrEmpty(piiEntity.SubCategory))
+                Console.WriteLine($"    SubCategory: {piiEntity.SubCategory}");
+            Console.WriteLine($"    Confidence score: {piiEntity.ConfidenceScore}");
+            Console.WriteLine("");
+        }
+
+        Console.WriteLine($"  Document statistics:");
+        Console.WriteLine($"    Character count: {piiEntititesInDocument.Statistics.CharacterCount}");
+        Console.WriteLine($"    Transaction count: {piiEntititesInDocument.Statistics.TransactionCount}");
+    }
+    Console.WriteLine("");
+}
+
+Console.WriteLine($"Batch operation statistics:");
+Console.WriteLine($"  Document count: {entititesPerDocuments.Statistics.DocumentCount}");
+Console.WriteLine($"  Valid document count: {entititesPerDocuments.Statistics.ValidDocumentCount}");
+Console.WriteLine($"  Invalid document count: {entititesPerDocuments.Statistics.InvalidDocumentCount}");
+Console.WriteLine($"  Transaction count: {entititesPerDocuments.Statistics.TransactionCount}");
+Console.WriteLine("");
 ```
 
 To see the full example source files, see:

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample6_RecognizeLinkedEntities.md
@@ -7,7 +7,9 @@ To create a new `TextAnalyticsClient` to recognize linked entities in a document
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample6CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 
@@ -16,19 +18,38 @@ var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(a
 To recognize linked entities in a document, use the `RecognizeLinkedEntities` method.  The returned value is the collection of `LinkedEntities` containing entities recognized in the document as well as links to those entities in a reference data source, such as Wikipedia.
 
 ```C# Snippet:RecognizeLinkedEntities
-string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+string document = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                    Steve Ballmer, eventually became CEO after Bill Gates as well. Steve Ballmer eventually stepped
+                    down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                    Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                    headquartered in Redmond";
 
-LinkedEntityCollection linkedEntities = client.RecognizeLinkedEntities(document);
-
-Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
-foreach (LinkedEntity linkedEntity in linkedEntities)
+try
 {
-    Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
-    foreach (LinkedEntityMatch match in linkedEntity.Matches)
+    Response<LinkedEntityCollection> response = client.RecognizeLinkedEntities(document);
+    LinkedEntityCollection linkedEntities = response.Value;
+
+    Console.WriteLine($"Recognized {linkedEntities.Count} entities:");
+    foreach (LinkedEntity linkedEntity in linkedEntities)
     {
-        Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
-        Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+        Console.WriteLine($"  Name: {linkedEntity.Name}");
+        Console.WriteLine($"  Language: {linkedEntity.Language}");
+        Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+        Console.WriteLine($"  URL: {linkedEntity.Url}");
+        Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+        foreach (LinkedEntityMatch match in linkedEntity.Matches)
+        {
+            Console.WriteLine($"    Match Text: {match.Text}");
+            Console.WriteLine($"    Offset: {match.Offset}");
+            Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+        }
+        Console.WriteLine("");
     }
+}
+catch (RequestFailedException exception)
+{
+    Console.WriteLine($"Error Code: {exception.ErrorCode}");
+    Console.WriteLine($"Message: {exception.Message}");
 }
 ```
 
@@ -37,29 +58,153 @@ foreach (LinkedEntity linkedEntity in linkedEntities)
 To recognize linked entities in multiple documents, call `RecognizeLinkedEntitiesBatch` on an `IEnumerable` of strings.  The results are returned as a `RecognizeLinkedEntitiesResultCollection`.
 
 ```C# Snippet:TextAnalyticsSample6RecognizeLinkedEntitiesConvenience
-RecognizeLinkedEntitiesResultCollection results = client.RecognizeLinkedEntitiesBatch(documents);
+string documentA = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                    Steve Ballmer, eventually became CEO after Bill Gates as well.Steve Ballmer eventually stepped
+                    down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                    Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                    headquartered in Redmond";
+
+string documentB = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and 
+                    sell BASIC interpreters for the Altair 8800. During his career at Microsoft, Gates held
+                    the positions of chairman chief executive officer, president and chief software architect
+                    while also being the largest individual shareholder until May 2014.";
+
+string documentC = string.Empty;
+
+var documents = new List<string>
+{
+    documentA,
+    documentB,
+    documentC
+};
+
+Response<RecognizeLinkedEntitiesResultCollection> response = client.RecognizeLinkedEntitiesBatch(documents);
+RecognizeLinkedEntitiesResultCollection entitiesInDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Entity Linking\", version: \"{entitiesInDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (RecognizeLinkedEntitiesResult entitiesInDocument in entitiesInDocuments)
+{
+    Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+    Console.WriteLine("");
+
+    if (entitiesInDocument.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"Recognized {entitiesInDocument.Entities.Count} entities:");
+        foreach (LinkedEntity linkedEntity in entitiesInDocument.Entities)
+        {
+            Console.WriteLine($"  Name: {linkedEntity.Name}");
+            Console.WriteLine($"  Language: {linkedEntity.Language}");
+            Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+            Console.WriteLine($"  URL: {linkedEntity.Url}");
+            Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+            foreach (LinkedEntityMatch match in linkedEntity.Matches)
+            {
+                Console.WriteLine($"    Match Text: {match.Text}");
+                Console.WriteLine($"    Offset: {match.Offset}");
+                Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+            }
+            Console.WriteLine("");
+        }
+    }
+    Console.WriteLine("");
+}
 ```
 
 To recognize linked entities in a collection of documents in different languages, call `RecognizeLinkedEntitiesBatch` on an `IEnumerable` of `TextDocumentInput` objects, setting the `Language` on each document.
 
 ```C# Snippet:TextAnalyticsSample6RecognizeLinkedEntitiesBatch
+string documentA = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                    Steve Ballmer, eventually became CEO after Bill Gates as well.Steve Ballmer eventually stepped
+                    down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                    Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                    headquartered in Redmond";
+
+string documentB = @"El CEO de Microsoft es Satya Nadella, quien asumió esta posición en Febrero de 2014. Él
+                    empezó como Ingeniero de Software en el año 1992.";
+
+string documentC = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and 
+                    sell BASIC interpreters for the Altair 8800. During his career at Microsoft, Gates held
+                    the positions of chairman chief executive officer, president and chief software architect
+                    while also being the largest individual shareholder until May 2014.";
+
 var documents = new List<TextDocumentInput>
 {
-    new TextDocumentInput("1", "Microsoft was founded by Bill Gates and Paul Allen.")
+    new TextDocumentInput("1", documentA)
     {
          Language = "en",
     },
-    new TextDocumentInput("2", "Text Analytics is one of the Azure Cognitive Services.")
+    new TextDocumentInput("2", documentB)
+    {
+         Language = "es",
+    },
+    new TextDocumentInput("3", documentC)
     {
          Language = "en",
     },
-    new TextDocumentInput("3", "Pike place market is my favorite Seattle attraction.")
-    {
-         Language = "en",
-    }
+    new TextDocumentInput("4", string.Empty)
 };
 
-RecognizeLinkedEntitiesResultCollection results = client.RecognizeLinkedEntitiesBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+Response<RecognizeLinkedEntitiesResultCollection> response = client.RecognizeLinkedEntitiesBatch(documents, options);
+RecognizeLinkedEntitiesResultCollection entitiesPerDocuments = response.Value;
+
+int i = 0;
+Console.WriteLine($"Results of Azure Text Analytics \"Entity Linking\", version: \"{entitiesPerDocuments.ModelVersion}\"");
+Console.WriteLine("");
+
+foreach (RecognizeLinkedEntitiesResult entitiesInDocument in entitiesPerDocuments)
+{
+    TextDocumentInput document = documents[i++];
+
+    Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
+
+    if (entitiesInDocument.HasError)
+    {
+        Console.WriteLine("  Error!");
+        Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+        Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
+    }
+    else
+    {
+        Console.WriteLine($"Recognized {entitiesInDocument.Entities.Count} entities:");
+        foreach (LinkedEntity linkedEntity in entitiesInDocument.Entities)
+        {
+            Console.WriteLine($"  Name: {linkedEntity.Name}");
+            Console.WriteLine($"  Language: {linkedEntity.Language}");
+            Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+            Console.WriteLine($"  URL: {linkedEntity.Url}");
+            Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+            foreach (LinkedEntityMatch match in linkedEntity.Matches)
+            {
+                Console.WriteLine($"    Match Text: {match.Text}");
+                Console.WriteLine($"    Offset: {match.Offset}");
+                Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+            }
+            Console.WriteLine("");
+        }
+
+        Console.WriteLine($"  Document statistics:");
+        Console.WriteLine($"    Character count: {entitiesInDocument.Statistics.CharacterCount}");
+        Console.WriteLine($"    Transaction count: {entitiesInDocument.Statistics.TransactionCount}");
+    }
+    Console.WriteLine("");
+}
+
+Console.WriteLine($"Batch operation statistics:");
+Console.WriteLine($"  Document count: {entitiesPerDocuments.Statistics.DocumentCount}");
+Console.WriteLine($"  Valid document count: {entitiesPerDocuments.Statistics.ValidDocumentCount}");
+Console.WriteLine($"  Invalid document count: {entitiesPerDocuments.Statistics.InvalidDocumentCount}");
+Console.WriteLine($"  Transaction count: {entitiesPerDocuments.Statistics.TransactionCount}");
+Console.WriteLine("");
 ```
 
 To see the full example source files, see:

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeOperation.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_AnalyzeOperation.md
@@ -7,7 +7,9 @@ To create a new `TextAnalyticsClient` to run analyze operation for a document, y
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample4CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_RecognizeHealthcareEntities.md
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/samples/Sample_RecognizeHealthcareEntities.md
@@ -7,7 +7,9 @@ To create a new `TextAnalyticsClient` to recognize healthcare entities in a docu
 
 You can set `endpoint` and `apiKey` based on an environment variable, a configuration setting, or any way that works for your application.
 
-```C# Snippet:TextAnalyticsSample4CreateClient
+```C# Snippet:CreateTextAnalyticsClient
+string endpoint = "<endpoint>";
+string apiKey = "<apiKey>";
 var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 ```
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguage.cs
@@ -17,16 +17,28 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
-            #region Snippet:TextAnalyticsSample1CreateClient
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            #endregion
 
             #region Snippet:DetectLanguage
-            string document = "Este documento está en español.";
+            string document = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                                cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                                También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                                para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                                La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                                dialectos y algunos idiomas regionales o culturales.";
 
-            DetectedLanguage language = client.DetectLanguage(document);
+            try
+            {
+                Response<DetectedLanguage> response = client.DetectLanguage(document);
 
-            Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+                DetectedLanguage language = response.Value;
+                Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
+            }
             #endregion
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageAsync.cs
@@ -21,11 +21,25 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:DetectLanguageAsync
-            string document = "Este documento está en español.";
+            string document = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                                cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                                También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                                para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                                La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                                dialectos y algunos idiomas regionales o culturales.";
 
-            DetectedLanguage language = await client.DetectLanguageAsync(document);
+            try
+            {
+                Response<DetectedLanguage> response = await client.DetectLanguageAsync(document);
 
-            Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+                DetectedLanguage language = response.Value;
+                Console.WriteLine($"Detected language {language.Name} with confidence score {language.ConfidenceScore}.");
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
+            }
             #endregion
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatch.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -22,61 +21,87 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:TextAnalyticsSample1DetectLanguageBatch
+            string documentA = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                                cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                                También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                                para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                                La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                                dialectos y algunos idiomas regionales o culturales.";
+
+            string documentB = @"This document is written in a language different than Spanish. It's objective is to demonstrate
+                                how to call the Detect Language method from the Microsoft Azure Text Analytics service.
+                                It also shows how to access the information returned from the service. This capability is useful
+                                for content stores that collect arbitrary text, where language is unknown.
+                                The Language Detection feature can detect a wide range of languages, variants, dialects, and some
+                                regional or cultural languages.";
+
+            string documentC = @"Ce document est rédigé dans une langue différente de l'espagnol. Son objectif est de montrer comment
+                                appeler la méthode Detect Language à partir du service Microsoft Azure Text Analytics.
+                                Il montre également comment accéder aux informations renvoyées par le service. Cette capacité est
+                                utile pour les magasins de contenu qui collectent du texte arbitraire dont la langue est inconnue.
+                                La fonctionnalité Détection de langue peut détecter une grande variété de langues, de variantes,
+                                de dialectes, et certaines langues régionales ou de culture.";
+
             var documents = new List<DetectLanguageInput>
             {
-                new DetectLanguageInput("1", "Hello world")
+                new DetectLanguageInput("1", documentA)
+                {
+                     CountryHint = "es",
+                },
+                new DetectLanguageInput("2", documentB)
                 {
                      CountryHint = "us",
                 },
-                new DetectLanguageInput("2", "Bonjour tout le monde")
+                new DetectLanguageInput("3", documentC)
                 {
                      CountryHint = "fr",
-                },
-                new DetectLanguageInput("3", "Hola mundo")
-                {
-                     CountryHint = "es",
                 },
                 new DetectLanguageInput("4", ":) :( :D")
                 {
                      CountryHint = DetectLanguageInput.None,
-                }
+                },
+                new DetectLanguageInput("5", "")
             };
 
-            DetectLanguageResultCollection results = client.DetectLanguageBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
-            #endregion
+            var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+
+            Response<DetectLanguageResultCollection> response = client.DetectLanguageBatch(documents, options);
+            DetectLanguageResultCollection documentsLanguage = response.Value;
 
             int i = 0;
-            Debug.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{results.ModelVersion}\"");
-            Debug.WriteLine("");
+            Console.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{documentsLanguage.ModelVersion}\"");
+            Console.WriteLine("");
 
-            foreach (DetectLanguageResult result in results)
+            foreach (DetectLanguageResult documentLanguage in documentsLanguage)
             {
                 DetectLanguageInput document = documents[i++];
 
-                Debug.WriteLine($"On document (Id={document.Id}, CountryHint=\"{document.CountryHint}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, CountryHint=\"{document.CountryHint}\"):");
 
-                if (result.HasError)
+                if (documentLanguage.HasError)
                 {
-                    Debug.WriteLine($"    Document error code: {result.Error.ErrorCode}.");
-                    Debug.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {documentLanguage.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {documentLanguage.Error.Message}");
                 }
                 else
                 {
-                    Debug.WriteLine($"    Detected language {result.PrimaryLanguage.Name} with confidence score {result.PrimaryLanguage.ConfidenceScore}.");
+                    Console.WriteLine($"  Detected language: {documentLanguage.PrimaryLanguage.Name}");
+                    Console.WriteLine($"  Confidence score: {documentLanguage.PrimaryLanguage.ConfidenceScore}");
 
-                    Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Debug.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {documentLanguage.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {documentLanguage.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
-            Debug.WriteLine($"Batch operation statistics:");
-            Debug.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Debug.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Debug.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Debug.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
-            Debug.WriteLine("");
+            Console.WriteLine($"Batch operation statistics:");
+            Console.WriteLine($"  Document count: {documentsLanguage.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {documentsLanguage.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {documentsLanguage.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {documentsLanguage.Statistics.TransactionCount}");
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchAsync.cs
@@ -21,60 +21,89 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                                cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                                También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                                para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                                La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                                dialectos y algunos idiomas regionales o culturales.";
+
+            string documentB = @"This document is written in a language different than Spanish. It's objective is to demonstrate
+                                how to call the Detect Language method from the Microsoft Azure Text Analytics service.
+                                It also shows how to access the information returned from the service. This capability is useful
+                                for content stores that collect arbitrary text, where language is unknown.
+                                The Language Detection feature can detect a wide range of languages, variants, dialects, and some
+                                regional or cultural languages.";
+
+            string documentC = @"Ce document est rédigé dans une langue différente de l'espagnol. Son objectif est de montrer comment
+                                appeler la méthode Detect Language à partir du service Microsoft Azure Text Analytics.
+                                Il montre également comment accéder aux informations renvoyées par le service. Cette capacité est
+                                utile pour les magasins de contenu qui collectent du texte arbitraire dont la langue est inconnue.
+                                La fonctionnalité Détection de langue peut détecter une grande variété de langues, de variantes,
+                                de dialectes, et certaines langues régionales ou de culture.";
+
             var documents = new List<DetectLanguageInput>
             {
-                new DetectLanguageInput("1", "Hello world")
+                new DetectLanguageInput("1", documentA)
+                {
+                     CountryHint = "es",
+                },
+                new DetectLanguageInput("2", documentB)
                 {
                      CountryHint = "us",
                 },
-                new DetectLanguageInput("2", "Bonjour tout le monde")
+                new DetectLanguageInput("3", documentC)
                 {
                      CountryHint = "fr",
-                },
-                new DetectLanguageInput("3", "Hola mundo")
-                {
-                     CountryHint = "es",
                 },
                 new DetectLanguageInput("4", ":) :( :D")
                 {
                      CountryHint = DetectLanguageInput.None,
+                },
+                new DetectLanguageInput("5", "")
+                {
+                     CountryHint = "en",
                 }
             };
 
-            DetectLanguageResultCollection results = await client.DetectLanguageBatchAsync(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+            var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+
+            Response<DetectLanguageResultCollection> response = await client.DetectLanguageBatchAsync(documents, options);
+            DetectLanguageResultCollection documentsLanguage = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{documentsLanguage.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (DetectLanguageResult result in results)
+            foreach (DetectLanguageResult documentLanguage in documentsLanguage)
             {
                 DetectLanguageInput document = documents[i++];
 
-                Console.WriteLine($"On document (Id={document.Id}, CountryHint=\"{document.CountryHint}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, CountryHint=\"{document.CountryHint}\")");
 
-                if (result.HasError)
+                if (documentLanguage.HasError)
                 {
-                    Console.WriteLine($"    Document error code: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {documentLanguage.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {documentLanguage.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine($"    Detected language {result.PrimaryLanguage.Name} with confidence score {result.PrimaryLanguage.ConfidenceScore}.");
+                    Console.WriteLine($"  Detected language: {documentLanguage.PrimaryLanguage.Name}");
+                    Console.WriteLine($"  Confidence score: {documentLanguage.PrimaryLanguage.ConfidenceScore}");
 
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Console.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {documentLanguage.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {documentLanguage.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
             Console.WriteLine($"Batch operation statistics:");
-            Console.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Console.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Console.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Console.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
-            Console.WriteLine("");
+            Console.WriteLine($"  Document count: {documentsLanguage.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {documentsLanguage.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {documentsLanguage.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {documentsLanguage.Statistics.TransactionCount}");
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenience.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -21,30 +20,63 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            #region Snippet:TextAnalyticsSample1DetectLanguagesConvenience
+            string documentA = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                                cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                                También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                                para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                                La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                                dialectos y algunos idiomas regionales o culturales.";
+
+            string documentB = @"This document is written in a language different than Spanish. It's objective is to demonstrate
+                                how to call the Detect Language method from the Microsoft Azure Text Analytics service.
+                                It also shows how to access the information returned from the service. This capability is useful
+                                for content stores that collect arbitrary text, where language is unknown.
+                                The Language Detection feature can detect a wide range of languages, variants, dialects, and some
+                                regional or cultural languages.";
+
+            string documentC = @"Ce document est rédigé dans une langue différente de l'espagnol. Son objectif est de montrer comment
+                                appeler la méthode Detect Language à partir du service Microsoft Azure Text Analytics.
+                                Il montre également comment accéder aux informations renvoyées par le service. Cette capacité est
+                                utile pour les magasins de contenu qui collectent du texte arbitraire dont la langue est inconnue.
+                                La fonctionnalité Détection de langue peut détecter une grande variété de langues, de variantes,
+                                de dialectes, et certaines langues régionales ou de culture.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "Hello world",
-                "Bonjour tout le monde",
-                "Hola mundo",
-                ":) :( :D",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            Debug.WriteLine($"Detecting language for documents:");
-            foreach (string document in documents)
-            {
-                Debug.WriteLine($"    {document}");
-            }
-
-            #region Snippet:TextAnalyticsSample1DetectLanguagesConvenience
-            DetectLanguageResultCollection results = client.DetectLanguageBatch(documents);
-            #endregion
+            Response<DetectLanguageResultCollection> response = client.DetectLanguageBatch(documents);
+            DetectLanguageResultCollection documentsLanguage = response.Value;
 
             int i = 0;
-            foreach (DetectLanguageResult result in results)
+            Console.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{documentsLanguage.ModelVersion}\"");
+            Console.WriteLine("");
+
+            foreach (DetectLanguageResult documentLanguage in documentsLanguage)
             {
-                Debug.WriteLine($"On document {documents[i++]}:");
-                Debug.WriteLine($"Detected language: {result.PrimaryLanguage.Name}, with confidence score {result.PrimaryLanguage.ConfidenceScore}.");
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+                if (documentLanguage.HasError)
+                {
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {documentLanguage.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {documentLanguage.Error.Message}");
+                }
+                else
+                {
+                    Console.WriteLine($"  Detected language: {documentLanguage.PrimaryLanguage.Name}");
+                    Console.WriteLine($"  Confidence score: {documentLanguage.PrimaryLanguage.ConfidenceScore}");
+                }
+                Console.WriteLine("");
             }
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample1_DetectLanguageBatchConvenienceAsync.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
@@ -22,27 +21,60 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"Este documento está escrito en un idioma diferente al Inglés. Tiene como objetivo demostrar
+                                cómo invocar el método de Detección de idioma del servicio de Text Analytics en Microsoft Azure.
+                                También muestra cómo acceder a la información retornada por el servicio. Esta capacidad es útil
+                                para los sistemas de contenido que recopilan texto arbitrario, donde el idioma es desconocido.
+                                La característica Detección de idioma puede detectar una amplia gama de idiomas, variantes,
+                                dialectos y algunos idiomas regionales o culturales.";
+
+            string documentB = @"This document is written in a language different than Spanish. It's objective is to demonstrate
+                                how to call the Detect Language method from the Microsoft Azure Text Analytics service.
+                                It also shows how to access the information returned from the service. This capability is useful
+                                for content stores that collect arbitrary text, where language is unknown.
+                                The Language Detection feature can detect a wide range of languages, variants, dialects, and some
+                                regional or cultural languages.";
+
+            string documentC = @"Ce document est rédigé dans une langue différente de l'espagnol. Son objectif est de montrer comment
+                                appeler la méthode Detect Language à partir du service Microsoft Azure Text Analytics.
+                                Il montre également comment accéder aux informations renvoyées par le service. Cette capacité est
+                                utile pour les magasins de contenu qui collectent du texte arbitraire dont la langue est inconnue.
+                                La fonctionnalité Détection de langue peut détecter une grande variété de langues, de variantes,
+                                de dialectes, et certaines langues régionales ou de culture.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "Hello world",
-                "Bonjour tout le monde",
-                "Hola mundo",
-                ":) :( :D",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            Console.WriteLine($"Detecting language for documents:");
-            foreach (string document in documents)
-            {
-                Debug.WriteLine($"    {document}");
-            }
-
-            DetectLanguageResultCollection results = await client.DetectLanguageBatchAsync(documents);
+            Response<DetectLanguageResultCollection> response = await client.DetectLanguageBatchAsync(documents);
+            DetectLanguageResultCollection documentsLanguage = response.Value;
 
             int i = 0;
-            foreach (DetectLanguageResult result in results)
+            Console.WriteLine($"Results of Azure Text Analytics \"Detect Language\" Model, version: \"{documentsLanguage.ModelVersion}\"");
+            Console.WriteLine("");
+
+            foreach (DetectLanguageResult documentLanguage in documentsLanguage)
             {
-                Console.WriteLine($"On document {documents[i++]}:");
-                Console.WriteLine($"Detected language: {result.PrimaryLanguage.Name}, with confidence score {result.PrimaryLanguage.ConfidenceScore}.");
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+                if (documentLanguage.HasError)
+                {
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {documentLanguage.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {documentLanguage.Error.Message}");
+                }
+                else
+                {
+                    Console.WriteLine($"  Detected language: {documentLanguage.PrimaryLanguage.Name}");
+                    Console.WriteLine($"  Confidence score: {documentLanguage.PrimaryLanguage.ConfidenceScore}");
+                }
+                Console.WriteLine("");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.cs
@@ -22,18 +22,34 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:TAAnalyzeSentimentWithOpinionMining
+            string reviewA = @"The food and service were unacceptable, but the concierge were nice.
+                             After talking to them about the quality of the food and the process
+                             to get room service they refunded the money we spent at the restaurant
+                             and gave us a voucher for near by restaurants.";
+
+            string reviewB = @"The rooms were beautiful. The AC was good and quiet, which was key for
+                            us as outside it was 100F and our baby was getting uncomfortable because of the heat.
+                            The breakfast was good too with good options and good servicing times.
+                            The thing we didn't like was that the toilet in our bathroom was smelly.
+                            It could have been that the toilet was not cleaned before we arrived.
+                            Either way it was very uncomfortable.
+                            Once we notified the staff, they came and cleaned it and left candles.";
+
+            string reviewC = @"Nice rooms! I had a great unobstructed view of the Microsoft campus
+                            but bathrooms were old and the toilet was dirty when we arrived. 
+                            It was close to bus stops and groceries stores. If you want to be close to
+                            campus I will recommend it, otherwise, might be better to stay in a cleaner one.";
+
             var documents = new List<string>
             {
-                "The food and service were unacceptable, but the concierge were nice.",
-                "The rooms were beautiful. The AC was good and quiet.",
-                "The breakfast was good, but the toilet was smelly.",
-                "Loved this hotel - good breakfast - nice shuttle service - clean rooms.",
-                "I had a great unobstructed view of the Microsoft campus.",
-                "Nice rooms but bathrooms were old and the toilet was dirty when we arrived.",
-                "We changed rooms as the toilet smelled."
+                reviewA,
+                reviewB,
+                reviewC
             };
 
-            AnalyzeSentimentResultCollection reviews = client.AnalyzeSentimentBatch(documents, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+            var options = new AnalyzeSentimentOptions() { IncludeOpinionMining = true };
+            Response<AnalyzeSentimentResultCollection> response = client.AnalyzeSentimentBatch(documents, options: options);
+            AnalyzeSentimentResultCollection reviews = response.Value;
 
             Dictionary<string, int> complaints = GetComplaints(reviews);
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMining.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string reviewA = @"The food and service were unacceptable, but the concierge were nice.
                              After talking to them about the quality of the food and the process
                              to get room service they refunded the money we spent at the restaurant
-                             and gave us a voucher for near by restaurants.";
+                             and gave us a voucher for nearby restaurants.";
 
             string reviewB = @"The rooms were beautiful. The AC was good and quiet, which was key for
                             us as outside it was 100F and our baby was getting uncomfortable because of the heat.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMiningAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMiningAsync.cs
@@ -22,18 +22,34 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string reviewA = @"The food and service were unacceptable, but the concierge were nice.
+                             After talking to them about the quality of the food and the process
+                             to get room service they refunded the money we spent at the restaurant
+                             and gave us a voucher for near by restaurants.";
+
+            string reviewB = @"The rooms were beautiful. The AC was good and quiet, which was key for
+                            us as outside it was 100F and our baby was getting uncomfortable because of the heat.
+                            The breakfast was good too with good options and good servicing times.
+                            The thing we didn't like was that the toilet in our bathroom was smelly.
+                            It could have been that the toilet was not cleaned before we arrived.
+                            Either way it was very uncomfortable.
+                            Once we notified the staff, they came and cleaned it and left candles.";
+
+            string reviewC = @"Nice rooms! I had a great unobstructed view of the Microsoft campus
+                            but bathrooms were old and the toilet was dirty when we arrived. 
+                            It was close to bus stops and groceries stores. If you want to be close to
+                            campus I will recommend it, otherwise, might be better to stay in a cleaner one.";
+
             var documents = new List<string>
             {
-                "The food and service were unacceptable, but the concierge were nice.",
-                "The rooms were beautiful. The AC was good and quiet.",
-                "The breakfast was good, but the toilet was smelly.",
-                "Loved this hotel - good breakfast - nice shuttle service - clean rooms.",
-                "I had a great unobstructed view of the Microsoft campus.",
-                "Nice rooms but bathrooms were old and the toilet was dirty when we arrived.",
-                "We changed rooms as the toilet smelled."
+                reviewA,
+                reviewB,
+                reviewC
             };
 
-            AnalyzeSentimentResultCollection reviews = await client.AnalyzeSentimentBatchAsync(documents, options: new AnalyzeSentimentOptions() { IncludeOpinionMining = true });
+            var options = new AnalyzeSentimentOptions() { IncludeOpinionMining = true };
+            Response<AnalyzeSentimentResultCollection> response = await client.AnalyzeSentimentBatchAsync(documents, options: options);
+            AnalyzeSentimentResultCollection reviews = response.Value;
 
             Dictionary<string, int> complaints = GetComplaint(reviews);
 

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMiningAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2.1_AnalyzeSentimentWithOpinionMiningAsync.cs
@@ -25,7 +25,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string reviewA = @"The food and service were unacceptable, but the concierge were nice.
                              After talking to them about the quality of the food and the process
                              to get room service they refunded the money we spent at the restaurant
-                             and gave us a voucher for near by restaurants.";
+                             and gave us a voucher for nearby restaurants.";
 
             string reviewB = @"The rooms were beautiful. The AC was good and quiet, which was key for
                             us as outside it was 100F and our baby was getting uncomfortable because of the heat.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentiment.cs
@@ -16,19 +16,29 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
-            #region Snippet:TextAnalyticsSample2CreateClient
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            #endregion
 
             #region Snippet:AnalyzeSentiment
-            string document = "That was the best day of my life!";
+            string document = @"I had the best day of my life. I decided to go sky-diving and it
+                                made me appreciate my whole life so much more.
+                                I developed a deep-connection with my instructor as well, and I
+                                feel as if I've made a life-long friend in her.";
 
-            DocumentSentiment docSentiment = client.AnalyzeSentiment(document);
+            try
+            {
+                Response<DocumentSentiment> response = client.AnalyzeSentiment(document);
+                DocumentSentiment docSentiment = response.Value;
 
-            Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
-            Console.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
-            Console.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
-            Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+                Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
+                Console.WriteLine($"  Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
+                Console.WriteLine($"  Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
+                Console.WriteLine($"  Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
+            }
             #endregion
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentAsync.cs
@@ -19,14 +19,26 @@ namespace Azure.AI.TextAnalytics.Samples
 
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string document = "That was the best day of my life!";
+            string document = @"I had the best day of my life. I decided to go sky-diving and it
+                                made me appreciate my whole life so much more.
+                                I developed a deep-connection with my instructor as well, and I
+                                feel as if I've made a life-long friend in her.";
 
-            DocumentSentiment docSentiment = await client.AnalyzeSentimentAsync(document);
+            try
+            {
+                Response<DocumentSentiment> response = await client.AnalyzeSentimentAsync(document);
+                DocumentSentiment docSentiment = response.Value;
 
-            Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
-            Console.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
-            Console.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
-            Console.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+                Console.WriteLine($"Sentiment was {docSentiment.Sentiment}, with confidence scores: ");
+                Console.WriteLine($"  Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
+                Console.WriteLine($"  Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
+                Console.WriteLine($"  Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
+            }
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string documentA = @"The food and service were unacceptable, but the concierge were nice.
                                 After talking to them about the quality of the food and the process
                                 to get room service they refunded the money we spent at the restaurant and
-                                gave us a voucher for near by restaurants.";
+                                gave us a voucher for nearby restaurants.";
 
             string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
                                 sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatch.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -22,76 +21,94 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:TextAnalyticsSample2AnalyzeSentimentBatch
+            string documentA = @"The food and service were unacceptable, but the concierge were nice.
+                                After talking to them about the quality of the food and the process
+                                to get room service they refunded the money we spent at the restaurant and
+                                gave us a voucher for near by restaurants.";
+
+            string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                                sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                                La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                                El próximo año volveremos.";
+
+            string documentC = @"The rooms were beautiful. The AC was good and quiet, which was key for us as outside
+                                it was 100F and our baby was getting uncomfortable because of the heat. The breakfast
+                                was good too with good options and good servicing times.
+                                The thing we didn't like was that the toilet in our bathroom was smelly.
+                                It could have been that the toilet was not cleaned before we arrived.
+                                Either way it was very uncomfortable. Once we notified the staff, they came and cleaned
+                                it and left candles.";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "That was the best day of my life!")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "This food is very bad. Everyone who ate with us got sick.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("3", "I'm not sure how I feel about this product.")
-                {
-                     Language = "en",
-                },
-                new TextDocumentInput("4", "Pike Place Market is my favorite Seattle attraction.  We had so much fun there.")
-                {
-                     Language = "en",
-                }
+                new TextDocumentInput("4", string.Empty)
             };
 
-            AnalyzeSentimentResultCollection results = client.AnalyzeSentimentBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
-            #endregion
+            var options = new AnalyzeSentimentOptions { IncludeStatistics = true };
+
+            Response<AnalyzeSentimentResultCollection> response = client.AnalyzeSentimentBatch(documents, options);
+            AnalyzeSentimentResultCollection sentimentPerDocuments = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{sentimentPerDocuments.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (AnalyzeSentimentResult result in results)
+            foreach (AnalyzeSentimentResult sentimentInDocument in sentimentPerDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (sentimentInDocument.HasError)
                 {
-                    Console.WriteLine($"    Document error: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {sentimentInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {sentimentInDocument.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine($"Document sentiment is {result.DocumentSentiment.Sentiment}, with confidence scores: ");
-                    Console.WriteLine($"    Positive confidence score: {result.DocumentSentiment.ConfidenceScores.Positive}.");
-                    Console.WriteLine($"    Neutral confidence score: {result.DocumentSentiment.ConfidenceScores.Neutral}.");
-                    Console.WriteLine($"    Negative confidence score: {result.DocumentSentiment.ConfidenceScores.Negative}.");
+                    Console.WriteLine($"Document sentiment is {sentimentInDocument.DocumentSentiment.Sentiment}, with confidence scores: ");
+                    Console.WriteLine($"  Positive confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Positive}.");
+                    Console.WriteLine($"  Neutral confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Neutral}.");
+                    Console.WriteLine($"  Negative confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Negative}.");
+                    Console.WriteLine("");
+                    Console.WriteLine($"  Sentence sentiment results:");
 
-                    Console.WriteLine($"    Sentence sentiment results:");
-
-                    foreach (SentenceSentiment sentenceSentiment in result.DocumentSentiment.Sentences)
+                    foreach (SentenceSentiment sentimentInSentence in sentimentInDocument.DocumentSentiment.Sentences)
                     {
-                        Console.WriteLine($"    For sentence: \"{sentenceSentiment.Text}\"");
-                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}");
-                        Console.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with confidence scores: ");
-                        Console.WriteLine($"        Positive confidence score: {sentenceSentiment.ConfidenceScores.Positive}.");
-                        Console.WriteLine($"        Neutral confidence score: {sentenceSentiment.ConfidenceScores.Neutral}.");
-                        Console.WriteLine($"        Negative confidence score: {sentenceSentiment.ConfidenceScores.Negative}.");
+                        Console.WriteLine($"  For sentence: \"{sentimentInSentence.Text}\"");
+                        Console.WriteLine($"  Sentiment is {sentimentInSentence.Sentiment}, with confidence scores: ");
+                        Console.WriteLine($"    Positive confidence score: {sentimentInSentence.ConfidenceScores.Positive}.");
+                        Console.WriteLine($"    Neutral confidence score: {sentimentInSentence.ConfidenceScores.Neutral}.");
+                        Console.WriteLine($"    Negative confidence score: {sentimentInSentence.ConfidenceScores.Negative}.");
+                        Console.WriteLine("");
                     }
 
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Console.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {sentimentInDocument.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {sentimentInDocument.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
             Console.WriteLine($"Batch operation statistics:");
-            Console.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Console.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Console.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Console.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
-            Console.WriteLine("");
+            Console.WriteLine($"  Document count: {sentimentPerDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {sentimentPerDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {sentimentPerDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {sentimentPerDocuments.Statistics.TransactionCount}");
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string documentA = @"The food and service were unacceptable, but the concierge were nice.
                                 After talking to them about the quality of the food and the process
                                 to get room service they refunded the money we spent at the restaurant and
-                                gave us a voucher for near by restaurants.";
+                                gave us a voucher for nearby restaurants.";
 
             string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
                                 sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchAsync.cs
@@ -21,75 +21,93 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-                var documents = new List<TextDocumentInput>
+            string documentA = @"The food and service were unacceptable, but the concierge were nice.
+                                After talking to them about the quality of the food and the process
+                                to get room service they refunded the money we spent at the restaurant and
+                                gave us a voucher for near by restaurants.";
+
+            string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                                sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                                La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                                El próximo año volveremos.";
+
+            string documentC = @"The rooms were beautiful. The AC was good and quiet, which was key for us as outside
+                                it was 100F and our baby was getting uncomfortable because of the heat. The breakfast
+                                was good too with good options and good servicing times.
+                                The thing we didn't like was that the toilet in our bathroom was smelly.
+                                It could have been that the toilet was not cleaned before we arrived.
+                                Either way it was very uncomfortable. Once we notified the staff, they came and cleaned
+                                it and left candles.";
+
+            var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "That was the best day of my life!")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "This food is very bad. Everyone who ate with us got sick.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("3", "I'm not sure how I feel about this product.")
-                {
-                     Language = "en",
-                },
-                new TextDocumentInput("4", "Pike Place Market is my favorite Seattle attraction.  We had so much fun there.")
-                {
-                     Language = "en",
-                }
+                new TextDocumentInput("4", string.Empty)
             };
 
-            AnalyzeSentimentResultCollection results = await client.AnalyzeSentimentBatchAsync(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+            var options = new AnalyzeSentimentOptions { IncludeStatistics = true };
+
+            Response<AnalyzeSentimentResultCollection> response = await client.AnalyzeSentimentBatchAsync(documents, options);
+            AnalyzeSentimentResultCollection sentimentPerDocuments = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{sentimentPerDocuments.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (AnalyzeSentimentResult result in results)
+            foreach (AnalyzeSentimentResult sentimentInDocument in sentimentPerDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (sentimentInDocument.HasError)
                 {
-                    Console.WriteLine($"    Document error: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {sentimentInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {sentimentInDocument.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine($"Document sentiment is {result.DocumentSentiment.Sentiment}, with confidence scores: ");
-                    Console.WriteLine($"    Positive confidence score: {result.DocumentSentiment.ConfidenceScores.Positive}.");
-                    Console.WriteLine($"    Neutral confidence score: {result.DocumentSentiment.ConfidenceScores.Neutral}.");
-                    Console.WriteLine($"    Negative confidence score: {result.DocumentSentiment.ConfidenceScores.Negative}.");
+                    Console.WriteLine($"Document sentiment is {sentimentInDocument.DocumentSentiment.Sentiment}, with confidence scores: ");
+                    Console.WriteLine($"  Positive confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Positive}.");
+                    Console.WriteLine($"  Neutral confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Neutral}.");
+                    Console.WriteLine($"  Negative confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Negative}.");
+                    Console.WriteLine("");
+                    Console.WriteLine($"  Sentence sentiment results:");
 
-                    Console.WriteLine($"    Sentence sentiment results:");
-
-                    foreach (SentenceSentiment sentenceSentiment in result.DocumentSentiment.Sentences)
+                    foreach (SentenceSentiment sentimentInSentence in sentimentInDocument.DocumentSentiment.Sentences)
                     {
-                        Console.WriteLine($"    For sentence: \"{sentenceSentiment.Text}\"");
-                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}");
-                        Console.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with confidence scores: ");
-                        Console.WriteLine($"        Positive confidence score: {sentenceSentiment.ConfidenceScores.Positive}.");
-                        Console.WriteLine($"        Neutral confidence score: {sentenceSentiment.ConfidenceScores.Neutral}.");
-                        Console.WriteLine($"        Negative confidence score: {sentenceSentiment.ConfidenceScores.Negative}.");
+                        Console.WriteLine($"  For sentence: \"{sentimentInSentence.Text}\"");
+                        Console.WriteLine($"  Sentiment is {sentimentInSentence.Sentiment}, with confidence scores: ");
+                        Console.WriteLine($"    Positive confidence score: {sentimentInSentence.ConfidenceScores.Positive}.");
+                        Console.WriteLine($"    Neutral confidence score: {sentimentInSentence.ConfidenceScores.Neutral}.");
+                        Console.WriteLine($"    Negative confidence score: {sentimentInSentence.ConfidenceScores.Negative}.");
+                        Console.WriteLine("");
                     }
 
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Console.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {sentimentInDocument.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {sentimentInDocument.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
             Console.WriteLine($"Batch operation statistics:");
-            Console.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Console.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Console.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Console.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
-            Console.WriteLine("");
+            Console.WriteLine($"  Document count: {sentimentPerDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {sentimentPerDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {sentimentPerDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {sentimentPerDocuments.Statistics.TransactionCount}");
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string documentA = @"The food and service were unacceptable, but the concierge were nice.
                                 After talking to them about the quality of the food and the process
                                 to get room service they refunded the money we spent at the restaurant and
-                                gave us a voucher for near by restaurants.";
+                                gave us a voucher for nearby restaurants.";
 
             string documentB = @"Nice rooms! I had a great unobstructed view of the Microsoft campus but bathrooms
                                 were old and the toilet was dirty when we arrived. It was close to bus stops and

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenience.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -21,33 +20,74 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            #region Snippet:TextAnalyticsSample2AnalyzeSentimentConvenience
+            string documentA = @"The food and service were unacceptable, but the concierge were nice.
+                                After talking to them about the quality of the food and the process
+                                to get room service they refunded the money we spent at the restaurant and
+                                gave us a voucher for near by restaurants.";
+
+            string documentB = @"Nice rooms! I had a great unobstructed view of the Microsoft campus but bathrooms
+                                were old and the toilet was dirty when we arrived. It was close to bus stops and
+                                groceries stores.
+                                If you want to be close to campus I will recommend it, otherwise, might be
+                                better to stay in a cleaner one";
+
+            string documentC = @"The rooms were beautiful. The AC was good and quiet, which was key for us as outside
+                                it was 100F and our baby was getting uncomfortable because of the heat. The breakfast
+                                was good too with good options and good servicing times.
+                                The thing we didn't like was that the toilet in our bathroom was smelly.
+                                It could have been that the toilet was not cleaned before we arrived.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "That was the best day of my life!",
-                "This food is very bad.",
-                "I'm not sure how I feel about this product.",
-                "Pike place market is my favorite Seattle attraction.",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            Debug.WriteLine($"Analyzing sentiment for documents:");
-            foreach (string document in documents)
-            {
-                Debug.WriteLine($"    {document}");
-            }
+            Response<AnalyzeSentimentResultCollection> response = client.AnalyzeSentimentBatch(documents);
+            AnalyzeSentimentResultCollection sentimentPerDocuments = response.Value;
 
-            #region Snippet:TextAnalyticsSample2AnalyzeSentimentConvenience
-            AnalyzeSentimentResultCollection results = client.AnalyzeSentimentBatch(documents);
+            int i = 0;
+            Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{sentimentPerDocuments.ModelVersion}\"");
+            Console.WriteLine("");
+
+            foreach (AnalyzeSentimentResult sentimentInDocument in sentimentPerDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (sentimentInDocument.HasError)
+                {
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {sentimentInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {sentimentInDocument.Error.Message}");
+                }
+                else
+                {
+                    Console.WriteLine($"Document sentiment is {sentimentInDocument.DocumentSentiment.Sentiment}, with confidence scores: ");
+                    Console.WriteLine($"  Positive confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Positive}.");
+                    Console.WriteLine($"  Neutral confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Neutral}.");
+                    Console.WriteLine($"  Negative confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Negative}.");
+                    Console.WriteLine("");
+                    Console.WriteLine($"  Sentence sentiment results:");
+
+                    foreach (SentenceSentiment sentimentInSentence in sentimentInDocument.DocumentSentiment.Sentences)
+                    {
+                        Console.WriteLine($"  For sentence: \"{sentimentInSentence.Text}\"");
+                        Console.WriteLine($"  Sentiment is {sentimentInSentence.Sentiment}, with confidence scores: ");
+                        Console.WriteLine($"    Positive confidence score: {sentimentInSentence.ConfidenceScores.Positive}.");
+                        Console.WriteLine($"    Neutral confidence score: {sentimentInSentence.ConfidenceScores.Neutral}.");
+                        Console.WriteLine($"    Negative confidence score: {sentimentInSentence.ConfidenceScores.Negative}.");
+                        Console.WriteLine("");
+                    }
+                }
+                Console.WriteLine("");
+            }
             #endregion
-
-            Debug.WriteLine($"Predicted sentiments are:");
-            foreach (AnalyzeSentimentResult result in results)
-            {
-                DocumentSentiment docSentiment = result.DocumentSentiment;
-                Debug.WriteLine($"Document sentiment is {docSentiment.Sentiment}, with confidence scores: ");
-                Debug.WriteLine($"    Positive confidence score: {docSentiment.ConfidenceScores.Positive}.");
-                Debug.WriteLine($"    Neutral confidence score: {docSentiment.ConfidenceScores.Neutral}.");
-                Debug.WriteLine($"    Negative confidence score: {docSentiment.ConfidenceScores.Negative}.");
-            }
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
@@ -24,7 +24,7 @@ namespace Azure.AI.TextAnalytics.Samples
             string documentA = @"The food and service were unacceptable, but the concierge were nice.
                                 After talking to them about the quality of the food and the process
                                 to get room service they refunded the money we spent at the restaurant and
-                                gave us a voucher for near by restaurants.";
+                                gave us a voucher for nearby restaurants.";
 
             string documentB = @"Nice rooms! I had a great unobstructed view of the Microsoft campus but bathrooms
                                 were old and the toilet was dirty when we arrived. It was close to bus stops and

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample2_AnalyzeSentimentBatchConvenienceAsync.cs
@@ -21,53 +21,71 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"The food and service were unacceptable, but the concierge were nice.
+                                After talking to them about the quality of the food and the process
+                                to get room service they refunded the money we spent at the restaurant and
+                                gave us a voucher for near by restaurants.";
+
+            string documentB = @"Nice rooms! I had a great unobstructed view of the Microsoft campus but bathrooms
+                                were old and the toilet was dirty when we arrived. It was close to bus stops and
+                                groceries stores.
+                                If you want to be close to campus I will recommend it, otherwise, might be
+                                better to stay in a cleaner one";
+
+            string documentC = @"The rooms were beautiful. The AC was good and quiet, which was key for us as outside
+                                it was 100F and our baby was getting uncomfortable because of the heat. The breakfast
+                                was good too with good options and good servicing times.
+                                The thing we didn't like was that the toilet in our bathroom was smelly.
+                                It could have been that the toilet was not cleaned before we arrived.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "That was the best day of my life!",
-                "This food is very bad.",
-                "I'm not sure how I feel about this product.",
-                "Pike place market is my favorite Seattle attraction.",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            AnalyzeSentimentResultCollection results = await client.AnalyzeSentimentBatchAsync(documents);
+            Response<AnalyzeSentimentResultCollection> response = await client.AnalyzeSentimentBatchAsync(documents);
+            AnalyzeSentimentResultCollection sentimentPerDocuments = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"Sentiment Analysis\" Model, version: \"{sentimentPerDocuments.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (AnalyzeSentimentResult result in results)
+            foreach (AnalyzeSentimentResult sentimentInDocument in sentimentPerDocuments)
             {
-                Console.WriteLine($"On document {documents[i++]}");
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
 
-                if (result.HasError)
+                if (sentimentInDocument.HasError)
                 {
-                    Console.WriteLine($"    Document error: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {sentimentInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {sentimentInDocument.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine($"Document sentiment is {result.DocumentSentiment.Sentiment}, with confidence scores: ");
-                    Console.WriteLine($"    Positive confidence score: {result.DocumentSentiment.ConfidenceScores.Positive}.");
-                    Console.WriteLine($"    Neutral confidence score: {result.DocumentSentiment.ConfidenceScores.Neutral}.");
-                    Console.WriteLine($"    Negative confidence score: {result.DocumentSentiment.ConfidenceScores.Negative}.");
-
-                    Console.WriteLine($"    Sentence sentiment results:");
-
-                    foreach (SentenceSentiment sentenceSentiment in result.DocumentSentiment.Sentences)
-                    {
-                        Console.WriteLine($"    For sentence: \"{sentenceSentiment.Text}\"");
-                        Console.WriteLine($"    Offset (in UTF-16 code units): {sentenceSentiment.Offset}");
-                        Console.WriteLine($"    Sentiment is {sentenceSentiment.Sentiment}, with confidence scores: ");
-                        Console.WriteLine($"        Positive confidence score: {sentenceSentiment.ConfidenceScores.Positive}.");
-                        Console.WriteLine($"        Neutral confidence score: {sentenceSentiment.ConfidenceScores.Neutral}.");
-                        Console.WriteLine($"        Negative confidence score: {sentenceSentiment.ConfidenceScores.Negative}.");
-                    }
-
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
+                    Console.WriteLine($"Document sentiment is {sentimentInDocument.DocumentSentiment.Sentiment}, with confidence scores: ");
+                    Console.WriteLine($"  Positive confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Positive}.");
+                    Console.WriteLine($"  Neutral confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Neutral}.");
+                    Console.WriteLine($"  Negative confidence score: {sentimentInDocument.DocumentSentiment.ConfidenceScores.Negative}.");
                     Console.WriteLine("");
+                    Console.WriteLine($"  Sentence sentiment results:");
+
+                    foreach (SentenceSentiment sentimentInSentence in sentimentInDocument.DocumentSentiment.Sentences)
+                    {
+                        Console.WriteLine($"  For sentence: \"{sentimentInSentence.Text}\"");
+                        Console.WriteLine($"  Sentiment is {sentimentInSentence.Sentiment}, with confidence scores: ");
+                        Console.WriteLine($"    Positive confidence score: {sentimentInSentence.ConfidenceScores.Positive}.");
+                        Console.WriteLine($"    Neutral confidence score: {sentimentInSentence.ConfidenceScores.Neutral}.");
+                        Console.WriteLine($"    Negative confidence score: {sentimentInSentence.ConfidenceScores.Negative}.");
+                        Console.WriteLine("");
+                    }
                 }
+                Console.WriteLine("");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
 
             #region Snippet:ExtractKeyPhrases
             string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
-                                little sister thinks it is funny, I a worried it has the cold that I got last week.
+                                little sister thinks it is funny, I am worried it has the cold that I got last week.
                                 We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
                                 will be covered by the cat's insurance.
                                 It might be good to not let it sleep in my room for a while.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrases.cs
@@ -16,19 +16,30 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
-            #region Snippet:TextAnalyticsSample3CreateClient
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            #endregion
 
             #region Snippet:ExtractKeyPhrases
-            string document = "My cat might need to see a veterinarian.";
+            string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
+                                little sister thinks it is funny, I a worried it has the cold that I got last week.
+                                We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
+                                will be covered by the cat's insurance.
+                                It might be good to not let it sleep in my room for a while.";
 
-            KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
-
-            Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
-            foreach (string keyPhrase in keyPhrases)
+            try
             {
-                Console.WriteLine(keyPhrase);
+                Response<KeyPhraseCollection> response = client.ExtractKeyPhrases(document);
+                KeyPhraseCollection keyPhrases = response.Value;
+
+                Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
+                foreach (string keyPhrase in keyPhrases)
+                {
+                    Console.WriteLine($"  {keyPhrase}");
+                }
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs
@@ -20,7 +20,7 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
-                                little sister thinks it is funny, I a worried it has the cold that I got last week.
+                                little sister thinks it is funny, I am worried it has the cold that I got last week.
                                 We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
                                 will be covered by the cat's insurance.
                                 It might be good to not let it sleep in my room for a while.";

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesAsync.cs
@@ -19,14 +19,27 @@ namespace Azure.AI.TextAnalytics.Samples
 
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string document = "My cat might need to see a veterinarian.";
+            string document = @"My cat might need to see a veterinarian. It has been sneezing more than normal, and although my 
+                                little sister thinks it is funny, I a worried it has the cold that I got last week.
+                                We are going to call tomorrow and try to schedule an appointment for this week. Hopefully it
+                                will be covered by the cat's insurance.
+                                It might be good to not let it sleep in my room for a while.";
 
-            KeyPhraseCollection keyPhrases = await client.ExtractKeyPhrasesAsync(document);
-
-            Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
-            foreach (string keyPhrase in keyPhrases)
+            try
             {
-                Console.WriteLine(keyPhrase);
+                Response<KeyPhraseCollection> response = await client.ExtractKeyPhrasesAsync(document);
+                KeyPhraseCollection keyPhrases = response.Value;
+
+                Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
+                foreach (string keyPhrase in keyPhrases)
+                {
+                    Console.WriteLine($"  {keyPhrase}");
+                }
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatch.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
@@ -23,62 +22,84 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:TextAnalyticsSample3ExtractKeyPhrasesBatch
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                                sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                                La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                                El próximo año volveremos.";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "Microsoft was founded by Bill Gates and Paul Allen.")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "Text Analytics is one of the Azure Cognitive Services.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("3", "My cat might need to see a veterinarian.")
-                {
-                     Language = "en",
-                }
+                new TextDocumentInput("4", string.Empty)
             };
 
-            ExtractKeyPhrasesResultCollection results = client.ExtractKeyPhrasesBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
-            #endregion
+            var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+            Response<ExtractKeyPhrasesResultCollection> response = client.ExtractKeyPhrasesBatch(documents, options);
+            ExtractKeyPhrasesResultCollection keyPhrasesInDocuments = response.Value;
 
             int i = 0;
-            Debug.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{results.ModelVersion}\"");
-            Debug.WriteLine("");
+            Console.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{keyPhrasesInDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-            foreach (ExtractKeyPhrasesResult result in results)
+            foreach (ExtractKeyPhrasesResult keyPhrases in keyPhrasesInDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (keyPhrases.HasError)
                 {
-                    Debug.WriteLine($"    Document error: {result.Error.ErrorCode}.");
-                    Debug.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {keyPhrases.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {keyPhrases.Error.Message}");
                 }
                 else
                 {
-                    Debug.WriteLine($"    Extracted the following {result.KeyPhrases.Count()} key phrases:");
+                    Console.WriteLine($"  Extracted the following {keyPhrases.KeyPhrases.Count()} key phrases:");
 
-                    foreach (string keyPhrase in result.KeyPhrases)
+                    foreach (string keyPhrase in keyPhrases.KeyPhrases)
                     {
-                        Debug.WriteLine($"        {keyPhrase}");
+                        Console.WriteLine($"    {keyPhrase}");
                     }
 
-                    Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Debug.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {keyPhrases.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {keyPhrases.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
-            Debug.WriteLine($"Batch operation statistics:");
-            Debug.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Debug.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Debug.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Debug.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
-            Debug.WriteLine("");
+            Console.WriteLine($"Batch operation statistics:");
+            Console.WriteLine($"  Document count: {keyPhrasesInDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {keyPhrasesInDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {keyPhrasesInDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {keyPhrasesInDocuments.Statistics.TransactionCount}");
+            Console.WriteLine("");
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchAsync.cs
@@ -22,60 +22,82 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                                sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                                La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                                El próximo año volveremos.";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "Microsoft was founded by Bill Gates and Paul Allen.")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "Text Analytics is one of the Azure Cognitive Services.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("3", "My cat might need to see a veterinarian.")
-                {
-                     Language = "en",
-                }
+                new TextDocumentInput("4", string.Empty)
             };
 
-            ExtractKeyPhrasesResultCollection results = await client.ExtractKeyPhrasesBatchAsync(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+            var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+            Response<ExtractKeyPhrasesResultCollection> response = await client.ExtractKeyPhrasesBatchAsync(documents, options);
+            ExtractKeyPhrasesResultCollection keyPhrasesInDocuments = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{keyPhrasesInDocuments.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (ExtractKeyPhrasesResult result in results)
+            foreach (ExtractKeyPhrasesResult keyPhrases in keyPhrasesInDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (keyPhrases.HasError)
                 {
-                    Console.WriteLine($"    Document error: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {keyPhrases.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {keyPhrases.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine($"    Extracted the following {result.KeyPhrases.Count()} key phrases:");
+                    Console.WriteLine($"  Extracted the following {keyPhrases.KeyPhrases.Count()} key phrases:");
 
-                    foreach (string keyPhrase in result.KeyPhrases)
+                    foreach (string keyPhrase in keyPhrases.KeyPhrases)
                     {
-                        Console.WriteLine($"        {keyPhrase}");
+                        Console.WriteLine($"    {keyPhrase}");
                     }
 
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Console.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {keyPhrases.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {keyPhrases.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
             Console.WriteLine($"Batch operation statistics:");
-            Console.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Console.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Console.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Console.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
+            Console.WriteLine($"  Document count: {keyPhrasesInDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {keyPhrasesInDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {keyPhrasesInDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {keyPhrasesInDocuments.Statistics.TransactionCount}");
             Console.WriteLine("");
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenience.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
@@ -22,29 +21,64 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            #region Snippet:TextAnalyticsSample3ExtractKeyPhrasesConvenience
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Last week we stayed at Hotel Foo to celebrate our anniversary. The staff knew about
+                                our anniversary so they helped me organize a little surprise for my partner.
+                                The room was clean and with the decoration I requested. It was perfect!";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "Microsoft was founded by Bill Gates and Paul Allen.",
-                "Text Analytics is one of the Azure Cognitive Services.",
-                "My cat might need to see a veterinarian.",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            #region Snippet:TextAnalyticsSample3ExtractKeyPhrasesConvenience
-            ExtractKeyPhrasesResultCollection results = client.ExtractKeyPhrasesBatch(documents);
-            #endregion
+            Response<ExtractKeyPhrasesResultCollection> response = client.ExtractKeyPhrasesBatch(documents);
+            ExtractKeyPhrasesResultCollection keyPhrasesInDocuments = response.Value;
 
-            Debug.WriteLine($"Extracted key phrases for each document are:");
             int i = 0;
-            foreach (ExtractKeyPhrasesResult result in results)
-            {
-                Debug.WriteLine($"For document: \"{documents[i++]}\",");
-                Debug.WriteLine($"the following {result.KeyPhrases.Count()} key phrases were found: ");
+            Console.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{keyPhrasesInDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                foreach (string keyPhrase in result.KeyPhrases)
+            foreach (ExtractKeyPhrasesResult keyPhrases in keyPhrasesInDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (keyPhrases.HasError)
                 {
-                    Debug.WriteLine($"    {keyPhrase}");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {keyPhrases.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {keyPhrases.Error.Message}");
                 }
+                else
+                {
+                    Console.WriteLine($"  Extracted the following {keyPhrases.KeyPhrases.Count()} key phrases:");
+
+                    foreach (string keyPhrase in keyPhrases.KeyPhrases)
+                    {
+                        Console.WriteLine($"    {keyPhrase}");
+                    }
+                }
+                Console.WriteLine("");
             }
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesBatchConvenienceAsync.cs
@@ -22,26 +22,61 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Last week we stayed at Hotel Foo to celebrate our anniversary. The staff knew about
+                                our anniversary so they helped me organize a little surprise for my partner.
+                                The room was clean and with the decoration I requested. It was perfect!";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "Microsoft was founded by Bill Gates and Paul Allen.",
-                "Text Analytics is one of the Azure Cognitive Services.",
-                "My cat might need to see a veterinarian.",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            ExtractKeyPhrasesResultCollection results = await client.ExtractKeyPhrasesBatchAsync(documents);
+            Response<ExtractKeyPhrasesResultCollection> response = await client.ExtractKeyPhrasesBatchAsync(documents);
+            ExtractKeyPhrasesResultCollection keyPhrasesInDocuments = response.Value;
 
-            Console.WriteLine($"Extracted key phrases for each document are:");
             int i = 0;
-            foreach (ExtractKeyPhrasesResult result in results)
-            {
-                Console.WriteLine($"For document: \"{documents[i++]}\",");
-                Console.WriteLine($"the following {result.KeyPhrases.Count()} key phrases were found: ");
+            Console.WriteLine($"Results of Azure Text Analytics \"Extract Key Phrases\" Model, version: \"{keyPhrasesInDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                foreach (string keyPhrase in result.KeyPhrases)
+            foreach (ExtractKeyPhrasesResult keyPhrases in keyPhrasesInDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (keyPhrases.HasError)
                 {
-                    Console.WriteLine($"    {keyPhrase}");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error: {keyPhrases.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {keyPhrases.Error.Message}");
                 }
+                else
+                {
+                    Console.WriteLine($"  Extracted the following {keyPhrases.KeyPhrases.Count()} key phrases:");
+
+                    foreach (string keyPhrase in keyPhrases.KeyPhrases)
+                    {
+                        Console.WriteLine($"    {keyPhrase}");
+                    }
+                }
+                Console.WriteLine("");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample3_ExtractKeyPhrasesWithWarnings.cs
@@ -18,23 +18,33 @@ namespace Azure.AI.TextAnalytics.Samples
 
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string document = "Anthony runs his own personal training business so thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareemittedintheapi";
+            string document = @"Anthony runs his own personal training business so
+                              thisisaverylongtokenwhichwillbetruncatedtoshowushowwarningsareemittedintheapi";
 
-            KeyPhraseCollection keyPhrases = client.ExtractKeyPhrases(document);
-
-            if (keyPhrases.Warnings.Count > 0)
+            try
             {
-                Console.WriteLine("**Warnings:**");
-                foreach (TextAnalyticsWarning warning in keyPhrases.Warnings)
+                Response<KeyPhraseCollection> response = client.ExtractKeyPhrases(document);
+                KeyPhraseCollection keyPhrases = response.Value;
+
+                if (keyPhrases.Warnings.Count > 0)
                 {
-                    Console.WriteLine($"    Warning: Code: {warning.WarningCode}, Message: {warning.Message}");
+                    Console.WriteLine("**Warnings:**");
+                    foreach (TextAnalyticsWarning warning in keyPhrases.Warnings)
+                    {
+                        Console.WriteLine($"  Warning: Code: {warning.WarningCode}, Message: {warning.Message}");
+                    }
+                }
+
+                Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
+                foreach (string keyPhrase in keyPhrases)
+                {
+                    Console.WriteLine($"  {keyPhrase}");
                 }
             }
-
-            Console.WriteLine($"Extracted {keyPhrases.Count} key phrases:");
-            foreach (string keyPhrase in keyPhrases)
+            catch (RequestFailedException exception)
             {
-                Console.WriteLine(keyPhrase);
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntities.cs
@@ -16,20 +16,37 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
-            #region Snippet:TextAnalyticsSample4CreateClient
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            #endregion
 
             #region Snippet:RecognizeEntities
-            string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+            string document = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
 
-            CategorizedEntityCollection entities = client.RecognizeEntities(document);
-
-            Console.WriteLine($"Recognized {entities.Count} entities:");
-            foreach (CategorizedEntity entity in entities)
+            try
             {
-                Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-                Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                Response<CategorizedEntityCollection> response = client.RecognizeEntities(document);
+                CategorizedEntityCollection entitiesInDocument = response.Value;
+
+                Console.WriteLine($"Recognized {entitiesInDocument.Count} entities:");
+                foreach (CategorizedEntity entity in entitiesInDocument)
+                {
+                    Console.WriteLine($"  Text: {entity.Text}");
+                    Console.WriteLine($"  Offset: {entity.Offset}");
+                    Console.WriteLine($"  Category: {entity.Category}");
+                    if (!string.IsNullOrEmpty(entity.SubCategory))
+                        Console.WriteLine($"  SubCategory: {entity.SubCategory}");
+                    Console.WriteLine($"  Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine("");
+                }
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesAsync.cs
@@ -21,15 +21,34 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:RecognizeEntitiesAsync
-            string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+            string document = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
 
-            CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document);
-
-            Console.WriteLine($"Recognized {entities.Count} entities:");
-            foreach (CategorizedEntity entity in entities)
+            try
             {
-                Console.WriteLine($"Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-                Console.WriteLine($"Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                Response<CategorizedEntityCollection> response = await client.RecognizeEntitiesAsync(document);
+                CategorizedEntityCollection entitiesInDocument = response.Value;
+
+                Console.WriteLine($"Recognized {entitiesInDocument.Count} entities:");
+                foreach (CategorizedEntity entity in entitiesInDocument)
+                {
+                    Console.WriteLine($"    Text: {entity.Text}");
+                    Console.WriteLine($"    Offset: {entity.Offset}");
+                    Console.WriteLine($"    Category: {entity.Category}");
+                    if (!string.IsNullOrEmpty(entity.SubCategory))
+                        Console.WriteLine($"    SubCategory: {entity.SubCategory}");
+                    Console.WriteLine($"    Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine("");
+                }
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatch.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
@@ -23,63 +22,90 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:TextAnalyticsSample4RecognizeEntitiesBatch
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                                sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                                La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                                El próximo año volveremos.";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "Microsoft was founded by Bill Gates and Paul Allen.")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "Text Analytics is one of the Azure Cognitive Services.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("3", "A key technology in Text Analytics is Named Entity Recognition (NER).")
-                {
-                     Language = "en",
-                }
+                new TextDocumentInput("4", string.Empty)
             };
 
-            RecognizeEntitiesResultCollection results = client.RecognizeEntitiesBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
-            #endregion
+            var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+            Response<RecognizeEntitiesResultCollection> response = client.RecognizeEntitiesBatch(documents, options);
+            RecognizeEntitiesResultCollection entitiesInDocuments = response.Value;
 
             int i = 0;
-            Debug.WriteLine($"Results of Azure Text Analytics \"Named Entity Recognition\" Model, version: \"{results.ModelVersion}\"");
-            Debug.WriteLine("");
+            Console.WriteLine($"Results of Azure Text Analytics \"Named Entity Recognition\" Model, version: \"{entitiesInDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-            foreach (RecognizeEntitiesResult result in results)
+            foreach (RecognizeEntitiesResult entitiesInDocument in entitiesInDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (entitiesInDocument.HasError)
                 {
-                    Debug.WriteLine($"    Document error code: {result.Error.ErrorCode}.");
-                    Debug.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
                 }
                 else
                 {
-                    Debug.WriteLine($"    Recognized the following {result.Entities.Count()} entities:");
+                    Console.WriteLine($"  Recognized the following {entitiesInDocument.Entities.Count()} entities:");
 
-                    foreach (CategorizedEntity entity in result.Entities)
+                    foreach (CategorizedEntity entity in entitiesInDocument.Entities)
                     {
-                        Debug.WriteLine($"        Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-                        Debug.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                        Console.WriteLine($"    Text: {entity.Text}");
+                        Console.WriteLine($"    Offset: {entity.Offset}");
+                        Console.WriteLine($"    Category: {entity.Category}");
+                        if (!string.IsNullOrEmpty(entity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {entity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {entity.ConfidenceScore}");
+                        Console.WriteLine("");
                     }
 
-                    Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Debug.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {entitiesInDocument.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {entitiesInDocument.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
-            Debug.WriteLine($"Batch operation statistics:");
-            Debug.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Debug.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Debug.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Debug.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
-            Debug.WriteLine("");
+            Console.WriteLine($"Batch operation statistics:");
+            Console.WriteLine($"  Document count: {entitiesInDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {entitiesInDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {entitiesInDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {entitiesInDocuments.Statistics.TransactionCount}");
+            Console.WriteLine("");
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchAsync.cs
@@ -22,61 +22,88 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Nos hospedamos en el Hotel Foo la semana pasada por nuestro aniversario. La gerencia
+                                sabía de nuestra celebración y me ayudaron a tenerle una sorpresa a mi pareja.
+                                La habitación estaba limpia y decorada como yo había pedido. Una gran experiencia.
+                                El próximo año volveremos.";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "Microsoft was founded by Bill Gates and Paul Allen.")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "Text Analytics is one of the Azure Cognitive Services.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("3", "A key technology in Text Analytics is Named Entity Recognition (NER).")
-                {
-                     Language = "en",
-                }
+                new TextDocumentInput("4", string.Empty)
             };
 
-            RecognizeEntitiesResultCollection results = await client.RecognizeEntitiesBatchAsync(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
+            var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+            Response<RecognizeEntitiesResultCollection> response = await client.RecognizeEntitiesBatchAsync(documents, options);
+            RecognizeEntitiesResultCollection entitiesInDocuments = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Named Entity Recognition\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"Named Entity Recognition\" Model, version: \"{entitiesInDocuments.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (RecognizeEntitiesResult result in results)
+            foreach (RecognizeEntitiesResult entitiesInDocument in entitiesInDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (entitiesInDocument.HasError)
                 {
-                    Console.WriteLine($"    Document error code: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine($"    Recognized the following {result.Entities.Count()} entities:");
+                    Console.WriteLine($"  Recognized the following {entitiesInDocument.Entities.Count()} entities:");
 
-                    foreach (CategorizedEntity entity in result.Entities)
+                    foreach (CategorizedEntity entity in entitiesInDocument.Entities)
                     {
-                        Console.WriteLine($"        Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-                        Console.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                        Console.WriteLine($"    Text: {entity.Text}");
+                        Console.WriteLine($"    Offset: {entity.Offset}");
+                        Console.WriteLine($"    Category: {entity.Category}");
+                        if (!string.IsNullOrEmpty(entity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {entity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {entity.ConfidenceScore}");
+                        Console.WriteLine("");
                     }
 
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Console.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {entitiesInDocument.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {entitiesInDocument.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
             Console.WriteLine($"Batch operation statistics:");
-            Console.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Console.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Console.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Console.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
+            Console.WriteLine($"  Document count: {entitiesInDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {entitiesInDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {entitiesInDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {entitiesInDocuments.Statistics.TransactionCount}");
             Console.WriteLine("");
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenience.cs
@@ -22,30 +22,70 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            #region Snippet:TextAnalyticsSample4RecognizeEntitiesConvenience
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Last week we stayed at Hotel Foo to celebrate our anniversary. The staff knew about
+                                our anniversary so they helped me organize a little surprise for my partner.
+                                The room was clean and with the decoration I requested. It was perfect!";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "Microsoft was founded by Bill Gates and Paul Allen.",
-                "Text Analytics is one of the Azure Cognitive Services.",
-                "A key technology in Text Analytics is Named Entity Recognition (NER).",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            #region Snippet:TextAnalyticsSample4RecognizeEntitiesConvenience
-            RecognizeEntitiesResultCollection results = client.RecognizeEntitiesBatch(documents);
-            #endregion
+            Response<RecognizeEntitiesResultCollection> response = client.RecognizeEntitiesBatch(documents);
+            RecognizeEntitiesResultCollection entititesPerDocuments = response.Value;
 
-            Debug.WriteLine($"Recognized entities for each document are:");
             int i = 0;
-            foreach (RecognizeEntitiesResult result in results)
-            {
-                Debug.WriteLine($"For document: \"{documents[i++]}\",");
-                Debug.WriteLine($"the following {result.Entities.Count()} entities were found: ");
+            Console.WriteLine($"Results of Azure Text Analytics \"Named Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                foreach (CategorizedEntity entity in result.Entities)
+            foreach (RecognizeEntitiesResult entitiesInDocument in entititesPerDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (entitiesInDocument.HasError)
                 {
-                    Debug.WriteLine($"    Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-                    Debug.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
                 }
+                else
+                {
+                    Console.WriteLine($"  Recognized the following {entitiesInDocument.Entities.Count()} entities:");
+
+                    foreach (CategorizedEntity entity in entitiesInDocument.Entities)
+                    {
+                        Console.WriteLine($"    Text: {entity.Text}");
+                        Console.WriteLine($"    Offset: {entity.Offset}");
+                        Console.WriteLine($"    Category: {entity.Category}");
+                        if (!string.IsNullOrEmpty(entity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {entity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {entity.ConfidenceScore}");
+                        Console.WriteLine("");
+                    }
+                }
+                Console.WriteLine("");
             }
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample4_RecognizeEntitiesBatchConvenienceAsync.cs
@@ -22,27 +22,67 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"We love this trail and make the trip every year. The views are breathtaking and well
+                                worth the hike! Yesterday was foggy though, so we missed the spectacular views.
+                                We tried again today and it was amazing. Everyone in my family liked the trail although
+                                it was too challenging for the less athletic among us.
+                                Not necessarily recommended for small children.
+                                A hotel close to the trail offers services for childcare in case you want that.";
+
+            string documentB = @"Last week we stayed at Hotel Foo to celebrate our anniversary. The staff knew about
+                                our anniversary so they helped me organize a little surprise for my partner.
+                                The room was clean and with the decoration I requested. It was perfect!";
+
+            string documentC = @"That was the best day of my life! We went on a 4 day trip where we stayed at Hotel Foo.
+                                They had great amenities that included an indoor pool, a spa, and a bar.
+                                The spa offered couples massages which were really good. 
+                                The spa was clean and felt very peaceful. Overall the whole experience was great.
+                                We will definitely come back.";
+
+            string documentD = string.Empty;
+
             var documents = new List<string>
             {
-                "Microsoft was founded by Bill Gates and Paul Allen.",
-                "Text Analytics is one of the Azure Cognitive Services.",
-                "A key technology in Text Analytics is Named Entity Recognition (NER).",
+                documentA,
+                documentB,
+                documentC,
+                documentD
             };
 
-            RecognizeEntitiesResultCollection results = await client.RecognizeEntitiesBatchAsync(documents);
+            Response<RecognizeEntitiesResultCollection> response = await client.RecognizeEntitiesBatchAsync(documents);
+            RecognizeEntitiesResultCollection entititesPerDocuments = response.Value;
 
-            Console.WriteLine($"Recognized entities for each document are:");
             int i = 0;
-            foreach (RecognizeEntitiesResult result in results)
-            {
-                Console.WriteLine($"For document: \"{documents[i++]}\",");
-                Console.WriteLine($"the following {result.Entities.Count()} entities were found: ");
+            Console.WriteLine($"Results of Azure Text Analytics \"Named Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                foreach (CategorizedEntity entity in result.Entities)
+            foreach (RecognizeEntitiesResult entitiesInDocument in entititesPerDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (entitiesInDocument.HasError)
                 {
-                    Console.WriteLine($"    Text: {entity.Text}, Offset (in UTF-16 code units): {entity.Offset}");
-                    Console.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
                 }
+                else
+                {
+                    Console.WriteLine($"  Recognized the following {entitiesInDocument.Entities.Count()} entities:");
+
+                    foreach (CategorizedEntity entity in entitiesInDocument.Entities)
+                    {
+                        Console.WriteLine($"    Text: {entity.Text}");
+                        Console.WriteLine($"    Offset: {entity.Offset}");
+                        Console.WriteLine($"    Category: {entity.Category}");
+                        if (!string.IsNullOrEmpty(entity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {entity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {entity.ConfidenceScore}");
+                        Console.WriteLine("");
+                    }
+                }
+                Console.WriteLine("");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntities.cs
@@ -17,27 +17,35 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
-            #region Snippet:TextAnalyticsSample5CreateClient
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            #endregion
 
             #region Snippet:RecognizePiiEntities
-            string document = "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.";
+            string document = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                                Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                                They are originally from Brazil and have document ID number 998.214.865-68";
 
-            PiiEntityCollection entities = client.RecognizePiiEntities(document).Value;
-
-            Console.WriteLine($"Redacted Text: {entities.RedactedText}");
-            if (entities.Count > 0)
+            try
             {
-                Console.WriteLine($"Recognized {entities.Count} PII entit{(entities.Count > 1 ? "ies" : "y")}:");
+                Response<PiiEntityCollection> response = client.RecognizePiiEntities(document);
+                PiiEntityCollection entities = response.Value;
+
+                Console.WriteLine($"Redacted Text: {entities.RedactedText}");
+                Console.WriteLine("");
+                Console.WriteLine($"Recognized {entities.Count} PII entities:");
                 foreach (PiiEntity entity in entities)
                 {
-                    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine($"  Text: {entity.Text}");
+                    Console.WriteLine($"  Category: {entity.Category}");
+                    if (!string.IsNullOrEmpty(entity.SubCategory))
+                        Console.WriteLine($"  SubCategory: {entity.SubCategory}");
+                    Console.WriteLine($"  Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine("");
                 }
             }
-            else
+            catch (RequestFailedException exception)
             {
-                Console.WriteLine("No entities were found.");
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesAsync.cs
@@ -20,22 +20,32 @@ namespace Azure.AI.TextAnalytics.Samples
 
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string document = "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.";
+            string document = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                                Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                                They are originally from Brazil and have document ID number 998.214.865-68";
 
-            PiiEntityCollection entities = await client.RecognizePiiEntitiesAsync(document);
-
-            Console.WriteLine($"Redacted Text: {entities.RedactedText}");
-            if (entities.Count > 0)
+            try
             {
-                Console.WriteLine($"Recognized {entities.Count} PII entit{(entities.Count > 1 ? "ies" : "y")}:");
+                Response<PiiEntityCollection> response = await client.RecognizePiiEntitiesAsync(document);
+                PiiEntityCollection entities = response.Value;
+
+                Console.WriteLine($"Redacted Text: {entities.RedactedText}");
+                Console.WriteLine("");
+                Console.WriteLine($"Recognized {entities.Count} PII entities:");
                 foreach (PiiEntity entity in entities)
                 {
-                    Console.WriteLine($"Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine($"  Text: {entity.Text}");
+                    Console.WriteLine($"  Category: {entity.Category}");
+                    if (!string.IsNullOrEmpty(entity.SubCategory))
+                        Console.WriteLine($"  SubCategory: {entity.SubCategory}");
+                    Console.WriteLine($"  Confidence score: {entity.ConfidenceScore}");
+                    Console.WriteLine("");
                 }
             }
-            else
+            catch (RequestFailedException exception)
             {
-                Console.WriteLine("No entities were found.");
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatch.cs
@@ -22,65 +22,84 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:TextAnalyticsSample5RecognizePiiEntitiesBatch
+            string documentA = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                                Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                                They are originally from Brazil and have document ID number 998.214.865-68";
+
+            string documentB = @"Hoy recibí una llamada al medio día del usuario Juanito Perez, quien preguntaba
+                                cómo acceder a su nuevo correo electrónico. Este trabaja en Microsoft y su correo es
+                                juanito.perez@contoso.com. El usuario accedió a compartir su número para futuras comunicaciones.
+                                El número es 800-102-1101";
+
+            string documentC = @"Yesterday, Dan Doe was asking where they could find the ABA number. I explained
+                                that it is the first 9 digits in the lower left hand corner of their personal check.
+                                After looking at their account they confirmed the number was 111000025";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 }
             };
 
-            RecognizePiiEntitiesResultCollection results = client.RecognizePiiEntitiesBatch(documents, new RecognizePiiEntitiesOptions { IncludeStatistics = true });
-            #endregion
+            var options = new RecognizePiiEntitiesOptions { IncludeStatistics = true };
+            Response<RecognizePiiEntitiesResultCollection> response = client.RecognizePiiEntitiesBatch(documents, options);
+            RecognizePiiEntitiesResultCollection entititesPerDocuments = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Pii Entity Recognition\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"PII Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (RecognizePiiEntitiesResult result in results)
+            foreach (RecognizePiiEntitiesResult piiEntititesInDocument in entititesPerDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (piiEntititesInDocument.HasError)
                 {
-                    Console.WriteLine($"    Document error code: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {piiEntititesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {piiEntititesInDocument.Error.Message}");
                 }
                 else
                 {
-                    if (result.Entities.Count > 0)
+                    Console.WriteLine($"  Redacted Text: {piiEntititesInDocument.Entities.RedactedText}");
+                    Console.WriteLine("");
+                    Console.WriteLine($"  Recognized {piiEntititesInDocument.Entities.Count} PII entities:");
+                    foreach (PiiEntity piiEntity in piiEntititesInDocument.Entities)
                     {
-                        Console.WriteLine($"    Redacted Text: {result.Entities.RedactedText}");
-                        Console.WriteLine($"    Recognized the following {result.Entities.Count} PII entit{(result.Entities.Count > 1 ? "ies" : "y ")}:");
-                        foreach (PiiEntity entity in result.Entities)
-                        {
-                            Console.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
-                        }
-                    }
-                    else
-                    {
-                        Console.WriteLine("No entities were found.");
+                        Console.WriteLine($"    Text: {piiEntity.Text}");
+                        Console.WriteLine($"    Category: {piiEntity.Category}");
+                        if (!string.IsNullOrEmpty(piiEntity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {piiEntity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {piiEntity.ConfidenceScore}");
+                        Console.WriteLine("");
                     }
 
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Console.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {piiEntititesInDocument.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {piiEntititesInDocument.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
             Console.WriteLine($"Batch operation statistics:");
-            Console.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Console.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Console.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Console.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
+            Console.WriteLine($"  Document count: {entititesPerDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {entititesPerDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {entititesPerDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {entititesPerDocuments.Statistics.TransactionCount}");
             Console.WriteLine("");
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchAsync.cs
@@ -22,63 +22,82 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                                Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                                They are originally from Brazil and have document ID number 998.214.865-68";
+
+            string documentB = @"Hoy recibí una llamada al medio día del usuario Juanito Perez, quien preguntaba
+                                cómo acceder a su nuevo correo electrónico. Este trabaja en Microsoft y su correo es
+                                juanito.perez@contoso.com. El usuario accedió a compartir su número para futuras comunicaciones.
+                                El número es 800-102-1101";
+
+            string documentC = @"Yesterday, Dan Doe was asking where they could find the ABA number. I explained
+                                that it is the first 9 digits in the lower left hand corner of their personal check.
+                                After looking at their account they confirmed the number was 111000025";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 }
             };
 
-            RecognizePiiEntitiesResultCollection results = await client.RecognizePiiEntitiesBatchAsync(documents, new RecognizePiiEntitiesOptions { IncludeStatistics = true });
+            var options = new RecognizePiiEntitiesOptions { IncludeStatistics = true };
+            Response<RecognizePiiEntitiesResultCollection> response = await client.RecognizePiiEntitiesBatchAsync(documents, options);
+            RecognizePiiEntitiesResultCollection entititesPerDocuments = response.Value;
 
             int i = 0;
-            Console.WriteLine($"Results of Azure Text Analytics \"Pii Entity Recognition\" Model, version: \"{results.ModelVersion}\"");
+            Console.WriteLine($"Results of Azure Text Analytics \"PII Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
             Console.WriteLine("");
 
-            foreach (RecognizePiiEntitiesResult result in results)
+            foreach (RecognizePiiEntitiesResult piiEntititesInDocument in entititesPerDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (piiEntititesInDocument.HasError)
                 {
-                    Console.WriteLine($"    Document error code: {result.Error.ErrorCode}.");
-                    Console.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {piiEntititesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {piiEntititesInDocument.Error.Message}");
                 }
                 else
                 {
-                    if (result.Entities.Count > 0)
+                    Console.WriteLine($"  Redacted Text: {piiEntititesInDocument.Entities.RedactedText}");
+                    Console.WriteLine("");
+                    Console.WriteLine($"  Recognized {piiEntititesInDocument.Entities.Count} PII entities:");
+                    foreach (PiiEntity piiEntity in piiEntititesInDocument.Entities)
                     {
-                        Console.WriteLine($"    Redacted Text: {result.Entities.RedactedText}");
-                        Console.WriteLine($"    Recognized the following {result.Entities.Count} PII entit{(result.Entities.Count > 1 ? "ies" : "y ")}:");
-                        foreach (PiiEntity entity in result.Entities)
-                        {
-                            Console.WriteLine($"        Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
-                        }
-                    }
-                    else
-                    {
-                        Console.WriteLine("No entities were found.");
+                        Console.WriteLine($"    Text: {piiEntity.Text}");
+                        Console.WriteLine($"    Category: {piiEntity.Category}");
+                        if (!string.IsNullOrEmpty(piiEntity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {piiEntity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {piiEntity.ConfidenceScore}");
+                        Console.WriteLine("");
                     }
 
-                    Console.WriteLine($"    Document statistics:");
-                    Console.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Console.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Console.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {piiEntititesInDocument.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {piiEntititesInDocument.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
             Console.WriteLine($"Batch operation statistics:");
-            Console.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Console.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Console.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Console.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
+            Console.WriteLine($"  Document count: {entititesPerDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {entititesPerDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {entititesPerDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {entititesPerDocuments.Statistics.TransactionCount}");
             Console.WriteLine("");
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenience.cs
@@ -21,35 +21,60 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            #region Snippet:TextAnalyticsSample5RecognizePiiEntitiesConvenience
+            string documentA = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                                Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                                They are originally from Brazil and have document ID number 998.214.865-68";
+
+            string documentB = @"Yesterday, Dan Doe was asking where they could find the ABA number. I explained
+                                that it is the first 9 digits in the lower left hand corner of their personal check.
+                                After looking at their account they confirmed the number was 111000025";
+
+            string documentC = string.Empty;
+
             var documents = new List<string>
             {
-                "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.",
-                "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."
+                documentA,
+                documentB,
+                documentC
             };
 
-            #region Snippet:TextAnalyticsSample5RecognizePiiEntitiesConvenience
-            RecognizePiiEntitiesResultCollection results = client.RecognizePiiEntitiesBatch(documents);
-            #endregion
+            Response<RecognizePiiEntitiesResultCollection> response = client.RecognizePiiEntitiesBatch(documents);
+            RecognizePiiEntitiesResultCollection entititesPerDocuments = response.Value;
 
             int i = 0;
-            foreach (RecognizePiiEntitiesResult result in results)
-            {
-                Console.WriteLine($"For document: {documents[i++]}");
-                if (result.Entities.Count > 0)
-                {
-                    Console.WriteLine($"Redacted Text: {result.Entities.RedactedText}");
-                    Console.WriteLine($"The following {result.Entities.Count} PII entit{(result.Entities.Count > 1 ? "ies were" : "y was")} found:");
+            Console.WriteLine($"Results of Azure Text Analytics \"PII Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                    foreach (PiiEntity entity in result.Entities)
-                    {
-                        Console.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
-                    }
+            foreach (RecognizePiiEntitiesResult piiEntititesInDocument in entititesPerDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (piiEntititesInDocument.HasError)
+                {
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {piiEntititesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {piiEntititesInDocument.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine("No entities were found.");
+                    Console.WriteLine($"  Redacted Text: {piiEntititesInDocument.Entities.RedactedText}");
+                    Console.WriteLine("");
+                    Console.WriteLine($"  Recognized {piiEntititesInDocument.Entities.Count} PII entities:");
+                    foreach (PiiEntity piiEntity in piiEntititesInDocument.Entities)
+                    {
+                        Console.WriteLine($"    Text: {piiEntity.Text}");
+                        Console.WriteLine($"    Category: {piiEntity.Category}");
+                        if (!string.IsNullOrEmpty(piiEntity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {piiEntity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {piiEntity.ConfidenceScore}");
+                        Console.WriteLine("");
+                    }
                 }
+                Console.WriteLine("");
             }
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample5_RecognizePiiEntitiesBatchConvenienceAsync.cs
@@ -22,32 +22,57 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"Parker Doe has repaid all of their loans as of 2020-04-25.
+                                Their SSN is 859-98-0987. To contact them, use their phone number 800-102-1100.
+                                They are originally from Brazil and have document ID number 998.214.865-68";
+
+            string documentB = @"Yesterday, Dan Doe was asking where they could find the ABA number. I explained
+                                that it is the first 9 digits in the lower left hand corner of their personal check.
+                                After looking at their account they confirmed the number was 111000025";
+
+            string documentC = string.Empty;
+
             var documents = new List<string>
             {
-                "A developer with SSN 859-98-0987 whose phone number is 800-102-1100 is building tools with our APIs.",
-                "Your ABA number - 111000025 - is the first 9 digits in the lower left hand corner of your personal check."
+                documentA,
+                documentB,
+                documentC
             };
 
-            RecognizePiiEntitiesResultCollection results = await client.RecognizePiiEntitiesBatchAsync(documents);
+            Response<RecognizePiiEntitiesResultCollection> response = await client.RecognizePiiEntitiesBatchAsync(documents);
+            RecognizePiiEntitiesResultCollection entititesPerDocuments = response.Value;
 
             int i = 0;
-            foreach (RecognizePiiEntitiesResult result in results)
-            {
-                Console.WriteLine($"For document: {documents[i++]}");
-                if (result.Entities.Count > 0)
-                {
-                    Console.WriteLine($"Redacted Text: {result.Entities.RedactedText}");
-                    Console.WriteLine($"The following {result.Entities.Count} PII entit{(result.Entities.Count > 1 ? "ies were" : "y was")} found:");
+            Console.WriteLine($"Results of Azure Text Analytics \"PII Entity Recognition\" Model, version: \"{entititesPerDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                    foreach (PiiEntity entity in result.Entities)
-                    {
-                        Console.WriteLine($"    Text: {entity.Text}, Category: {entity.Category}, SubCategory: {entity.SubCategory}, Confidence score: {entity.ConfidenceScore}");
-                    }
+            foreach (RecognizePiiEntitiesResult piiEntititesInDocument in entititesPerDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (piiEntititesInDocument.HasError)
+                {
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {piiEntititesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {piiEntititesInDocument.Error.Message}");
                 }
                 else
                 {
-                    Console.WriteLine("No entities were found.");
+                    Console.WriteLine($"  Redacted Text: {piiEntititesInDocument.Entities.RedactedText}");
+                    Console.WriteLine("");
+                    Console.WriteLine($"  Recognized {piiEntititesInDocument.Entities.Count} PII entities:");
+                    foreach (PiiEntity piiEntity in piiEntititesInDocument.Entities)
+                    {
+                        Console.WriteLine($"    Text: {piiEntity.Text}");
+                        Console.WriteLine($"    Category: {piiEntity.Category}");
+                        if (!string.IsNullOrEmpty(piiEntity.SubCategory))
+                            Console.WriteLine($"    SubCategory: {piiEntity.SubCategory}");
+                        Console.WriteLine($"    Confidence score: {piiEntity.ConfidenceScore}");
+                        Console.WriteLine("");
+                    }
                 }
+                Console.WriteLine("");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntities.cs
@@ -16,24 +16,41 @@ namespace Azure.AI.TextAnalytics.Samples
             string endpoint = TestEnvironment.Endpoint;
             string apiKey = TestEnvironment.ApiKey;
 
-            #region Snippet:TextAnalyticsSample6CreateClient
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
-            #endregion
 
             #region Snippet:RecognizeLinkedEntities
-            string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+            string document = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                                Steve Ballmer, eventually became CEO after Bill Gates as well. Steve Ballmer eventually stepped
+                                down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                                Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                                headquartered in Redmond";
 
-            LinkedEntityCollection linkedEntities = client.RecognizeLinkedEntities(document);
-
-            Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
-            foreach (LinkedEntity linkedEntity in linkedEntities)
+            try
             {
-                Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
-                foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                Response<LinkedEntityCollection> response = client.RecognizeLinkedEntities(document);
+                LinkedEntityCollection linkedEntities = response.Value;
+
+                Console.WriteLine($"Recognized {linkedEntities.Count} entities:");
+                foreach (LinkedEntity linkedEntity in linkedEntities)
                 {
-                    Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
-                    Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+                    Console.WriteLine($"  Name: {linkedEntity.Name}");
+                    Console.WriteLine($"  Language: {linkedEntity.Language}");
+                    Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+                    Console.WriteLine($"  URL: {linkedEntity.Url}");
+                    Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+                    foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                    {
+                        Console.WriteLine($"    Match Text: {match.Text}");
+                        Console.WriteLine($"    Offset: {match.Offset}");
+                        Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+                    }
+                    Console.WriteLine("");
                 }
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
             #endregion
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesAsync.cs
@@ -19,19 +19,38 @@ namespace Azure.AI.TextAnalytics.Samples
 
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
-            string document = "Microsoft was founded by Bill Gates and Paul Allen.";
+            string document = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                                Steve Ballmer, eventually became CEO after Bill Gates as well. Steve Ballmer eventually stepped
+                                down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                                Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                                headquartered in Redmond";
 
-            LinkedEntityCollection linkedEntities = await client.RecognizeLinkedEntitiesAsync(document);
-
-            Console.WriteLine($"Extracted {linkedEntities.Count} linked entit{(linkedEntities.Count > 1 ? "ies" : "y")}:");
-            foreach (LinkedEntity linkedEntity in linkedEntities)
+            try
             {
-                Console.WriteLine($"Name: {linkedEntity.Name}, Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url}, Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
-                foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                Response<LinkedEntityCollection> response = await client.RecognizeLinkedEntitiesAsync(document);
+                LinkedEntityCollection linkedEntities = response.Value;
+
+                Console.WriteLine($"Recognized {linkedEntities.Count} entities:");
+                foreach (LinkedEntity linkedEntity in linkedEntities)
                 {
-                    Console.WriteLine($"    Match Text: {match.Text}, Offset (in UTF-16 code units): {match.Offset}");
-                    Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+                    Console.WriteLine($"  Name: {linkedEntity.Name}");
+                    Console.WriteLine($"  Language: {linkedEntity.Language}");
+                    Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+                    Console.WriteLine($"  URL: {linkedEntity.Url}");
+                    Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+                    foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                    {
+                        Console.WriteLine($"    Match Text: {match.Text}");
+                        Console.WriteLine($"    Offset: {match.Offset}");
+                        Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+                    }
+                    Console.WriteLine("");
                 }
+            }
+            catch (RequestFailedException exception)
+            {
+                Console.WriteLine($"Error Code: {exception.ErrorCode}");
+                Console.WriteLine($"Message: {exception.Message}");
             }
         }
     }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatch.cs
@@ -5,8 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -23,67 +21,90 @@ namespace Azure.AI.TextAnalytics.Samples
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
             #region Snippet:TextAnalyticsSample6RecognizeLinkedEntitiesBatch
+            string documentA = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                                Steve Ballmer, eventually became CEO after Bill Gates as well.Steve Ballmer eventually stepped
+                                down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                                Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                                headquartered in Redmond";
+
+            string documentB = @"El CEO de Microsoft es Satya Nadella, quien asumió esta posición en Febrero de 2014. Él
+                                empezó como Ingeniero de Software en el año 1992.";
+
+            string documentC = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and 
+                                sell BASIC interpreters for the Altair 8800. During his career at Microsoft, Gates held
+                                the positions of chairman chief executive officer, president and chief software architect
+                                while also being the largest individual shareholder until May 2014.";
+
             var documents = new List<TextDocumentInput>
             {
-                new TextDocumentInput("1", "Microsoft was founded by Bill Gates and Paul Allen.")
+                new TextDocumentInput("1", documentA)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("2", "Text Analytics is one of the Azure Cognitive Services.")
+                new TextDocumentInput("2", documentB)
+                {
+                     Language = "es",
+                },
+                new TextDocumentInput("3", documentC)
                 {
                      Language = "en",
                 },
-                new TextDocumentInput("3", "Pike place market is my favorite Seattle attraction.")
-                {
-                     Language = "en",
-                }
+                new TextDocumentInput("4", string.Empty)
             };
 
-            RecognizeLinkedEntitiesResultCollection results = client.RecognizeLinkedEntitiesBatch(documents, new TextAnalyticsRequestOptions { IncludeStatistics = true });
-            #endregion
+            var options = new TextAnalyticsRequestOptions { IncludeStatistics = true };
+            Response<RecognizeLinkedEntitiesResultCollection> response = client.RecognizeLinkedEntitiesBatch(documents, options);
+            RecognizeLinkedEntitiesResultCollection entitiesPerDocuments = response.Value;
 
             int i = 0;
-            Debug.WriteLine($"Results of Azure Text Analytics \"Entity Linking\", version: \"{results.ModelVersion}\"");
-            Debug.WriteLine("");
+            Console.WriteLine($"Results of Azure Text Analytics \"Entity Linking\", version: \"{entitiesPerDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-            foreach (RecognizeLinkedEntitiesResult result in results)
+            foreach (RecognizeLinkedEntitiesResult entitiesInDocument in entitiesPerDocuments)
             {
                 TextDocumentInput document = documents[i++];
 
-                Debug.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\", Text=\"{document.Text}\"):");
+                Console.WriteLine($"On document (Id={document.Id}, Language=\"{document.Language}\"):");
 
-                if (result.HasError)
+                if (entitiesInDocument.HasError)
                 {
-                    Debug.WriteLine($"    Document error code: {result.Error.ErrorCode}.");
-                    Debug.WriteLine($"    Message: {result.Error.Message}.");
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
                 }
                 else
                 {
-                    Debug.WriteLine($"    Extracted the following {result.Entities.Count()} linked entities:");
-
-                    foreach (LinkedEntity linkedEntity in result.Entities)
+                    Console.WriteLine($"Recognized {entitiesInDocument.Entities.Count} entities:");
+                    foreach (LinkedEntity linkedEntity in entitiesInDocument.Entities)
                     {
-                        Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
+                        Console.WriteLine($"  Name: {linkedEntity.Name}");
+                        Console.WriteLine($"  Language: {linkedEntity.Language}");
+                        Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+                        Console.WriteLine($"  URL: {linkedEntity.Url}");
+                        Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
                         foreach (LinkedEntityMatch match in linkedEntity.Matches)
                         {
-                            Debug.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}");
-                            Debug.WriteLine($"        Confidence score: {match.ConfidenceScore}");
+                            Console.WriteLine($"    Match Text: {match.Text}");
+                            Console.WriteLine($"    Offset: {match.Offset}");
+                            Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
                         }
+                        Console.WriteLine("");
                     }
 
-                    Debug.WriteLine($"    Document statistics:");
-                    Debug.WriteLine($"        Character count (in Unicode graphemes): {result.Statistics.CharacterCount}");
-                    Debug.WriteLine($"        Transaction count: {result.Statistics.TransactionCount}");
-                    Debug.WriteLine("");
+                    Console.WriteLine($"  Document statistics:");
+                    Console.WriteLine($"    Character count: {entitiesInDocument.Statistics.CharacterCount}");
+                    Console.WriteLine($"    Transaction count: {entitiesInDocument.Statistics.TransactionCount}");
                 }
+                Console.WriteLine("");
             }
 
-            Debug.WriteLine($"Batch operation statistics:");
-            Debug.WriteLine($"    Document count: {results.Statistics.DocumentCount}");
-            Debug.WriteLine($"    Valid document count: {results.Statistics.ValidDocumentCount}");
-            Debug.WriteLine($"    Invalid document count: {results.Statistics.InvalidDocumentCount}");
-            Debug.WriteLine($"    Transaction count: {results.Statistics.TransactionCount}");
-            Debug.WriteLine("");
+            Console.WriteLine($"Batch operation statistics:");
+            Console.WriteLine($"  Document count: {entitiesPerDocuments.Statistics.DocumentCount}");
+            Console.WriteLine($"  Valid document count: {entitiesPerDocuments.Statistics.ValidDocumentCount}");
+            Console.WriteLine($"  Invalid document count: {entitiesPerDocuments.Statistics.InvalidDocumentCount}");
+            Console.WriteLine($"  Transaction count: {entitiesPerDocuments.Statistics.TransactionCount}");
+            Console.WriteLine("");
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenience.cs
@@ -5,8 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 namespace Azure.AI.TextAnalytics.Samples
 {
@@ -22,36 +20,67 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            #region Snippet:TextAnalyticsSample6RecognizeLinkedEntitiesConvenience
+            string documentA = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                                Steve Ballmer, eventually became CEO after Bill Gates as well.Steve Ballmer eventually stepped
+                                down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                                Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                                headquartered in Redmond";
+
+            string documentB = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and 
+                                sell BASIC interpreters for the Altair 8800. During his career at Microsoft, Gates held
+                                the positions of chairman chief executive officer, president and chief software architect
+                                while also being the largest individual shareholder until May 2014.";
+
+            string documentC = string.Empty;
+
             var documents = new List<string>
             {
-                "Microsoft was founded by Bill Gates and Paul Allen.",
-                "Text Analytics is one of the Azure Cognitive Services.",
-                "Pike place market is my favorite Seattle attraction.",
+                documentA,
+                documentB,
+                documentC
             };
 
-            #region Snippet:TextAnalyticsSample6RecognizeLinkedEntitiesConvenience
-            RecognizeLinkedEntitiesResultCollection results = client.RecognizeLinkedEntitiesBatch(documents);
-            #endregion
+            Response<RecognizeLinkedEntitiesResultCollection> response = client.RecognizeLinkedEntitiesBatch(documents);
+            RecognizeLinkedEntitiesResultCollection entitiesInDocuments = response.Value;
 
-            Debug.WriteLine($"Linked entities for each document are:\n");
             int i = 0;
-            foreach (RecognizeLinkedEntitiesResult result in results)
-            {
-                Debug.Write($"For document: \"{documents[i++]}\", ");
-                Debug.WriteLine($"extracted {result.Entities.Count()} linked entit{(result.Entities.Count() > 1 ? "ies" : "y")}:");
+            Console.WriteLine($"Results of Azure Text Analytics \"Entity Linking\", version: \"{entitiesInDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                foreach (LinkedEntity linkedEntity in result.Entities)
+            foreach (RecognizeLinkedEntitiesResult entitiesInDocument in entitiesInDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (entitiesInDocument.HasError)
                 {
-                    Debug.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
-                    foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
+                }
+                else
+                {
+                    Console.WriteLine($"Recognized {entitiesInDocument.Entities.Count} entities:");
+                    foreach (LinkedEntity linkedEntity in entitiesInDocument.Entities)
                     {
-                        Debug.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}");
-                        Debug.WriteLine($"        Confidence score: {match.ConfidenceScore}");
+                        Console.WriteLine($"  Name: {linkedEntity.Name}");
+                        Console.WriteLine($"  Language: {linkedEntity.Language}");
+                        Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+                        Console.WriteLine($"  URL: {linkedEntity.Url}");
+                        Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+                        foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                        {
+                            Console.WriteLine($"    Match Text: {match.Text}");
+                            Console.WriteLine($"    Offset: {match.Offset}");
+                            Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+                        }
+                        Console.WriteLine("");
                     }
                 }
-
-                Debug.WriteLine("");
+                Console.WriteLine("");
             }
+            #endregion
         }
     }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenienceAsync.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/Sample6_RecognizeLinkedEntitiesBatchConvenienceAsync.cs
@@ -5,7 +5,6 @@ using Azure.Core.TestFramework;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Azure.AI.TextAnalytics.Samples
@@ -22,32 +21,63 @@ namespace Azure.AI.TextAnalytics.Samples
             // Instantiate a client that will be used to call the service.
             var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
 
+            string documentA = @"Microsoft was founded by Bill Gates with some friends he met at Harvard. One of his friends,
+                                Steve Ballmer, eventually became CEO after Bill Gates as well.Steve Ballmer eventually stepped
+                                down as CEO of Microsoft, and was succeeded by Satya Nadella.
+                                Microsoft originally moved its headquarters to Bellevue, Washington in Januaray 1979, but is now
+                                headquartered in Redmond";
+
+            string documentB = @"Microsoft was founded by Bill Gates and Paul Allen on April 4, 1975, to develop and 
+                                sell BASIC interpreters for the Altair 8800. During his career at Microsoft, Gates held
+                                the positions of chairman chief executive officer, president and chief software architect
+                                while also being the largest individual shareholder until May 2014.";
+
+            string documentC = string.Empty;
+
             var documents = new List<string>
             {
-                "Microsoft was founded by Bill Gates and Paul Allen.",
-                "Text Analytics is one of the Azure Cognitive Services.",
-                "Pike place market is my favorite Seattle attraction.",
+                documentA,
+                documentB,
+                documentC
             };
 
-            RecognizeLinkedEntitiesResultCollection results = await client.RecognizeLinkedEntitiesBatchAsync(documents);
+            Response<RecognizeLinkedEntitiesResultCollection> response = await client.RecognizeLinkedEntitiesBatchAsync(documents);
+            RecognizeLinkedEntitiesResultCollection entitiesPerDocuments = response.Value;
 
-            Console.WriteLine($"Linked entities for each document are:\n");
             int i = 0;
-            foreach (RecognizeLinkedEntitiesResult result in results)
-            {
-                Console.Write($"For document: \"{documents[i++]}\", ");
-                Console.WriteLine($"extracted {result.Entities.Count()} linked entit{(result.Entities.Count() > 1 ? "ies" : "y")}:");
+            Console.WriteLine($"Results of Azure Text Analytics \"Entity Linking\", version: \"{entitiesPerDocuments.ModelVersion}\"");
+            Console.WriteLine("");
 
-                foreach (LinkedEntity linkedEntity in result.Entities)
+            foreach (RecognizeLinkedEntitiesResult entitiesInDocument in entitiesPerDocuments)
+            {
+                Console.WriteLine($"On document with Text: \"{documents[i++]}\"");
+                Console.WriteLine("");
+
+                if (entitiesInDocument.HasError)
                 {
-                    Console.WriteLine($"    Name: \"{linkedEntity.Name}\", Language: {linkedEntity.Language}, Data Source: {linkedEntity.DataSource}, Url: {linkedEntity.Url.ToString()}, Entity Id in Data Source: \"{linkedEntity.DataSourceEntityId}\"");
-                    foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                    Console.WriteLine("  Error!");
+                    Console.WriteLine($"  Document error code: {entitiesInDocument.Error.ErrorCode}.");
+                    Console.WriteLine($"  Message: {entitiesInDocument.Error.Message}");
+                }
+                else
+                {
+                    Console.WriteLine($"Recognized {entitiesInDocument.Entities.Count} entities:");
+                    foreach (LinkedEntity linkedEntity in entitiesInDocument.Entities)
                     {
-                        Console.WriteLine($"        Match Text: \"{match.Text}\", Offset (in UTF-16 code units): {match.Offset}");
-                        Console.WriteLine($"        Confidence score: {match.ConfidenceScore}");
+                        Console.WriteLine($"  Name: {linkedEntity.Name}");
+                        Console.WriteLine($"  Language: {linkedEntity.Language}");
+                        Console.WriteLine($"  Data Source: {linkedEntity.DataSource}");
+                        Console.WriteLine($"  URL: {linkedEntity.Url}");
+                        Console.WriteLine($"  Entity Id in Data Source: {linkedEntity.DataSourceEntityId}");
+                        foreach (LinkedEntityMatch match in linkedEntity.Matches)
+                        {
+                            Console.WriteLine($"    Match Text: {match.Text}");
+                            Console.WriteLine($"    Offset: {match.Offset}");
+                            Console.WriteLine($"    Confidence score: {match.ConfidenceScore}");
+                        }
+                        Console.WriteLine("");
                     }
                 }
-
                 Console.WriteLine("");
             }
         }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/samples/SampleSnippets.cs
@@ -23,8 +23,7 @@ namespace Azure.AI.TextAnalytics.Samples
             #region Snippet:CreateTextAnalyticsClient
             //@@ string endpoint = "<endpoint>";
             //@@ string apiKey = "<apiKey>";
-            var credential = new AzureKeyCredential(apiKey);
-            var client = new TextAnalyticsClient(new Uri(endpoint), credential);
+            var client = new TextAnalyticsClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
             #endregion
         }
 


### PR DESCRIPTION
The cleanup involves:
- Use `Response<T>` instead of implicit cast 
- Showcase try/catch or `HasError` property
- The .md code blocks shouldn't have scroll bars, so avoiding as much as possible
- Use "real" documents instead of one sentence documents. fixes https://github.com/Azure/azure-sdk-for-net/issues/16361
- Remove unused `using`  
- Format output
- Use `Console` instead of `Debug`

It does not include:
- Changes to Healthcare or Analyze Operations as this will change with new design
- Samples driven by real user scenarios

Fixes part of: https://github.com/Azure/azure-sdk-for-net/issues/14833

Apologies for the big PR :(