### PR TITLE
Fixed bug where ChangeFeed couldn't handle BlobChangeFeedEvent.EventD…

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.0.0-preview.8 (Unreleased)
-- Fixed bug where we couldn't handle BlobChangeFeedEvent.EventData.ClientRequestIdentifiers that were not GUIDs.
+- Fixed bug where we couldn't handle BlobChangeFeedEvent.EventData.ClientRequestIds that were not GUIDs.
 
 ## 12.0.0-preview.7 (2020-12-07)
 - Added support for service version 2020-04-08.

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 12.0.0-preview.8 (Unreleased)
-
+- Fixed bug where we couldn't handle BlobChangeFeedEvent.EventData.ClientRequestIdentifiers that were not GUIDs.
 
 ## 12.0.0-preview.7 (2020-12-07)
 - Added support for service version 2020-04-08.

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/api/Azure.Storage.Blobs.ChangeFeed.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/api/Azure.Storage.Blobs.ChangeFeed.netstandard2.0.cs
@@ -33,9 +33,7 @@ namespace Azure.Storage.Blobs.ChangeFeed
         internal BlobChangeFeedEventData() { }
         public Azure.Storage.Blobs.ChangeFeed.BlobOperationName BlobOperationName { get { throw null; } }
         public Azure.Storage.Blobs.Models.BlobType BlobType { get { throw null; } }
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public System.Guid ClientRequestId { get { throw null; } }
-        public string ClientRequestIdentifier { get { throw null; } }
+        public string ClientRequestId { get { throw null; } }
         public long ContentLength { get { throw null; } }
         public long? ContentOffset { get { throw null; } }
         public string ContentType { get { throw null; } }
