### PR TITLE
[DRAFT] Test Pipeline: Allow project exclusions

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -302,7 +302,7 @@ try {
     }
 
     if ($PSBoundParameters.ContainsKey('DeleteAfterHours')) {
-        $deleteAfter = [DateTime]::UtcNow.AddHours($DeleteAfterHours)
+        $deleteAfter = [DateTime]::UtcNow.AddHours(-120)
         $tags.Add('DeleteAfter', $deleteAfter.ToString('o'))
     }
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,8 +1,3 @@
-parameters:
-- name: ExcludeProjects
-  type: object
-  default: []
-
 jobs:
   - job: Build
     variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,3 +1,8 @@
+parameters:
+- name: ExcludeProjects
+  type: object
+  default: []
+
 jobs:
   - job: Build
     variables:
@@ -39,6 +44,7 @@ jobs:
           dotnet pack eng/service.proj -warnaserror
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeTests=false
+          /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           /p:PublicSign=false $(VersioningProperties)
           /p:Configuration=$(BuildConfiguration)
           /p:CommitSHA=$(Build.SourceVersion)
@@ -160,10 +166,11 @@ jobs:
             ${{ pair.key }}: ${{ pair.value }}
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
       - script: >-
-          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework)
+          dotnet test eng/service.proj --filter "(TestCategory!=Manually) & (TestCategory!=Live)" --framework $(TestTargetFramework)
           --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{parameters.ServiceToTest}}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
+          /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption)
           /p:CollectCoverage=$(CollectCoverage) /p:CodeCoverageDirectory=${{parameters.ServiceDirectory}}
         displayName: "Build & Test ($(TestTargetFramework))"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -59,7 +59,7 @@ jobs:
         inputs:
           artifactName: packages
           path: $(Build.ArtifactStagingDirectory)
-      
+
       - template: /eng/pipelines/templates/steps/create-apireview.yml
         parameters:
           Artifacts: ${{parameters.Artifacts}}

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -103,7 +103,7 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
         inputs:
           filePath: "eng/scripts/CodeChecks.ps1"
-          arguments: -ServiceDirectory ${{parameters.ServiceToTest}}
+          arguments: -ServiceDirectory ${{parameters.ServiceToTest}} -ExcludeProjects "${{ join('|', parameters.ExcludeProjects) }}"
           pwsh: true
           failOnStderr:  false
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -94,7 +94,7 @@ jobs:
           --framework $(TestTargetFramework)
           --filter "(TestCategory!=Manually) & (TestCategory!=Live)"
           --logger "trx"
