### PR TITLE
Authorization refresh fix

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -53,13 +53,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   refreshing authorization.  Authorization will be refreshed earlier
         ///   than the expected expiration by this amount.
         /// </summary>
-        private static TimeSpan AuthorizationRefreshBuffer { get; } = TimeSpan.FromMinutes(5);
+        private static TimeSpan AuthorizationRefreshBuffer { get; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
         ///   The minimum amount of time for authorization to be refreshed; any calculations that
         ///   call for refreshing more frequently will be substituted with this value.
         /// </summary>
-        private static TimeSpan MinimumAuthorizationRefresh { get; } = TimeSpan.FromMinutes(4);
+        private static TimeSpan MinimumAuthorizationRefresh { get; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
         ///   The amount time to allow to refresh authorization of an AMQP link.
@@ -956,6 +956,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string[] requiredClaims,
             TimeSpan timeout)
         {
+            ServiceBusEventSource.Log.RequestAuthorizationStart(ActiveConnection.ToString(), exception.ToString());
+
             AmqpCbsLink authLink = connection.Extensions.Find<AmqpCbsLink>();
             DateTime cbsTokenExpiresAtUtc = DateTime.MaxValue;
             foreach (string resource in audience)
@@ -967,6 +969,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     cbsTokenExpiresAtUtc = expiresAt;
                 }
             }
