### PR TITLE
[MetricsAdvisor] Bug fix: service returns null in unexpected scenarios

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Key Bug Fixes
 - Fixed a bug in which setting `WebNotificationHook.CertificatePassword` would actually set the property `Username` instead.
+- Fixed a bug in which an `ArgumentNullException` was thrown when getting a `DataFeed` from the service as a Viewer.
 
 ## 1.0.0-beta.2 (2020-11-10)
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureApplicationInsightsParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureApplicationInsightsParameter.Serialization.cs
@@ -15,14 +15,42 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("azureCloud");
-            writer.WriteStringValue(AzureCloud);
-            writer.WritePropertyName("applicationId");
-            writer.WriteStringValue(ApplicationId);
-            writer.WritePropertyName("apiKey");
-            writer.WriteStringValue(ApiKey);
-            writer.WritePropertyName("query");
-            writer.WriteStringValue(Query);
+            if (AzureCloud != null)
+            {
+                writer.WritePropertyName("azureCloud");
+                writer.WriteStringValue(AzureCloud);
+            }
+            else
+            {
+                writer.WriteNull("azureCloud");
+            }
+            if (ApplicationId != null)
+            {
+                writer.WritePropertyName("applicationId");
+                writer.WriteStringValue(ApplicationId);
+            }
+            else
+            {
+                writer.WriteNull("applicationId");
+            }
+            if (ApiKey != null)
+            {
+                writer.WritePropertyName("apiKey");
+                writer.WriteStringValue(ApiKey);
+            }
+            else
+            {
+                writer.WriteNull("apiKey");
+            }
+            if (Query != null)
+            {
+                writer.WritePropertyName("query");
+                writer.WriteStringValue(Query);
+            }
+            else
+            {
+                writer.WriteNull("query");
+            }
             writer.WriteEndObject();
         }
 
@@ -36,21 +64,41 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("azureCloud"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        azureCloud = null;
+                        continue;
+                    }
                     azureCloud = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("applicationId"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        applicationId = null;
+                        continue;
+                    }
                     applicationId = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("apiKey"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        apiKey = null;
+                        continue;
+                    }
                     apiKey = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("query"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        query = null;
+                        continue;
+                    }
                     query = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureApplicationInsightsParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureApplicationInsightsParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The AzureApplicationInsightsParameter. </summary>
@@ -17,26 +15,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="applicationId"> Azure Application Insights ID. </param>
         /// <param name="apiKey"> API Key. </param>
         /// <param name="query"> Query. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="azureCloud"/>, <paramref name="applicationId"/>, <paramref name="apiKey"/>, or <paramref name="query"/> is null. </exception>
         public AzureApplicationInsightsParameter(string azureCloud, string applicationId, string apiKey, string query)
         {
-            if (azureCloud == null)
-            {
-                throw new ArgumentNullException(nameof(azureCloud));
-            }
-            if (applicationId == null)
-            {
-                throw new ArgumentNullException(nameof(applicationId));
-            }
-            if (apiKey == null)
-            {
-                throw new ArgumentNullException(nameof(apiKey));
-            }
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
             AzureCloud = azureCloud;
             ApplicationId = applicationId;
             ApiKey = apiKey;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureBlobParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureBlobParameter.Serialization.cs
@@ -15,12 +15,33 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("connectionString");
-            writer.WriteStringValue(ConnectionString);
-            writer.WritePropertyName("container");
-            writer.WriteStringValue(Container);
-            writer.WritePropertyName("blobTemplate");
-            writer.WriteStringValue(BlobTemplate);
+            if (ConnectionString != null)
+            {
+                writer.WritePropertyName("connectionString");
+                writer.WriteStringValue(ConnectionString);
+            }
+            else
+            {
+                writer.WriteNull("connectionString");
+            }
+            if (Container != null)
+            {
+                writer.WritePropertyName("container");
+                writer.WriteStringValue(Container);
+            }
+            else
+            {
+                writer.WriteNull("container");
+            }
+            if (BlobTemplate != null)
+            {
+                writer.WritePropertyName("blobTemplate");
+                writer.WriteStringValue(BlobTemplate);
+            }
+            else
+            {
+                writer.WriteNull("blobTemplate");
+            }
             writer.WriteEndObject();
         }
 