-          --logger:"console;verbosity=normal"
+          --logger:"console;verbosity=minimal"
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:BuildInParallel=${{ parameters.BuildInParallel }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -94,7 +94,7 @@ jobs:
           --framework $(TestTargetFramework)
           --filter "(TestCategory!=Manually) & (TestCategory!=Live)"
           --logger "trx"
-          --logger:"console;verbosity=minimal"
+          --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:BuildInParallel=${{ parameters.BuildInParallel }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -98,7 +98,7 @@ jobs:
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:BuildInParallel=${{ parameters.BuildInParallel }}
-          ${{ gt(0, length(parameters.ExcludeProjects)) }}:
+          ${{ if gt(0, length(parameters.ExcludeProjects)) }}:
             /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           $(AdditionalTestArguments)
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -92,7 +92,7 @@ jobs:
       - pwsh: >
           dotnet test eng/service.proj
           --framework $(TestTargetFramework)
-          --filter "(TestCategory!=Manually) & (TestCategory!=Live)"
+          --filter "TestCategory!=Manually"
           --logger "trx"
           --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -65,6 +65,9 @@ jobs:
     ${{ if eq(parameters.UsePlatformContainer, 'true') }}:
       container: $[ variables['Container'] ]
 
+    ${{ if gt(0, length(parameters.ExcludeProjects)) }}:
+       excludeProjects: format('/p:ExcludeProjects="{0}"', join('|', parameters.ExcludeProjects))
+
     steps:
       - ${{ parameters.PreSteps }}
 
@@ -98,8 +101,7 @@ jobs:
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:BuildInParallel=${{ parameters.BuildInParallel }}
-          ${{ if gt(0, length(parameters.ExcludeProjects)) }}:
-            /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
+          $(excludeProjects)
           $(AdditionalTestArguments)
 
         displayName: "Build & Test (all tests for $(TestTargetFramework))"

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -23,6 +23,9 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
+- name: ExcludeProjects
+  type: object
+  default: []
 - name: TestSetupSteps
   type: stepList
   default: []
@@ -89,12 +92,14 @@ jobs:
       - pwsh: >
           dotnet test eng/service.proj
           --framework $(TestTargetFramework)
-          --filter "TestCategory!=Manually"
+          --filter "(TestCategory!=Manually) & (TestCategory!=Live)"
           --logger "trx"
           --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:BuildInParallel=${{ parameters.BuildInParallel }}
+          ${{ gt(0, length(parameters.ExcludeProjects)) }}:
+            /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           $(AdditionalTestArguments)
 
         displayName: "Build & Test (all tests for $(TestTargetFramework))"

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -65,9 +65,6 @@ jobs:
     ${{ if eq(parameters.UsePlatformContainer, 'true') }}:
       container: $[ variables['Container'] ]
 
-    ${{ if gt(0, length(parameters.ExcludeProjects)) }}:
-       excludeProjects: format('/p:ExcludeProjects="{0}"', join('|', parameters.ExcludeProjects))
-
     steps:
       - ${{ parameters.PreSteps }}
 
@@ -101,7 +98,7 @@ jobs:
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:BuildInParallel=${{ parameters.BuildInParallel }}
-          $(excludeProjects)
+          /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           $(AdditionalTestArguments)
 
         displayName: "Build & Test (all tests for $(TestTargetFramework))"

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -18,6 +18,9 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
+- name: ExcludeProjects
+  type: object
+  default: []
 - name: ServiceToTest
   type: string
   default: ''
@@ -38,6 +41,7 @@ stages:
       parameters:
         ServiceToTest: ${{ coalesce(parameters.ServiceToTest, parameters.ServiceDirectory) }}
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        ExcludeProjects: ${{ parameters.ExcludeProjects }}
         Artifacts: ${{ parameters.Artifacts }}
         TestPipeline: ${{ parameters.TestPipeline }}
         ArtifactName: packages

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -57,4 +57,4 @@ stages:
         TestPipeline: ${{ parameters.TestPipeline }}
         ArtifactName: packages
         TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
-        TargetDocRepoName: ${{ parameters.TargetDocRepoName }} 
+        TargetDocRepoName: ${{ parameters.TargetDocRepoName }}

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -31,10 +31,10 @@ parameters:
   default: ''
 - name: ServiceDirectory
   type: string
+  default: not-specified
 - name: ExcludeProjects
   type: object
   default: []
-  default: not-specified
 - name: TestSetupSteps
   type: stepList
   default: []

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -31,6 +31,9 @@ parameters:
   default: ''
 - name: ServiceDirectory
   type: string
+- name: ExcludeProjects
+  type: object
+  default: []
   default: not-specified
 - name: TestSetupSteps
   type: stepList
@@ -128,6 +131,7 @@ stages:
               TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
               Location: ${{ parameters.Location }}
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
+              ExcludeProjects: ${{ parameters.ExcludeProjects }}
               TestSetupSteps: ${{ parameters.TestSetupSteps }}
             Platforms:
               # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -80,14 +80,14 @@ try {
         }
     }
 
-    Write-Host "Re-generating readmes"
+    Write-Host "Re-generating snippets"
     Invoke-Block {
         & $PSScriptRoot\Update-Snippets.ps1 -ServiceDirectory $ServiceDirectory
     }
 
     Write-Host "Re-generating listings"
     Invoke-Block {
-        & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory
+        & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory -ExcludeProjects "$ExcludeProjects"
     }
 
     if (-not $ProjectDirectory)

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -4,7 +4,8 @@
 param (
     [Parameter(Position=0)]
     [string] $ServiceDirectory,
-    [string] $ProjectDirectory
+    [string] $ProjectDirectory,
+    [string] $ExcludeProjects
 )
 
 $ErrorActionPreference = 'Stop'