+            ServiceBusEventSource.Log.(ActiveConnection.ToString(), exception.ToString());
             return cbsTokenExpiresAtUtc;
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpConnectionScope.cs
@@ -230,6 +230,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 var link = await CreateManagementLinkAsync(
                     entityPath,
+                    identifier,
                     connection,
                     timeout.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -249,6 +250,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <summary>
         ///   Opens an AMQP link for use with receiver operations.
         /// </summary>
+        /// <param name="identifier">The identifier of the entity that is receiving.</param>
         /// <param name="entityPath">The entity path to receive from.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.</param>
@@ -260,6 +262,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <returns>A link for use with consumer operations.</returns>
         ///
         public virtual async Task<ReceivingAmqpLink> OpenReceiverLinkAsync(
+            string identifier,
             string entityPath,
             TimeSpan timeout,
             uint prefetchCount,
@@ -277,15 +280,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             ReceivingAmqpLink link = await CreateReceivingLinkAsync(
-                entityPath,
-                connection,
-                receiverEndpoint,
-                timeout.CalculateRemaining(stopWatch.GetElapsedTime()),
-                prefetchCount,
-                receiveMode,
-                sessionId,
-                isSessionReceiver,
-                cancellationToken
+                entityPath: entityPath,
+                identifier: identifier,
+                connection: connection,
+                endpoint: receiverEndpoint,
+                timeout: timeout.CalculateRemaining(stopWatch.GetElapsedTime()),
+                prefetchCount: prefetchCount,
+                receiveMode: receiveMode,
+                sessionId: sessionId,
+                isSessionReceiver: isSessionReceiver,
+                cancellationToken: cancellationToken
             ).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -299,6 +303,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Opens an AMQP link for use with sender operations.
         /// </summary>
         /// <param name="entityPath"></param>
+        /// <param name="identifier">The identifier for the sender that is opening a send link.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
@@ -306,6 +311,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///
         public virtual async Task<SendingAmqpLink> OpenSenderLinkAsync(
             string entityPath,
+            string identifier,
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
@@ -317,9 +323,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
             SendingAmqpLink link = await CreateSendingLinkAsync(
-                entityPath,
-                connection,
-                timeout.CalculateRemaining(stopWatch.GetElapsedTime()), cancellationToken).ConfigureAwait(false);
+                entityPath: entityPath,
+                identifier: identifier,
+                connection: connection,
+                timeout: timeout.CalculateRemaining(stopWatch.GetElapsedTime()),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
@@ -415,7 +423,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Creates an AMQP link for use with management operations.
         /// </summary>
         /// <param name="entityPath"></param>
-        ///
+        /// <param name="identifier">The identifier for the sender or receiver that is opening a management link.</param>
         /// <param name="connection">The active and opened AMQP connection to use for this link.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
@@ -423,6 +431,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <returns>A link for use with management operations.</returns>
         protected virtual async Task<RequestResponseAmqpLink> CreateManagementLinkAsync(
             string entityPath,
+            string identifier,
             AmqpConnection connection,
             TimeSpan timeout,
             CancellationToken cancellationToken)
@@ -456,12 +465,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 var endpoint = new Uri(ServiceEndpoint, entityPath);
                 var audience = new[] { endpoint.AbsoluteUri };
                 DateTime authExpirationUtc = await RequestAuthorizationUsingCbsAsync(
-                    connection,
-                    TokenProvider,
-                    ServiceEndpoint,
-                    audience,
-                    claims,
-                    timeout.CalculateRemaining(stopWatch.GetElapsedTime()))
+                    connection: connection,
+                    tokenProvider: TokenProvider,
+                    endpoint: ServiceEndpoint,
+                    audience: audience,
+                    requiredClaims: claims,
+                    timeout: timeout.CalculateRemaining(stopWatch.GetElapsedTime()),
+                    identifier: identifier)
                     .ConfigureAwait(false);
 
                 var link = new RequestResponseAmqpLink(
@@ -476,16 +486,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 TimerCallback refreshHandler = CreateAuthorizationRefreshHandler
                 (
-                    entityPath,
-                    connection,
-                    link,
-                    TokenProvider,
-                    ServiceEndpoint,
-                    audience,
-                    claims,
-                    AuthorizationRefreshTimeout,
-                    () => (ActiveLinks.ContainsKey(link) ? refreshTimer : null)
-                );
+                    entityPath: entityPath,
+                    connection: connection,
+                    amqpLink: link,
+                    tokenProvider: TokenProvider,
+                    endpoint: ServiceEndpoint,
+                    audience: audience,
+                    requiredClaims: claims,
+                    refreshTimeout: AuthorizationRefreshTimeout,
+                    refreshTimerFactory: () => (ActiveLinks.ContainsKey(link) ? refreshTimer : null),
+                    identifier: identifier);
 
                 refreshTimer = new Timer(refreshHandler, null, CalculateLinkAuthorizationRefreshInterval(authExpirationUtc), Timeout.InfiniteTimeSpan);
 
@@ -515,6 +525,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Creates an AMQP link for use with receiving operations.
         /// </summary>
         /// <param name="entityPath">The entity path to receive from.</param>
+        /// <param name="identifier">The identifier for the receiver that is creating a receive link.</param>
         /// <param name="connection">The active and opened AMQP connection to use for this link.</param>
         /// <param name="endpoint">The fully qualified endpoint to open the link for.</param>
         /// <param name="prefetchCount">Controls the number of events received and queued locally without regard to whether an operation was requested.</param>
@@ -527,6 +538,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <returns>A link for use for operations related to receiving events.</returns>
         protected virtual async Task<ReceivingAmqpLink> CreateReceivingLinkAsync(
             string entityPath,
+            string identifier,
             AmqpConnection connection,
             Uri endpoint,
             TimeSpan timeout,
@@ -549,12 +561,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 string[] authClaims = new string[] { ServiceBusClaim.Send };
                 var audience = new[] { endpoint.AbsoluteUri };
                 DateTime authExpirationUtc = await RequestAuthorizationUsingCbsAsync(
-                    connection,
-                    TokenProvider,
-                    endpoint,
-                    audience,
-                    authClaims,
-                    timeout.CalculateRemaining(stopWatch.GetElapsedTime())).ConfigureAwait(false);
+                    connection: connection,
+                    tokenProvider: TokenProvider,
+                    endpoint: endpoint,
+                    audience: audience,
+                    requiredClaims: authClaims,
+                    timeout: timeout.CalculateRemaining(stopWatch.GetElapsedTime()),
+                    identifier: identifier).ConfigureAwait(false);
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
 
                 // Create and open the AMQP session associated with the link.
@@ -600,16 +613,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 TimerCallback refreshHandler = CreateAuthorizationRefreshHandler
                 (
-                    entityPath,
-                    connection,
-                    link,
-                    TokenProvider,
-                    endpoint,
-                    audience,
-                    authClaims,
-                    AuthorizationRefreshTimeout,
-                    () => (ActiveLinks.ContainsKey(link) ? refreshTimer : null)
-                );
+                    entityPath: entityPath,
+                    connection: connection,
+                    amqpLink: link,
+                    tokenProvider: TokenProvider,
+                    endpoint: endpoint,
+                    audience: audience,
+                    requiredClaims: authClaims,
+                    refreshTimeout: AuthorizationRefreshTimeout,
+                    refreshTimerFactory: () => (ActiveLinks.ContainsKey(link) ? refreshTimer : null),
+                    identifier: identifier);
 
                 refreshTimer = new Timer(refreshHandler, null, CalculateLinkAuthorizationRefreshInterval(authExpirationUtc), Timeout.InfiniteTimeSpan);
 
@@ -639,6 +652,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Creates an AMQP link for use with publishing operations.
         /// </summary>
         /// <param name="entityPath">The entity path to send to.</param>
+        /// <param name="identifier">The identifier of the sender that is creating a send link.</param>
         /// <param name="connection">The active and opened AMQP connection to use for this link.</param>
         /// <param name="timeout">The timeout to apply when creating the link.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
@@ -646,6 +660,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <returns>A link for use for operations related to receiving events.</returns>
         protected virtual async Task<SendingAmqpLink> CreateSendingLinkAsync(
             string entityPath,
+            string identifier,
             AmqpConnection connection,
             TimeSpan timeout,
             CancellationToken cancellationToken)
@@ -669,12 +684,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 var authClaims = new[] { ServiceBusClaim.Send };
 
                 DateTime authExpirationUtc = await RequestAuthorizationUsingCbsAsync(
-                    connection,
-                    TokenProvider,
-                    destinationEndpoint,
-                    audience,
-                    authClaims,
-                    timeout.CalculateRemaining(stopWatch.GetElapsedTime()))
+                    connection: connection,
+                    tokenProvider: TokenProvider,
+                    endpoint: destinationEndpoint,
+                    audience: audience,
+                    requiredClaims: authClaims,
+                    timeout: timeout.CalculateRemaining(stopWatch.GetElapsedTime()),
+                    identifier: identifier)
                     .ConfigureAwait(false);
 
                 cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