@@ -33,16 +54,31 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("connectionString"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        connectionString = null;
+                        continue;
+                    }
                     connectionString = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("container"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        container = null;
+                        continue;
+                    }
                     container = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("blobTemplate"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        blobTemplate = null;
+                        continue;
+                    }
                     blobTemplate = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureBlobParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureBlobParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The AzureBlobParameter. </summary>
@@ -16,22 +14,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="connectionString"> Azure Blob connection string. </param>
         /// <param name="container"> Container. </param>
         /// <param name="blobTemplate"> Blob Template. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="connectionString"/>, <paramref name="container"/>, or <paramref name="blobTemplate"/> is null. </exception>
         public AzureBlobParameter(string connectionString, string container, string blobTemplate)
         {
-            if (connectionString == null)
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-            if (container == null)
-            {
-                throw new ArgumentNullException(nameof(container));
-            }
-            if (blobTemplate == null)
-            {
-                throw new ArgumentNullException(nameof(blobTemplate));
-            }
-
             ConnectionString = connectionString;
             Container = container;
             BlobTemplate = blobTemplate;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureCosmosDBParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureCosmosDBParameter.Serialization.cs
@@ -15,14 +15,42 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("connectionString");
-            writer.WriteStringValue(ConnectionString);
-            writer.WritePropertyName("sqlQuery");
-            writer.WriteStringValue(SqlQuery);
-            writer.WritePropertyName("database");
-            writer.WriteStringValue(Database);
-            writer.WritePropertyName("collectionId");
-            writer.WriteStringValue(CollectionId);
+            if (ConnectionString != null)
+            {
+                writer.WritePropertyName("connectionString");
+                writer.WriteStringValue(ConnectionString);
+            }
+            else
+            {
+                writer.WriteNull("connectionString");
+            }
+            if (SqlQuery != null)
+            {
+                writer.WritePropertyName("sqlQuery");
+                writer.WriteStringValue(SqlQuery);
+            }
+            else
+            {
+                writer.WriteNull("sqlQuery");
+            }
+            if (Database != null)
+            {
+                writer.WritePropertyName("database");
+                writer.WriteStringValue(Database);
+            }
+            else
+            {
+                writer.WriteNull("database");
+            }
+            if (CollectionId != null)
+            {
+                writer.WritePropertyName("collectionId");
+                writer.WriteStringValue(CollectionId);
+            }
+            else
+            {
+                writer.WriteNull("collectionId");
+            }
             writer.WriteEndObject();
         }
 
@@ -36,21 +64,41 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("connectionString"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        connectionString = null;
+                        continue;
+                    }
                     connectionString = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("sqlQuery"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        sqlQuery = null;
+                        continue;
+                    }
                     sqlQuery = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("database"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        database = null;
+                        continue;
+                    }
                     database = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("collectionId"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        collectionId = null;
+                        continue;
+                    }
                     collectionId = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureCosmosDBParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureCosmosDBParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The AzureCosmosDBParameter. </summary>