@@ -72,7 +73,7 @@ try {
 
         Write-Host "Re-generating clients"
         Invoke-Block {
-            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:ServiceDirectory=$ServiceDirectory
+            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:ServiceDirectory=$ServiceDirectory /p:ExcludeProjects="$ExcludeProjects"
 
             # https://github.com/Azure/azure-sdk-for-net/issues/8584
             # & $repoRoot\storage\generate.ps1

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -2,9 +2,10 @@
 param (
     [Parameter(Position=0)]
     [ValidateNotNullOrEmpty()]
-    [string] $ServiceDirectory
+    [string] $ServiceDirectory,
+    [string] $ExcludeProjects
 )
 
 $servicesProj = Resolve-Path "$PSScriptRoot/../service.proj"
 
-dotnet build /p:GenerateApiListingOnBuild=true /p:RunApiCompat=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /restore $servicesProj
+dotnet build /p:GenerateApiListingOnBuild=true /p:RunApiCompat=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:ExcludeProjects="$ExcludeProjects" /restore $servicesProj

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -44,9 +44,8 @@
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
   <Target Name="CheckProjects" AfterTargets="Build">
-    <Message Text="Exclude:: @(ExcludePaths)" />
-    <Error Text="PROJECTS:: @(ProjectReference)" />
-
+    <Error Text="PROJECTS:: @(ProjectReference) || EXCLUDE:: @(ExcludePaths)" />
+    
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->
     <Error Condition="'$(Scope)' == '' and '@(ProjectReference)' == ''"
         Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -43,8 +43,6 @@
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
   <Target Name="CheckProjects" AfterTargets="Build">
-    <Error Text="PROJECTS:: @(ProjectReference)" />
-
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->
     <Error Condition="'$(Scope)' == '' and '@(ProjectReference)' == ''"
         Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -43,9 +43,11 @@
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
-  <Target Name="CheckProjects" AfterTargets="Build">
-    <Error Text="PROJECTS:: @(ProjectReference" />
+  <Target Name="CheckProjects" BeforeTargets="Build">
+    <Error Text="PROJECTS:: @(ProjectReference)" />
+  </Target>
 
+  <Target Name="CheckProjects" AfterTargets="Build">
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->
     <Error Condition="'$(Scope)' == '' and '@(ProjectReference)' == ''"
         Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -35,7 +35,7 @@
      Override project inclusions and force removal of those that have been explicitly excluded by the associated parameter.
      Assume each item identifies a project name under the service directory and build the appropriate path mask.
   -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(ExcludeProjects)' != ''">
     <_ExcludePathsSource Include="$(ExcludeProjects.Split('$(ExcludeProjectsDelimiter)'))" />
     <ExcludePaths Include="@(_ExcludePathsSource -> '$(MSBuildThisFileDirectory)..\sdk\$(ServiceDirectory)\%(Identity)\**\*.csproj')" />
     <ProjectReference Remove="@(ExcludePaths)" />
@@ -44,6 +44,8 @@
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
   <Target Name="CheckProjects" AfterTargets="Build">
+    <Error Text="PROJECTS:: @(ProjectReference" />
+
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->
     <Error Condition="'$(Scope)' == '' and '@(ProjectReference)' == ''"
         Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -43,11 +43,10 @@
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
-  <Target Name="CheckProjects" BeforeTargets="Build">
-    <Error Text="PROJECTS:: @(ProjectReference)" />
-  </Target>
-
   <Target Name="CheckProjects" AfterTargets="Build">
+    <Message Text="Exclude:: @(ExcludePaths)" />
+    <Error Text="PROJECTS:: @(ProjectReference)" />
+
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->
     <Error Condition="'$(Scope)' == '' and '@(ProjectReference)' == ''"
         Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -31,7 +31,7 @@
     <PerfProjects Include="..\sdk\$(ServiceDirectory)\**\perf\**\*.csproj" />
     <StressProjects Include="..\sdk\$(ServiceDirectory)\**\stress\**\*.csproj" />
     <SampleApplications Include="..\samples\**\*.csproj" />
-    <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects);@(SamplesProjects)"/>
+    <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects);@(SamplesProjects);@(ExcludePaths)"/>
     <ProjectReference Include="@(TestProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeTests)' == 'true'" />
     <ProjectReference Include="@(SamplesProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSamples)' == 'true'" />
     <ProjectReference Include="@(PerfProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludePerf)' == 'true'" />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -15,29 +15,29 @@
     </TraversalGlobalProperties>
   </PropertyGroup>
 
