### PR TITLE
Increase TimeoutInMinutes for FR

### DIFF
--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -4,3 +4,4 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: formrecognizer
+    TimeoutInMinutes: 90


### PR DESCRIPTION
With the addition of the AAD tests for every endpoint, the FR tests are taking an average of 50min (before 40min) and sometimes, if the server is busy, it can take more than 60min.
Our pipelines have a default of 60min per run, so the build fails.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17708