@@ -17,26 +15,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="sqlQuery"> Query script. </param>
         /// <param name="database"> Database name. </param>
         /// <param name="collectionId"> Collection id. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="connectionString"/>, <paramref name="sqlQuery"/>, <paramref name="database"/>, or <paramref name="collectionId"/> is null. </exception>
         public AzureCosmosDBParameter(string connectionString, string sqlQuery, string database, string collectionId)
         {
-            if (connectionString == null)
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-            if (sqlQuery == null)
-            {
-                throw new ArgumentNullException(nameof(sqlQuery));
-            }
-            if (database == null)
-            {
-                throw new ArgumentNullException(nameof(database));
-            }
-            if (collectionId == null)
-            {
-                throw new ArgumentNullException(nameof(collectionId));
-            }
-
             ConnectionString = connectionString;
             SqlQuery = sqlQuery;
             Database = database;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureDataLakeStorageGen2Parameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureDataLakeStorageGen2Parameter.Serialization.cs
@@ -15,16 +15,51 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("accountName");
-            writer.WriteStringValue(AccountName);
-            writer.WritePropertyName("accountKey");
-            writer.WriteStringValue(AccountKey);
-            writer.WritePropertyName("fileSystemName");
-            writer.WriteStringValue(FileSystemName);
-            writer.WritePropertyName("directoryTemplate");
-            writer.WriteStringValue(DirectoryTemplate);
-            writer.WritePropertyName("fileTemplate");
-            writer.WriteStringValue(FileTemplate);
+            if (AccountName != null)
+            {
+                writer.WritePropertyName("accountName");
+                writer.WriteStringValue(AccountName);
+            }
+            else
+            {
+                writer.WriteNull("accountName");
+            }
+            if (AccountKey != null)
+            {
+                writer.WritePropertyName("accountKey");
+                writer.WriteStringValue(AccountKey);
+            }
+            else
+            {
+                writer.WriteNull("accountKey");
+            }
+            if (FileSystemName != null)
+            {
+                writer.WritePropertyName("fileSystemName");
+                writer.WriteStringValue(FileSystemName);
+            }
+            else
+            {
+                writer.WriteNull("fileSystemName");
+            }
+            if (DirectoryTemplate != null)
+            {
+                writer.WritePropertyName("directoryTemplate");
+                writer.WriteStringValue(DirectoryTemplate);
+            }
+            else
+            {
+                writer.WriteNull("directoryTemplate");
+            }
+            if (FileTemplate != null)
+            {
+                writer.WritePropertyName("fileTemplate");
+                writer.WriteStringValue(FileTemplate);
+            }
+            else
+            {
+                writer.WriteNull("fileTemplate");
+            }
             writer.WriteEndObject();
         }
 
@@ -39,26 +74,51 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("accountName"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        accountName = null;
+                        continue;
+                    }
                     accountName = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("accountKey"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        accountKey = null;
+                        continue;
+                    }
                     accountKey = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("fileSystemName"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        fileSystemName = null;
+                        continue;
+                    }
                     fileSystemName = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("directoryTemplate"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        directoryTemplate = null;
+                        continue;
+                    }
                     directoryTemplate = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("fileTemplate"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        fileTemplate = null;
+                        continue;
+                    }
                     fileTemplate = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureDataLakeStorageGen2Parameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureDataLakeStorageGen2Parameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The AzureDataLakeStorageGen2Parameter. </summary>
@@ -18,30 +16,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="fileSystemName"> File system name (Container). </param>
         /// <param name="directoryTemplate"> Directory template. </param>
         /// <param name="fileTemplate"> File template. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="accountName"/>, <paramref name="accountKey"/>, <paramref name="fileSystemName"/>, <paramref name="directoryTemplate"/>, or <paramref name="fileTemplate"/> is null. </exception>
         public AzureDataLakeStorageGen2Parameter(string accountName, string accountKey, string fileSystemName, string directoryTemplate, string fileTemplate)
         {
-            if (accountName == null)
-            {
-                throw new ArgumentNullException(nameof(accountName));
-            }
-            if (accountKey == null)
-            {
-                throw new ArgumentNullException(nameof(accountKey));
-            }
-            if (fileSystemName == null)
-            {
-                throw new ArgumentNullException(nameof(fileSystemName));
-            }
-            if (directoryTemplate == null)
-            {
-                throw new ArgumentNullException(nameof(directoryTemplate));
-            }
-            if (fileTemplate == null)
-            {
-                throw new ArgumentNullException(nameof(fileTemplate));
-            }
-
             AccountName = accountName;
             AccountKey = accountKey;
             FileSystemName = fileSystemName;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureTableParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureTableParameter.Serialization.cs
@@ -15,12 +15,33 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("connectionString");
-            writer.WriteStringValue(ConnectionString);
-            writer.WritePropertyName("table");
-            writer.WriteStringValue(Table);
-            writer.WritePropertyName("query");
-            writer.WriteStringValue(Query);
+            if (ConnectionString != null)
+            {
+                writer.WritePropertyName("connectionString");
+                writer.WriteStringValue(ConnectionString);
+            }
+            else
+            {
+                writer.WriteNull("connectionString");
+            }
+            if (Table != null)
+            {
+                writer.WritePropertyName("table");
+                writer.WriteStringValue(Table);
+            }
+            else
+            {
+                writer.WriteNull("table");
+            }
+            if (Query != null)
+            {
+                writer.WritePropertyName("query");
+                writer.WriteStringValue(Query);
+            }
+            else
+            {
+                writer.WriteNull("query");
+            }
             writer.WriteEndObject();
         }
 
