### PR TITLE
#17662 [bug] add setters to LengthTokenilter

### DIFF
--- a/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
+++ b/sdk/search/Azure.Search.Documents/api/Azure.Search.Documents.netstandard2.0.cs
@@ -824,8 +824,8 @@ namespace Azure.Search.Documents.Indexes.Models
     public partial class LengthTokenFilter : Azure.Search.Documents.Indexes.Models.TokenFilter
     {
         public LengthTokenFilter(string name) { }
-        public int? MaxLength { get { throw null; } }
-        public int? MinLength { get { throw null; } }
+        public int? MaxLength { get { throw null; } set { } }
+        public int? MinLength { get { throw null; } set { } }
     }
     public partial class LexicalAnalyzer
     {

--- a/sdk/search/Azure.Search.Documents/src/Indexes/Models/LengthTokenFilter.cs
+++ b/sdk/search/Azure.Search.Documents/src/Indexes/Models/LengthTokenFilter.cs
@@ -11,12 +11,12 @@ namespace Azure.Search.Documents.Indexes.Models
         /// Gets the minimum length in characters. Default is 0. Maximum is 300. Must be less than the value of <see cref="MinLength"/>.
         /// </summary>
         [CodeGenMember("min")]
-        public int? MinLength { get; }
+        public int? MinLength { get; set; }
 
         /// <summary>
         /// Gets the maximum length in characters. Default and maximum is 300.
         /// </summary>
         [CodeGenMember("max")]
-        public int? MaxLength { get; }
+        public int? MaxLength { get; set; }
     }
 }


### PR DESCRIPTION
The simplest approach to fixing the defect and it's the one used by all the other filter class with non-IList properties