### PR TITLE
Fixed bug where parsing an Account Name that is partioned was returni…

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -220,24 +220,28 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [Test]
+        public void DataLakeUriBuilder_PartitionedAccountName()
+        {
+            var blobUriBuilder = new BlobUriBuilder(new Uri("https://account.zone.blob.core.windows.net/share/dir"));
+
+            Assert.AreEqual("account.zone", blobUriBuilder.AccountName);
+        }
+
+        [Test]
         public void BlobUriBuilder_RegularUrl_MalformedSubdomain()
         {
-            // core and blob swapped
-            var blobUriBuilder1 = new BlobUriBuilder(new Uri("https://account.core.blob.windows.net/container/blob"));
-
             // account and blob swapped
-            var blobUriBuilder2 = new BlobUriBuilder(new Uri("https://blob.account.core.windows.net/container/blob"));
+            var blobUriBuilder1 = new BlobUriBuilder(new Uri("https://blob.account.core.windows.net/container/blob"));
 
             // wrong service
-            var blobUriBuilder3 = new BlobUriBuilder(new Uri("https://account.file.core.windows.net/container/blob"));
+            var blobUriBuilder2 = new BlobUriBuilder(new Uri("https://account.file.core.windows.net/container/blob"));
 
             // empty service
-            var blobUriBuilder4 = new BlobUriBuilder(new Uri("https://account./container/blob"));
+            var blobUriBuilder3 = new BlobUriBuilder(new Uri("https://account./container/blob"));
 
             Assert.AreEqual(string.Empty, blobUriBuilder1.AccountName);
             Assert.AreEqual(string.Empty, blobUriBuilder2.AccountName);
             Assert.AreEqual(string.Empty, blobUriBuilder3.AccountName);
-            Assert.AreEqual(string.Empty, blobUriBuilder4.AccountName);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobUriBuilderTests/DataLakeUriBuilder_PartitionedAccountName.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobUriBuilderTests/DataLakeUriBuilder_PartitionedAccountName.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobUriBuilderTests/DataLakeUriBuilder_PartitionedAccountNameAsync.json
+++ b/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/BlobUriBuilderTests/DataLakeUriBuilder_PartitionedAccountNameAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Common/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Common/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.7.0-beta.2 (Unreleased)
-
+- Fixed bug where parsing an Account Name that is partioned was returning an empty account name when building the full Uri
 
 ## 12.7.0-beta.1 (2020-12-07)
 - This release contains bug fixes to improve quality.

--- a/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
@@ -77,7 +77,8 @@ namespace Azure.Storage
             GetAccountNameFromDomain(uri.Host, serviceSubDomain);
 
         /// <summary>
-        /// Get the account name from the host.
+        /// Get the account name from the host. We assume the storage account name characters
+        /// before the service subdomain section.
         /// </summary>
         /// <param name="host">Host.</param>
         /// <param name="serviceSubDomain">The service subdomain used to validate that the
@@ -86,19 +87,11 @@ namespace Azure.Storage
         /// <returns>Account name or null if not able to be parsed.</returns>
         public static string GetAccountNameFromDomain(string host, string serviceSubDomain)
         {
-            var accountEndIndex = host.IndexOf(".", StringComparison.InvariantCulture);
+            string subDomainPeriodAdded = '.' + serviceSubDomain + '.';
+            var accountEndIndex = host.IndexOf(subDomainPeriodAdded, StringComparison.InvariantCulture);
             if (accountEndIndex >= 0)
             {
-                var serviceStartIndex = accountEndIndex + 1;
-                var serviceEndIndex = host.IndexOf(".", serviceStartIndex, StringComparison.InvariantCulture);
-                if (serviceEndIndex > serviceStartIndex)
-                {
-                    var service = host.Substring(serviceStartIndex, serviceEndIndex - serviceStartIndex);
-                    if (service == serviceSubDomain)
-                    {
-                        return host.Substring(0, accountEndIndex);
-                    }
-                }
+                return host.Substring(0, accountEndIndex);
             }
             return null;
         }

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeUriBuilderTests.cs
@@ -96,24 +96,28 @@ namespace Azure.Storage.Files.DataLake.Tests
         }
 
         [Test]