-  <!--
-     Exclude projects requeted by the assocaited parameter; assume each item identifies a
-     project name under the service directory and build the appropriate path mask.
-  -->
   <ItemGroup>
-    <_ExcludePathsSource Include="$(ExcludeProjects.Split('$(ExcludeProjectsDelimiter)'))" />
-    <ExcludePaths Include="@(_ExcludePathsSource -> '$(MSBuildThisFileDirectory)..\sdk\$(ServiceDirectory)\%(Identity)\**\*.csproj')" />
     <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <TestProjects Include="..\sdk\$(ServiceDirectory)\**\tests\**\*.csproj" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\**\samples\**\*.csproj" />
     <PerfProjects Include="..\sdk\$(ServiceDirectory)\**\perf\**\*.csproj" />
     <StressProjects Include="..\sdk\$(ServiceDirectory)\**\stress\**\*.csproj" />
     <SampleApplications Include="..\samples\**\*.csproj" />
-    <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects);@(SamplesProjects);@(ExcludePaths)"/>
-    <ProjectReference Include="@(TestProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeTests)' == 'true'" />
-    <ProjectReference Include="@(SamplesProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSamples)' == 'true'" />
-    <ProjectReference Include="@(PerfProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludePerf)' == 'true'" />
-    <ProjectReference Include="@(StressProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeStress)' == 'true'" />
-    <ProjectReference Include="@(SampleApplications)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
-    <ProjectReference Include="@(SrcProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSrc)' == 'true'" />
+    <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects);@(SamplesProjects)"/>
+    <ProjectReference Include="@(TestProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeTests)' == 'true'" />
+    <ProjectReference Include="@(SamplesProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSamples)' == 'true'" />
+    <ProjectReference Include="@(PerfProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludePerf)' == 'true'" />
+    <ProjectReference Include="@(StressProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeStress)' == 'true'" />
+    <ProjectReference Include="@(SampleApplications)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
+    <ProjectReference Include="@(SrcProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSrc)' == 'true'" />
+  </ItemGroup>
+
+  <!--
+     Override project inclusions and force removal of those that have been explicitly excluded by the associated parameter.
+     Assume each item identifies a project name under the service directory and build the appropriate path mask.
+  -->
+  <ItemGroup>
+    <_ExcludePathsSource Include="$(ExcludeProjects.Split('$(ExcludeProjectsDelimiter)'))" />
+    <ExcludePaths Include="@(_ExcludePathsSource -> '$(MSBuildThisFileDirectory)..\sdk\$(ServiceDirectory)\%(Identity)\**\*.csproj')" />
     <ProjectReference Remove="@(ExcludePaths)" />
   </ItemGroup>
 

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -9,28 +9,46 @@
     <IncludeStress Condition="'$(IncludeStress)' == ''">true</IncludeStress>
     <IncludeSamplesApplications Condition="'$(IncludeSamplesApplications)' == ''">true</IncludeSamplesApplications>
     <IncludeSamplesApplications Condition="'$(ServiceDirectory)' != '*' or '$(IncludeSamples)' == 'false'">false</IncludeSamplesApplications>
