### PR TITLE
Fix(Pipeline): Wait 30 seconds after deployment is done.

### DIFF
--- a/sdk/digitaltwins/test-resources-post.ps1
+++ b/sdk/digitaltwins/test-resources-post.ps1
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# IMPORTANT: Do not invoke this file directly. Please instead run eng/New-TestResources.ps1 from the repository root.
+
+#Requires -Version 6.0
+#Requires -PSEdition Core
+
+# Use same parameter names as declared in eng/New-TestResources.ps1 (assume validation therein).
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    [Parameter()]
+    [hashtable] $DeploymentOutputs,
+
+    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArguments
+)
+
+# By default stop for any error.
+if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
+    $ErrorActionPreference = 'Stop'
+}
+
+function Log($Message) {
+    Write-Host ('{0} - {1}' -f [DateTime]::Now.ToLongTimeString(), $Message)
+}
+
+# Wait 30 seconds before build/test phase.
+Log "Waiting 30 seconds to allow for permissions to propagate before build/test phase."
+Start-Sleep -s 30
+
+Log "Finished waiting for permission propagation."


### PR DESCRIPTION
Based on a conversation with the ADT team, it has been suggested that we wait 30 seconds before making the first API call after the resources have been deployed and role-assignments have been performed to avoid permission issues during test run.