### PR TITLE
Add config for 1ES hosted Linux pool.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -68,7 +68,8 @@ jobs:
     variables:
       - template: ../variables/globals.yml
     pool:
-      vmImage: ubuntu-18.04
+      name: azsdk-pool-mms-ubuntu-1804-general
+      vmImage:
     steps:
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
@@ -121,8 +122,8 @@ jobs:
       maxParallel: $[ variables['MaxParallelTestJobs'] ]
       matrix:
         Linux:
-          Pool: # Intentionally blank.
-          OSVmImage: "ubuntu-18.04"
+          Pool: azsdk-pool-mms-ubuntu-1804-general # Comment out to swap back to public hosted pool.
+          OSVmImage: # "ubuntu-18.04" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: netcoreapp2.1
         Windows_NetCoreApp:
           Pool: azsdk-pool-mms-win-2019-general # Comment out to swap back to public hosted pool.

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,10 +1,28 @@
 parameters:
-  - name: WindowsPool
-    type: string
-    default: azsdk-pool-mms-win-2019-general
-  - name: LinuxPool
-    type: string
-    default: azsdk-pool-mms-ubuntu-1804-general
+- name: Artifacts
+  type: object
+  default: []
+- name: TestPipeline
+  type: boolean
+  default: false
+- name: ArtifactName
+  type: string
+  default: packages
+- name: ServiceDirectory
+  type: string
+  default: not-specified
+- name: ServiceToTest
+  type: string
+  default: ''
+- name: TestSetupSteps
+  type: stepList
+  default: []
+- name: WindowsPool
+  type: string
+  default: azsdk-pool-mms-win-2019-general
+- name: LinuxPool
+  type: string
+  default: azsdk-pool-mms-ubuntu-1804-general
 
 jobs:
   - job: Build

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -71,8 +71,6 @@ jobs:
       name: azsdk-pool-mms-ubuntu-1804-general
       vmImage:
     steps:
-      - script: |
-          ls /mnt/vss-agent-2.179.0/_work/_tool
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -71,6 +71,8 @@ jobs:
       name: azsdk-pool-mms-ubuntu-1804-general
       vmImage:
     steps:
+      - script: |
+          ls /mnt/vss-agent-2.179.0/_work/_tool
       - task: UsePythonVersion@0
         displayName: "Use Python 3.6"
         inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,9 +1,17 @@
+parameters:
+  - name: WindowsPool
+    type: string
+    default: azsdk-pool-mms-win-2019-general
+  - name: LinuxPool
+    type: string
+    default: azsdk-pool-mms-ubuntu-1804-general
+
 jobs:
   - job: Build
     variables:
       - template: ../variables/globals.yml
     pool:
-      name: azsdk-pool-mms-win-2019-general # Comment this line back-out to switch to public pools.
+      name: ${{ parameters.WindowsPool }} # Comment this line back-out to switch to public pools.
       # vmImage: windows-2019 # Comment this line back-in to switch to public pools.
     steps:
       - ${{if eq(parameters.TestPipeline, 'true')}}:
@@ -68,7 +76,7 @@ jobs:
     variables:
       - template: ../variables/globals.yml
     pool:
-      name: azsdk-pool-mms-ubuntu-1804-general
+      name: ${{ parameters.LinuxPool }}
       vmImage:
     steps:
       - task: UsePythonVersion@0
@@ -122,25 +130,25 @@ jobs:
       maxParallel: $[ variables['MaxParallelTestJobs'] ]
       matrix:
         Linux:
-          Pool: azsdk-pool-mms-ubuntu-1804-general # Comment out to swap back to public hosted pool.
+          Pool: ${{ parameters.LinuxPool }} # Comment out to swap back to public hosted pool.
           OSVmImage: # "ubuntu-18.04" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: netcoreapp2.1
         Windows_NetCoreApp:
-          Pool: azsdk-pool-mms-win-2019-general # Comment out to swap back to public hosted pool.
+          Pool: ${{ parameters.WindowsPool }} # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: netcoreapp2.1
           CollectCoverage: true
         Windows_NetCoreApp_ProjectReferences:
-          Pool: azsdk-pool-mms-win-2019-general # Comment out to swap back to public hosted pool.
+          Pool: ${{ parameters.WindowsPool }} # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: netcoreapp2.1
           ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
         Windows_NetFramework:
-          Pool: azsdk-pool-mms-win-2019-general # Comment out to swap back to public hosted pool.
+          Pool: ${{ parameters.WindowsPool }} # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net461
         Windows_NetFramework_ProjectReferences:
-          Pool: azsdk-pool-mms-win-2019-general # Comment out to swap back to public hosted pool.
+          Pool: ${{ parameters.WindowsPool }} # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net461
           ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
@@ -149,7 +157,7 @@ jobs:
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1
         Windows_Net50:
-          Pool: azsdk-pool-mms-win-2019-general # Comment out to swap back to public hosted pool.
+          Pool: ${{ parameters.WindowsPool }} # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net5.0
     pool:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -30,6 +30,10 @@ parameters:
 - name: TestSetupSteps
   type: stepList
   default: []
+- name: WindowsPool
+  type: string
+- name: LinuxPool
+  type: string
 
 stages:
   - stage: Build
@@ -42,6 +46,8 @@ stages:
         TestPipeline: ${{ parameters.TestPipeline }}
         ArtifactName: packages
         TestSetupSteps: ${{ parameters.TestSetupSteps }}
+        WindowsPool: ${{ parameters.WindowsPool }}
+        LinuxPool: ${{ parameters.LinuxPool }}
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -32,8 +32,10 @@ parameters:
   default: []
 - name: WindowsPool
   type: string
+  default: azsdk-pool-mms-win-2019-general
 - name: LinuxPool
   type: string
+  default: azsdk-pool-mms-ubuntu-1804-general
 
 stages:
   - stage: Build

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -25,6 +25,8 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: storage
+    LinuxPool: azsdk-pool-mms-ubuntu-1804-general
+    WindowsPool: azsdk-pool-mms-win-2019-general
     ArtifactName: packages
     Artifacts:
     - name: Azure.Storage.Blobs


### PR DESCRIPTION
This PR does two things:

1) Swaps the Windows pool to a new one (fresh name): ```azsdk-pool-mms-win-2019-general```
2) Introduces a pool for Linux: ```azsdk-pool-mms-ubuntu-1804-general```

The convention that I'm using here should be fairly self explanatory. I'll decommission the old pool as soon as I've confirmed that these ones are working with the PR. I opted to remove the machine sizes from the pool because other than the image we use (which will be selected by changing pool), the VM size is probably the next thing that will change so its not a good idea to put it in the pool name.

I'm also going to be introducing some top-level archetype parameter templates that set these as defaults which will then be overridable.