+        public void DataLakeUriBuilder_PartitionedAccountName()
+        {
+            var datalakeUriBuilder = new DataLakeUriBuilder(new Uri("https://account.zone.blob.core.windows.net/share/dir"));
+
+            Assert.AreEqual("account.zone", datalakeUriBuilder.AccountName);
+        }
+
+        [Test]
         public void DataLakeUriBuilder_MalformedSubdomain()
         {
-            // core and file swapped
-            var datalakeUriBuilder1 = new DataLakeUriBuilder(new Uri("https://account.core.blob.windows.net/share/dir"));
-
             // account and file swapped
-            var datalakeUriBuilder2 = new DataLakeUriBuilder(new Uri("https://blob.account.core.windows.net/share/dir"));
+            var datalakeUriBuilder1 = new DataLakeUriBuilder(new Uri("https://blob.account.core.windows.net/share/dir"));
 
             // wrong service
-            var datalakeUriBuilder3 = new DataLakeUriBuilder(new Uri("https://account.queue.core.windows.net/share/dir"));
+            var datalakeUriBuilder2 = new DataLakeUriBuilder(new Uri("https://account.queue.core.windows.net/share/dir"));
 
             // empty service
-            var datalakeUriBuilder4 = new DataLakeUriBuilder(new Uri("https://account./share/dir"));
+            var datalakeUriBuilder3 = new DataLakeUriBuilder(new Uri("https://account./share/dir"));
 
             Assert.AreEqual(string.Empty, datalakeUriBuilder1.AccountName);
             Assert.AreEqual(string.Empty, datalakeUriBuilder2.AccountName);
             Assert.AreEqual(string.Empty, datalakeUriBuilder3.AccountName);
-            Assert.AreEqual(string.Empty, datalakeUriBuilder4.AccountName);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeUriBuilderTests/DataLakeUriBuilder_PartitionedAccountName.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeUriBuilderTests/DataLakeUriBuilder_PartitionedAccountName.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeUriBuilderTests/DataLakeUriBuilder_PartitionedAccountNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DataLakeUriBuilderTests/DataLakeUriBuilder_PartitionedAccountNameAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
@@ -188,24 +188,28 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [Test]
+        public void FileUriBuilder_PartitionedAccountName()
+        {
+            var fileUriBuilder = new ShareUriBuilder(new Uri("https://account.zone.file.core.windows.net/share/dir"));
+
+            Assert.AreEqual("account.zone", fileUriBuilder.AccountName);
+        }
+
+        [Test]
         public void FileUriBuilder_MalformedSubdomain()
         {
-            // core and file swapped
-            var shareUriBuilder1 = new ShareUriBuilder(new Uri("https://account.core.file.windows.net/share/dir"));
-
             // account and file swapped
-            var shareUriBuilder2 = new ShareUriBuilder(new Uri("https://file.account.core.windows.net/share/dir"));
+            var shareUriBuilder1 = new ShareUriBuilder(new Uri("https://file.account.core.windows.net/share/dir"));
 
             // wrong service
-            var shareUriBuilder3 = new ShareUriBuilder(new Uri("https://account.blob.core.windows.net/share/dir"));
+            var shareUriBuilder2 = new ShareUriBuilder(new Uri("https://account.blob.core.windows.net/share/dir"));
 
             // empty service
-            var shareUriBuilder4 = new ShareUriBuilder(new Uri("https://account./share/dir"));
+            var shareUriBuilder3 = new ShareUriBuilder(new Uri("https://account./share/dir"));
 
             Assert.AreEqual(string.Empty, shareUriBuilder1.AccountName);
             Assert.AreEqual(string.Empty, shareUriBuilder2.AccountName);
             Assert.AreEqual(string.Empty, shareUriBuilder3.AccountName);
-            Assert.AreEqual(string.Empty, shareUriBuilder4.AccountName);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileUriBuilderTests/FileUriBuilder_PartitionedAccountName.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileUriBuilderTests/FileUriBuilder_PartitionedAccountName.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileUriBuilderTests/FileUriBuilder_PartitionedAccountNameAsync.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/SessionRecords/FileUriBuilderTests/FileUriBuilder_PartitionedAccountNameAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueUriBuilder_RegularUrl_AccountTest()
         {
             // Arrange
-            var uriString = "https://account.core.queue.windows.net?comp=list";
+            var uriString = "https://account.queue.core.windows.net?comp=list";
             var originalUri = new UriBuilder(uriString);
 
             // Act
@@ -31,9 +31,9 @@ namespace Azure.Storage.Queues.Test
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
-            Assert.AreEqual("account.core.queue.windows.net", queueUriBuilder.Host);
+            Assert.AreEqual("account.queue.core.windows.net", queueUriBuilder.Host);
             Assert.AreEqual(443, queueUriBuilder.Port);
-            Assert.AreEqual("", queueUriBuilder.AccountName);
+            Assert.AreEqual("account", queueUriBuilder.AccountName);
             Assert.AreEqual("", queueUriBuilder.QueueName);
             Assert.IsFalse(queueUriBuilder.Messages);
             Assert.AreEqual("", queueUriBuilder.MessageId);
@@ -47,7 +47,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueUriBuilder_RegularUrl_QueueTest()
         {
             // Arrange
-            var uriString = "https://account.core.queue.windows.net/queue";
+            var uriString = "https://account.queue.core.windows.net/queue";
             var originalUri = new UriBuilder(uriString);
 
             // Act
@@ -56,9 +56,9 @@ namespace Azure.Storage.Queues.Test
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
-            Assert.AreEqual("account.core.queue.windows.net", queueUriBuilder.Host);
+            Assert.AreEqual("account.queue.core.windows.net", queueUriBuilder.Host);
             Assert.AreEqual(443, queueUriBuilder.Port);
-            Assert.AreEqual("", queueUriBuilder.AccountName);
+            Assert.AreEqual("account", queueUriBuilder.AccountName);
             Assert.AreEqual("queue", queueUriBuilder.QueueName);
             Assert.IsFalse(queueUriBuilder.Messages);
             Assert.AreEqual("", queueUriBuilder.MessageId);
@@ -72,7 +72,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueUriBuilder_RegularUrl_MessagesTest()
         {
             // Arrange
-            var uriString = "https://account.core.queue.windows.net/queue/messages";
+            var uriString = "https://account.queue.core.windows.net/queue/messages";
             var originalUri = new UriBuilder(uriString);
 
             // Act
@@ -81,9 +81,9 @@ namespace Azure.Storage.Queues.Test
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
-            Assert.AreEqual("account.core.queue.windows.net", queueUriBuilder.Host);
+            Assert.AreEqual("account.queue.core.windows.net", queueUriBuilder.Host);
             Assert.AreEqual(443, queueUriBuilder.Port);
-            Assert.AreEqual("", queueUriBuilder.AccountName);
+            Assert.AreEqual("account", queueUriBuilder.AccountName);
             Assert.IsTrue(queueUriBuilder.Messages);
             Assert.AreEqual("queue", queueUriBuilder.QueueName);
             Assert.AreEqual("", queueUriBuilder.MessageId);
@@ -97,7 +97,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueUriBuilder_RegularUrl_MessageIdTest()
         {
             // Arrange
-            var uriString = "https://account.core.queue.windows.net/queue/messages/messageId";
+            var uriString = "https://account.queue.core.windows.net/queue/messages/messageId";
             var originalUri = new UriBuilder(uriString);
 
             // Act
@@ -106,9 +106,9 @@ namespace Azure.Storage.Queues.Test
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
-            Assert.AreEqual("account.core.queue.windows.net", queueUriBuilder.Host);
+            Assert.AreEqual("account.queue.core.windows.net", queueUriBuilder.Host);
             Assert.AreEqual(443, queueUriBuilder.Port);
-            Assert.AreEqual("", queueUriBuilder.AccountName);
+            Assert.AreEqual("account", queueUriBuilder.AccountName);
             Assert.AreEqual("queue", queueUriBuilder.QueueName);
             Assert.IsTrue(queueUriBuilder.Messages);
             Assert.AreEqual("messageId", queueUriBuilder.MessageId);
@@ -122,7 +122,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueUriBuilder_RegularUrl_PortTest()
         {
             // Arrange
-            var uriString = "https://account.core.queue.windows.net:8080/queue";
+            var uriString = "https://account.queue.core.windows.net:8080/queue";
             var originalUri = new UriBuilder(uriString);
 
             // Act
@@ -131,9 +131,9 @@ namespace Azure.Storage.Queues.Test
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
-            Assert.AreEqual("account.core.queue.windows.net", queueUriBuilder.Host);
+            Assert.AreEqual("account.queue.core.windows.net", queueUriBuilder.Host);
             Assert.AreEqual(8080, queueUriBuilder.Port);
-            Assert.AreEqual("", queueUriBuilder.AccountName);
+            Assert.AreEqual("account", queueUriBuilder.AccountName);
             Assert.AreEqual("queue", queueUriBuilder.QueueName);
             Assert.IsFalse(queueUriBuilder.Messages);
             Assert.AreEqual("", queueUriBuilder.MessageId);
@@ -147,7 +147,7 @@ namespace Azure.Storage.Queues.Test
         public void QueueUriBuilder_RegularUrl_SasTest()
         {
             // Arrange
-            var uriString = "https://account.core.queue.windows.net/queue?sv=2015-04-05&spr=https&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sip=168.1.5.60-168.1.5.70&sr=b&sp=rw&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D";
+            var uriString = "https://account.queue.core.windows.net/queue?sv=2015-04-05&spr=https&st=2015-04-29T22%3A18%3A26Z&se=2015-04-30T02%3A23%3A26Z&sip=168.1.5.60-168.1.5.70&sr=b&sp=rw&sig=Z%2FRHIX5Xcg0Mq2rqI3OlWTjEg2tYkboXr1P9ZUXDtkk%3D";
             var originalUri = new UriBuilder(uriString);
 
             // Act
@@ -156,9 +156,9 @@ namespace Azure.Storage.Queues.Test
 
             // Assert
             Assert.AreEqual("https", queueUriBuilder.Scheme);
-            Assert.AreEqual("account.core.queue.windows.net", queueUriBuilder.Host);
+            Assert.AreEqual("account.queue.core.windows.net", queueUriBuilder.Host);
             Assert.AreEqual(443, queueUriBuilder.Port);
-            Assert.AreEqual("", queueUriBuilder.AccountName);
+            Assert.AreEqual("account", queueUriBuilder.AccountName);
             Assert.AreEqual("queue", queueUriBuilder.QueueName);
             Assert.IsFalse(queueUriBuilder.Messages);
             Assert.AreEqual("", queueUriBuilder.MessageId);
@@ -375,24 +375,28 @@ namespace Azure.Storage.Queues.Test
         }
 
         [Test]
+        public void QueueUriBuilder_PartitionedAccountName()
+        {
+            var queueUriBuilder = new QueueUriBuilder(new Uri("https://account.zone.queue.core.windows.net/share/dir"));
+
+            Assert.AreEqual("account.zone", queueUriBuilder.AccountName);
+        }
+
+        [Test]
         public void QueueUriBuilder_MalformedSubdomain()
         {
-            // core and queue swapped
-            var queueUriBuilder1 = new QueueUriBuilder(new Uri("https://account.core.queue.windows.net/queue"));
-
             // account and queue swapped
-            var queueUriBuilder2 = new QueueUriBuilder(new Uri("https://queue.account.core.windows.net/queue"));
+            var queueUriBuilder1 = new QueueUriBuilder(new Uri("https://queue.account.core.windows.net/queue"));
 
             // wrong service
-            var queueUriBuilder3 = new QueueUriBuilder(new Uri("https://account.blob.core.windows.net/queue"));
+            var queueUriBuilder2 = new QueueUriBuilder(new Uri("https://account.blob.core.windows.net/queue"));
 
             // empty service
-            var queueUriBuilder4 = new QueueUriBuilder(new Uri("https://account./queue"));
+            var queueUriBuilder3 = new QueueUriBuilder(new Uri("https://account./queue"));
 
             Assert.AreEqual(string.Empty, queueUriBuilder1.AccountName);
             Assert.AreEqual(string.Empty, queueUriBuilder2.AccountName);
             Assert.AreEqual(string.Empty, queueUriBuilder3.AccountName);
-            Assert.AreEqual(string.Empty, queueUriBuilder4.AccountName);
         }
 
         [Test]

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueUriBuilderTests/QueueUriBuilder_PartitionedAccountName.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueUriBuilderTests/QueueUriBuilder_PartitionedAccountName.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}

--- a/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueUriBuilderTests/QueueUriBuilder_PartitionedAccountNameAsync.json
+++ b/sdk/storage/Azure.Storage.Queues/tests/SessionRecords/QueueUriBuilderTests/QueueUriBuilder_PartitionedAccountNameAsync.json
@@ -1,0 +1,4 @@
+{
+  "Entries": [],
+  "Variables": {}
+}


### PR DESCRIPTION
…ng an empty account name

Uris that were getting passed to constructors "https://account.zone.blob.core.windows.net" was just looking to see if the second value was the service subdomain (e.g. blob, file, dfs). If this was not the case we would send back an empty account name.

This used to be an acceptable case however, now a period can be included in the account name to identity the zone.