### PR TITLE
Add exclude projects parameter.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -23,6 +23,9 @@ parameters:
 - name: LinuxPool
   type: string
   default: azsdk-pool-mms-ubuntu-1804-general
+- name: ExcludeProjects
+  type: object
+  default: []
 
 jobs:
   - job: Build


### PR DESCRIPTION
Adding the ExcludeProjects parameter to the list of parameters in the ```archetype-sdk-client.yml``` jobs template. This will fix the broken builds on master.