### PR TITLE
Fixed bug where DataLakeDirectoryClient(Uri,..).GetPaths() would throw an exception

### DIFF
--- a/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed bug where the Stream returned by DataLakeFileClient.OpenRead() would return a different Length after calls to Seek().
 - Added constructors taking connection string to DataLakeServiceClient, DataLakeFileSystemClient, DataLakeDirectoryClient, and DataLakeFileClient.
 - Fixed bug where DataLakePathClient.SetPermissions(), DataLakeFileClient.SetPermissions(), and DataLakeDirectoryClient.SetPermissions() could not just set Owner or Group.
+- Fixed bug where DataLakeDirectoryClient initialized with a Uri would throw a null exception when GetPaths() was called.
 
 ## 12.6.0-beta.1 (2020-12-07)
 - Added support for service version 2020-04-08.

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakePathClient.cs
@@ -435,6 +435,14 @@ namespace Azure.Storage.Files.DataLake
             _clientDiagnostics = new ClientDiagnostics(options);
             _storageSharedKeyCredential = storageSharedKeyCredential;
             _blockBlobClient = BlockBlobClientInternals.Create(_blobUri, _pipeline, Version.AsBlobsVersion(), _clientDiagnostics);
+
+            uriBuilder.DirectoryOrFilePath = null;
+            _fileSystemClient = new DataLakeFileSystemClient(
+                uriBuilder.ToDfsUri(),
+                _pipeline,
+                storageSharedKeyCredential,
+                Version,
+                ClientDiagnostics);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DirectoryClientTests.cs
@@ -4837,6 +4837,31 @@ namespace Azure.Storage.Files.DataLake.Tests
         }
 
         [Test]
+        public async Task GetPathsAsync_UriCtor()
+        {
+            // Arrange
+            await using DisposingFileSystem test = await GetNewFileSystem();
+            string directoryName = GetNewDirectoryName();
+            DataLakeUriBuilder uriBuilder = new DataLakeUriBuilder(test.FileSystem.Uri)
+            {
+                DirectoryOrFilePath = directoryName
+            };
+            DataLakeDirectoryClient directory = InstrumentClient(
+                new DataLakeDirectoryClient(uriBuilder.ToUri(), GetStorageSharedKeyCredentials(), GetOptions()));
+            await SetUpDirectoryForListing(directory);
+
+            // Act
+            AsyncPageable<PathItem> response = directory.GetPathsAsync();
+            IList<PathItem> paths = await response.ToListAsync();
+
+            // Assert
+            Assert.AreEqual(3, paths.Count);
+            Assert.AreEqual($"{directoryName}/bar", paths[0].Name);
+            Assert.AreEqual($"{directoryName}/baz", paths[1].Name);
+            Assert.AreEqual($"{directoryName}/foo", paths[2].Name);
+        }
+
+        [Test]
         public async Task GetPathsAsync_Recursive()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetPathsAsync_UriCtor.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetPathsAsync_UriCtor.json
