### PR TITLE
[Event Hubs] Exclude Legacy Packages from Pipelines

### DIFF
--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -9,7 +9,12 @@ trigger:
   paths:
     include:
     - sdk/eventhub/
-
+    exclude:
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
+    - sdk/eventhub/Microsoft.Azure.EventHubs
+    - sdk/eventhub/Microsoft.Azure.EventHubs.Processor
+    - sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
 pr:
   branches:
     include:
@@ -20,24 +25,28 @@ pr:
   paths:
     include:
     - sdk/eventhub/
+    exclude:
+    - sdk/eventhub/Azure.ResourceManager.EventHubs
+    - sdk/eventhub/Microsoft.Azure.EventHubs
+    - sdk/eventhub/Microsoft.Azure.EventHubs.Processor
+    - sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - sdk/eventhub/Microsoft.Azure.Management.EventHub
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: eventhub
+    ExcludeProjects:
+    - Azure.ResourceManager.EventHubs
+    - Microsoft.Azure.EventHubs
+    - Microsoft.Azure.EventHubs.Processor
+    - Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - Microsoft.Azure.EventHubs.*
     ArtifactName: packages
     Artifacts:
     - name: Azure.Messaging.EventHubs
       safeName: AzureMessagingEventHubs
     - name: Azure.Messaging.EventHubs.Processor
       safeName: AzureMessagingEventHubsProcessor
-    - name: Microsoft.Azure.EventHubs
-      safeName: MicrosoftAzureEventHubs
-    - name: Microsoft.Azure.EventHubs.Processor
-      safeName: MicrosoftAzureEventHubsProcessor
-    - name: Microsoft.Azure.EventHubs.ServiceFabricProcessor
-      safeName: MicrosoftAzureEventHubsServiceFabricProcessor
     - name: Microsoft.Azure.WebJobs.Extensions.EventHubs
       safeName: MicrosoftAzureWebJobsExtensionsEventHubs
-    - name: Azure.ResourceManager.EventHubs
-      safeName: AzureResourceManagerEventHubs

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -6,4 +6,10 @@ extends:
     MaxParallel: 6
     ServiceDirectory: eventhub
     TimeoutInMinutes: 190
+    ExcludeProjects:
+    - Azure.ResourceManager.EventHubs
+    - Microsoft.Azure.EventHubs
+    - Microsoft.Azure.EventHubs.Processor
+    - Microsoft.Azure.EventHubs.ServiceFabricProcessor
+    - Microsoft.Azure.EventHubs.*
     Clouds: 'Public,Canary'


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the legacy packages from the build pipeline definitions, as they're now covered under a dedicated set of pipeline definitions.  This is intended to allow the T1 and T2 Event Hubs packages to be treated as separate units of work, as they will continue to evolve independently
and are maintained by different teams.

**Note:** This set of changes depends on #17658, which should be committed and validated first.  In addition, the new T1-centric pipeline definitions should be created prior to merging these changes.

# Last Upstream Rebase

Monday, December 21, 11:55am (EST)

# References and Related

- [[EngSys] Allow Project Exclusions (#17658)](https://github.com/Azure/azure-sdk-for-net/issues/17658)
- [Event Hubs Test Pipelines: Split out Management, Legacy Client, and Client Tests (#15101)](https://github.com/Azure/azure-sdk-for-net/issues/15101)