### PR TITLE
Use PostConfigure for InitialOffsetOptions

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Config/EventHubWebJobsBuilderExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Hosting
             builder.Services.AddAzureClientsCore();
             builder.Services.AddSingleton<EventHubClientFactory>();
             builder.Services.Configure<EventHubOptions>(configure);
-            builder.Services.Configure<EventHubOptions>(ConfigureInitialOffsetOptions);
+            builder.Services.PostConfigure<EventHubOptions>(ConfigureInitialOffsetOptions);
 
             return builder;
         }

--- a/sdk/eventhub/test-resources-post.ps1
+++ b/sdk/eventhub/test-resources-post.ps1
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# The purpose of this script is to add a small delay between the creation of the live test resources
+# and the execution of the live tests. This allows RBAC to replicate and avoids flakiness in the first set 
+# of live tests that might otherwise start running before RBAC has replicated.
+
+param (
+    [hashtable] $DeploymentOutputs,
+    [string] $TenantId,
+    [string] $TestApplicationId,
+    [string] $TestApplicationSecret
+)
+
+Write-Verbose "Sleeping for 60 seconds to let RBAC replicate"
+Start-Sleep -s 60


### PR DESCRIPTION
PostConfigure ensures that the InitialOffsetOptions will be propagated to the EventProcessorOptions regardless of the ordering used when doing configuration.