@@ -33,16 +54,31 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("connectionString"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        connectionString = null;
+                        continue;
+                    }
                     connectionString = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("table"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        table = null;
+                        continue;
+                    }
                     table = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("query"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        query = null;
+                        continue;
+                    }
                     query = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureTableParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/AzureTableParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The AzureTableParameter. </summary>
@@ -16,22 +14,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="connectionString"> Azure Table connection string. </param>
         /// <param name="table"> Table name. </param>
         /// <param name="query"> Query script. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="connectionString"/>, <paramref name="table"/>, or <paramref name="query"/> is null. </exception>
         public AzureTableParameter(string connectionString, string table, string query)
         {
-            if (connectionString == null)
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-            if (table == null)
-            {
-                throw new ArgumentNullException(nameof(table));
-            }
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
             ConnectionString = connectionString;
             Table = table;
             Query = query;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ElasticsearchParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ElasticsearchParameter.Serialization.cs
@@ -15,14 +15,42 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("host");
-            writer.WriteStringValue(Host);
-            writer.WritePropertyName("port");
-            writer.WriteStringValue(Port);
-            writer.WritePropertyName("authHeader");
-            writer.WriteStringValue(AuthHeader);
-            writer.WritePropertyName("query");
-            writer.WriteStringValue(Query);
+            if (Host != null)
+            {
+                writer.WritePropertyName("host");
+                writer.WriteStringValue(Host);
+            }
+            else
+            {
+                writer.WriteNull("host");
+            }
+            if (Port != null)
+            {
+                writer.WritePropertyName("port");
+                writer.WriteStringValue(Port);
+            }
+            else
+            {
+                writer.WriteNull("port");
+            }
+            if (AuthHeader != null)
+            {
+                writer.WritePropertyName("authHeader");
+                writer.WriteStringValue(AuthHeader);
+            }
+            else
+            {
+                writer.WriteNull("authHeader");
+            }
+            if (Query != null)
+            {
+                writer.WritePropertyName("query");
+                writer.WriteStringValue(Query);
+            }
+            else
+            {
+                writer.WriteNull("query");
+            }
             writer.WriteEndObject();
         }
 
@@ -36,21 +64,41 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("host"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        host = null;
+                        continue;
+                    }
                     host = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("port"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        port = null;
+                        continue;
+                    }
                     port = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("authHeader"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        authHeader = null;
+                        continue;
+                    }
                     authHeader = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("query"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        query = null;
+                        continue;
+                    }
                     query = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ElasticsearchParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/ElasticsearchParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The ElasticsearchParameter. </summary>
@@ -17,26 +15,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="port"> Port. </param>
         /// <param name="authHeader"> Authorization header. </param>
         /// <param name="query"> Query. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="host"/>, <paramref name="port"/>, <paramref name="authHeader"/>, or <paramref name="query"/> is null. </exception>
         public ElasticsearchParameter(string host, string port, string authHeader, string query)
         {
-            if (host == null)
-            {
-                throw new ArgumentNullException(nameof(host));
-            }
-            if (port == null)
-            {
-                throw new ArgumentNullException(nameof(port));
-            }
-            if (authHeader == null)
-            {
-                throw new ArgumentNullException(nameof(authHeader));
-            }
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
             Host = host;
             Port = port;
             AuthHeader = authHeader;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HttpRequestParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HttpRequestParameter.Serialization.cs
@@ -15,14 +15,42 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("url");
-            writer.WriteStringValue(Url);
-            writer.WritePropertyName("httpHeader");
-            writer.WriteStringValue(HttpHeader);
-            writer.WritePropertyName("httpMethod");
-            writer.WriteStringValue(HttpMethod);
-            writer.WritePropertyName("payload");
-            writer.WriteStringValue(Payload);
+            if (Url != null)
+            {
+                writer.WritePropertyName("url");
+                writer.WriteStringValue(Url);
+            }
+            else
+            {
+                writer.WriteNull("url");
+            }
+            if (HttpHeader != null)
+            {
+                writer.WritePropertyName("httpHeader");
+                writer.WriteStringValue(HttpHeader);
+            }
+            else
+            {
+                writer.WriteNull("httpHeader");
+            }
+            if (HttpMethod != null)
+            {
+                writer.WritePropertyName("httpMethod");
+                writer.WriteStringValue(HttpMethod);
+            }
+            else
+            {
+                writer.WriteNull("httpMethod");
+            }
+            if (Payload != null)
+            {
+                writer.WritePropertyName("payload");
+                writer.WriteStringValue(Payload);
+            }
+            else
+            {
+                writer.WriteNull("payload");
+            }
             writer.WriteEndObject();
         }
 
