### PR TITLE
[FR] Enable receipts tests

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -552,8 +552,8 @@ namespace Azure.AI.FormRecognizer.Tests
         /// Recognizer cognitive service and perform analysis of receipts.
         /// </summary>
         [Test]
-        [TestCase(true, Ignore= "Receipts latest changes not yet in this region")]
-        [TestCase(false, Ignore = "Receipts latest changes not yet in this region")]
+        [TestCase(true)]
+        [TestCase(false)]
         public async Task StartRecognizeReceiptsPopulatesExtractedReceiptJpg(bool useStream)
         {
             var client = CreateFormRecognizerClient();
@@ -663,8 +663,8 @@ namespace Azure.AI.FormRecognizer.Tests
         }
 
         [Test]
-        [TestCase(true, Ignore="Receipts latest changes not yet in this region")]
-        [TestCase(false, Ignore="Receipts latest changes not yet in this region")]
+        [TestCase(true)]
+        [TestCase(false)]
         public async Task StartRecognizeReceiptsPopulatesExtractedReceiptPng(bool useStream)
         {
             var client = CreateFormRecognizerClient();
@@ -777,8 +777,8 @@ namespace Azure.AI.FormRecognizer.Tests
         }
 
         [Test]
-        [TestCase(true, Ignore = "Receipts latest changes not yet in this region")]
-        [TestCase(false, Ignore = "Receipts latest changes not yet in this region")]
+        [TestCase(true)]
+        [TestCase(false)]
         public async Task StartRecognizeReceiptsCanParseMultipageForm(bool useStream)
         {
             var client = CreateFormRecognizerClient();


### PR DESCRIPTION
Latest expected changes from the service have been propagated to all regions so we can enable the tests again.
The recordings don't need to be updated as they were done against Canary which included the changes in receipts our SDK needed.