### PR TITLE
Fix Microsoft.Azure.WebJobs.Extensions.EventHubs inheritdoc failures

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubListener.cs
@@ -57,6 +57,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs
                     _logger));
         }
 
+        /// <summary>
+        /// Cancel any in progress listen operation.
+        /// </summary>
         void IListener.Cancel()
         {
             StopAsync(CancellationToken.None).Wait();

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsScaleMonitor.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
 
         public ScaleMonitorDescriptor Descriptor { get; }
 
+        /// <summary>
+        /// Returns the state of the event hub for scaling purposes.
+        /// </summary>
         async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync()
         {
             return await GetMetricsAsync().ConfigureAwait(false);
@@ -180,6 +183,9 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Listeners
             return (count < 0) ? 0 : count;
         }
 
+        /// <summary>
+        /// Return the current scaling decision based on the EventHub status.
+        /// </summary>
         ScaleStatus IScaleMonitor.GetScaleStatus(ScaleStatusContext context)
         {
             return GetScaleStatusCore(context.WorkerCount, context.Metrics?.Cast<EventHubsTriggerMetrics>().ToArray());

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Microsoft.Azure.WebJobs.Extensions.EventHubs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Microsoft Azure WebJobs SDK EventHubs Extension</Description>
     <Version>5.0.0-beta.1</Version>
     <NoWarn>$(NoWarn);AZC0001;CS1591;SA1636</NoWarn>


### PR DESCRIPTION
This is a fun one. 

A combination of 

https://github.com/Azure/azure-webjobs-sdk/issues/2627
https://github.com/Azure/azure-sdk-for-net/issues/17549
https://github.com/Azure/azure-sdk-for-net/issues/17550
and https://github.com/Azure/azure-sdk-for-net/issues/17548