### PR TITLE
[Perf, Stress] Downgrade Azure.Core dependency

### DIFF
--- a/common/Perf/Azure.Test.Perf/Azure.Test.Perf.csproj
+++ b/common/Perf/Azure.Test.Perf/Azure.Test.Perf.csproj
@@ -1,9 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" />
+    <!--
+      Perf framework should depend on lowest version of Azure.Core for maximum compat, allowing test
+      projects to choose a higher version if desired.
+    -->
+    <PackageReference Include="Azure.Core" VersionOverride="1.0.0" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="System.Reflection.Emit" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Threading.Channels" />
     <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>

--- a/common/Stress/Azure.Test.Stress/Azure.Test.Stress.csproj
+++ b/common/Stress/Azure.Test.Stress/Azure.Test.Stress.csproj
@@ -1,9 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" />
+    <!--
+      Stress framework should depend on lowest version of Azure.Core for maximum compat, allowing test
+      projects to choose a higher version if desired.
+    -->
+    <PackageReference Include="Azure.Core" VersionOverride="1.0.0" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="System.Reflection.Emit" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Frameworks should depend on lowest version of Azure.Core for maximum compat