@@ -709,15 +725,16 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 TimerCallback refreshHandler = CreateAuthorizationRefreshHandler
                 (
-                    entityPath,
-                    connection,
-                    link,
-                    TokenProvider,
-                    destinationEndpoint,
-                    audience,
-                    authClaims,
-                    AuthorizationRefreshTimeout,
-                    () => refreshTimer
+                    entityPath: entityPath,
+                    connection: connection,
+                    amqpLink: link,
+                    tokenProvider: TokenProvider,
+                    endpoint: destinationEndpoint,
+                    audience: audience,
+                    requiredClaims: authClaims,
+                    refreshTimeout: AuthorizationRefreshTimeout,
+                    refreshTimerFactory: () => refreshTimer,
+                    identifier: identifier
                 );
 
                 refreshTimer = new Timer(refreshHandler, null, CalculateLinkAuthorizationRefreshInterval(authExpirationUtc), Timeout.InfiniteTimeSpan);
@@ -819,8 +836,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         ///   Creates the timer event handler to support refreshing AMQP link authorization
         ///   on a recurring basis.
         /// </summary>
-        /// <param name="entityPath"></param>
-        ///
+        /// <param name="entityPath">The entity path to refresh authorization with.</param>
         /// <param name="connection">The AMQP connection to which the link being refreshed is bound to.</param>
         /// <param name="amqpLink">The AMQP link to refresh authorization for.</param>
         /// <param name="tokenProvider">The <see cref="CbsTokenProvider" /> to use for obtaining access tokens.</param>
