### PR TITLE
[EngSys] Allow Project Exclusions

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -39,6 +39,7 @@ jobs:
           dotnet pack eng/service.proj -warnaserror
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeTests=false
+          /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           /p:PublicSign=false $(VersioningProperties)
           /p:Configuration=$(BuildConfiguration)
           /p:CommitSHA=$(Build.SourceVersion)
@@ -58,7 +59,7 @@ jobs:
         inputs:
           artifactName: packages
           path: $(Build.ArtifactStagingDirectory)
-      
+
       - template: /eng/pipelines/templates/steps/create-apireview.yml
         parameters:
           Artifacts: ${{parameters.Artifacts}}
@@ -102,7 +103,9 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
         inputs:
           filePath: "eng/scripts/CodeChecks.ps1"
-          arguments: -ServiceDirectory ${{parameters.ServiceToTest}}
+          arguments: >
+            -ServiceDirectory ${{parameters.ServiceToTest}} 
+            -ExcludeProjects "${{ join('|', parameters.ExcludeProjects) }}"
           pwsh: true
           failOnStderr:  false
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
@@ -160,10 +163,11 @@ jobs:
             ${{ pair.key }}: ${{ pair.value }}
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
       - script: >-
-          dotnet test eng/service.proj --filter TestCategory!=Live --framework $(TestTargetFramework)
+          dotnet test eng/service.proj --filter "(TestCategory!=Manually) & (TestCategory!=Live)" --framework $(TestTargetFramework)
           --logger "trx;LogFileName=$(TestTargetFramework).trx" --logger:"console;verbosity=normal"
           /p:ServiceDirectory=${{parameters.ServiceToTest}}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
+          /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           /p:Configuration=$(BuildConfiguration) $(ConvertToProjectReferenceOption)
           /p:CollectCoverage=$(CollectCoverage) /p:CodeCoverageDirectory=${{parameters.ServiceDirectory}}
         displayName: "Build & Test ($(TestTargetFramework))"

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -23,6 +23,9 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
+- name: ExcludeProjects
+  type: object
+  default: []
 - name: TestSetupSteps
   type: stepList
   default: []
@@ -95,6 +98,7 @@ jobs:
           /p:ServiceDirectory=${{ parameters.ServiceDirectory }}
           /p:IncludeSrc=false /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false
           /p:BuildInParallel=${{ parameters.BuildInParallel }}
+          /p:ExcludeProjects="${{ join('|', parameters.ExcludeProjects) }}"
           $(AdditionalTestArguments)
 
         displayName: "Build & Test (all tests for $(TestTargetFramework))"

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -18,6 +18,9 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
+- name: ExcludeProjects
+  type: object
+  default: []
 - name: ServiceToTest
   type: string
   default: ''
@@ -38,6 +41,7 @@ stages:
       parameters:
         ServiceToTest: ${{ coalesce(parameters.ServiceToTest, parameters.ServiceDirectory) }}
         ServiceDirectory: ${{ parameters.ServiceDirectory }}
+        ExcludeProjects: ${{ parameters.ExcludeProjects }}
         Artifacts: ${{ parameters.Artifacts }}
         TestPipeline: ${{ parameters.TestPipeline }}
         ArtifactName: packages
@@ -53,4 +57,4 @@ stages:
         TestPipeline: ${{ parameters.TestPipeline }}
         ArtifactName: packages
         TargetDocRepoOwner: ${{ parameters.TargetDocRepoOwner }}
-        TargetDocRepoName: ${{ parameters.TargetDocRepoName }} 
+        TargetDocRepoName: ${{ parameters.TargetDocRepoName }}

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -32,6 +32,9 @@ parameters:
 - name: ServiceDirectory
   type: string
   default: not-specified
+- name: ExcludeProjects
+  type: object
+  default: []
 - name: TestSetupSteps
   type: stepList
   default: []
@@ -128,6 +131,7 @@ stages:
               TimeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
               Location: ${{ parameters.Location }}
               ServiceDirectory: ${{ parameters.ServiceDirectory }}