@@ -1,0 +1,401 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-8a35f918e0f32a469b24fdcc896a4b73-6518ea42edf7084b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "79e2f578-c7c3-dfa8-0a08-08d6dfe4d2e1",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:33 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:33 GMT",
+        "ETag": "\u00220x8D8A797CFB73ADA\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "79e2f578-c7c3-dfa8-0a08-08d6dfe4d2e1",
+        "x-ms-request-id": "6322e59e-301e-001d-2080-d9fb9d000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-14100f68376e0f438fe818f0746b84a1-d47c289729241c48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "c9e26fc4-b5f0-fb17-7d63-df58bfd27287",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797CFFBF6B1\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c9e26fc4-b5f0-fb17-7d63-df58bfd27287",
+        "x-ms-request-id": "a5b701c2-b01f-00ba-5e80-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-d2df210356fd87418387c3800be531e9-cf78264a1e228f4d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "fc11614a-949f-dad6-7c30-b2f1d9fb9f70",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D008A186\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "fc11614a-949f-dad6-7c30-b2f1d9fb9f70",
+        "x-ms-request-id": "a5b701c3-b01f-00ba-5f80-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/baz?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-6f81edf222168249ace5c005a1025686-c6f376dc7a5dca43-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "5e0df3f0-76c1-16e7-6a6d-ce88ef9af677",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D014C48A\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "5e0df3f0-76c1-16e7-6a6d-ce88ef9af677",
+        "x-ms-request-id": "a5b701c4-b01f-00ba-6080-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/baz/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-68839902a52a4b46aad177344e6debbb-22c14b5e308b3044-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "e5011d34-40ee-60af-0dce-60f906653148",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D020B2FD\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e5011d34-40ee-60af-0dce-60f906653148",
+        "x-ms-request-id": "a5b701c5-b01f-00ba-6180-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/foo/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-30b4cf38c6654642a45f4dee903b4af8-9e20f18c25d57045-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "d15441c5-1098-ba89-63f0-fd35488c6e0e",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D02C892F\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d15441c5-1098-ba89-63f0-fd35488c6e0e",
+        "x-ms-request-id": "a5b701c6-b01f-00ba-6280-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/foo/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-440bbab46b6ec7488d89ed93011086ad-d0a799cecc0ba44c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "c53376f6-5f11-0cb0-54a0-bcadf35cfee1",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D03871AB\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c53376f6-5f11-0cb0-54a0-bcadf35cfee1",
+        "x-ms-request-id": "a5b701ce-b01f-00ba-6380-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/baz/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-eeb00a86ad358c44a9f5e07b38e059d8-e9a2567f9b5d1c48-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "d23e4aed-a958-5dfd-1f63-0d85cc405030",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D0444A37\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "d23e4aed-a958-5dfd-1f63-0d85cc405030",
+        "x-ms-request-id": "a5b701d0-b01f-00ba-6480-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/baz/foo/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-938028886877104a861a33b977aa53d4-a5c0909840250948-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "a9bf363c-2c1d-7f88-deb5-6d87683d7012",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D0502D8C\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "a9bf363c-2c1d-7f88-deb5-6d87683d7012",
+        "x-ms-request-id": "a5b701d1-b01f-00ba-6580-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117/test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/baz/bar/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-fa927b4517d7894a8d0ddf5553bb0f5c-375c500d64c1224d-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "9549ebef-a680-8f12-0eaf-9b15073f1875",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:34 GMT",
+        "ETag": "\u00220x8D8A797D05C052E\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9549ebef-a680-8f12-0eaf-9b15073f1875",
+        "x-ms-request-id": "a5b701d2-b01f-00ba-6680-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117?resource=filesystem\u0026recursive=false\u0026directory=test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b85504c647e21847a4a4f1a59bc23d2c-0d0dc33472510047-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "7d981f71-dbf3-1992-0293-f3534fa57044",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "7d981f71-dbf3-1992-0293-f3534fa57044",
+        "x-ms-request-id": "a5b701d4-b01f-00ba-6780-d9135f000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Wed, 23 Dec 2020 23:09:34 GMT\u0022,\u0022etag\u0022:\u00220x8D8A797D008A186\u0022,\u0022group\u0022:\u0022$superuser\u0022,\u0022isDirectory\u0022:\u0022true\u0022,\u0022lastModified\u0022:\u0022Wed, 23 Dec 2020 23:09:34 GMT\u0022,\u0022name\u0022:\u0022test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/bar\u0022,\u0022owner\u0022:\u0022$superuser\u0022,\u0022permissions\u0022:\u0022rwxr-x---\u0022},{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Wed, 23 Dec 2020 23:09:34 GMT\u0022,\u0022etag\u0022:\u00220x8D8A797D014C48A\u0022,\u0022group\u0022:\u0022$superuser\u0022,\u0022isDirectory\u0022:\u0022true\u0022,\u0022lastModified\u0022:\u0022Wed, 23 Dec 2020 23:09:34 GMT\u0022,\u0022name\u0022:\u0022test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/baz\u0022,\u0022owner\u0022:\u0022$superuser\u0022,\u0022permissions\u0022:\u0022rwxr-x---\u0022},{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Wed, 23 Dec 2020 23:09:34 GMT\u0022,\u0022etag\u0022:\u00220x8D8A797CFFBF6B1\u0022,\u0022group\u0022:\u0022$superuser\u0022,\u0022isDirectory\u0022:\u0022true\u0022,\u0022lastModified\u0022:\u0022Wed, 23 Dec 2020 23:09:34 GMT\u0022,\u0022name\u0022:\u0022test-directory-c5f9c787-7c71-7e77-996b-08d56c825dc7/foo\u0022,\u0022owner\u0022:\u0022$superuser\u0022,\u0022permissions\u0022:\u0022rwxr-x---\u0022}]}\n"
+      ]
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-936c1e92-bd6c-eeec-b00a-1ea325373117?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-b21fa45b8ec6b8439b53048e1a2fae00-333ff76a725bc94b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "e8a3b867-9ba6-ab81-cc27-021b7ecb02d6",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "e8a3b867-9ba6-ab81-cc27-021b7ecb02d6",
+        "x-ms-request-id": "6322e630-301e-001d-1780-d9fb9d000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "1659786005",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary\nU2FuaXRpemVk\nhttps://amandaadlscanary.blob.core.windows.net\nhttp://amandaadlscanary.file.core.windows.net\nhttps://amandaadlscanary.queue.core.windows.net\nhttp://amandaadlscanary.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary-secondary.blob.core.windows.net\nhttp://amandaadlscanary-secondary.file.core.windows.net\nhttp://amandaadlscanary-secondary.queue.core.windows.net\nhttp://amandaadlscanary-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://amandaadlscanary.blob.core.windows.net/;QueueEndpoint=https://amandaadlscanary.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary-secondary.file.core.windows.net/;AccountName=amandaadlscanary;AccountKey=Sanitized\n"
+  }
+}

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetPathsAsync_UriCtorAsync.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/SessionRecords/DirectoryClientTests/GetPathsAsync_UriCtorAsync.json
@@ -1,0 +1,400 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-293b4601a4ff4344910ef6d024abd0c9-952c9004245d3344-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-blob-public-access": "container",
+        "x-ms-client-request-id": "6ad05fba-6e8a-1a78-7268-ed219e9e88c8",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D0BE6E9C\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "6ad05fba-6e8a-1a78-7268-ed219e9e88c8",
+        "x-ms-request-id": "06999f8c-e01e-0098-2780-d9d640000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-265457f41ca1d74db7ce198b907c9ac0-c24070ef8a6f0e41-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "68273f60-07ac-05b7-8c89-9d9df2a6c208",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D0F680F2\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "68273f60-07ac-05b7-8c89-9d9df2a6c208",
+        "x-ms-request-id": "c97428e1-701f-001c-4680-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-0738899451c2494c848156340333c991-935f59785d919e45-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "18715472-e742-69d1-a811-89cfc41143e0",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D103260A\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "18715472-e742-69d1-a811-89cfc41143e0",
+        "x-ms-request-id": "c97428e2-701f-001c-4780-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/baz?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-f1f51f987a9a7a469688a6dbafa5028a-3a01490beabdbd44-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "9d2bea80-a934-31c6-9c46-9675e8a02181",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D10FC3AC\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "9d2bea80-a934-31c6-9c46-9675e8a02181",
+        "x-ms-request-id": "c97428e3-701f-001c-4880-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/baz/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-61a7be1dd968e4419db328ea910b97e7-c5b67ed380274a46-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "da4e3a4b-a6e6-dbab-a54c-3221a52a062f",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D11C56C5\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "da4e3a4b-a6e6-dbab-a54c-3221a52a062f",
+        "x-ms-request-id": "c97428e4-701f-001c-4980-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/foo/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-b2de7dece40e624d868fca53357f92df-bcfb11c6f7a6f24a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "ad2a1493-4751-f99a-c531-2e71072a9189",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D128E64D\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "ad2a1493-4751-f99a-c531-2e71072a9189",
+        "x-ms-request-id": "c97428e5-701f-001c-4a80-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/foo/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-540948e5f4e7a44b8c719693a062358b-97a59525b33db041-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "918d9e2d-58ff-d8dd-b92f-80e8c41e4073",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D135763F\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "918d9e2d-58ff-d8dd-b92f-80e8c41e4073",
+        "x-ms-request-id": "c97428e6-701f-001c-4b80-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/baz/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-fee70cacd2f1ad469d3a95783d5460af-b707da797b68aa40-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "68444eb6-009d-2389-3c08-03b0ec7f948a",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D1420461\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "68444eb6-009d-2389-3c08-03b0ec7f948a",
+        "x-ms-request-id": "c97428e7-701f-001c-4c80-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/baz/foo/bar?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-b53c439ce7694049a2855efa4091e6bb-372f584384aaf74a-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "7531b4f1-d8d9-63d6-d712-0adc5f03392c",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:35 GMT",
+        "ETag": "\u00220x8D8A797D14E9169\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "7531b4f1-d8d9-63d6-d712-0adc5f03392c",
+        "x-ms-request-id": "c97428e9-701f-001c-4e80-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a/test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/baz/bar/foo?resource=directory",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "If-None-Match": "*",
+        "traceparent": "00-dca536949936e94880ecb17337143147-8f05d75262f7aa4b-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "38bef23b-1e4d-eeb0-f22a-83b0281e6ae7",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "ETag": "\u00220x8D8A797D15B2F35\u0022",
+        "Last-Modified": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "38bef23b-1e4d-eeb0-f22a-83b0281e6ae7",
+        "x-ms-request-id": "c97428ea-701f-001c-4f80-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.dfs.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a?resource=filesystem\u0026recursive=false\u0026directory=test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e\u0026upn=false",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "6da06043-0144-1edf-c895-50f15e585a35",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-HDFS/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "x-ms-client-request-id": "6da06043-0144-1edf-c895-50f15e585a35",
+        "x-ms-request-id": "c97428eb-701f-001c-5080-d9a441000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": [
+        "{\u0022paths\u0022:[{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Wed, 23 Dec 2020 23:09:36 GMT\u0022,\u0022etag\u0022:\u00220x8D8A797D103260A\u0022,\u0022group\u0022:\u0022$superuser\u0022,\u0022isDirectory\u0022:\u0022true\u0022,\u0022lastModified\u0022:\u0022Wed, 23 Dec 2020 23:09:36 GMT\u0022,\u0022name\u0022:\u0022test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/bar\u0022,\u0022owner\u0022:\u0022$superuser\u0022,\u0022permissions\u0022:\u0022rwxr-x---\u0022},{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Wed, 23 Dec 2020 23:09:36 GMT\u0022,\u0022etag\u0022:\u00220x8D8A797D10FC3AC\u0022,\u0022group\u0022:\u0022$superuser\u0022,\u0022isDirectory\u0022:\u0022true\u0022,\u0022lastModified\u0022:\u0022Wed, 23 Dec 2020 23:09:36 GMT\u0022,\u0022name\u0022:\u0022test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/baz\u0022,\u0022owner\u0022:\u0022$superuser\u0022,\u0022permissions\u0022:\u0022rwxr-x---\u0022},{\u0022contentLength\u0022:\u00220\u0022,\u0022creationTime\u0022:\u0022Wed, 23 Dec 2020 23:09:36 GMT\u0022,\u0022etag\u0022:\u00220x8D8A797D0F680F2\u0022,\u0022group\u0022:\u0022$superuser\u0022,\u0022isDirectory\u0022:\u0022true\u0022,\u0022lastModified\u0022:\u0022Wed, 23 Dec 2020 23:09:36 GMT\u0022,\u0022name\u0022:\u0022test-directory-d7194249-b4d9-46d3-ccec-7cd1576a4f7e/foo\u0022,\u0022owner\u0022:\u0022$superuser\u0022,\u0022permissions\u0022:\u0022rwxr-x---\u0022}]}\n"
+      ]
+    },
+    {
+      "RequestUri": "https://amandaadlscanary.blob.core.windows.net/test-filesystem-42040771-60ba-fbdb-444f-f0d17529cd3a?restype=container",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "traceparent": "00-87235b6f5a424c40a4ac13bd537a25fa-fe2fe3be0ebb2b4c-00",
+        "User-Agent": [
+          "azsdk-net-Storage.Files.DataLake/12.6.0-alpha.20201223.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "c86d07e2-fd7e-2ba3-d8d1-12783a03b153",
+        "x-ms-date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "x-ms-return-client-request-id": "true",
+        "x-ms-version": "2020-04-08"
+      },
+      "RequestBody": null,
+      "StatusCode": 202,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 23 Dec 2020 23:09:36 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-client-request-id": "c86d07e2-fd7e-2ba3-d8d1-12783a03b153",
+        "x-ms-request-id": "0699a008-e01e-0098-0c80-d9d640000000",
+        "x-ms-version": "2020-04-08"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "RandomSeed": "558317770",
+    "Storage_TestConfigHierarchicalNamespace": "NamespaceTenant\namandaadlscanary\nU2FuaXRpemVk\nhttps://amandaadlscanary.blob.core.windows.net\nhttp://amandaadlscanary.file.core.windows.net\nhttps://amandaadlscanary.queue.core.windows.net\nhttp://amandaadlscanary.table.core.windows.net\n\n\n\n\nhttp://amandaadlscanary-secondary.blob.core.windows.net\nhttp://amandaadlscanary-secondary.file.core.windows.net\nhttp://amandaadlscanary-secondary.queue.core.windows.net\nhttp://amandaadlscanary-secondary.table.core.windows.net\n68390a19-a643-458b-b726-408abf67b4fc\nSanitized\n72f988bf-86f1-41af-91ab-2d7cd011db47\nhttps://login.microsoftonline.com/\nCloud\nBlobEndpoint=https://amandaadlscanary.blob.core.windows.net/;QueueEndpoint=https://amandaadlscanary.queue.core.windows.net/;FileEndpoint=http://amandaadlscanary.file.core.windows.net/;BlobSecondaryEndpoint=http://amandaadlscanary-secondary.blob.core.windows.net/;QueueSecondaryEndpoint=http://amandaadlscanary-secondary.queue.core.windows.net/;FileSecondaryEndpoint=http://amandaadlscanary-secondary.file.core.windows.net/;AccountName=amandaadlscanary;AccountKey=Sanitized\n"
+  }
+}


### PR DESCRIPTION
If a `DataLakeDirectoryClient` was constructed/initialized with a `Uri` (any additional parameters don't matter) and when the user would go to call `GetPaths(..)` it would throw an exception. This is because when it goes to call `GetPaths` it would pass the `FileSystemClient` member within `DataLakeDirectoryClient` to call the `GetPaths` API however the `FileSystemClient` was not getting constructed within this case.