@@ -829,6 +845,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="requiredClaims">The set of claims required to support the operations of the AMQP link.</param>
         /// <param name="refreshTimeout">The timeout to apply when requesting authorization refresh.</param>
         /// <param name="refreshTimerFactory">A function to allow retrieving the <see cref="Timer" /> associated with the link authorization.</param>
+        /// <param name="identifier">The identifier of the entity that will be refreshing authorization.</param>
         ///
         /// <returns>A <see cref="TimerCallback"/> delegate to perform the refresh when a timer is due.</returns>
         protected virtual TimerCallback CreateAuthorizationRefreshHandler(
@@ -840,7 +857,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
             string[] audience,
             string[] requiredClaims,
             TimeSpan refreshTimeout,
-            Func<Timer> refreshTimerFactory)
+            Func<Timer> refreshTimerFactory,
+            string identifier)
         {
             return async _ =>
             {
@@ -855,12 +873,13 @@ namespace Azure.Messaging.ServiceBus.Amqp
                     }
 
                     DateTime authExpirationUtc = await RequestAuthorizationUsingCbsAsync(
-                        connection,
-                        tokenProvider,
-                        endpoint,
-                        audience,
-                        requiredClaims,
-                        refreshTimeout)
+                        connection: connection,
+                        tokenProvider: tokenProvider,
+                        endpoint: endpoint,
+                        audience: audience,
+                        requiredClaims: requiredClaims,
+                        timeout: refreshTimeout,
+                        identifier: identifier)
                     .ConfigureAwait(false);
 
                     // Reset the timer for the next refresh.
@@ -940,6 +959,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         /// <param name="audience">The audience associated with the authorization.  This is likely the <paramref name="endpoint"/> absolute URI.</param>
         /// <param name="requiredClaims">The set of claims required to support the operations of the AMQP link.</param>
         /// <param name="timeout">The timeout to apply when requesting authorization.</param>
+        /// <param name="identifier">The identifier of the entity requesting authorization.</param>
         ///
         /// <returns>The date/time, in UTC, when the authorization expires.</returns>
         ///
@@ -954,22 +974,33 @@ namespace Azure.Messaging.ServiceBus.Amqp
             Uri endpoint,
             string[] audience,
             string[] requiredClaims,
