### PR TITLE
[synapse] Re-enable many disabled tests by bumping to swagger with nullability fix

### DIFF
--- a/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.AccessControl/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 
 ```yaml
-repo: https://github.com/Azure/azure-rest-api-specs/blob/eea7c0141c0b7ad9f66f8ba06560b549c6b3b014
+repo: https://github.com/Azure/azure-rest-api-specs/blob/ca0ac888f84b97feaef05fad6632f41ef1a399e6
 ```
 
 ``` yaml

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/Models/NotebookCell.Serialization.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/Models/NotebookCell.Serialization.cs
@@ -29,8 +29,15 @@ namespace Azure.Analytics.Synapse.Artifacts.Models
             writer.WriteEndArray();
             if (Optional.IsDefined(Attachments))
             {
-                writer.WritePropertyName("attachments");
-                writer.WriteObjectValue(Attachments);
+                if (Attachments != null)
+                {
+                    writer.WritePropertyName("attachments");
+                    writer.WriteObjectValue(Attachments);
+                }
+                else
+                {
+                    writer.WriteNull("attachments");
+                }
             }
             if (Optional.IsCollectionDefined(Outputs))
             {
@@ -85,7 +92,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        attachments = null;
                         continue;
                     }
                     attachments = property.Value.GetObject();

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/Models/NotebookMetadata.Serialization.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/Models/NotebookMetadata.Serialization.cs
@@ -23,8 +23,15 @@ namespace Azure.Analytics.Synapse.Artifacts.Models
             }
             if (Optional.IsDefined(LanguageInfo))
             {
-                writer.WritePropertyName("language_info");
-                writer.WriteObjectValue(LanguageInfo);
+                if (LanguageInfo != null)
+                {
+                    writer.WritePropertyName("language_info");
+                    writer.WriteObjectValue(LanguageInfo);
+                }
+                else
+                {
+                    writer.WriteNull("language_info");
+                }
             }
             foreach (var item in AdditionalProperties)
             {
@@ -56,7 +63,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        languageInfo = null;
                         continue;
                     }
                     languageInfo = NotebookLanguageInfo.DeserializeNotebookLanguageInfo(property.Value);

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/Models/SparkScheduler.Serialization.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/Generated/Models/SparkScheduler.Serialization.cs
@@ -18,7 +18,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Models
             Optional<DateTimeOffset?> submittedAt = default;
             Optional<DateTimeOffset?> scheduledAt = default;
             Optional<DateTimeOffset?> endedAt = default;
-            Optional<DateTimeOffset> cancellationRequestedAt = default;
+            Optional<DateTimeOffset?> cancellationRequestedAt = default;
             Optional<SchedulerCurrentState> currentState = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -56,7 +56,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        cancellationRequestedAt = null;
                         continue;
                     }
                     cancellationRequestedAt = property.Value.GetDateTimeOffset("O");

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 
 ```yaml