-    <TraversalGlobalProperties>
+    <ExcludeProjectsDelimiter Condition="'$(ExcludeProjectsDelimiter)' == ''">|</ExcludeProjectsDelimiter>
+    <!--TraversalGlobalProperties>
       CodeCoverageDirectory=$([System.IO.Path]::GetFullPath("$(CodeCoverageDirectory)", "$(MSBuildThisFileDirectory)..\sdk"));
-    </TraversalGlobalProperties>
+    </TraversalGlobalProperties-->
   </PropertyGroup>
 
+  <!--
+     Exclude projects passed as a parameter; assume each item identifies a project name
+     under the service directory and build the appropriate path mask.
+  -->
   <ItemGroup>
-    <ExcludeMgmtLib Include="..\sdk\*\Microsoft.*.Management.*\**\*.csproj;..\sdk\*mgmt*\**\*.csproj;" />
+    <_ExcludePathsSource Include="$(ExcludeProjects.Split('$(ExcludeProjectsDelimiter)'))" />
+    <ExcludePaths Include="@(_ExcludePathsSource -> '$(MSBuildThisFileDirectory)..\sdk\$(ServiceDirectory)\%(Identity)\**\*.csproj')" />
+    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <TestProjects Include="..\sdk\$(ServiceDirectory)\**\tests\**\*.csproj" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\**\samples\**\*.csproj" />
     <PerfProjects Include="..\sdk\$(ServiceDirectory)\**\perf\**\*.csproj" />
     <StressProjects Include="..\sdk\$(ServiceDirectory)\**\stress\**\*.csproj" />
     <SampleApplications Include="..\samples\**\*.csproj" />
     <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects);@(SamplesProjects)"/>
-    <ProjectReference Include="@(TestProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeTests)' == 'true'" />
-    <ProjectReference Include="@(SamplesProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeSamples)' == 'true'" />
-    <ProjectReference Include="@(PerfProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludePerf)' == 'true'" />
-    <ProjectReference Include="@(StressProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeStress)' == 'true'" />
-    <ProjectReference Include="@(SampleApplications)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
-    <ProjectReference Include="@(SrcProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeSrc)' == 'true'" />
+    <ProjectReference Include="@(TestProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeTests)' == 'true'" />
+    <ProjectReference Include="@(SamplesProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSamples)' == 'true'" />
+    <ProjectReference Include="@(PerfProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludePerf)' == 'true'" />
+    <ProjectReference Include="@(StressProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeStress)' == 'true'" />
+    <ProjectReference Include="@(SampleApplications)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
+    <ProjectReference Include="@(SrcProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSrc)' == 'true'" />
   </ItemGroup>
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
+
+  <Target Name="Dump" BeforeTargets="Build">
+    <Message Text="Delimiter: $(ExcludeProjectsDelimiter)" />
+    <Message Text="|| Exclude Definition ||" />
+    <Message Text="@(ExcludePaths)" />
+    <Message Text="|| Project References ||" />
+    <Message Text="@(ProjectReference)" />
+  </Target>
 
   <Target Name="CheckProjects" AfterTargets="Build">
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <!--
-     Exclude projects passed as a parameter; assume each item identifies a project name
-     under the service directory and build the appropriate path mask.
+     Exclude projects requeted by the assocaited parameter; assume each item identifies a
+     project name under the service directory and build the appropriate path mask.
   -->
   <ItemGroup>
     <_ExcludePathsSource Include="$(ExcludeProjects.Split('$(ExcludeProjectsDelimiter)'))" />
@@ -42,13 +42,15 @@
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
-  <Target Name="Dump" BeforeTargets="Build">
+  <!-- JESSE: Remove Debug Logging -->
+  <Target Name="JESSE-Debug" AfterTargets="Build">
     <Message Text="Delimiter: $(ExcludeProjectsDelimiter)" />
     <Message Text="|| Exclude Definition ||" />
     <Message Text="@(ExcludePaths)" />
     <Message Text="|| Project References ||" />
     <Message Text="@(ProjectReference)" />
   </Target>
