### PR TITLE
Prepare Azure.Extensions.AspNetCore.DataProtection.Blobs for release

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Release History
 
-## 1.1.0-preview.1 (Unreleased)
+## 1.1.0 (2020-08-06)
 
+### Changes
+
+#### Key Bug Fixes
+
+- The `Azure.Storage.Blobs` dependency updated to 12.6.0 to avoid a breaking change in an early package version.
 
 ## 1.0.1 (2020-08-06)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/en-us/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
     <PackageTags>aspnetcore;dataprotection;azure;blob;key store</PackageTags>
-    <Version>1.1.0-preview.1</Version>
+    <Version>1.1.0</Version>
     <ApiCompatVersion>1.0.1</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <NoWarn>$(NoWarn);AZC0102</NoWarn>


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17321

The centralized version was bumped a long time ago. We just need to re-release.