### PR TITLE
[Storage][Webjobs] Retry Azurite start

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/Shared/AzuriteNUnitFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/Shared/AzuriteNUnitFixture.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
 using NUnit.Framework;
 
@@ -14,12 +16,29 @@ public class AzuriteNUnitFixture
     [OneTimeSetUp]
     public void SetUp()
     {
-        Instance = new AzuriteFixture();
+        Instance = InitializeAzuriteWithRetry(2);
+    }
+
+    private AzuriteFixture InitializeAzuriteWithRetry(int numberOfTries)
+    {
+        List<Exception> exceptions = null;
+        for (int i = 0; i<numberOfTries; i++)
+        {
+            try
+            {
+                return new AzuriteFixture();
+            } catch (Exception e)
+            {
+                exceptions ??= new List<Exception>();
+                exceptions.Add(e);
+            }
+        }
+        throw new AggregateException(exceptions);
     }
 
     [OneTimeTearDown]
     public void TearDown()
     {
-        Instance.Dispose();
+        Instance?.Dispose();
     }
 }


### PR DESCRIPTION
This is attempt to fix https://github.com/Azure/azure-sdk-for-net/issues/17410 .

The analysis of builds where Azurite couldn't start revealed that:
- Azurite is being stood up once per test assembly
- In one test run there are many test assemblies that run azurite
- Usually it's just one assembly that failed to run Azurite but rest succeeded, which suggest that installation of Azurite is correct

In this PR we add retry on the top of Azurite initialization.