### PR TITLE
[COMMUNICATION] - [LIVE TESTS] - adding missing env var

### DIFF
--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -53,7 +53,7 @@
         "COMMUNICATION_ENDPOINT_STRING": {
             "type": "string",
             "value": "[concat('https://', parameters('baseName'), '-', parameters('endpointPrefix'), '.communication.azure.com')]"
-        }​​​​,
+        },
         "RESOURCE_GROUP_NAME": {
             "type": "string",
             "value": "[resourceGroup().Name]"

--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -50,6 +50,10 @@
             "type": "string",
             "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
         },
+        "COMMUNICATION_ENDPOINT_STRING": {
+            "type": "string",
+            "value": "[concat('https://', parameters('baseName'), '-', parameters('endpointPrefix'), '.communication.azure.com')]"
+        }​​​​,
         "RESOURCE_GROUP_NAME": {
             "type": "string",
             "value": "[resourceGroup().Name]"


### PR DESCRIPTION
Live tests are failing because of a new environment variable that was introduced. 
Introducing it into the test resources to fix tests