+              ExcludeProjects: ${{ parameters.ExcludeProjects }}
               TestSetupSteps: ${{ parameters.TestSetupSteps }}
             Platforms:
               # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -4,12 +4,16 @@
 param (
     [Parameter(Position=0)]
     [string] $ServiceDirectory,
-    [string] $ProjectDirectory
+
+    [Parameter()]
+    [string] $ProjectDirectory,
+
+    [Parameter()]
+    [string] $ExcludeProjects
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 1
-
 
 [string[]] $errors = @()
 
@@ -72,21 +76,21 @@ try {
 
         Write-Host "Re-generating clients"
         Invoke-Block {
-            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:ServiceDirectory=$ServiceDirectory
+            & dotnet msbuild $PSScriptRoot\..\service.proj /restore /t:GenerateCode /p:ServiceDirectory=$ServiceDirectory /p:ExcludeProjects="$ExcludeProjects"
 
             # https://github.com/Azure/azure-sdk-for-net/issues/8584
             # & $repoRoot\storage\generate.ps1
         }
     }
 
-    Write-Host "Re-generating readmes"
+    Write-Host "Re-generating snippets"
     Invoke-Block {
         & $PSScriptRoot\Update-Snippets.ps1 -ServiceDirectory $ServiceDirectory
     }
 
     Write-Host "Re-generating listings"
     Invoke-Block {
-        & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory
+        & $PSScriptRoot\Export-API.ps1 -ServiceDirectory $ServiceDirectory -ExcludeProjects "$ExcludeProjects"
     }
 
     if (-not $ProjectDirectory)

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -2,9 +2,10 @@
 param (
     [Parameter(Position=0)]
     [ValidateNotNullOrEmpty()]
-    [string] $ServiceDirectory
+    [string] $ServiceDirectory,
+    [string] $ExcludeProjects
 )
 
 $servicesProj = Resolve-Path "$PSScriptRoot/../service.proj"
 
-dotnet build /p:GenerateApiListingOnBuild=true /p:RunApiCompat=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /restore $servicesProj
+dotnet build /p:GenerateApiListingOnBuild=true /p:RunApiCompat=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$ServiceDirectory" /p:ExcludeProjects="$ExcludeProjects" /restore $servicesProj

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -9,25 +9,35 @@
     <IncludeStress Condition="'$(IncludeStress)' == ''">true</IncludeStress>
     <IncludeSamplesApplications Condition="'$(IncludeSamplesApplications)' == ''">true</IncludeSamplesApplications>
     <IncludeSamplesApplications Condition="'$(ServiceDirectory)' != '*' or '$(IncludeSamples)' == 'false'">false</IncludeSamplesApplications>
+    <ExcludeProjectsDelimiter Condition="'$(ExcludeProjectsDelimiter)' == ''">|</ExcludeProjectsDelimiter>
     <TraversalGlobalProperties>
       CodeCoverageDirectory=$([System.IO.Path]::GetFullPath("$(CodeCoverageDirectory)", "$(MSBuildThisFileDirectory)..\sdk"));
     </TraversalGlobalProperties>
   </PropertyGroup>
 
   <ItemGroup>
-    <ExcludeMgmtLib Include="..\sdk\*\Microsoft.*.Management.*\**\*.csproj;..\sdk\*mgmt*\**\*.csproj;" />
+    <MgmtExcludePaths Include="$(MSBuildThisFileDirectory)..\sdk\*\Microsoft.*.Management.*\**\*.csproj;$(MSBuildThisFileDirectory)..\sdk\*mgmt*\**\*.csproj" />
     <TestProjects Include="..\sdk\$(ServiceDirectory)\**\tests\**\*.csproj" />
     <SamplesProjects Include="..\sdk\$(ServiceDirectory)\**\samples\**\*.csproj" />
     <PerfProjects Include="..\sdk\$(ServiceDirectory)\**\perf\**\*.csproj" />
     <StressProjects Include="..\sdk\$(ServiceDirectory)\**\stress\**\*.csproj" />
     <SampleApplications Include="..\samples\**\*.csproj" />
     <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects);@(SamplesProjects)"/>