+  <!-- END JESSE: Remove Debug Logging -->
 
   <Target Name="CheckProjects" AfterTargets="Build">
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -37,15 +37,14 @@
   -->
   <ItemGroup Condition="'$(ExcludeProjects)' != ''">
     <_ExcludePathsSource Include="$(ExcludeProjects.Split('$(ExcludeProjectsDelimiter)'))" />
-    <ExcludePaths Include="@(_ExcludePathsSource -> '$(MSBuildThisFileDirectory)..\sdk\$(ServiceDirectory)\%(Identity)\**\*.csproj')" />
-    <ProjectReference Remove="@(ExcludePaths)" />
+    <ProjectReference Remove="@(_ExcludePathsSource -> '$(MSBuildThisFileDirectory)..\sdk\$(ServiceDirectory)\%(Identity)\**\*.csproj')" />
   </ItemGroup>
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
   <Target Name="CheckProjects" AfterTargets="Build">
-    <Error Text="PROJECTS:: @(ProjectReference) || EXCLUDE:: @(ExcludePaths)" />
-    
+    <Error Text="PROJECTS:: @(ProjectReference)" />
+
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->
     <Error Condition="'$(Scope)' == '' and '@(ProjectReference)' == ''"
         Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -10,9 +10,9 @@
     <IncludeSamplesApplications Condition="'$(IncludeSamplesApplications)' == ''">true</IncludeSamplesApplications>
     <IncludeSamplesApplications Condition="'$(ServiceDirectory)' != '*' or '$(IncludeSamples)' == 'false'">false</IncludeSamplesApplications>
     <ExcludeProjectsDelimiter Condition="'$(ExcludeProjectsDelimiter)' == ''">|</ExcludeProjectsDelimiter>
-    <!--TraversalGlobalProperties>
+    <TraversalGlobalProperties>
       CodeCoverageDirectory=$([System.IO.Path]::GetFullPath("$(CodeCoverageDirectory)", "$(MSBuildThisFileDirectory)..\sdk"));
-    </TraversalGlobalProperties-->
+    </TraversalGlobalProperties>
   </PropertyGroup>
 
   <!--
@@ -41,16 +41,6 @@
   </ItemGroup>
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
-
-  <!-- JESSE: Remove Debug Logging -->
-  <Target Name="JESSE-Debug" AfterTargets="Build">
-    <Message Text="Delimiter: $(ExcludeProjectsDelimiter)" />
-    <Message Text="|| Exclude Definition ||" />
-    <Message Text="@(ExcludePaths)" />
-    <Message Text="|| Project References ||" />
-    <Message Text="@(ProjectReference)" />
-  </Target>
-  <!-- END JESSE: Remove Debug Logging -->
 
   <Target Name="CheckProjects" AfterTargets="Build">
     <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -38,6 +38,7 @@
     <ProjectReference Include="@(StressProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeStress)' == 'true'" />
     <ProjectReference Include="@(SampleApplications)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
     <ProjectReference Include="@(SrcProjects)" Exclude="@(MgmtExcludePaths);@(ExcludePaths)" Condition="'$(IncludeSrc)' == 'true'" />
+    <ProjectReference Remove="@(ExcludePaths)" />
   </ItemGroup>
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />

--- a/sdk/eventhub/ci.legacy.yml
+++ b/sdk/eventhub/ci.legacy.yml
@@ -42,6 +42,8 @@ extends:
     ExcludeProjects:
       - Azure.ResourceManager.EventHubs
       - Azure.Messaging.EventHubs
+      - Azure.Messaging.EventHubs.Processor
+      - Azure.Messaging.EventHubs.Shared
       - Azure.Messaging.EventHubs.*
     ArtifactName: packages
     Artifacts:

--- a/sdk/eventhub/ci.legacy.yml
+++ b/sdk/eventhub/ci.legacy.yml
@@ -13,6 +13,8 @@ trigger:
     - sdk/eventhub/Azure.Messaging.EventHubs
     - sdk/eventhub/Azure.Messaging.EventHubs.Processor
     - sdk/eventhub/Azure.Messaging.EventHubs.Shared
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
     - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
 
 pr:
