### PR TITLE
Added pipelines for Mixed Reality SDKs

### DIFF
--- a/sdk/mixedreality/ci.yml
+++ b/sdk/mixedreality/ci.yml
@@ -25,7 +25,6 @@ extends:
   parameters:
     ServiceDirectory: mixedreality
     ArtifactName: packages
-    TestPipeline: true
     Artifacts:
     - name: Azure.MixedReality.Authentication
       safeName: AzureMixedRealityAuthentication

--- a/sdk/mixedreality/ci.yml
+++ b/sdk/mixedreality/ci.yml
@@ -18,7 +18,7 @@ pr:
     - release/*
   paths:
     include:
-    - common/mixedreality/
+    - sdk/mixedreality/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/mixedreality/ci.yml
+++ b/sdk/mixedreality/ci.yml
@@ -1,0 +1,31 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+trigger:
+  branches:
+    include:
+    - master
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/mixedreality/
+
+pr:
+  branches:
+    include:
+    - master
+    - feature/*
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - common/mixedreality/
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: mixedreality
+    ArtifactName: packages
+    TestPipeline: true
+    Artifacts:
+    - name: Azure.MixedReality.Authentication
+      safeName: AzureMixedRealityAuthentication

--- a/sdk/mixedreality/tests.yml
+++ b/sdk/mixedreality/tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    ServiceDirectory: mixedreality


### PR DESCRIPTION
This change adds the ci and tests pipelines for Mixed Reality SDKs, the first being `Azure.MixedReality.Authentication`, which will reside at `sdk/mixedreality/Azure.MixedReality.Authentication`. The intent is to get the pipelines checked-in, an automated process should kick in to setup those pipelines, and then I can submit the `Azure.MixedReality.Authentication` library to be checked in and validated using those pipelines.

@AlexGhiondea @JoshLove-msft @pakrym 