### PR TITLE
[synapse] Add two new champion scenario tests, refactor one, and disable a few

### DIFF
--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/NotebookClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/NotebookClientLiveTests.cs
@@ -26,6 +26,7 @@ namespace Azure.Analytics.Synapse.Tests.Artifacts
         {
         }
 
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public async Task TestGetNotebook()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/NotebookSampleSnippets.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/NotebookSampleSnippets.cs
@@ -13,6 +13,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Samples
 {
     public partial class NotebookSnippets : SampleFixture
     {
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public async Task NotebookSample()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample1_ExecutePipeline.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample1_ExecutePipeline.cs
@@ -16,6 +16,7 @@ namespace Azure.Analytics.Synapse.Samples
     /// </summary>
     public partial class ExecutePipelines
     {
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public async Task CreateAndRunPipeline()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample1_ExecutePipeline.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample1_ExecutePipeline.cs
@@ -20,8 +20,16 @@ namespace Azure.Analytics.Synapse.Samples
         public async Task CreateAndRunPipeline()
         {
             const string PipelineName = "Test-Pipeline";
+
+            await CreatePipeline(PipelineName);
+            await RunPipeline(PipelineName);
+        }
+
+        private async Task CreatePipeline (string pipelineName)
+        {
             const string JobName = "SparkJobName";
             const string ActivityName = "ActivityName";
+
             string endpoint = TestEnvironment.EndpointUrl;
 
             var pipelineClient = new PipelineClient(endpoint: new Uri(endpoint), credential: new DefaultAzureCredential());
@@ -32,24 +40,19 @@ namespace Azure.Analytics.Synapse.Samples
             pipelineResource.Activities.Add(activity);
 
             Console.WriteLine("Create pipeline if not already exists.");
-            await pipelineClient.StartCreateOrUpdatePipelineAsync(PipelineName, pipelineResource);
+            var operation = await pipelineClient.StartCreateOrUpdatePipelineAsync(pipelineName, pipelineResource);
+            await operation.WaitForCompletionAsync ();
             Console.WriteLine("Pipeline created");
-
-            Console.WriteLine("Running pipeline.");
-            CreateRunResponse runOperation = await pipelineClient.CreatePipelineRunAsync(PipelineName);
-            Console.WriteLine("Run started. ID: {0}", runOperation.RunId);
         }
 
-        [Test]
-        public async Task RunPipeline()
+        private async Task RunPipeline(string pipelineName)
         {
-            const string PipelineName = "Test-Pipeline";
             string endpoint = TestEnvironment.EndpointUrl;
 
             var pipelineClient = new PipelineClient(endpoint: new Uri(endpoint), credential: new DefaultAzureCredential());
 
             Console.WriteLine("Running pipeline.");
-            CreateRunResponse runOperation = await pipelineClient.CreatePipelineRunAsync(PipelineName);
+            CreateRunResponse runOperation = await pipelineClient.CreatePipelineRunAsync(pipelineName);
             Console.WriteLine("Run started. ID: {0}", runOperation.RunId);
         }
     }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample1_ExecutePipeline.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample1_ExecutePipeline.cs
@@ -41,7 +41,7 @@ namespace Azure.Analytics.Synapse.Samples
             pipelineResource.Activities.Add(activity);
 
             Console.WriteLine("Create pipeline if not already exists.");
-            var operation = await pipelineClient.StartCreateOrUpdatePipelineAsync(pipelineName, pipelineResource);
+            PipelineCreateOrUpdatePipelineOperation operation = await pipelineClient.StartCreateOrUpdatePipelineAsync(pipelineName, pipelineResource);
             await operation.WaitForCompletionAsync ();
             Console.WriteLine("Pipeline created");
         }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample2_CreateNotebook.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample2_CreateNotebook.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Identity;
+using NUnit.Framework;
+using Azure.Analytics.Synapse.Artifacts;
+using Azure.Analytics.Synapse.Artifacts.Models;
+using Azure.Core.TestFramework;
+
+namespace Azure.Analytics.Synapse.Samples
+{
+    /// <summary>
+    /// This sample demonstrates how to create and upload a notebook using asynchronous methods of <see cref="NotebookClient"/>.
+    /// </summary>
+    public partial class NotebookSample
+    {
+        [Test]
+        public async Task CreateAndUploadNotebook()
+        {
+            string notebookName = "demo_notebook";
+            string endpoint = TestEnvironment.EndpointUrl;
+
+            var client = new NotebookClient(endpoint: new Uri(endpoint), credential: new DefaultAzureCredential());
+
+            var cell = new NotebookCell("code", new NotebookMetadata (), new string[] {
+                "from azureml.opendatasets import NycTlcYellow\n",
+                "\n",
+                "data = NycTlcYellow()\n",
+                "df = data.to_spark_dataframe()\n",
+                "# Display 10 rows\n",
+                "display(df.limit(10))"
+            });
+            var notebook = new Notebook(new NotebookMetadata(), 4, 2, new NotebookCell[] { cell });
+            var notebookResource = new NotebookResource(notebookName, notebook);
+
+            NotebookCreateOrUpdateNotebookOperation operation = await client.StartCreateOrUpdateNotebookAsync(notebookName, notebookResource);
+            await operation.WaitForCompletionAsync();
+            Console.WriteLine("Notebook is created");
+        }
+    }
+}

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample2_CreateNotebook.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample2_CreateNotebook.cs
@@ -16,6 +16,7 @@ namespace Azure.Analytics.Synapse.Samples
     /// </summary>
     public partial class NotebookSample
     {
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public async Task CreateAndUploadNotebook()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
@@ -17,6 +17,7 @@ namespace Azure.Analytics.Synapse.Samples
     /// </summary>
     public partial class PipelineMonitoring
     {
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public void MonitorPipelineRuns()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Azure.Analytics.Synapse.Monitoring;
+using Azure.Analytics.Synapse.Monitoring.Models;
+using Azure.Identity;
+using NUnit.Framework;
+
+namespace Azure.Analytics.Synapse.Samples
+{
+    /// <summary>
+    /// This sample demonstrates how to monitor pipeline runs using synchronous methods of <see cref="MonitoringClient"/>.
+    /// </summary>
+    public partial class PipelineMonitoring
+    {
+        [Test]
+        public void MonitorPipelineRuns()
+        {
+            string endpoint = TestEnvironment.EndpointUrl;
+            MonitoringClient client = new MonitoringClient(new Uri(endpoint), new DefaultAzureCredential());
+
+            SparkJobListViewResponse sparkJobList = client.GetSparkJobList();
+            foreach (var sparkJob in sparkJobList.SparkJobs)
+            {
+                if (sparkJob.State == "Running")
+                {
+                    Console.WriteLine ($"{sparkJob.Name} has been running for {sparkJob.RunningDuration}");
+                }
+                else
+                {
+                    Console.WriteLine ($"{sparkJob.Name} has been in {sparkJob.State} for {sparkJob.QueuedDuration}");
+                }
+            }
+        }
+    }
+}

--- a/sdk/synapse/Azure.Analytics.Synapse.Shared/tests/SampleFixture.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Shared/tests/SampleFixture.cs
@@ -25,5 +25,8 @@ namespace Azure.Analytics.Synapse.Samples
     public partial class ExecuteSparkStatement : SampleFixture { }
     public partial class AddAndRemoveRoleAssignment : SampleFixture { }
     public partial class ExecutePipelines : SampleFixture { }
+    public partial class NotebookSample : SampleFixture { }
+    public partial class PipelineMonitoring : SampleFixture { }
+
 #pragma warning restore SA1402 // File may only contain a single type
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/Sample2_ExecuteSparkStatement.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/Sample2_ExecuteSparkStatement.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Collections.Generic;
 using Azure.Analytics.Synapse.Spark;
 using Azure.Analytics.Synapse.Spark.Models;
 using Azure.Identity;
@@ -38,6 +40,9 @@ namespace Azure.Analytics.Synapse.Samples
 
             SparkSession sessionCreated = client.CreateSparkSession(request);
 
+            // Waiting session creation completion
+            sessionCreated = PollSparkSession(client, sessionCreated);
+
             SparkSession session = client.GetSparkSession(sessionCreated.Id);
             Debug.WriteLine($"Session is returned with name {session.Name} and state {session.State}");
 
@@ -48,6 +53,9 @@ namespace Azure.Analytics.Synapse.Samples
             };
             SparkStatement statementCreated = client.CreateSparkStatement(sessionCreated.Id, sparkStatementRequest);
 
+            // Wait operation completion
+            statementCreated = PollSparkStatement(client, sessionCreated.Id, statementCreated);
+
             SparkStatement statement = client.GetSparkStatement(sessionCreated.Id, statementCreated.Id);
             Debug.WriteLine($"Statement is returned with id {statement.Id} and state {statement.State}");
 
@@ -55,6 +63,114 @@ namespace Azure.Analytics.Synapse.Samples
             Debug.WriteLine($"Statement is cancelled with message {cancellationResult.Msg}");
 
             Response operation = client.CancelSparkSession(sessionCreated.Id);
+        }
+
+        private const string Error = "error";
+        private const string Dead = "dead";
+        private const string Success = "success";
+        private const string Killed = "killed";
+        private const string Idle = "idle";
+
+       public static List<string> SessionSubmissionFinalStates = new List<string>
+        {
+            Idle,
+            Error,
+            Dead,
+            Success,
+            Killed
+        };
+
+        public static SparkSession PollSparkSession(
+            SparkSessionClient client,
+            SparkSession session,
+            IList<string> livyReadyStates = null)
+        {
+            if (livyReadyStates == null)
+            {
+                livyReadyStates = SessionSubmissionFinalStates;
+            }
+
+            return Poll(
+                session,
+                s => s.Result.ToString(),
+                s => s.State,
+                s => client.GetSparkSession(s.Id, true),
+                livyReadyStates);
+        }
+
+        private const string Starting = "starting";
+        private const string Waiting = "waiting";
+        private const string Running = "running";
+        private const string Cancelling = "cancelling";
+
+        private static List<string> ExecutingStates = new List<string>
+        {
+            Starting,
+            Waiting,
+            Running,
+            Cancelling
+        };
+
+        private static SparkStatement PollSparkStatement(
+            SparkSessionClient client,
+            int sessionId,
+            SparkStatement statement)
+        {
+            return Poll(
+                statement,
+                s => null,
+                s => s.State,
+                s => client.GetSparkStatement(sessionId, s.Id),
+                ExecutingStates,
+                isFinalState: false);
+        }
+
+        private static T Poll<T>(
+            T job,
+            Func<T, string> getJobState,
+            Func<T, string> getLivyState,
+            Func<T, T> refresh,
+            IList<string> livyReadyStates,
+            bool isFinalState = true,
+            int pollingInMilliseconds = 0,
+            int timeoutInMilliseconds = 0,
+            Action<T> writeLog = null)
+        {
+            var timeWaitedInMilliSeconds = 0;
+            if (pollingInMilliseconds == 0)
+            {
+                pollingInMilliseconds = 5000;
+            }
+
+            while (IsJobRunning(getJobState(job), getLivyState(job), livyReadyStates, isFinalState))
+            {
+                if (timeoutInMilliseconds > 0 && timeWaitedInMilliSeconds >= timeoutInMilliseconds)
+                {
+                    throw new TimeoutException();
+                }
+
+                writeLog?.Invoke(job);
+                //TestMockSupport.Delay(pollingInMilliseconds);
+                System.Threading.Thread.Sleep(pollingInMilliseconds);
+                timeWaitedInMilliSeconds += pollingInMilliseconds;
+
+                // TODO: handle retryable excetpion
+                job = refresh(job);
+            }
+
+            return job;
+        }
+
+        private static bool IsJobRunning(string jobState, string livyState, IList<string> livyStates, bool isFinalState = true)
+        {
+            if ("Succeeded".Equals(jobState, StringComparison.OrdinalIgnoreCase)
+                || "Failed".Equals(jobState, StringComparison.OrdinalIgnoreCase)
+                || "Cancelled".Equals(jobState, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return isFinalState ? !livyStates.Contains(livyState) : livyStates.Contains(livyState);
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/Sample2_ExecuteSparkStatement.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/Sample2_ExecuteSparkStatement.cs
@@ -65,6 +65,10 @@ namespace Azure.Analytics.Synapse.Samples
             Response operation = client.CancelSparkSession(sessionCreated.Id);
         }
 
+        // https://github.com/Azure/azure-sdk-for-net/issues/17587
+        // This code is copied from SparkTestUtilities.cs and modified, as there is no current way to monitor/poll for spark completion
+        // It belongs in a helper class, likely a LRO
+        // It is being left here only temporarily.
         private const string Error = "error";
         private const string Dead = "dead";
         private const string Success = "success";


### PR DESCRIPTION
- Add beginnings of two new champion scenario tests (Upload artifact notebook and monitoring pipelines)
  - Once all of the tests are in they will be turned into snippets and made markdown
  - Significant amount of polling code in Sample2_ExecuteSparkStatement.cs is from service team recommendation right now
      - Moving it into the binding as a LRO is a future research topic
      - Tracked in https://github.com/Azure/azure-sdk-for-net/issues/17587 to track the copied code. 
- Refactor CreateAndRunPipeline test which had two tests, which were order dependent :facepalm: 
- Disable a few more tests that now fail in LIVE (will be reenabled when the [swagger PR](https://github.com/Azure/azure-rest-api-specs/pull/12093) lands and is bumped to)