### PR TITLE
Generate 'SourcePath' attribute in Perf test assemblies

### DIFF
--- a/sdk/Directory.Build.props
+++ b/sdk/Directory.Build.props
@@ -3,10 +3,10 @@
     <IsMgmtProject Condition="'$(IsMgmtProject)' == '' and $(MSBuildProjectName.Contains('.Management.'))">true</IsMgmtProject>
     <IsDataPlaneProject Condition="'$(IsDataPlaneProject)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Azure.')) and '$(IsMgmtProject)' != 'true'">true</IsDataPlaneProject>
   </PropertyGroup>  
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerfProject)' == 'true'">
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
     <_Parameter1>SourcePath</_Parameter1>
-    <_Parameter2>$(MSBuildProjectDirectory)</_Parameter2>       
+    <_Parameter2>$(MSBuildProjectDirectory)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
   <Import Project="..\Directory.Build.props" />

--- a/sdk/Directory.Build.props
+++ b/sdk/Directory.Build.props
@@ -3,10 +3,10 @@
     <IsMgmtProject Condition="'$(IsMgmtProject)' == '' and $(MSBuildProjectName.Contains('.Management.'))">true</IsMgmtProject>
     <IsDataPlaneProject Condition="'$(IsDataPlaneProject)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Azure.')) and '$(IsMgmtProject)' != 'true'">true</IsDataPlaneProject>
   </PropertyGroup>  
-  <ItemGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerfProject)' == 'true'">
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true'">
     <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
-    <_Parameter1>SourcePath</_Parameter1>
-    <_Parameter2>$(MSBuildProjectDirectory)</_Parameter2>
+      <_Parameter1>SourcePath</_Parameter1>
+      <_Parameter2>$(MSBuildProjectDirectory)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
   <Import Project="..\Directory.Build.props" />


### PR DESCRIPTION
[PerfTestEnvironment](https://github.com/Azure/azure-sdk-for-net/blob/0785a3b41e478b1f0029a0257958963cc721ff16/sdk/core/Azure.Core.TestFramework/src/TestEnvironment.cs#L308) now depends on reading the 'SourcePath' attribute from the test assembly.
This change fixes the failure in all .NET perf tests by generating the attribute in the output assemblies.