-    <ProjectReference Include="@(TestProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeTests)' == 'true'" />
-    <ProjectReference Include="@(SamplesProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeSamples)' == 'true'" />
-    <ProjectReference Include="@(PerfProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludePerf)' == 'true'" />
-    <ProjectReference Include="@(StressProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeStress)' == 'true'" />
-    <ProjectReference Include="@(SampleApplications)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
-    <ProjectReference Include="@(SrcProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeSrc)' == 'true'" />
+    <ProjectReference Include="@(TestProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeTests)' == 'true'" />
+    <ProjectReference Include="@(SamplesProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSamples)' == 'true'" />
+    <ProjectReference Include="@(PerfProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludePerf)' == 'true'" />
+    <ProjectReference Include="@(StressProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeStress)' == 'true'" />
+    <ProjectReference Include="@(SampleApplications)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSamplesApplications)' == 'true'"/>
+    <ProjectReference Include="@(SrcProjects)" Exclude="@(MgmtExcludePaths)" Condition="'$(IncludeSrc)' == 'true'" />
+  </ItemGroup>
+
+  <!--
+     Override project inclusions and force removal of those that have been explicitly excluded by the associated parameter.
+     Assume each item identifies a project name under the service directory and build the appropriate path mask.
+  -->
+  <ItemGroup Condition="'$(ExcludeProjects)' != ''">
+    <_ExcludePathsSource Include="$(ExcludeProjects.Split('$(ExcludeProjectsDelimiter)'))" />
+    <ProjectReference Remove="@(_ExcludePathsSource -> '$(MSBuildThisFileDirectory)..\sdk\$(ServiceDirectory)\%(Identity)\**\*.csproj')" />
   </ItemGroup>
 
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />

--- a/sdk/eventhub/ci.legacy.yml
+++ b/sdk/eventhub/ci.legacy.yml
@@ -1,0 +1,55 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+
+trigger:
+  branches:
+    include:
+    - master
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/eventhub/
+    exclude:
+    - sdk/eventhub/Azure.Messaging.EventHubs
+    - sdk/eventhub/Azure.Messaging.EventHubs.Processor
+    - sdk/eventhub/Azure.Messaging.EventHubs.Shared
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
+    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
+
+pr:
+  branches:
+    include:
+    - master
+    - feature/*
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/eventhub/
+    exclude:
+    - sdk/eventhub/Azure.Messaging.EventHubs
+    - sdk/eventhub/Azure.Messaging.EventHubs.Processor
+    - sdk/eventhub/Azure.Messaging.EventHubs.Shared
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
+    - sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: eventhub
+    ExcludeProjects:
+      - Azure.ResourceManager.EventHubs
+      - Azure.Messaging.EventHubs
+      - Azure.Messaging.EventHubs.Processor
+      - Azure.Messaging.EventHubs.Shared
+      - Azure.Messaging.EventHubs.*
+    ArtifactName: packages
+    Artifacts:
+    - name: Microsoft.Azure.EventHubs
+      safeName: MicrosoftAzureEventHubs
+    - name: Microsoft.Azure.EventHubs.Processor
+      safeName: MicrosoftAzureEventHubsProcessor
+    - name: Microsoft.Azure.EventHubs.ServiceFabricProcessor
+      safeName: MicrosoftAzureEventHubsServiceFabricProcessor

--- a/sdk/eventhub/tests.legacy.yml
+++ b/sdk/eventhub/tests.legacy.yml
@@ -1,0 +1,15 @@
+trigger: none
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    MaxParallel: 6
+    ServiceDirectory: eventhub
+    TimeoutInMinutes: 190
+    ExcludeProjects:
+    - Azure.ResourceManager.EventHubs
+    - Azure.Messaging.EventHubs
+    - Azure.Messaging.EventHubs.Processor
+    - Azure.Messaging.EventHubs.Shared
+    - Azure.Messaging.EventHubs.*
+    Clouds: 'Public,Canary'


### PR DESCRIPTION
# Summary

Extending the build pipeline to allow project exclusions to be specified within the service directory.  This is intended to enable splitting the pipeline into multiple definitions for service directories that contain both T1 and T2 packages, particularly in the case where those are maintained by different teams.

Also included in this set of changes is a configuration set for the legacy Event Hubs packages.

# Last Upstream Rebase

Monday, December 21, 11:55am (EST)

# References

- [[Event Hubs] Exclude Legacy Packages from Pipelines (#17659)](https://github.com/Azure/azure-sdk-for-net/issues/17659)
- [Event Hubs Test Pipelines: Split out Management, Legacy Client, and Client Tests (#15101)](https://github.com/Azure/azure-sdk-for-net/issues/15101)