### PR TITLE
1es pool centralcanada test

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -145,6 +145,7 @@ jobs:
           Pool: azsdk-canadacentral-winmms2019 # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net5.0
+          
     pool:
       vmImage: "$(OSVmImage)"
       name: "$(Pool)"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -3,7 +3,7 @@ jobs:
     variables:
       - template: ../variables/globals.yml
     pool:
-      name: azsdk-pool-mms2019-ds2v2-general # Comment this line back-out to switch to public pools.
+      name: azsdk-canadacentral-winmms2019 # Comment this line back-out to switch to public pools.
       # vmImage: windows-2019 # Comment this line back-in to switch to public pools.
     steps:
       - ${{if eq(parameters.TestPipeline, 'true')}}:
@@ -119,21 +119,21 @@ jobs:
           OSVmImage: "ubuntu-18.04"
           TestTargetFramework: netcoreapp2.1
         Windows_NetCoreApp:
-          Pool: azsdk-pool-mms2019-ds2v2-general # Comment out to swap back to public hosted pool.
+          Pool: azsdk-canadacentral-winmms2019 # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: netcoreapp2.1
           CollectCoverage: true
         Windows_NetCoreApp_ProjectReferences:
-          Pool: azsdk-pool-mms2019-ds2v2-general # Comment out to swap back to public hosted pool.
+          Pool: azsdk-canadacentral-winmms2019 # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: netcoreapp2.1
           ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
         Windows_NetFramework:
-          Pool: azsdk-pool-mms2019-ds2v2-general # Comment out to swap back to public hosted pool.
+          Pool: azsdk-canadacentral-winmms2019 # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net461
         Windows_NetFramework_ProjectReferences:
-          Pool: azsdk-pool-mms2019-ds2v2-general # Comment out to swap back to public hosted pool.
+          Pool: azsdk-canadacentral-winmms2019 # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net461
           ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
@@ -142,7 +142,7 @@ jobs:
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
         Windows_Net50:
-          Pool: azsdk-pool-mms2019-ds2v2-general # Comment out to swap back to public hosted pool.
+          Pool: azsdk-canadacentral-winmms2019 # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net5.0
     pool:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -56,7 +56,8 @@ jobs:
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
-    pool: $(Pool)
+    pool:
+      name: $(Pool)
       vmImage: $(OSVmImage)
 
     ${{ if eq(parameters.UsePlatformContainer, 'true') }}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -66,8 +66,6 @@ jobs:
     steps:
       - ${{ parameters.PreSteps }}
 
-      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
-
       - ${{ each step in parameters.TestSetupSteps }}:
         - ${{ each pair in step }}:
             ${{ pair.key }}: ${{ pair.value }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -56,7 +56,7 @@ jobs:
 
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
-    pool:
+    pool: $(Pool)
       vmImage: $(OSVmImage)
 
     ${{ if eq(parameters.UsePlatformContainer, 'true') }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -57,21 +57,21 @@ parameters:
       OSVmImage: "ubuntu-18.04"
       TestTargetFramework: netcoreapp2.1
     Windows_NetCore:
-      Pool: azsdk-pool-mms2019-ds2v2-general
+      Pool: azsdk-canadacentral-winmms2019
       OSVmImage:
       TestTargetFramework: netcoreapp2.1
       SupportsRecording: true
     Windows_NetCore_ProjectRefAzureClients:
-      Pool: azsdk-pool-mms2019-ds2v2-general
+      Pool: azsdk-canadacentral-winmms2019
       OSVmImage:
       TestTargetFramework: netcoreapp2.1
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     Windows_NetFramework:
-      Pool: azsdk-pool-mms2019-ds2v2-general
+      Pool: azsdk-canadacentral-winmms2019
       OSVmImage:
       TestTargetFramework: net461
     Windows_NetFramework_ProjectRefAzureClients:
-      Pool: azsdk-pool-mms2019-ds2v2-general
+      Pool: azsdk-canadacentral-winmms2019
       OSVmImage:
       TestTargetFramework: net461
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -53,21 +53,26 @@ parameters:
   type: object
   default:
     Linux_NetCore:
+      Pool:
       OSVmImage: "ubuntu-18.04"
       TestTargetFramework: netcoreapp2.1
     Windows_NetCore:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: netcoreapp2.1
       SupportsRecording: true
     Windows_NetCore_ProjectRefAzureClients:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: netcoreapp2.1
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     Windows_NetFramework:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: net461
     Windows_NetFramework_ProjectRefAzureClients:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms2019-ds2v2-general
+      OSVmImage:
       TestTargetFramework: net461
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     MacOS:


### PR DESCRIPTION
This PR moves the pools over to Central Canada as an experiment for storage. We won't merge this because if this has an impact we'll probably want to make pool selectable in the ```ci.yml``` file.