@@ -36,21 +64,41 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("url"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        url = null;
+                        continue;
+                    }
                     url = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("httpHeader"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        httpHeader = null;
+                        continue;
+                    }
                     httpHeader = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("httpMethod"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        httpMethod = null;
+                        continue;
+                    }
                     httpMethod = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("payload"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        payload = null;
+                        continue;
+                    }
                     payload = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HttpRequestParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/HttpRequestParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The HttpRequestParameter. </summary>
@@ -17,26 +15,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="httpHeader"> HTTP header. </param>
         /// <param name="httpMethod"> HTTP method. </param>
         /// <param name="payload"> HTTP reuqest body. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="url"/>, <paramref name="httpHeader"/>, <paramref name="httpMethod"/>, or <paramref name="payload"/> is null. </exception>
         public HttpRequestParameter(string url, string httpHeader, string httpMethod, string payload)
         {
-            if (url == null)
-            {
-                throw new ArgumentNullException(nameof(url));
-            }
-            if (httpHeader == null)
-            {
-                throw new ArgumentNullException(nameof(httpHeader));
-            }
-            if (httpMethod == null)
-            {
-                throw new ArgumentNullException(nameof(httpMethod));
-            }
-            if (payload == null)
-            {
-                throw new ArgumentNullException(nameof(payload));
-            }
-
             Url = url;
             HttpHeader = httpHeader;
             HttpMethod = httpMethod;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/InfluxDBParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/InfluxDBParameter.Serialization.cs
@@ -15,16 +15,51 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("connectionString");
-            writer.WriteStringValue(ConnectionString);
-            writer.WritePropertyName("database");
-            writer.WriteStringValue(Database);
-            writer.WritePropertyName("userName");
-            writer.WriteStringValue(UserName);
-            writer.WritePropertyName("password");
-            writer.WriteStringValue(Password);
-            writer.WritePropertyName("query");
-            writer.WriteStringValue(Query);
+            if (ConnectionString != null)
+            {
+                writer.WritePropertyName("connectionString");
+                writer.WriteStringValue(ConnectionString);
+            }
+            else
+            {
+                writer.WriteNull("connectionString");
+            }
+            if (Database != null)
+            {
+                writer.WritePropertyName("database");
+                writer.WriteStringValue(Database);
+            }
+            else
+            {
+                writer.WriteNull("database");
+            }
+            if (UserName != null)
+            {
+                writer.WritePropertyName("userName");
+                writer.WriteStringValue(UserName);
+            }
+            else
+            {
+                writer.WriteNull("userName");
+            }
+            if (Password != null)
+            {
+                writer.WritePropertyName("password");
+                writer.WriteStringValue(Password);
+            }
+            else
+            {
+                writer.WriteNull("password");
+            }
+            if (Query != null)
+            {
+                writer.WritePropertyName("query");
+                writer.WriteStringValue(Query);
+            }
+            else
+            {
+                writer.WriteNull("query");
+            }
             writer.WriteEndObject();
         }
 
@@ -39,26 +74,51 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("connectionString"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        connectionString = null;
+                        continue;
+                    }
                     connectionString = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("database"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        database = null;
+                        continue;
+                    }
                     database = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("userName"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        userName = null;
+                        continue;
+                    }
                     userName = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("password"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        password = null;
+                        continue;
+                    }
                     password = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("query"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        query = null;
+                        continue;
+                    }
                     query = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/InfluxDBParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/InfluxDBParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The InfluxDBParameter. </summary>
