### PR TITLE
Ensure that type is populated when deserializing into a CloudEvent

### DIFF
--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/BinaryDataExtensions.cs
@@ -47,12 +47,6 @@ namespace Azure.Messaging.EventGrid
             JsonDocument requestDocument = JsonDocument.Parse(binaryData.ToMemory());
             CloudEventInternal cloudEventInternal = CloudEventInternal.DeserializeCloudEventInternal(requestDocument.RootElement);
 
-            // Case where Data and Type are null - cannot pass null Type into CloudEvent constructor
-            if (cloudEventInternal.Type == null)
-            {
-                cloudEventInternal.Type = "";
-            }
-
             CloudEvent cloudEvent = new CloudEvent(
                     cloudEventInternal.Id,
                     cloudEventInternal.Source,

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEvent.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/src/Customization/CloudEvent.cs
@@ -87,6 +87,9 @@ namespace Azure.Messaging.EventGrid
 
         internal CloudEvent(string id, string source, string type, DateTimeOffset? time, string dataSchema, string dataContentType, string subject, JsonElement serializedData, byte[] dataBase64)
         {
+            // we only validate that the type is required when deserializing since the service allows sending a CloudEvent without a Source.
+            Argument.AssertNotNull(type, nameof(type));
+
             Id = id;
             Source = source;
             Type = type;

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/ConsumeEventTests.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/ConsumeEventTests.cs
@@ -1532,16 +1532,49 @@ namespace Azure.Messaging.EventGrid.Tests
         }
 
         [Test]
-        public void CloudEventParseDoesNotThrowIfMissingRequiredProperties()
+        public void CloudEventParseDoesNotThrowIfMissingSource()
         {
-            // missing Id, Source, SpecVersion, and Type
-            string requestContent = "[{ \"subject\": \"Subject-0\",  \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  }}]";
+            // missing Id, Source, SpecVersion
+            string requestContent = "[{ \"subject\": \"Subject-0\", \"type\": \"type\", \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  }}]";
             CloudEvent[] events = CloudEvent.Parse(requestContent);
             var cloudEvent = events[0];
             Assert.IsNull(cloudEvent.Id);
             Assert.IsNull(cloudEvent.Source);
-            Assert.IsNull(cloudEvent.Type);
+            Assert.AreEqual("type", cloudEvent.Type);
             Assert.AreEqual("Subject-0", cloudEvent.Subject);
+        }
+
+        [Test]
+        public void ToCloudEventDoesNotThrowIfMissingSource()
+        {
+            // missing Id, Source, SpecVersion
+            BinaryData requestContent = new BinaryData("{ \"subject\": \"Subject-0\", \"type\": \"type\", \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  }}");
+            var cloudEvent = requestContent.ToCloudEvent();
+            Assert.IsNull(cloudEvent.Id);
+            Assert.IsNull(cloudEvent.Source);
+            Assert.AreEqual("type", cloudEvent.Type);
+            Assert.AreEqual("Subject-0", cloudEvent.Subject);
+        }
+
+        [Test]
+        public void CloudEventParseThrowsIfMissingType()
+        {
+            // missing Id, Source, SpecVersion
+            string requestContent = "[{ \"subject\": \"Subject-0\", \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  }}]";
+
+            Assert.That(
+                () => CloudEvent.Parse(requestContent),
+                Throws.InstanceOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void ToCloudEventThrowsIfMissingType()
+        {
+            // missing Id, Source, SpecVersion
+            BinaryData requestContent = new BinaryData("{ \"subject\": \"Subject-0\", \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  }}");
+            Assert.That(
+                () => requestContent.ToCloudEvent(),
+                Throws.InstanceOf<ArgumentNullException>());
         }
         #endregion
 
@@ -1602,7 +1635,7 @@ namespace Azure.Messaging.EventGrid.Tests
         [Test]
         public void ConsumeCloudEventWithNoData()
         {
-            string requestContent = "[{\"id\":\"994bc3f8-c90c-6fc3-9e83-6783db2221d5\",\"source\":\"Subject-0\",\"specversion\":\"1.0\"}]";
+            string requestContent = "[{\"id\":\"994bc3f8-c90c-6fc3-9e83-6783db2221d5\",\"type\":\"type\",\"source\":\"Subject-0\",\"specversion\":\"1.0\"}]";
 
             CloudEvent[] events = CloudEvent.Parse(requestContent);
             var eventData1 = events[0].GetData<object>();
@@ -1610,13 +1643,13 @@ namespace Azure.Messaging.EventGrid.Tests
 
             Assert.AreEqual(eventData1, null);
             Assert.AreEqual(eventData2, null);
-            Assert.IsNull(events[0].Type);
+            Assert.AreEqual("type", events[0].Type);
         }
 
         [Test]
         public void ConsumeCloudEventWithExplicitlyNullData()
         {
-            string requestContent = "[{\"id\":\"994bc3f8-c90c-6fc3-9e83-6783db2221d5\",\"source\":\"Subject-0\", \"data\":null, \"specversion\":\"1.0\"}]";
+            string requestContent = "[{\"id\":\"994bc3f8-c90c-6fc3-9e83-6783db2221d5\", \"type\":\"type\", \"source\":\"Subject-0\", \"data\":null, \"specversion\":\"1.0\"}]";
 
             CloudEvent[] events = CloudEvent.Parse(requestContent);
             var eventData1 = events[0].GetData<object>();
@@ -1624,7 +1657,7 @@ namespace Azure.Messaging.EventGrid.Tests
 
             Assert.AreEqual(eventData1, null);
             Assert.AreEqual(eventData2, null);
-            Assert.IsNull(events[0].Type);
+            Assert.AreEqual("type", events[0].Type);
         }
         #endregion
 

--- a/sdk/eventgrid/Azure.Messaging.EventGrid/tests/ConsumeEventTests.cs
+++ b/sdk/eventgrid/Azure.Messaging.EventGrid/tests/ConsumeEventTests.cs
@@ -1559,7 +1559,7 @@ namespace Azure.Messaging.EventGrid.Tests
         [Test]
         public void CloudEventParseThrowsIfMissingType()
         {
-            // missing Id, Source, SpecVersion
+            // missing Id, Source, SpecVersion, and Type
             string requestContent = "[{ \"subject\": \"Subject-0\", \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  }}]";
 
             Assert.That(
@@ -1570,7 +1570,7 @@ namespace Azure.Messaging.EventGrid.Tests
         [Test]
         public void ToCloudEventThrowsIfMissingType()
         {
-            // missing Id, Source, SpecVersion
+            // missing Id, Source, SpecVersion, and Type
             BinaryData requestContent = new BinaryData("{ \"subject\": \"Subject-0\", \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  }}");
             Assert.That(
                 () => requestContent.ToCloudEvent(),


### PR DESCRIPTION
During UX studies, users were easily confused if they attempted to deserialize an event grid event into a CloudEvent as no exception was thrown. We intentionally removed the validation as part of addressing https://github.com/Azure/azure-sdk-for-net/issues/16012, but this may have gone too far in the other direction. A good compromise seems to leave in the validation that the service uses which is to ensure that Type is populated for CloudEvents, while allowing Source to be null.