### PR TITLE
Bump InheritDoc to 1.2.0 and set InheritDocTrimLevel=private

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -55,7 +55,8 @@
     <GenerateAPIListing Condition="'$(IsShippingClientLibrary)' == 'true'">true</GenerateAPIListing>
     <UpdateSourceOnBuild Condition="'$(UpdateSourceOnBuild)' == ''">$(AZURE_DEV_UPDATESOURCESONBUILD)</UpdateSourceOnBuild>
     <PowerShellExe Condition="'$(PowerShellExe)' == ''">pwsh</PowerShellExe>
-    <InheritDocEnabled>false</InheritDocEnabled>
+    <InheritDocEnabled>true</InheritDocEnabled>
+    <InheritDocTrimLevel>private</InheritDocTrimLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsShippingClientLibrary)' == 'true' and '$(TF_BUILD)' == 'true'">

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -199,7 +199,7 @@
 
   <!-- InheritDoc-->
   <ItemGroup>
-    <PackageReference Update="SauceControl.InheritDoc" Version="1.1.1" />
+    <PackageReference Update="SauceControl.InheritDoc" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">


### PR DESCRIPTION
Version 1.2.0 of InheritDoc includes a fix that should address the various CI failures.