@@ -29,6 +31,8 @@ pr:
     - sdk/eventhub/Azure.Messaging.EventHubs
     - sdk/eventhub/Azure.Messaging.EventHubs.Processor
     - sdk/eventhub/Azure.Messaging.EventHubs.Shared
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
     - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
 
 extends:

--- a/sdk/eventhub/ci.legacy.yml
+++ b/sdk/eventhub/ci.legacy.yml
@@ -10,9 +10,11 @@ trigger:
     include:
     - sdk/eventhub/
     exclude:
-    - sdk/eventhub/Microsoft.Azure.EventHubs
-    - sdk/eventhub/Microsoft.Azure.EventHubs.Processor
-    - sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - sdk/eventhub/Azure.Messaging.EventHubs
+    - sdk/eventhub/Azure.Messaging.EventHubs.Processor
+    - sdk/eventhub/Azure.Messaging.EventHubs.Shared
+    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
+
 pr:
   branches:
     include:
@@ -24,9 +26,10 @@ pr:
     include:
     - sdk/eventhub/
     exclude:
-    - sdk/eventhub/Microsoft.Azure.EventHubs
-    - sdk/eventhub/Microsoft.Azure.EventHubs.Processor
-    - sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - sdk/eventhub/Azure.Messaging.EventHubs
+    - sdk/eventhub/Azure.Messaging.EventHubs.Processor
+    - sdk/eventhub/Azure.Messaging.EventHubs.Shared
+    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/eventhub/ci.legacy.yml
+++ b/sdk/eventhub/ci.legacy.yml
@@ -39,19 +39,15 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: eventhub
+    ExcludeProjects:
+      - Azure.ResourceManager.EventHubs
+      - Azure.Messaging.EventHubs
+      - Azure.Messaging.EventHubs.*
     ArtifactName: packages
     Artifacts:
-    - name: Azure.Messaging.EventHubs
-      safeName: AzureMessagingEventHubs
-    - name: Azure.Messaging.EventHubs.Processor
-      safeName: AzureMessagingEventHubsProcessor
     - name: Microsoft.Azure.EventHubs
       safeName: MicrosoftAzureEventHubs
     - name: Microsoft.Azure.EventHubs.Processor
       safeName: MicrosoftAzureEventHubsProcessor
     - name: Microsoft.Azure.EventHubs.ServiceFabricProcessor
       safeName: MicrosoftAzureEventHubsServiceFabricProcessor
-    - name: Microsoft.Azure.WebJobs.Extensions.EventHubs
-      safeName: MicrosoftAzureWebJobsExtensionsEventHubs
-    - name: Azure.ResourceManager.EventHubs
-      safeName: AzureResourceManagerEventHubs

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -10,9 +10,11 @@ trigger:
     include:
     - sdk/eventhub/
     exclude:
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
     - sdk/eventhub/Microsoft.Azure.EventHubs
     - sdk/eventhub/Microsoft.Azure.EventHubs.Processor
     - sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
 pr:
   branches:
     include:
@@ -24,9 +26,11 @@ pr:
     include:
     - sdk/eventhub/
     exclude:
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
     - sdk/eventhub/Microsoft.Azure.EventHubs
     - sdk/eventhub/Microsoft.Azure.EventHubs.Processor
     - sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -40,6 +40,8 @@ extends:
     - Azure.ResourceManager.EventHubs
     - Microsoft.Azure.EventHubs
     - Microsoft.Azure.EventHubs.*
+    - Microsoft.Azure.EventHubs.Processor
+    - Microsoft.Azure.EventHubs.ServiceFabricProcessor
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.EventHubs

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -39,9 +39,9 @@ extends:
     ExcludeProjects:
     - Azure.ResourceManager.EventHubs
     - Microsoft.Azure.EventHubs
