### PR TITLE
Switch live test pipelines to use 1ES pools.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -56,7 +56,8 @@ jobs:
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
-    pool: $(Pool)
+    pool:
+      name: $(Pool)
       vmImage: $(OSVmImage)
 
     ${{ if eq(parameters.UsePlatformContainer, 'true') }}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -66,8 +66,6 @@ jobs:
     steps:
       - ${{ parameters.PreSteps }}
 
-      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-
       - ${{ each step in parameters.TestSetupSteps }}:
         - ${{ each pair in step }}:
             ${{ pair.key }}: ${{ pair.value }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -56,7 +56,7 @@ jobs:
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
-    pool:
+    pool: $(Pool)
       vmImage: $(OSVmImage)
 
     ${{ if eq(parameters.UsePlatformContainer, 'true') }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -53,21 +53,26 @@ parameters:
   type: object
   default:
     Linux_NetCore:
+      Pool:
       OSVmImage: "ubuntu-18.04"
       TestTargetFramework: netcoreapp2.1
     Windows_NetCore:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: netcoreapp2.1
       SupportsRecording: true
     Windows_NetCore_ProjectRefAzureClients:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: netcoreapp2.1
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     Windows_NetFramework:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: net461
     Windows_NetFramework_ProjectRefAzureClients:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: net461
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     MacOS:


### PR DESCRIPTION
This PR makes changes to the pipeline definitions for live tests to make use of the 1ES pools for Windows.