-            TimeSpan timeout)
+            TimeSpan timeout,
+            string identifier)
         {
-            ServiceBusEventSource.Log.RequestAuthorizationStart(ActiveConnection.ToString(), exception.ToString());
-
+            string uri = endpoint.AbsoluteUri;
+            ServiceBusEventSource.Log.RequestAuthorizationStart(identifier, uri);
             AmqpCbsLink authLink = connection.Extensions.Find<AmqpCbsLink>();
             DateTime cbsTokenExpiresAtUtc = DateTime.MaxValue;
-            foreach (string resource in audience)
+
+            try
             {
-                DateTime expiresAt =
-                    await authLink.SendTokenAsync(TokenProvider, endpoint, resource, resource, requiredClaims, timeout).ConfigureAwait(false);
-                if (expiresAt < cbsTokenExpiresAtUtc)
+                foreach (string resource in audience)
                 {
-                    cbsTokenExpiresAtUtc = expiresAt;
+                    DateTime expiresAt =
+                        await authLink.SendTokenAsync(TokenProvider, endpoint, resource, resource, requiredClaims, timeout).ConfigureAwait(false);
+                    if (expiresAt < cbsTokenExpiresAtUtc)
+                    {
+                        cbsTokenExpiresAtUtc = expiresAt;
+                    }
                 }
             }
-            ServiceBusEventSource.Log.(ActiveConnection.ToString(), exception.ToString());
+            catch (Exception ex)
+            {
+                ServiceBusEventSource.Log.RequestAuthorizationException(identifier, uri, ex.ToString());
+                throw;
+            }
+
+            ServiceBusEventSource.Log.RequestAuthorizationComplete(identifier, uri, cbsTokenExpiresAtUtc.ToString(CultureInfo.InvariantCulture));
             return cbsTokenExpiresAtUtc;
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs
@@ -142,7 +142,8 @@ namespace Azure.Messaging.ServiceBus.Amqp
                         timeout: timeout,
                         prefetchCount: prefetchCount,
                         receiveMode: receiveMode,
-                        isSessionReceiver: isSessionReceiver),
+                        isSessionReceiver: isSessionReceiver,
+                        identifier: identifier),
                 link => CloseLink(link));
 
             _managementLink = new FaultTolerantAmqpObject<RequestResponseAmqpLink>(
@@ -166,13 +167,15 @@ namespace Azure.Messaging.ServiceBus.Amqp
             TimeSpan timeout,
             uint prefetchCount,
             ServiceBusReceiveMode receiveMode,
-            bool isSessionReceiver)
+            bool isSessionReceiver,
+            string identifier)
         {
             ServiceBusEventSource.Log.CreateReceiveLinkStart(_identifier);
 
             try
             {
                 ReceivingAmqpLink link = await _connectionScope.OpenReceiverLinkAsync(
+                    identifier: identifier,
                     entityPath: _entityPath,
                     timeout: timeout,
                     prefetchCount: prefetchCount,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -583,9 +583,10 @@ namespace Azure.Messaging.ServiceBus.Amqp
             try
             {
                 SendingAmqpLink link = await _connectionScope.OpenSenderLinkAsync(
-                    _entityPath,
-                    timeout,
-                    cancellationToken).ConfigureAwait(false);
+                    entityPath: _entityPath,
+                    identifier: _identifier,
+                    timeout: timeout,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 if (!MaxMessageSize.HasValue)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -1100,6 +1100,33 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
                 WriteEvent(ManagementLinkClosedEvent, identifier, linkException);
             }
         }
+
+        [Event(RequestAuthorizationStartEvent, Level = EventLevel.Verbose, Message = "{0}: Requesting authorization to {1}")]
+        public virtual void RequestAuthorizationStart(string identifier, string endpoint)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(RequestAuthorizationStartEvent, identifier, endpoint);
+            }
+        }
+
+        [Event(RequestAuthorizationCompleteEvent, Level = EventLevel.Verbose, Message = "{0}: Authorization to {1} complete. Expiration time: {2}")]
+        public virtual void RequestAuthorizationComplete(string identifier, string endpoint, string expiration)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(RequestAuthorizationCompleteEvent, identifier, endpoint, expiration);
+            }
+        }
+
+        [Event(RequestAuthorizationExceptionEvent, Level = EventLevel.Verbose, Message = "{0}: An exception occured while requesting authorization to {1}. Exception: {2}.")]
+        public virtual void RequestAuthorizationException(string identifier, string endpoint, string exception)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(RequestAuthorizationExceptionEvent, identifier, endpoint, exception);
+            }
+        }
         #endregion
 
         #region Retries

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Diagnostics/ServiceBusEventSource.cs
@@ -186,6 +186,10 @@ namespace Azure.Messaging.ServiceBus.Diagnostics
         internal const int ProcessorMessageHandlerCompleteEvent = 103;
         internal const int ProcessorMessageHandlerExceptionEvent = 104;
 
