### PR TITLE
[FR] Don't use inheritdoc for now

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Appearance.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Appearance.cs
@@ -6,7 +6,6 @@ using Azure.Core;
 
 namespace Azure.AI.FormRecognizer
 {
-    /// <summary> An object representing the appearance of the text line. </summary>
     [CodeGenModel("Appearance")]
     [SuppressMessage("Usage", "AZC0012:Avoid single word type names", Justification = "Will fix name in future release")]
     public partial class Appearance

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Appearance.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Appearance.cs
@@ -6,7 +6,7 @@ using Azure.Core;
 
 namespace Azure.AI.FormRecognizer
 {
-    /// <inheritdoc />
+    /// <summary> An object representing the appearance of the text line. </summary>
     [CodeGenModel("Appearance")]
     [SuppressMessage("Usage", "AZC0012:Avoid single word type names", Justification = "Will fix name in future release")]
     public partial class Appearance

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Style.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Style.cs
@@ -6,7 +6,6 @@ using Azure.Core;
 
 namespace Azure.AI.FormRecognizer
 {
-    /// <summary> An object representing the style of the text line. </summary>
     [CodeGenModel("Style")]
     [SuppressMessage("Usage", "AZC0012:Avoid single word type names", Justification = "Will fix name in future release")]
     public partial class Style

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Style.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Style.cs
@@ -6,7 +6,7 @@ using Azure.Core;
 
 namespace Azure.AI.FormRecognizer
 {
-    /// <inheritdoc />
+    /// <summary> An object representing the style of the text line. </summary>
     [CodeGenModel("Style")]
     [SuppressMessage("Usage", "AZC0012:Avoid single word type names", Justification = "Will fix name in future release")]
     public partial class Style


### PR DESCRIPTION
Looks like validating inheritdocs work  is inconsistent. This should have failed when inheritdoc was enable. Instead it was passing and suddenly on Monday, decided to fail again.   Filed issue: https://github.com/Azure/azure-sdk-for-net/issues/17505 to look into why this behavior happens