@@ -78,7 +76,7 @@ namespace Azure.Storage.Blobs.ChangeFeed
     public static partial class BlobChangeFeedModelFactory
     {
         public static Azure.Storage.Blobs.ChangeFeed.BlobChangeFeedEvent BlobChangeFeedEvent(string topic, string subject, Azure.Storage.Blobs.ChangeFeed.BlobChangeFeedEventType eventType, System.DateTimeOffset eventTime, System.Guid id, Azure.Storage.Blobs.ChangeFeed.BlobChangeFeedEventData eventData, long dataVersion, string metadataVersion) { throw null; }
-        public static Azure.Storage.Blobs.ChangeFeed.BlobChangeFeedEventData BlobChangeFeedEventData(string api, System.Guid clientRequestId, System.Guid requestId, Azure.ETag eTag, string contentType, long contentLength, Azure.Storage.Blobs.Models.BlobType blobType, long contentOffset, System.Uri destinationUri, System.Uri sourceUri, System.Uri uri, bool recursive, string sequencer) { throw null; }
+        public static Azure.Storage.Blobs.ChangeFeed.BlobChangeFeedEventData BlobChangeFeedEventData(string api, string clientRequestId, System.Guid requestId, Azure.ETag eTag, string contentType, long contentLength, Azure.Storage.Blobs.Models.BlobType blobType, long contentOffset, System.Uri destinationUri, System.Uri sourceUri, System.Uri uri, bool recursive, string sequencer) { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct BlobOperationName : System.IEquatable<Azure.Storage.Blobs.ChangeFeed.BlobOperationName>

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/api/Azure.Storage.Blobs.ChangeFeed.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/api/Azure.Storage.Blobs.ChangeFeed.netstandard2.0.cs
@@ -33,7 +33,9 @@ namespace Azure.Storage.Blobs.ChangeFeed
         internal BlobChangeFeedEventData() { }
         public Azure.Storage.Blobs.ChangeFeed.BlobOperationName BlobOperationName { get { throw null; } }
         public Azure.Storage.Blobs.Models.BlobType BlobType { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public System.Guid ClientRequestId { get { throw null; } }
+        public string ClientRequestIdentifier { get { throw null; } }
         public long ContentLength { get { throw null; } }
         public long? ContentOffset { get { throw null; } }
         public string ContentType { get { throw null; } }

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Models/BlobChangeFeedEventData.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Models/BlobChangeFeedEventData.cs
@@ -21,8 +21,7 @@ namespace Azure.Storage.Blobs.ChangeFeed
         internal BlobChangeFeedEventData(Dictionary<string, object> record)
         {
             BlobOperationName = new BlobOperationName((string)record[Constants.ChangeFeed.EventData.Api]);
-            ClientRequestId = Guid.Empty;
-            ClientRequestIdentifier = (string)record[Constants.ChangeFeed.EventData.ClientRequestId];
+            ClientRequestId = (string)record[Constants.ChangeFeed.EventData.ClientRequestId];
             RequestId = Guid.Parse((string)record[Constants.ChangeFeed.EventData.RequestId]);
             ETag = new ETag((string)record[Constants.ChangeFeed.EventData.Etag]);
             ContentType = (string)record[Constants.ChangeFeed.EventData.ContentType];
@@ -53,17 +52,11 @@ namespace Azure.Storage.Blobs.ChangeFeed
         public BlobOperationName BlobOperationName { get; internal set; }
 
         /// <summary>
-        /// Use <see cref="ClientRequestIdentifier"/> instead.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Guid ClientRequestId { get; internal set; }
-
-        /// <summary>
         /// A client-provided request id for the storage API operation. This id can be used to correlate to Azure Storage
         /// diagnostic logs using the "client-request-id" field in the logs, and can be provided in client requests using
         /// the "x-ms-client-request-id" header.
         /// </summary>
-        public string ClientRequestIdentifier { get; internal set; }
+        public string ClientRequestId { get; internal set; }
 
         /// <summary>
         /// Service-generated request id for the storage API operation. Can be used to correlate to Azure Storage diagnostic

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Models/BlobChangeFeedEventData.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Models/BlobChangeFeedEventData.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Azure.Storage.Blobs.Models;
 
 namespace Azure.Storage.Blobs.ChangeFeed
@@ -20,7 +21,8 @@ namespace Azure.Storage.Blobs.ChangeFeed
         internal BlobChangeFeedEventData(Dictionary<string, object> record)
         {
             BlobOperationName = new BlobOperationName((string)record[Constants.ChangeFeed.EventData.Api]);
-            ClientRequestId = Guid.Parse((string)record[Constants.ChangeFeed.EventData.ClientRequestId]);
+            ClientRequestId = Guid.Empty;
+            ClientRequestIdentifier = (string)record[Constants.ChangeFeed.EventData.ClientRequestId];
             RequestId = Guid.Parse((string)record[Constants.ChangeFeed.EventData.RequestId]);
             ETag = new ETag((string)record[Constants.ChangeFeed.EventData.Etag]);
             ContentType = (string)record[Constants.ChangeFeed.EventData.ContentType];
@@ -51,11 +53,17 @@ namespace Azure.Storage.Blobs.ChangeFeed
         public BlobOperationName BlobOperationName { get; internal set; }
 
         /// <summary>
+        /// Use <see cref="ClientRequestIdentifier"/> instead.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Guid ClientRequestId { get; internal set; }
+
+        /// <summary>
         /// A client-provided request id for the storage API operation. This id can be used to correlate to Azure Storage
         /// diagnostic logs using the "client-request-id" field in the logs, and can be provided in client requests using
         /// the "x-ms-client-request-id" header.
         /// </summary>
-        public Guid ClientRequestId { get; internal set; }
+        public string ClientRequestIdentifier { get; internal set; }
 
         /// <summary>
         /// Service-generated request id for the storage API operation. Can be used to correlate to Azure Storage diagnostic

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Models/BlobChangeFeedModelFactory.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/src/Models/BlobChangeFeedModelFactory.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage.Blobs.ChangeFeed
         /// </summary>
         public static BlobChangeFeedEventData BlobChangeFeedEventData(
             string api,
-            Guid clientRequestId,
+            string clientRequestId,
             Guid requestId,
             ETag eTag,
             string contentType,

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChunkTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChunkTests.cs
@@ -137,7 +137,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             string metadataVersion = "1";
 
             string api = "PutBlob";
-            string clientRequestIdentifier = $"Azure-Storage-Powershell-{Guid.NewGuid()}";
+            string clientRequestId = $"Azure-Storage-Powershell-{Guid.NewGuid()}";
             Guid requestId = Guid.NewGuid();
             ETag etag = new ETag("0x8D75EF45A3B8617");
             string contentType = "contentType";
@@ -162,7 +162,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
                 { Constants.ChangeFeed.Event.Data, new Dictionary<string, object>
                     {
                         { Constants.ChangeFeed.EventData.Api, api },
-                        { Constants.ChangeFeed.EventData.ClientRequestId, clientRequestIdentifier.ToString() },
+                        { Constants.ChangeFeed.EventData.ClientRequestId, clientRequestId.ToString() },
                         { Constants.ChangeFeed.EventData.RequestId, requestId.ToString() },
                         { Constants.ChangeFeed.EventData.Etag, etag.ToString() },
                         { Constants.ChangeFeed.EventData.ContentType, contentType },
@@ -231,8 +231,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             Assert.AreEqual(metadataVersion, changeFeedEvent.MetadataVersion);
 
             Assert.AreEqual(BlobOperationName.PutBlob, changeFeedEvent.EventData.BlobOperationName);
-            Assert.AreEqual(Guid.Empty, changeFeedEvent.EventData.ClientRequestId);
-            Assert.AreEqual(clientRequestIdentifier, changeFeedEvent.EventData.ClientRequestIdentifier);
+            Assert.AreEqual(clientRequestId, changeFeedEvent.EventData.ClientRequestId);
             Assert.AreEqual(requestId, changeFeedEvent.EventData.RequestId);
             Assert.AreEqual(etag, changeFeedEvent.EventData.ETag);
             Assert.AreEqual(contentType, changeFeedEvent.EventData.ContentType);

--- a/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChunkTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.ChangeFeed/tests/ChunkTests.cs
@@ -137,7 +137,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             string metadataVersion = "1";
 
             string api = "PutBlob";
-            Guid clientRequestId = Guid.NewGuid();
+            string clientRequestIdentifier = $"Azure-Storage-Powershell-{Guid.NewGuid()}";
             Guid requestId = Guid.NewGuid();
             ETag etag = new ETag("0x8D75EF45A3B8617");
             string contentType = "contentType";
@@ -162,7 +162,7 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
                 { Constants.ChangeFeed.Event.Data, new Dictionary<string, object>
                     {
                         { Constants.ChangeFeed.EventData.Api, api },
-                        { Constants.ChangeFeed.EventData.ClientRequestId, clientRequestId.ToString() },
+                        { Constants.ChangeFeed.EventData.ClientRequestId, clientRequestIdentifier.ToString() },
                         { Constants.ChangeFeed.EventData.RequestId, requestId.ToString() },
                         { Constants.ChangeFeed.EventData.Etag, etag.ToString() },
                         { Constants.ChangeFeed.EventData.ContentType, contentType },
@@ -231,7 +231,8 @@ namespace Azure.Storage.Blobs.ChangeFeed.Tests
             Assert.AreEqual(metadataVersion, changeFeedEvent.MetadataVersion);
 
             Assert.AreEqual(BlobOperationName.PutBlob, changeFeedEvent.EventData.BlobOperationName);
-            Assert.AreEqual(clientRequestId, changeFeedEvent.EventData.ClientRequestId);
+            Assert.AreEqual(Guid.Empty, changeFeedEvent.EventData.ClientRequestId);
+            Assert.AreEqual(clientRequestIdentifier, changeFeedEvent.EventData.ClientRequestIdentifier);
             Assert.AreEqual(requestId, changeFeedEvent.EventData.RequestId);
             Assert.AreEqual(etag, changeFeedEvent.EventData.ETag);
             Assert.AreEqual(contentType, changeFeedEvent.EventData.ContentType);


### PR DESCRIPTION
…ata.ClientRequestIdentifiers that were not GUIDs.

Resolves https://github.com/Azure/azure-sdk-for-net/issues/17705