### PR TITLE
[Event Hubs] Exclude Functions Bindings from Legacy

### DIFF
--- a/sdk/eventhub/ci.legacy.yml
+++ b/sdk/eventhub/ci.legacy.yml
@@ -45,6 +45,7 @@ extends:
       - Azure.Messaging.EventHubs.Processor
       - Azure.Messaging.EventHubs.Shared
       - Azure.Messaging.EventHubs.*
+      - Microsoft.Azure.WebJobs.Extensions.EventHubs
     ArtifactName: packages
     Artifacts:
     - name: Microsoft.Azure.EventHubs

--- a/sdk/eventhub/tests.legacy.yml
+++ b/sdk/eventhub/tests.legacy.yml
@@ -12,4 +12,5 @@ extends:
     - Azure.Messaging.EventHubs.Processor
     - Azure.Messaging.EventHubs.Shared
     - Azure.Messaging.EventHubs.*
+    - Microsoft.Azure.WebJobs.Extensions.EventHubs
     Clouds: 'Public,Canary'


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the Azure Function bindings projects from the legacy pipeline definitions.

# Last Upstream Rebase

Monday, January 4, 4:15pm (EST)

# References and Related

- [Event Hubs Test Pipelines: Split out Management, Legacy Client, and Client Tests (#15101)](https://github.com/Azure/azure-sdk-for-net/issues/15101)