@@ -18,30 +16,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="userName"> Database access user. </param>
         /// <param name="password"> Database access password. </param>
         /// <param name="query"> Query script. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="connectionString"/>, <paramref name="database"/>, <paramref name="userName"/>, <paramref name="password"/>, or <paramref name="query"/> is null. </exception>
         public InfluxDBParameter(string connectionString, string database, string userName, string password, string query)
         {
-            if (connectionString == null)
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-            if (database == null)
-            {
-                throw new ArgumentNullException(nameof(database));
-            }
-            if (userName == null)
-            {
-                throw new ArgumentNullException(nameof(userName));
-            }
-            if (password == null)
-            {
-                throw new ArgumentNullException(nameof(password));
-            }
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
             ConnectionString = connectionString;
             Database = database;
             UserName = userName;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MongoDBParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MongoDBParameter.Serialization.cs
@@ -15,12 +15,33 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("connectionString");
-            writer.WriteStringValue(ConnectionString);
-            writer.WritePropertyName("database");
-            writer.WriteStringValue(Database);
-            writer.WritePropertyName("command");
-            writer.WriteStringValue(Command);
+            if (ConnectionString != null)
+            {
+                writer.WritePropertyName("connectionString");
+                writer.WriteStringValue(ConnectionString);
+            }
+            else
+            {
+                writer.WriteNull("connectionString");
+            }
+            if (Database != null)
+            {
+                writer.WritePropertyName("database");
+                writer.WriteStringValue(Database);
+            }
+            else
+            {
+                writer.WriteNull("database");
+            }
+            if (Command != null)
+            {
+                writer.WritePropertyName("command");
+                writer.WriteStringValue(Command);
+            }
+            else
+            {
+                writer.WriteNull("command");
+            }
             writer.WriteEndObject();
         }
 
@@ -33,16 +54,31 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("connectionString"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        connectionString = null;
+                        continue;
+                    }
                     connectionString = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("database"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        database = null;
+                        continue;
+                    }
                     database = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("command"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        command = null;
+                        continue;
+                    }
                     command = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MongoDBParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/MongoDBParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The MongoDBParameter. </summary>
@@ -16,22 +14,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <param name="connectionString"> MongoDB connection string. </param>
         /// <param name="database"> Database name. </param>
         /// <param name="command"> Query script. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="connectionString"/>, <paramref name="database"/>, or <paramref name="command"/> is null. </exception>
         public MongoDBParameter(string connectionString, string database, string command)
         {
-            if (connectionString == null)
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-            if (database == null)
-            {
-                throw new ArgumentNullException(nameof(database));
-            }
-            if (command == null)
-            {
-                throw new ArgumentNullException(nameof(command));
-            }
-
             ConnectionString = connectionString;
             Database = database;
             Command = command;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlSourceParameter.Serialization.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlSourceParameter.Serialization.cs
@@ -15,10 +15,24 @@ namespace Azure.AI.MetricsAdvisor.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer)
         {
             writer.WriteStartObject();
-            writer.WritePropertyName("connectionString");
-            writer.WriteStringValue(ConnectionString);
-            writer.WritePropertyName("query");
-            writer.WriteStringValue(Query);
+            if (ConnectionString != null)
+            {
+                writer.WritePropertyName("connectionString");
+                writer.WriteStringValue(ConnectionString);
+            }
+            else
+            {
+                writer.WriteNull("connectionString");
+            }
+            if (Query != null)
+            {
+                writer.WritePropertyName("query");
+                writer.WriteStringValue(Query);
+            }
+            else
+            {
+                writer.WriteNull("query");
+            }
             writer.WriteEndObject();
         }
 