-repo: https://github.com/Azure/azure-rest-api-specs/tree/eea7c0141c0b7ad9f66f8ba06560b549c6b3b014
+repo: https://github.com/Azure/azure-rest-api-specs/tree/ca0ac888f84b97feaef05fad6632f41ef1a399e6
 ```
 
 ``` yaml

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/NotebookClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/NotebookClientLiveTests.cs
@@ -26,7 +26,6 @@ namespace Azure.Analytics.Synapse.Tests.Artifacts
         {
         }
 
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public async Task TestGetNotebook()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/NotebookSampleSnippets.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/NotebookSampleSnippets.cs
@@ -13,7 +13,6 @@ namespace Azure.Analytics.Synapse.Artifacts.Samples
 {
     public partial class NotebookSnippets : SampleFixture
     {
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public async Task NotebookSample()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample2_CreateNotebook.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/samples/Sample2_CreateNotebook.cs
@@ -16,7 +16,6 @@ namespace Azure.Analytics.Synapse.Samples
     /// </summary>
     public partial class NotebookSample
     {
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public async Task CreateAndUploadNotebook()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 
 ```yaml
-repo: https://github.com/Azure/azure-rest-api-specs/blob/eea7c0141c0b7ad9f66f8ba06560b549c6b3b014
+repo: https://github.com/Azure/azure-rest-api-specs/blob/ca0ac888f84b97feaef05fad6632f41ef1a399e6
 ```
 
 ``` yaml

--- a/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/ManagedPrivateEndpointsClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/ManagedPrivateEndpointsClientLiveTests.cs
@@ -27,8 +27,8 @@ namespace Azure.Analytics.Synapse.Tests.ManagedPrivateEndpoints
         {
         }
 
-        [Test]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
+        [Test]
         public async Task TestManagedPrivateEndpoints()
         {
             // Create a managed private endpoint

--- a/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/samples/SampleSnippets.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.ManagedPrivateEndpoints/tests/samples/SampleSnippets.cs
@@ -14,7 +14,6 @@ namespace Azure.Analytics.Synapse.ManagedPrivateEndpoints.Samples
     public partial class Snippets : SampleFixture
     {
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         public void TestManagedPrivateEndpoint()
         {
             #region Snippet:CreateClient

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/Generated/Models/SparkJob.Serialization.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/Generated/Models/SparkJob.Serialization.cs
@@ -26,8 +26,8 @@ namespace Azure.Analytics.Synapse.Monitoring.Models
             Optional<string> sparkJobDefinition = default;
             Optional<IReadOnlyList<SparkJob>> pipeline = default;
             Optional<string> jobType = default;
-            Optional<DateTimeOffset> submitTime = default;
-            Optional<DateTimeOffset> endTime = default;
+            Optional<DateTimeOffset?> submitTime = default;
+            Optional<DateTimeOffset?> endTime = default;
             Optional<string> queuedDuration = default;
             Optional<string> runningDuration = default;
             Optional<string> totalDuration = default;
@@ -112,7 +112,7 @@ namespace Azure.Analytics.Synapse.Monitoring.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        submitTime = null;
                         continue;
                     }
                     submitTime = property.Value.GetDateTimeOffset("O");
@@ -122,7 +122,7 @@ namespace Azure.Analytics.Synapse.Monitoring.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        endTime = null;
                         continue;
                     }
                     endTime = property.Value.GetDateTimeOffset("O");

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet msbuild /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 
 ```yaml
-repo: https://github.com/Azure/azure-rest-api-specs/tree/eea7c0141c0b7ad9f66f8ba06560b549c6b3b014
+repo: https://github.com/Azure/azure-rest-api-specs/tree/ca0ac888f84b97feaef05fad6632f41ef1a399e6
 ```
 
 ``` yaml

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/MonitoringClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/MonitoringClientLiveTests.cs
@@ -25,7 +25,6 @@ namespace Azure.Analytics.Synapse.Tests.Monitoring
         }
 
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         public async Task TestListSparkApplications()
         {
             SparkJobListViewResponse sparkJobList = await MonitoringClient.GetSparkJobListAsync();

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
@@ -17,7 +17,6 @@ namespace Azure.Analytics.Synapse.Samples
     /// </summary>
     public partial class PipelineMonitoring
     {
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         [Test]
         public void MonitorPipelineRuns()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/SampleSnippets.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/SampleSnippets.cs
@@ -12,7 +12,6 @@ namespace Azure.Analytics.Synapse.Monitoring.Samples
     public partial class Snippets : SampleFixture
     {
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         public void MonitoringSample()
         {
             #region Snippet:CreateMonitoringClient

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Generated/Models/SparkScheduler.Serialization.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Generated/Models/SparkScheduler.Serialization.cs
@@ -18,7 +18,7 @@ namespace Azure.Analytics.Synapse.Spark.Models
             Optional<DateTimeOffset?> submittedAt = default;
             Optional<DateTimeOffset?> scheduledAt = default;
             Optional<DateTimeOffset?> endedAt = default;
-            Optional<DateTimeOffset> cancellationRequestedAt = default;
+            Optional<DateTimeOffset?> cancellationRequestedAt = default;
             Optional<SchedulerCurrentState> currentState = default;
             foreach (var property in element.EnumerateObject())
             {
@@ -56,7 +56,7 @@ namespace Azure.Analytics.Synapse.Spark.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        cancellationRequestedAt = null;
                         continue;
                     }
                     cancellationRequestedAt = property.Value.GetDateTimeOffset("O");

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Generated/Models/SparkStatement.Serialization.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Generated/Models/SparkStatement.Serialization.cs
@@ -39,7 +39,7 @@ namespace Azure.Analytics.Synapse.Spark.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        output = null;
                         continue;
                     }
                     output = SparkStatementOutput.DeserializeSparkStatementOutput(property.Value);

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Generated/Models/SparkStatementOutput.Serialization.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Generated/Models/SparkStatementOutput.Serialization.cs
@@ -45,11 +45,21 @@ namespace Azure.Analytics.Synapse.Spark.Models
                 }
                 if (property.NameEquals("ename"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        ename = null;
+                        continue;
+                    }
                     ename = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("evalue"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        evalue = null;
+                        continue;
+                    }
                     evalue = property.Value.GetString();
                     continue;
                 }
@@ -57,7 +67,7 @@ namespace Azure.Analytics.Synapse.Spark.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        traceback = null;
                         continue;
                     }
                     List<string> array = new List<string>();

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/src/autorest.md
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/src/autorest.md
@@ -6,7 +6,7 @@ Run `dotnet build /t:GenerateCode` to generate code.
 > see https://aka.ms/autorest
 
 ```yaml
-repo: https://github.com/Azure/azure-rest-api-specs/blob/eea7c0141c0b7ad9f66f8ba06560b549c6b3b014
+repo: https://github.com/Azure/azure-rest-api-specs/blob/ca0ac888f84b97feaef05fad6632f41ef1a399e6
 ```
 
 ``` yaml

--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/Sample2_ExecuteSparkStatement.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/tests/samples/Sample2_ExecuteSparkStatement.cs
@@ -18,7 +18,6 @@ namespace Azure.Analytics.Synapse.Samples
     public partial class ExecuteSparkStatement
     {
         [Test]
-        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17455")]
         public void ExecuteSparkStatementSync()
         {
             // Environment variable with the Synapse workspace endpoint.


### PR DESCRIPTION
- This fixes almost all of https://github.com/Azure/azure-sdk-for-net/issues/17455
- Two tests remain: A managed private endpoint issue that's been raised w\ the service team and a pipeline test that I'm rewriting in another PR
- This PR may be better reviewed commit by commit