### PR TITLE
Copy iothub connection string sample into smoke test arm template

### DIFF
--- a/common/SmokeTests/SmokeTest/test-resources.json
+++ b/common/SmokeTests/SmokeTest/test-resources.json
@@ -55,22 +55,6 @@
             }
         },
         {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
-            "name": "sample-IotHubConnectionString",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri":"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/samples/iothub-connect-to-eventhubs/sample-resources.json",
-                    "contentVersion":"1.0.0.0"
-                },
-                "parameters": {
-                    "hubname": {"value": "[variables('iotHubName')]" },
-                    "location": {"value": "[parameters('location')]" }
-                }
-            }
-        },
-        {
             "type": "Microsoft.KeyVault/vaults",
             "apiVersion": "2016-10-01",
             "name": "[variables('keyVaultName')]",
@@ -251,6 +235,25 @@
             "properties": {
                 "publicAccess": "None"
             }
+        },
+        { /* TODO: Remove this once file URIs are supported. See https://github.com/Azure/azure-sdk-for-net/pull/17524#discussion_r543362690 */
+            "apiVersion": "2019-11-04",
+            "type": "Microsoft.Devices/IotHubs",
+            "name": "[variables('iotHubName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "eventHubEndpoints": {
+                    "events": {
+                        "retentionTimeInDays": 1,
+                        "partitionCount": "4"
+                    }
+                },
+                "features": "None"
+            },
+            "sku": {
+                "name": "B1",
+                "capacity": "5"
+            }
         }
     ],
     "outputs": {
@@ -282,9 +285,13 @@
             "type": "string",
             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
         },
-        "IOTHUB_CONNECTION_STRING": {
+        "IOTHUB_CONNECTION_STRING": { /* TODO: Remove this once file URIs are supported. See https://github.com/Azure/azure-sdk-for-net/pull/17524#discussion_r543362690 */
             "type": "string",
-            "value": "[reference('sample-IotHubConnectionString').outputs.IoTHubConnectionString.value]"
+            "value": "[concat('HostName=', reference(resourceId('Microsoft.Devices/IoTHubs', variables('iotHubName')), providers('Microsoft.Devices', 'IoTHubs').apiVersions[0]).hostName, ';SharedAccessKeyName=iothubowner;SharedAccessKey=', listKeys(resourceId('Microsoft.Devices/IotHubs', variables('iotHubName')), providers('Microsoft.Devices', 'IoTHubs').apiVersions[0]).value[0].primaryKey)]"
+        },
+        "IoTHubName": { /* TODO: Remove this once file URIs are supported. See https://github.com/Azure/azure-sdk-for-net/pull/17524#discussion_r543362690 */
+            "type": "string",
+            "value": "[variables('iotHubName')]"
         }
     }
 }


### PR DESCRIPTION
This is a temporary fix for an issue that causes frequent failures in the smoke tests for azure china cloud. The smoke test test-resources.json ARM template uses a template link which tries to download from github.com. This often fails:

```
 "message": "Unable to download deployment content from 'https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/samples/iothub-connect-to-eventhubs/sample-resources.json'. 
The tracking Id is '8bc97f2c-776d-4e04-9518-d92cc78ac6c0'. Please see https://aka.ms/arm-deploy for usage details."
```

The fix involves copying the linked template into the smoke test template. There is an outstanding feature to add file link support in ARM templates ([here](https://github.com/azure/azure-sdk-for-net/issues/17757)). Once that is completed, we can remove this inline update.

Related discussion: https://github.com/Azure/azure-sdk-for-net/pull/17524#discussion_r543362690
Issue to remove this update: https://github.com/azure/azure-sdk-for-net/issues/17757