@@ -30,11 +44,21 @@ namespace Azure.AI.MetricsAdvisor.Models
             {
                 if (property.NameEquals("connectionString"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        connectionString = null;
+                        continue;
+                    }
                     connectionString = property.Value.GetString();
                     continue;
                 }
                 if (property.NameEquals("query"))
                 {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        query = null;
+                        continue;
+                    }
                     query = property.Value.GetString();
                     continue;
                 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlSourceParameter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Generated/Models/SqlSourceParameter.cs
@@ -5,8 +5,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Azure.AI.MetricsAdvisor.Models
 {
     /// <summary> The SqlSourceParameter. </summary>
@@ -15,18 +13,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary> Initializes a new instance of SqlSourceParameter. </summary>
         /// <param name="connectionString"> Database connection string. </param>
         /// <param name="query"> Query script. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="connectionString"/> or <paramref name="query"/> is null. </exception>
         public SqlSourceParameter(string connectionString, string query)
         {
-            if (connectionString == null)
-            {
-                throw new ArgumentNullException(nameof(connectionString));
-            }
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-
             ConnectionString = connectionString;
             Query = query;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/HttpRequestDataFeedSource.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSources/HttpRequestDataFeedSource.cs
@@ -43,7 +43,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             Parameter = parameter;
 
-            Url = new Uri(parameter.Url);
+            Url = parameter.Url == null ? null : new Uri(parameter.Url);
             HttpHeader = parameter.HttpHeader;
             HttpMethod = parameter.HttpMethod;
             Payload = parameter.Payload;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/autorest.md
@@ -83,6 +83,113 @@ directive:
     $.properties.upperBoundaryList.items["x-nullable"] = true;
 ```
 
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.AzureApplicationInsightsParameter
+  transform: >
+    $.properties.apiKey["x-nullable"] = true;
+    $.properties.applicationId["x-nullable"] = true;
+    $.properties.azureCloud["x-nullable"] = true;
+    $.properties.query["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.AzureBlobParameter
+  transform: >
+    $.properties.connectionString["x-nullable"] = true;
+    $.properties.container["x-nullable"] = true;
+    $.properties.blobTemplate["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.AzureCosmosDBParameter
+  transform: >
+    $.properties.collectionId["x-nullable"] = true;
+    $.properties.connectionString["x-nullable"] = true;
+    $.properties.database["x-nullable"] = true;
+    $.properties.sqlQuery["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.AzureDataLakeStorageGen2Parameter
+  transform: >
+    $.properties.accountKey["x-nullable"] = true;
+    $.properties.accountName["x-nullable"] = true;
+    $.properties.directoryTemplate["x-nullable"] = true;
+    $.properties.fileSystemName["x-nullable"] = true;
+    $.properties.fileTemplate["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.AzureTableParameter
+  transform: >
+    $.properties.connectionString["x-nullable"] = true;
+    $.properties.query["x-nullable"] = true;
+    $.properties.table["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.ElasticsearchParameter
+  transform: >
+    $.properties.authHeader["x-nullable"] = true;
+    $.properties.host["x-nullable"] = true;
+    $.properties.port["x-nullable"] = true;
+    $.properties.query["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.HttpRequestParameter
+  transform: >
+    $.properties.httpHeader["x-nullable"] = true;
+    $.properties.httpMethod["x-nullable"] = true;
+    $.properties.payload["x-nullable"] = true;
+    $.properties.url["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.InfluxDBParameter
+  transform: >
+    $.properties.connectionString["x-nullable"] = true;
+    $.properties.database["x-nullable"] = true;
+    $.properties.password["x-nullable"] = true;
+    $.properties.query["x-nullable"] = true;
+    $.properties.userName["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.MongoDBParameter
+  transform: >
+    $.properties.command["x-nullable"] = true;
+    $.properties.connectionString["x-nullable"] = true;
+    $.properties.database["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.SqlSourceParameter
+  transform: >
+    $.properties.connectionString["x-nullable"] = true;
+    $.properties.query["x-nullable"] = true;
+```
+
 ### Add required properties
 
 ``` yaml


### PR DESCRIPTION
When making a `GetDataFeed` request to the service, the parameters of the returned Data Source will be `null` if the requester doesn't have an Administrator role. The corresponding properties are not marked with `x-nullable = true` in the swagger, so we're throwing a `NullReferenceException` in these scenarios.

This PR adds transforms to `autorest.md` and regenerates the code to fix this issue.