-    - Microsoft.Azure.EventHubs.*
     - Microsoft.Azure.EventHubs.Processor
     - Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - Microsoft.Azure.EventHubs.*
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.EventHubs

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -36,19 +36,15 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: eventhub
+    ExcludeProjects:
+    - Azure.ResourceManager.EventHubs
+    - Microsoft.Azure.EventHubs
+    - Microsoft.Azure.EventHubs.*
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.EventHubs
       safeName: AzureMessagingEventHubs
     - name: Azure.Messaging.EventHubs.Processor
       safeName: AzureMessagingEventHubsProcessor
-    - name: Microsoft.Azure.EventHubs
-      safeName: MicrosoftAzureEventHubs
-    - name: Microsoft.Azure.EventHubs.Processor
-      safeName: MicrosoftAzureEventHubsProcessor
-    - name: Microsoft.Azure.EventHubs.ServiceFabricProcessor
-      safeName: MicrosoftAzureEventHubsServiceFabricProcessor
     - name: Microsoft.Azure.WebJobs.Extensions.EventHubs
       safeName: MicrosoftAzureWebJobsExtensionsEventHubs
-    - name: Azure.ResourceManager.EventHubs
-      safeName: AzureResourceManagerEventHubs

--- a/sdk/eventhub/tests.legacy.yml
+++ b/sdk/eventhub/tests.legacy.yml
@@ -8,8 +8,8 @@ extends:
     TimeoutInMinutes: 190
     ExcludeProjects:
     - Azure.ResourceManager.EventHubs
-    - Microsoft.Azure.EventHubs
-    - Microsoft.Azure.EventHubs.Processor
-    - Microsoft.Azure.EventHubs.ServiceFabricProcessor
-    - Microsoft.Azure.EventHubs.*
+    - Azure.Messaging.EventHubs
+    - Azure.Messaging.EventHubs.Processor
+    - Azure.Messaging.EventHubs.Shared
+    - Azure.Messaging.EventHubs.*
     Clouds: 'Public,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -6,4 +6,8 @@ extends:
     MaxParallel: 6
     ServiceDirectory: eventhub
     TimeoutInMinutes: 190
+    ExcludeProjects:
+      - Azure.ResourceManager.EventHubs
+      - Microsoft.Azure.EventHubs
+      - Microsoft.Azure.EventHubs.*
     Clouds: 'Public,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -7,9 +7,9 @@ extends:
     ServiceDirectory: eventhub
     TimeoutInMinutes: 190
     ExcludeProjects:
-      - Azure.ResourceManager.EventHubs
-      - Microsoft.Azure.EventHubs
-      - Microsoft.Azure.EventHubs.*
-      - Microsoft.Azure.EventHubs.Processor
-      - Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - Azure.ResourceManager.EventHubs
+    - Microsoft.Azure.EventHubs
+    - Microsoft.Azure.EventHubs.*
+    - Microsoft.Azure.EventHubs.Processor
+    - Microsoft.Azure.EventHubs.ServiceFabricProcessor
     Clouds: 'Public,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -6,8 +6,4 @@ extends:
     MaxParallel: 6
     ServiceDirectory: eventhub
     TimeoutInMinutes: 190
-    ExcludeProjects:
-      - Azure.ResourceManager.EventHubs
-      - Microsoft.Azure.EventHubs
-      - Microsoft.Azure.EventHubs.*
     Clouds: 'Public,Canary'

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -10,4 +10,6 @@ extends:
       - Azure.ResourceManager.EventHubs
       - Microsoft.Azure.EventHubs
       - Microsoft.Azure.EventHubs.*
+      - Microsoft.Azure.EventHubs.Processor
+      - Microsoft.Azure.EventHubs.ServiceFabricProcessor
     Clouds: 'Public,Canary'


### PR DESCRIPTION
This is a draft to allow testing of tweaks to the pipeline configuration for testing, in order to support explicitly requested project exclusions from test runs, rather than always including all packages under a service directory.    These efforts are a pre-cursor to splitting out track one and track two tests for service directories with split ownership, such as Event Hubs and Service Bus.