+        internal const int RequestAuthorizationStartEvent = 105;
+        internal const int RequestAuthorizationCompleteEvent = 106;
+        internal const int RequestAuthorizationExceptionEvent = 107;
+
         #endregion
         // add new event numbers here incrementing from previous
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpReceiverTests.cs
@@ -157,6 +157,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             mockScope
                .Setup(scope => scope.OpenReceiverLinkAsync(
                    It.IsAny<string>(),
+                   It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
                    It.IsAny<ServiceBusReceiveMode>(),
@@ -173,6 +174,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
+                   It.IsAny<string>(),
                    It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
@@ -211,6 +213,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             mockScope
                .Setup(scope => scope.OpenReceiverLinkAsync(
                    It.IsAny<string>(),
+                   It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
                    It.IsAny<ServiceBusReceiveMode>(),
@@ -227,6 +230,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
+                   It.IsAny<string>(),
                    It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
@@ -273,6 +277,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             mockScope
                .Setup(scope => scope.OpenReceiverLinkAsync(
                    It.IsAny<string>(),
+                   It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
                    It.IsAny<ServiceBusReceiveMode>(),
@@ -288,6 +293,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 cancellationSource.Token), Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.ServiceBusy));
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
+                   It.IsAny<string>(),
                    It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
@@ -330,6 +336,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             mockScope
                .Setup(scope => scope.OpenReceiverLinkAsync(
                    It.IsAny<string>(),
+                   It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
                    It.IsAny<ServiceBusReceiveMode>(),
@@ -346,6 +353,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
+                   It.IsAny<string>(),
                    It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
@@ -383,6 +391,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             mockScope
                .Setup(scope => scope.OpenReceiverLinkAsync(
                    It.IsAny<string>(),
+                   It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
                    It.IsAny<ServiceBusReceiveMode>(),
@@ -399,6 +408,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan>(),
                     It.IsAny<uint>(),
@@ -436,6 +446,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             mockScope
                .Setup(scope => scope.OpenReceiverLinkAsync(
                    It.IsAny<string>(),
+                   It.IsAny<string>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<uint>(),
                    It.IsAny<ServiceBusReceiveMode>(),
@@ -452,6 +463,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             mockScope
                 .Verify(scope => scope.OpenReceiverLinkAsync(
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan>(),
                     It.IsAny<uint>(),

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -42,7 +42,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var messageCount = 10;
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
-
                 _listener.EventsById(ServiceBusEventSource.ClientCreateStartEvent).Where(e => e.Payload.Contains(nameof(ServiceBusSender)) && e.Payload.Contains(sender.FullyQualifiedNamespace) && e.Payload.Contains(sender.EntityPath));
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchStartEvent, e => e.Payload.Contains(sender.Identifier));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceLiveTests.cs
@@ -42,6 +42,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 var messageCount = 10;
 
                 ServiceBusSender sender = client.CreateSender(scope.QueueName);
+
                 _listener.EventsById(ServiceBusEventSource.ClientCreateStartEvent).Where(e => e.Payload.Contains(nameof(ServiceBusSender)) && e.Payload.Contains(sender.FullyQualifiedNamespace) && e.Payload.Contains(sender.EntityPath));
                 using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync();
                 _listener.SingleEventById(ServiceBusEventSource.CreateMessageBatchStartEvent, e => e.Payload.Contains(sender.Identifier));
@@ -51,6 +52,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                 await sender.SendMessagesAsync(batch);
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkStartEvent, e => e.Payload.Contains(sender.Identifier));
+                _listener.SingleEventById(ServiceBusEventSource.RequestAuthorizationStartEvent, e => e.Payload.Contains(sender.Identifier));
+                _listener.SingleEventById(ServiceBusEventSource.RequestAuthorizationCompleteEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkCompleteEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.SendMessageStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.SendMessageCompleteEvent, e => e.Payload.Contains(sender.Identifier));
@@ -77,6 +80,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                     }
                 }
                 _listener.SingleEventById(ServiceBusEventSource.CreateReceiveLinkStartEvent, e => e.Payload.Contains(receiver.Identifier));
+                _listener.SingleEventById(ServiceBusEventSource.RequestAuthorizationStartEvent, e => e.Payload.Contains(receiver.Identifier));
+                _listener.SingleEventById(ServiceBusEventSource.RequestAuthorizationCompleteEvent, e => e.Payload.Contains(receiver.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateReceiveLinkCompleteEvent, e => e.Payload.Contains(receiver.Identifier));
                 Assert.IsTrue(_listener.EventsById(ServiceBusEventSource.ReceiveMessageStartEvent).Any());
                 Assert.IsTrue(_listener.EventsById(ServiceBusEventSource.ReceiveMessageCompleteEvent).Any());
@@ -144,6 +149,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
 
                 await sender.SendMessagesAsync(batch);
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkStartEvent, e => e.Payload.Contains(sender.Identifier));
+                _listener.SingleEventById(ServiceBusEventSource.RequestAuthorizationStartEvent, e => e.Payload.Contains(sender.Identifier));
+                _listener.SingleEventById(ServiceBusEventSource.RequestAuthorizationCompleteEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.CreateSendLinkCompleteEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.SendMessageStartEvent, e => e.Payload.Contains(sender.Identifier));
                 _listener.SingleEventById(ServiceBusEventSource.SendMessageCompleteEvent, e => e.Payload.Contains(sender.Identifier));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -843,6 +843,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Logger = mockLogger.Object
             };
 
+            var mockClient = new Mock<ServiceBusClient>();
+
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
             await receiver.AbandonMessageAsync(msg);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Diagnostics/EventSourceTests.cs
@@ -843,8 +843,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Diagnostics
                 Logger = mockLogger.Object
             };
 
-            var mockClient = new Mock<ServiceBusClient>();
-
             var msg = new ServiceBusReceivedMessage() { LockTokenGuid = Guid.NewGuid() };
             await receiver.AbandonMessageAsync(msg);
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorLiveTests.cs
@@ -296,7 +296,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                             Throws.InstanceOf<ServiceBusException>().And.Property(nameof(ServiceBusException.Reason)).EqualTo(ServiceBusFailureReason.MessageLockLost));
                         Interlocked.Increment(ref messageCt);
                         var setIndex = Interlocked.Increment(ref completionSourceIndex);
-                        completionSources[setIndex].SetResult(true);
+                        if (setIndex < numThreads)
+                        {
+                            completionSources[setIndex].SetResult(true);
+                        }
                     }
                 }
                 await Task.WhenAll(completionSources.Select(source => source.Task));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorLiveTests.cs
@@ -748,7 +748,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                     }
                     Interlocked.Increment(ref messageCt);
                     var setIndex = Interlocked.Increment(ref completionSourceIndex);
-                    completionSources[setIndex].SetResult(true);
+                    if (setIndex < numThreads)
+                    {
+                        completionSources[setIndex].SetResult(true);
+                    }
                 }
                 await Task.WhenAll(completionSources.Select(source => source.Task));
                 await processor.StopProcessingAsync();

--- a/sdk/servicebus/test-resources-post.ps1
+++ b/sdk/servicebus/test-resources-post.ps1
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# The purpose of this script is to add a small delay between the creation of the live test resources
+# and the execution of the live tests. This allows RBAC to replicate and avoids flakiness in the first set 
+# of live tests that might otherwise start running before RBAC has replicated.
+
+param (
+    [hashtable] $DeploymentOutputs,
+    [string] $TenantId,
+    [string] $TestApplicationId,
+    [string] $TestApplicationSecret
+)
+
+Write-Verbose "Sleeping for 60 seconds to let RBAC replicate"
+Start-Sleep -s 60


### PR DESCRIPTION
- Add the same tweak to AmqpConnectionScope that was added for Event Hubs in https://github.com/Azure/azure-sdk-for-net/pull/17330
- Add logging for the AuthorizationRequest and thread the Identifier through.
- Add a delay after test resource creation to avoid flakiness in tests
- Fix other flaky tests.