### PR TITLE
[Docs] Add PowerShell to Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
 - Install the **.NET Core cross-platform development** workloads in VisualStudio
 - Install **.NET Core 5.0.100 SDK** for your specific platform. (or a higher version within the 5.0.*** band)  (https://dotnet.microsoft.com/download/dotnet-core/5.0)
 - Install the latest version of git (https://git-scm.com/downloads)
+- Install [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell), version 6 or higher, if you plan to make public API changes or are working with generated code snippets.
 - Install [NodeJS](https://nodejs.org/en/) (14.x.x) if you plan to use [C# code generation](https://github.com/Azure/autorest.csharp).
 
 ## GENERAL THINGS TO KNOW:


### PR DESCRIPTION
# Summary

The focus of these changes is to highlight the PowerShell 6/7 dependency when working with the engineering scripts, such as generating the API listing or updating code snippets.

# Last Upstream Rebase

Tuesday, December 22, 4:23pm (EST)