### PR TITLE
[TA] Assigning canary to centraluseuap

### DIFF
--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -5,6 +5,8 @@ extends:
   parameters:
     ServiceDirectory: textanalytics
     CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
       Canary:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'
-    UnsupportedClouds: 'China'

--- a/sdk/textanalytics/tests.yml
+++ b/sdk/textanalytics/tests.yml
@@ -4,5 +4,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: textanalytics
-    Clouds: 'Preview'
+    CloudConfig:
+      Canary:
+        Location: 'centraluseuap'
     UnsupportedClouds: 'China'


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17483 (TA part)
Following guidance here: https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/389/-.net-Configuring-Live-Tests?anchor=supported-clouds