### PR TITLE
[MetricsAdvisor] Added tests for Data Feed CRUD operations (3/4)

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -572,7 +572,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -600,7 +600,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -681,7 +681,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -708,7 +708,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -788,7 +788,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -816,7 +816,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -898,7 +898,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -926,7 +926,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1007,7 +1007,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1034,7 +1034,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1113,7 +1113,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1140,7 +1140,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1219,7 +1219,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1246,7 +1246,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1325,7 +1325,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1352,7 +1352,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1429,7 +1429,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1456,7 +1456,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1535,7 +1535,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1562,7 +1562,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1641,7 +1641,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1668,7 +1668,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1747,7 +1747,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1774,7 +1774,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1853,7 +1853,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1880,7 +1880,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
-            var description = "This data feed was created to test the .NET client.";
+            const string description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -14,29 +14,29 @@ namespace Azure.AI.MetricsAdvisor.Tests
 {
     public class DataFeedLiveTests : MetricsAdvisorLiveTestBase
     {
-        private const string OriginalAccount = "account";
-        private const string OriginalAppId = "appId";
-        private const string OriginalAuth = "auth";
-        private const string OriginalCloud = "cloud";
-        private const string OriginalCollectionId = "collectId";
-        private const string OriginalCommand = "command";
-        private const string OriginalConnectionString = "connectionStr";
-        private const string OriginalContainer = "container";
-        private const string OriginalDatabase = "database";
-        private const string OriginalDirectory = "dir";
-        private const string OriginalFile = "file";
-        private const string OriginalFileSystem = "fileSystem";
-        private const string OriginalHeader = "header";
-        private const string OriginalHost = "host";
-        private const string OriginalKey = "key";
-        private const string OriginalMethod = "method";
-        private const string OriginalPassword = "pass";
-        private const string OriginalPayload = "payload";
-        private const string OriginalPort = "port";
-        private const string OriginalQuery = "query";
-        private const string OriginalTable = "table";
-        private const string OriginalTemplate = "template";
-        private const string OriginalUsername = "username";
+        private const string DataSourceAccount = "account";
+        private const string DataSourceAppId = "appId";
+        private const string DataSourceAuth = "auth";
+        private const string DataSourceCloud = "cloud";
+        private const string DataSourceCollectionId = "collectId";
+        private const string DataSourceCommand = "command";
+        private const string DataSourceConnectionString = "connectionStr";
+        private const string DataSourceContainer = "container";
+        private const string DataSourceDatabase = "database";
+        private const string DataSourceDirectory = "dir";
+        private const string DataSourceFile = "file";
+        private const string DataSourceFileSystem = "fileSystem";
+        private const string DataSourceHeader = "header";
+        private const string DataSourceHost = "host";
+        private const string DataSourceKey = "key";
+        private const string DataSourceMethod = "method";
+        private const string DataSourcePassword = "pass";
+        private const string DataSourcePayload = "payload";
+        private const string DataSourcePort = "port";
+        private const string DataSourceQuery = "query";
+        private const string DataSourceTable = "table";
+        private const string DataSourceTemplate = "template";
+        private const string DataSourceUsername = "username";
 
         public DataFeedLiveTests(bool isAsync) : base(isAsync)
         {
@@ -48,7 +48,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -61,13 +61,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
+            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
             Assert.That(createdDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -76,7 +76,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -89,13 +89,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
+            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
             Assert.That(createdDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -104,7 +104,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -117,12 +117,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Container, Is.EqualTo(OriginalContainer));
-            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
+            Assert.That(createdDataSource.Container, Is.EqualTo(DataSourceContainer));
+            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
         }
 
         [RecordedTest]
@@ -131,7 +131,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -144,12 +144,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Container, Is.EqualTo(OriginalContainer));
-            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
+            Assert.That(createdDataSource.Container, Is.EqualTo(DataSourceContainer));
+            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
         }
 
         [RecordedTest]
@@ -158,7 +158,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -171,13 +171,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
-            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(createdDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
+            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(createdDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
         }
 
         [RecordedTest]
@@ -186,7 +186,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -199,13 +199,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
-            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(createdDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
+            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(createdDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
         }
 
         [RecordedTest]
@@ -214,7 +214,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -227,11 +227,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -240,7 +240,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -253,11 +253,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -266,7 +266,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -279,14 +279,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.AccountName, Is.EqualTo(OriginalAccount));
+            Assert.That(createdDataSource.AccountName, Is.EqualTo(DataSourceAccount));
             Assert.That(createdDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
-            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
-            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(OriginalFile));
+            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
+            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
+            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
         }
 
         [RecordedTest]
@@ -295,7 +295,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -308,14 +308,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.AccountName, Is.EqualTo(OriginalAccount));
+            Assert.That(createdDataSource.AccountName, Is.EqualTo(DataSourceAccount));
             Assert.That(createdDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
-            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
-            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(OriginalFile));
+            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
+            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
+            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
         }
 
         [RecordedTest]
@@ -324,7 +324,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
+            var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -337,12 +337,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Table, Is.EqualTo(OriginalTable));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Table, Is.EqualTo(DataSourceTable));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -351,7 +351,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
+            var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -364,12 +364,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Table, Is.EqualTo(OriginalTable));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Table, Is.EqualTo(DataSourceTable));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -378,7 +378,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -391,13 +391,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Host, Is.EqualTo(OriginalHost));
-            Assert.That(createdDataSource.Port, Is.EqualTo(OriginalPort));
+            Assert.That(createdDataSource.Host, Is.EqualTo(DataSourceHost));
+            Assert.That(createdDataSource.Port, Is.EqualTo(DataSourcePort));
             Assert.That(createdDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -406,7 +406,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -419,13 +419,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Host, Is.EqualTo(OriginalHost));
-            Assert.That(createdDataSource.Port, Is.EqualTo(OriginalPort));
+            Assert.That(createdDataSource.Host, Is.EqualTo(DataSourceHost));
+            Assert.That(createdDataSource.Port, Is.EqualTo(DataSourcePort));
             Assert.That(createdDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -435,7 +435,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -448,13 +448,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(createdDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
-            Assert.That(createdDataSource.Payload, Is.EqualTo(OriginalPayload));
+            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
+            Assert.That(createdDataSource.Payload, Is.EqualTo(DataSourcePayload));
         }
 
         [RecordedTest]
@@ -464,7 +464,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -477,13 +477,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(createdDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
-            Assert.That(createdDataSource.Payload, Is.EqualTo(OriginalPayload));
+            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
+            Assert.That(createdDataSource.Payload, Is.EqualTo(DataSourcePayload));
         }
 
         [RecordedTest]
@@ -492,7 +492,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
+            var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -505,14 +505,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(createdDataSource.Username, Is.EqualTo(OriginalUsername));
-            Assert.That(createdDataSource.Password, Is.EqualTo(OriginalPassword));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(createdDataSource.Username, Is.EqualTo(DataSourceUsername));
+            Assert.That(createdDataSource.Password, Is.EqualTo(DataSourcePassword));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -521,7 +521,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
+            var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -534,14 +534,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(createdDataSource.Username, Is.EqualTo(OriginalUsername));
-            Assert.That(createdDataSource.Password, Is.EqualTo(OriginalPassword));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(createdDataSource.Username, Is.EqualTo(DataSourceUsername));
+            Assert.That(createdDataSource.Password, Is.EqualTo(DataSourcePassword));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -550,7 +550,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
+            var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -563,12 +563,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(createdDataSource.Command, Is.EqualTo(OriginalCommand));
+            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(createdDataSource.Command, Is.EqualTo(DataSourceCommand));
         }
 
         [RecordedTest]
@@ -577,7 +577,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
+            var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -590,12 +590,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(createdDataSource.Command, Is.EqualTo(OriginalCommand));
+            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(createdDataSource.Command, Is.EqualTo(DataSourceCommand));
         }
 
         [RecordedTest]
@@ -604,7 +604,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -617,11 +617,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -630,7 +630,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -643,11 +643,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -656,7 +656,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -669,11 +669,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -682,7 +682,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -695,11 +695,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -708,7 +708,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -721,11 +721,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -734,7 +734,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -747,11 +747,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -761,7 +761,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -781,13 +781,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -797,7 +797,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -817,13 +817,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -833,7 +833,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -852,13 +852,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -868,7 +868,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -887,13 +887,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -902,7 +902,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -922,12 +922,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
         }
 
         [RecordedTest]
@@ -936,7 +936,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -956,12 +956,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
         }
 
         [RecordedTest]
@@ -970,7 +970,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -989,12 +989,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
         }
 
         [RecordedTest]
@@ -1003,7 +1003,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1022,12 +1022,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
         }
 
         [RecordedTest]
@@ -1037,7 +1037,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1057,13 +1057,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
         }
 
         [RecordedTest]
@@ -1073,7 +1073,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1093,13 +1093,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
         }
 
         [RecordedTest]
@@ -1109,7 +1109,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1128,13 +1128,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
         }
 
         [RecordedTest]
@@ -1144,7 +1144,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1163,13 +1163,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
         }
 
         [RecordedTest]
@@ -1179,7 +1179,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1199,11 +1199,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1213,7 +1213,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1233,11 +1233,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1247,7 +1247,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1266,11 +1266,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1280,7 +1280,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1299,11 +1299,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1312,7 +1312,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1332,14 +1332,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
         }
 
         [RecordedTest]
@@ -1348,7 +1348,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1368,14 +1368,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
         }
 
         [RecordedTest]
@@ -1384,7 +1384,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1403,14 +1403,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
         }
 
         [RecordedTest]
@@ -1419,7 +1419,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1438,14 +1438,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
         }
 
         [RecordedTest]
@@ -1454,7 +1454,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
+            var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1474,12 +1474,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1488,7 +1488,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
+            var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1508,12 +1508,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1522,7 +1522,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
+            var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1541,12 +1541,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1555,7 +1555,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
+            var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1574,12 +1574,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1588,7 +1588,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1608,13 +1608,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1623,7 +1623,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1643,13 +1643,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1658,7 +1658,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1677,13 +1677,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1692,7 +1692,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1711,13 +1711,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1727,7 +1727,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1747,13 +1747,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
         }
 
         [RecordedTest]
@@ -1763,7 +1763,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1783,13 +1783,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
         }
 
         [RecordedTest]
@@ -1799,7 +1799,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1818,13 +1818,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
         }
 
         [RecordedTest]
@@ -1834,7 +1834,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1853,13 +1853,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
         }
 
         [RecordedTest]
@@ -1868,7 +1868,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
+            var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1888,14 +1888,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1904,7 +1904,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
+            var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1924,14 +1924,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1940,7 +1940,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
+            var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1959,14 +1959,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -1975,7 +1975,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
+            var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1994,14 +1994,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2010,7 +2010,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
+            var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2030,12 +2030,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
         }
 
         [RecordedTest]
@@ -2044,7 +2044,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
+            var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2064,12 +2064,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
         }
 
         [RecordedTest]
@@ -2078,7 +2078,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
+            var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2097,12 +2097,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
         }
 
         [RecordedTest]
@@ -2111,7 +2111,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
+            var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2130,12 +2130,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
         }
 
         [RecordedTest]
@@ -2144,7 +2144,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2164,11 +2164,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2177,7 +2177,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2197,11 +2197,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2210,7 +2210,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2229,11 +2229,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2242,7 +2242,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2261,11 +2261,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2274,7 +2274,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2294,11 +2294,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2307,7 +2307,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2327,11 +2327,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2340,7 +2340,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2359,11 +2359,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2372,7 +2372,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2391,11 +2391,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2404,7 +2404,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2424,11 +2424,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2437,7 +2437,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2457,11 +2457,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2470,7 +2470,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2489,11 +2489,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]
@@ -2502,7 +2502,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
+            var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2521,11 +2521,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
         [RecordedTest]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -923,6 +923,86 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
 
         [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17726")]
+        public async Task UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalAppId = "appId";
+            var originalKey = "key";
+            var originalCloud = "cloud";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
+
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(originalCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17726")]
+        public async Task UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalAppId = "appId";
+            var originalKey = "key";
+            var originalCloud = "cloud";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
+
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(originalCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
         public async Task UpdateAzureBlobDataFeedWithMinimumSetupAndGetInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
@@ -985,6 +1065,80 @@ namespace Azure.AI.MetricsAdvisor.Tests
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
             ValidateDataFeedWithMinimumSetup(updatedDataFeed, disposableDataFeed.Id, dataFeedName, description);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(originalContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+        }
+
+        [RecordedTest]
+        public async Task UpdateAzureBlobDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalContainer = "container";
+            var originalTemplate = "template";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(originalContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+        }
+
+        [RecordedTest]
+        public async Task UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalContainer = "container";
+            var originalTemplate = "template";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
@@ -1082,6 +1236,86 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
         [RecordedTest]
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17726")]
+        public async Task UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+            var originalDatabase = "database";
+            var originalCollectionId = "collectId";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+        }
+
+        [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17726")]
+        public async Task UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+            var originalDatabase = "database";
+            var originalCollectionId = "collectId";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+        }
+
+        [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17726")]
         public async Task UpdateAzureDataExplorerDataFeedWithMinimumSetupAndGetInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
@@ -1142,6 +1376,78 @@ namespace Azure.AI.MetricsAdvisor.Tests
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
             ValidateDataFeedWithMinimumSetup(updatedDataFeed, disposableDataFeed.Id, dataFeedName, description);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17726")]
+        public async Task UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/17726")]
+        public async Task UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
@@ -1239,6 +1545,88 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
 
         [RecordedTest]
+        public async Task UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalAccount = "account";
+            var originalKey = "key";
+            var originalFileSystem = "fileSystem";
+            var originalDirectory = "dir";
+            var originalFile = "file";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
+
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(originalFile));
+        }
+
+        [RecordedTest]
+        public async Task UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalAccount = "account";
+            var originalKey = "key";
+            var originalFileSystem = "fileSystem";
+            var originalDirectory = "dir";
+            var originalFile = "file";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
+
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(originalFile));
+        }
+
+        [RecordedTest]
         public async Task UpdateAzureTableDataFeedWithMinimumSetupAndGetInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
@@ -1301,6 +1689,80 @@ namespace Azure.AI.MetricsAdvisor.Tests
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
             ValidateDataFeedWithMinimumSetup(updatedDataFeed, disposableDataFeed.Id, dataFeedName, description);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(originalTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdateAzureTableDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalTable = "table";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
+
+            var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(originalTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdateAzureTableDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalTable = "table";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
@@ -1395,6 +1857,84 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
 
         [RecordedTest]
+        public async Task UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalHost = "host";
+            var originalPort = "port";
+            var originalAuth = "auth";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
+
+            var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
+
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.Host, Is.EqualTo(originalHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalHost = "host";
+            var originalPort = "port";
+            var originalAuth = "auth";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
+
+            var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
+
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.Host, Is.EqualTo(originalHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
         public async Task UpdateHttpRequestDataFeedWithMinimumSetupAndGetInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
@@ -1460,6 +2000,84 @@ namespace Azure.AI.MetricsAdvisor.Tests
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
             ValidateDataFeedWithMinimumSetup(updatedDataFeed, disposableDataFeed.Id, dataFeedName, description);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
+
+            var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
+
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
+            Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(originalMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(originalPayload));
+        }
+
+        [RecordedTest]
+        public async Task UpdateHttpRequestDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalHeader = "header";
+            var originalMethod = "method";
+            var originalPayload = "payload";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSourceHost = new Uri("https://fakehost.com/");
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
+
+            var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
+
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
+            Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(originalMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(originalPayload));
+        }
+
+        [RecordedTest]
+        public async Task UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalHeader = "header";
+            var originalMethod = "method";
+            var originalPayload = "payload";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSourceHost = new Uri("https://fakehost.com/");
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
 
@@ -1559,6 +2177,88 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
 
         [RecordedTest]
+        public async Task UpdateInfluxDbDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalDatabase = "database";
+            var originalUsername = "username";
+            var originalPassword = "pass";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
+
+            var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(originalUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(originalPassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalDatabase = "database";
+            var originalUsername = "username";
+            var originalPassword = "pass";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
+
+            var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(originalUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(originalPassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
         public async Task UpdateMongoDbDataFeedWithMinimumSetupAndGetInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
@@ -1621,6 +2321,80 @@ namespace Azure.AI.MetricsAdvisor.Tests
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
             ValidateDataFeedWithMinimumSetup(updatedDataFeed, disposableDataFeed.Id, dataFeedName, description);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
+
+            var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(originalCommand));
+        }
+
+        [RecordedTest]
+        public async Task UpdateMongoDbDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalDatabase = "database";
+            var originalCommand = "command";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
+
+            var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(originalCommand));
+        }
+
+        [RecordedTest]
+        public async Task UpdateMongoDbDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalDatabase = "database";
+            var originalCommand = "command";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
@@ -1707,6 +2481,76 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
 
         [RecordedTest]
+        public async Task UpdateMySqlDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
+
+            var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdateMySqlDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
+
+            var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
         public async Task UpdatePostgreSqlDataFeedWithMinimumSetupAndGetInstance()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
@@ -1766,6 +2610,76 @@ namespace Azure.AI.MetricsAdvisor.Tests
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
             ValidateDataFeedWithMinimumSetup(updatedDataFeed, disposableDataFeed.Id, dataFeedName, description);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
+
+            var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
+
+            var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
@@ -1851,6 +2765,76 @@ namespace Azure.AI.MetricsAdvisor.Tests
         }
 
         [RecordedTest]
+        public async Task UpdateSqlServerDataFeedWithEveryMemberAndGetInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
+
+            var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
+        public async Task UpdateSqlServerDataFeedWithEveryMemberAndNewInstance()
+        {
+            MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
+
+            var originalConnectionString = "connectionStr";
+            var originalQuery = "query";
+
+            var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
+
+            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+
+            SetOptionalMembers(dataFeedToUpdate);
+
+            await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
+
+            DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
+
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+
+            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
+
+            var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
+
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+
+            Assert.That(updatedDataSource, Is.Not.Null);
+            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+        }
+
+        [RecordedTest]
         public async Task DeleteDataFeed()
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
@@ -1923,6 +2907,27 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Administrators = new List<string>() { "fake@admin.com" },
                 Viewers = new List<string>() { "fake@viewer.com" },
                 MissingDataPointFillSettings = new () { FillType = DataFeedMissingDataPointFillType.CustomValue, CustomFillValue = 45.0 }
+            };
+        }
+
+        private void SetOptionalMembers(DataFeed dataFeed)
+        {
+            dataFeed.Description = "This data feed was updated to test the .NET client.";
+            dataFeed.AccessMode = DataFeedAccessMode.Public;
+            dataFeed.ActionLinkTemplate = "https://fakeurl.com/%datafeed/%metric";
+            // TODO: add administrator update validation. Related: https://github.com/Azure/azure-sdk-for-net/issues/17766
+            dataFeed.Viewers.Add("fake@viewer.com");
+
+            dataFeed.Schema.TimestampColumn = "updatedTimestampColumn";
+
+            dataFeed.IngestionSettings.IngestionStartOffset = TimeSpan.FromMinutes(40);
+            dataFeed.IngestionSettings.IngestionRetryDelay = TimeSpan.FromSeconds(90);
+            dataFeed.IngestionSettings.StopRetryAfter = TimeSpan.FromMinutes(20);
+            dataFeed.IngestionSettings.DataSourceRequestConcurrency = 6;
+
+            dataFeed.MissingDataPointFillSettings = new ()
+            {
+                FillType = DataFeedMissingDataPointFillType.NoFilling
             };
         }
 
@@ -2041,6 +3046,59 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(80)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(10)));
             Assert.That(dataFeed.IngestionSettings.DataSourceRequestConcurrency, Is.EqualTo(5));
+        }
+
+        private void ValidateUpdatedDataFeedWithOptionalMembersSet(DataFeed dataFeed, string expectedId, string expectedName)
+        {
+            var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
+
+            Assert.That(dataFeed.Id, Is.EqualTo(expectedId));
+            Assert.That(dataFeed.Name, Is.EqualTo(expectedName));
+            Assert.That(dataFeed.Description, Is.EqualTo("This data feed was updated to test the .NET client."));
+            Assert.That(dataFeed.Status, Is.EqualTo(DataFeedStatus.Active));
+            Assert.That(dataFeed.AccessMode, Is.EqualTo(DataFeedAccessMode.Public));
+            Assert.That(dataFeed.ActionLinkTemplate, Is.EqualTo("https://fakeurl.com/%datafeed/%metric"));
+            Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
+
+            Assert.That(dataFeed.Administrators, Is.Not.Null);
+            Assert.That(dataFeed.Administrators.Count, Is.EqualTo(1));
+            Assert.That(dataFeed.Administrators, Contains.Item(dataFeed.Creator));
+
+            Assert.That(dataFeed.Viewers, Is.Not.Null);
+            Assert.That(dataFeed.Viewers.Count, Is.EqualTo(1));
+            Assert.That(dataFeed.Viewers, Contains.Item("fake@viewer.com"));
+
+            DateTimeOffset justNow = Recording.UtcNow.Subtract(TimeSpan.FromMinutes(5));
+            Assert.That(dataFeed.CreatedTime, Is.GreaterThan(justNow));
+
+            Assert.That(dataFeed.MissingDataPointFillSettings, Is.Not.Null);
+            Assert.That(dataFeed.MissingDataPointFillSettings.FillType, Is.EqualTo(DataFeedMissingDataPointFillType.NoFilling));
+            Assert.That(dataFeed.MissingDataPointFillSettings.CustomFillValue, Is.Null);
+
+            Assert.That(dataFeed.Granularity, Is.Not.Null);
+            Assert.That(dataFeed.Granularity.GranularityType, Is.EqualTo(DataFeedGranularityType.Daily));
+            Assert.That(dataFeed.Granularity.CustomGranularityValue, Is.Null);
+
+            Assert.That(dataFeed.Schema, Is.Not.Null);
+            Assert.That(dataFeed.Schema.MetricColumns, Is.Not.Null);
+
+            DataFeedMetric metric = dataFeed.Schema.MetricColumns.Single();
+
+            Assert.That(metric, Is.Not.Null);
+            Assert.That(metric.MetricId, Is.Not.Null.And.Not.Empty);
+            Assert.That(metric.MetricName, Is.EqualTo("cost"));
+            Assert.That(metric.MetricDisplayName, Is.EqualTo("cost"));
+            Assert.That(metric.MetricDescription, Is.Empty);
+
+            Assert.That(dataFeed.Schema.DimensionColumns, Is.Not.Null.And.Empty);
+            Assert.That(dataFeed.Schema.TimestampColumn, Is.EqualTo("updatedTimestampColumn"));
+
+            Assert.That(dataFeed.IngestionSettings, Is.Not.Null);
+            Assert.That(dataFeed.IngestionSettings.IngestionStartTime, Is.EqualTo(ingestionStartTime));
+            Assert.That(dataFeed.IngestionSettings.IngestionStartOffset, Is.EqualTo(TimeSpan.FromMinutes(40)));
+            Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(90)));
+            Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(20)));
+            Assert.That(dataFeed.IngestionSettings.DataSourceRequestConcurrency, Is.EqualTo(6));
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -14,6 +14,30 @@ namespace Azure.AI.MetricsAdvisor.Tests
 {
     public class DataFeedLiveTests : MetricsAdvisorLiveTestBase
     {
+        private const string OriginalAccount = "account";
+        private const string OriginalAppId = "appId";
+        private const string OriginalAuth = "auth";
+        private const string OriginalCloud = "cloud";
+        private const string OriginalCollectionId = "collectId";
+        private const string OriginalCommand = "command";
+        private const string OriginalConnectionString = "connectionStr";
+        private const string OriginalContainer = "container";
+        private const string OriginalDatabase = "database";
+        private const string OriginalDirectory = "dir";
+        private const string OriginalFile = "file";
+        private const string OriginalFileSystem = "fileSystem";
+        private const string OriginalHeader = "header";
+        private const string OriginalHost = "host";
+        private const string OriginalKey = "key";
+        private const string OriginalMethod = "method";
+        private const string OriginalPassword = "pass";
+        private const string OriginalPayload = "payload";
+        private const string OriginalPort = "port";
+        private const string OriginalQuery = "query";
+        private const string OriginalTable = "table";
+        private const string OriginalTemplate = "template";
+        private const string OriginalUsername = "username";
+
         public DataFeedLiveTests(bool isAsync) : base(isAsync)
         {
         }
@@ -23,13 +47,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAppId = "appId";
-            var originalKey = "key";
-            var originalCloud = "cloud";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -42,13 +61,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
             Assert.That(createdDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(originalCloud));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -56,13 +75,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAppId = "appId";
-            var originalKey = "key";
-            var originalCloud = "cloud";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -75,13 +89,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
             Assert.That(createdDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(originalCloud));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -89,12 +103,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalContainer = "container";
-            var originalTemplate = "template";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -107,12 +117,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Container, Is.EqualTo(originalContainer));
-            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+            Assert.That(createdDataSource.Container, Is.EqualTo(OriginalContainer));
+            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
         }
 
         [RecordedTest]
@@ -120,12 +130,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalContainer = "container";
-            var originalTemplate = "template";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -138,12 +144,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Container, Is.EqualTo(originalContainer));
-            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+            Assert.That(createdDataSource.Container, Is.EqualTo(OriginalContainer));
+            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
         }
 
         [RecordedTest]
@@ -151,13 +157,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-            var originalDatabase = "database";
-            var originalCollectionId = "collectId";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -170,13 +171,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(originalQuery));
-            Assert.That(createdDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(createdDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(createdDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
         }
 
         [RecordedTest]
@@ -184,13 +185,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-            var originalDatabase = "database";
-            var originalCollectionId = "collectId";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -203,13 +199,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(originalQuery));
-            Assert.That(createdDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(createdDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(createdDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
         }
 
         [RecordedTest]
@@ -217,11 +213,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -234,11 +227,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -246,11 +239,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -263,11 +253,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -275,14 +265,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAccount = "account";
-            var originalKey = "key";
-            var originalFileSystem = "fileSystem";
-            var originalDirectory = "dir";
-            var originalFile = "file";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -295,14 +279,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(createdDataSource.AccountName, Is.EqualTo(OriginalAccount));
             Assert.That(createdDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
-            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
-            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(originalFile));
+            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
+            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
+            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(OriginalFile));
         }
 
         [RecordedTest]
@@ -310,14 +294,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAccount = "account";
-            var originalKey = "key";
-            var originalFileSystem = "fileSystem";
-            var originalDirectory = "dir";
-            var originalFile = "file";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -330,14 +308,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(createdDataSource.AccountName, Is.EqualTo(OriginalAccount));
             Assert.That(createdDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
-            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
-            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(originalFile));
+            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
+            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
+            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(OriginalFile));
         }
 
         [RecordedTest]
@@ -345,12 +323,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalTable = "table";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -363,12 +337,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Table, Is.EqualTo(originalTable));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Table, Is.EqualTo(OriginalTable));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -376,12 +350,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalTable = "table";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -394,12 +364,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Table, Is.EqualTo(originalTable));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Table, Is.EqualTo(OriginalTable));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -407,13 +377,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHost = "host";
-            var originalPort = "port";
-            var originalAuth = "auth";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -426,13 +391,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Host, Is.EqualTo(originalHost));
-            Assert.That(createdDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(createdDataSource.Host, Is.EqualTo(OriginalHost));
+            Assert.That(createdDataSource.Port, Is.EqualTo(OriginalPort));
             Assert.That(createdDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -440,13 +405,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHost = "host";
-            var originalPort = "port";
-            var originalAuth = "auth";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -459,13 +419,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
 
             Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Host, Is.EqualTo(originalHost));
-            Assert.That(createdDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(createdDataSource.Host, Is.EqualTo(OriginalHost));
+            Assert.That(createdDataSource.Port, Is.EqualTo(OriginalPort));
             Assert.That(createdDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -473,13 +433,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHeader = "header";
-            var originalMethod = "method";
-            var originalPayload = "payload";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -492,13 +448,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(createdDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(originalMethod));
-            Assert.That(createdDataSource.Payload, Is.EqualTo(originalPayload));
+            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
+            Assert.That(createdDataSource.Payload, Is.EqualTo(OriginalPayload));
         }
 
         [RecordedTest]
@@ -506,13 +462,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHeader = "header";
-            var originalMethod = "method";
-            var originalPayload = "payload";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -525,13 +477,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(createdDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(originalMethod));
-            Assert.That(createdDataSource.Payload, Is.EqualTo(originalPayload));
+            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
+            Assert.That(createdDataSource.Payload, Is.EqualTo(OriginalPayload));
         }
 
         [RecordedTest]
@@ -539,14 +491,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalUsername = "username";
-            var originalPassword = "pass";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -559,14 +505,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(createdDataSource.Username, Is.EqualTo(originalUsername));
-            Assert.That(createdDataSource.Password, Is.EqualTo(originalPassword));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(createdDataSource.Username, Is.EqualTo(OriginalUsername));
+            Assert.That(createdDataSource.Password, Is.EqualTo(OriginalPassword));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -574,14 +520,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalUsername = "username";
-            var originalPassword = "pass";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -594,14 +534,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(createdDataSource.Username, Is.EqualTo(originalUsername));
-            Assert.That(createdDataSource.Password, Is.EqualTo(originalPassword));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(createdDataSource.Username, Is.EqualTo(OriginalUsername));
+            Assert.That(createdDataSource.Password, Is.EqualTo(OriginalPassword));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -609,12 +549,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalCommand = "command";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -627,12 +563,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(createdDataSource.Command, Is.EqualTo(originalCommand));
+            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(createdDataSource.Command, Is.EqualTo(OriginalCommand));
         }
 
         [RecordedTest]
@@ -640,12 +576,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalCommand = "command";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -658,12 +590,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(createdDataSource.Command, Is.EqualTo(originalCommand));
+            Assert.That(createdDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(createdDataSource.Command, Is.EqualTo(OriginalCommand));
         }
 
         [RecordedTest]
@@ -671,11 +603,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -688,11 +617,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -700,11 +629,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -717,11 +643,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -729,11 +655,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -746,11 +669,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -758,11 +681,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -775,11 +695,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -787,11 +707,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -804,11 +721,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -816,11 +733,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -833,11 +747,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(createdDataSource, Is.Not.Null);
             Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(createdDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -846,13 +760,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAppId = "appId";
-            var originalKey = "key";
-            var originalCloud = "cloud";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -872,13 +781,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(originalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -887,13 +796,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAppId = "appId";
-            var originalKey = "key";
-            var originalCloud = "cloud";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -913,13 +817,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(originalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -928,13 +832,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAppId = "appId";
-            var originalKey = "key";
-            var originalCloud = "cloud";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -953,13 +852,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(originalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -968,13 +867,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAppId = "appId";
-            var originalKey = "key";
-            var originalCloud = "cloud";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureApplicationInsightsDataFeedSource(originalAppId, originalKey, originalCloud, originalQuery);
+            var dataSource = new AzureApplicationInsightsDataFeedSource(OriginalAppId, OriginalKey, OriginalCloud, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -993,13 +887,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(originalAppId));
+            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(OriginalAppId));
             Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(originalCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(OriginalCloud));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1007,12 +901,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalContainer = "container";
-            var originalTemplate = "template";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1032,12 +922,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(originalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
         }
 
         [RecordedTest]
@@ -1045,12 +935,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalContainer = "container";
-            var originalTemplate = "template";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1070,12 +956,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(originalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
         }
 
         [RecordedTest]
@@ -1083,12 +969,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalContainer = "container";
-            var originalTemplate = "template";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1107,12 +989,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(originalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
         }
 
         [RecordedTest]
@@ -1120,12 +1002,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalContainer = "container";
-            var originalTemplate = "template";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureBlobDataFeedSource(originalConnectionString, originalContainer, originalTemplate);
+            var dataSource = new AzureBlobDataFeedSource(OriginalConnectionString, OriginalContainer, OriginalTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1144,12 +1022,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(originalContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(originalTemplate));
+            Assert.That(updatedDataSource.Container, Is.EqualTo(OriginalContainer));
+            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(OriginalTemplate));
         }
 
         [RecordedTest]
@@ -1158,13 +1036,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-            var originalDatabase = "database";
-            var originalCollectionId = "collectId";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1184,13 +1057,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(originalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
         }
 
         [RecordedTest]
@@ -1199,13 +1072,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-            var originalDatabase = "database";
-            var originalCollectionId = "collectId";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1225,13 +1093,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(originalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
         }
 
         [RecordedTest]
@@ -1240,13 +1108,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-            var originalDatabase = "database";
-            var originalCollectionId = "collectId";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1265,13 +1128,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(originalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
         }
 
         [RecordedTest]
@@ -1280,13 +1143,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-            var originalDatabase = "database";
-            var originalCollectionId = "collectId";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureCosmosDbDataFeedSource(originalConnectionString, originalQuery, originalDatabase, originalCollectionId);
+            var dataSource = new AzureCosmosDbDataFeedSource(OriginalConnectionString, OriginalQuery, OriginalDatabase, OriginalCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1305,13 +1163,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(originalQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(originalCollectionId));
+            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(OriginalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(OriginalCollectionId));
         }
 
         [RecordedTest]
@@ -1320,11 +1178,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1344,11 +1199,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1357,11 +1212,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1381,11 +1233,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1394,11 +1246,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1417,11 +1266,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1430,11 +1279,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataExplorerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new AzureDataExplorerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1453,11 +1299,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1465,14 +1311,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAccount = "account";
-            var originalKey = "key";
-            var originalFileSystem = "fileSystem";
-            var originalDirectory = "dir";
-            var originalFile = "file";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1492,14 +1332,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(originalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
         }
 
         [RecordedTest]
@@ -1507,14 +1347,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAccount = "account";
-            var originalKey = "key";
-            var originalFileSystem = "fileSystem";
-            var originalDirectory = "dir";
-            var originalFile = "file";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1534,14 +1368,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(originalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
         }
 
         [RecordedTest]
@@ -1549,14 +1383,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAccount = "account";
-            var originalKey = "key";
-            var originalFileSystem = "fileSystem";
-            var originalDirectory = "dir";
-            var originalFile = "file";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1575,14 +1403,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(originalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
         }
 
         [RecordedTest]
@@ -1590,14 +1418,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalAccount = "account";
-            var originalKey = "key";
-            var originalFileSystem = "fileSystem";
-            var originalDirectory = "dir";
-            var originalFile = "file";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(originalAccount, originalKey, originalFileSystem, originalDirectory, originalFile);
+            var dataSource = new AzureDataLakeStorageGen2DataFeedSource(OriginalAccount, OriginalKey, OriginalFileSystem, OriginalDirectory, OriginalFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1616,14 +1438,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
 
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalKey;
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalKey;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(originalAccount));
+            Assert.That(updatedDataSource.AccountName, Is.EqualTo(OriginalAccount));
             Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(originalFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(originalDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(originalFile));
+            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(OriginalFileSystem));
+            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(OriginalDirectory));
+            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(OriginalFile));
         }
 
         [RecordedTest]
@@ -1631,12 +1453,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalTable = "table";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1656,12 +1474,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(originalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1669,12 +1487,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalTable = "table";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1694,12 +1508,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(originalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1707,12 +1521,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalTable = "table";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1731,12 +1541,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(originalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1744,12 +1554,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalTable = "table";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new AzureTableDataFeedSource(originalConnectionString, originalTable, originalQuery);
+            var dataSource = new AzureTableDataFeedSource(OriginalConnectionString, OriginalTable, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1768,12 +1574,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(originalTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Table, Is.EqualTo(OriginalTable));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1781,13 +1587,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHost = "host";
-            var originalPort = "port";
-            var originalAuth = "auth";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1807,13 +1608,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(originalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1821,13 +1622,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHost = "host";
-            var originalPort = "port";
-            var originalAuth = "auth";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1847,13 +1643,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(originalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1861,13 +1657,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHost = "host";
-            var originalPort = "port";
-            var originalAuth = "auth";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1886,13 +1677,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(originalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1900,13 +1691,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHost = "host";
-            var originalPort = "port";
-            var originalAuth = "auth";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new ElasticsearchDataFeedSource(originalHost, originalPort, originalAuth, originalQuery);
+            var dataSource = new ElasticsearchDataFeedSource(OriginalHost, OriginalPort, OriginalAuth, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1925,13 +1711,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
 
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalAuth;
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalAuth;
 
             Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(originalHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(originalPort));
+            Assert.That(updatedDataSource.Host, Is.EqualTo(OriginalHost));
+            Assert.That(updatedDataSource.Port, Is.EqualTo(OriginalPort));
             Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -1939,13 +1725,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHeader = "header";
-            var originalMethod = "method";
-            var originalPayload = "payload";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1965,13 +1747,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(originalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(originalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
         }
 
         [RecordedTest]
@@ -1979,13 +1761,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHeader = "header";
-            var originalMethod = "method";
-            var originalPayload = "payload";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2005,13 +1783,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(originalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(originalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
         }
 
         [RecordedTest]
@@ -2019,13 +1797,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHeader = "header";
-            var originalMethod = "method";
-            var originalPayload = "payload";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2044,13 +1818,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(originalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(originalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
         }
 
         [RecordedTest]
@@ -2058,13 +1832,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalHeader = "header";
-            var originalMethod = "method";
-            var originalPayload = "payload";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, originalHeader, originalMethod, originalPayload);
+            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, OriginalHeader, OriginalMethod, OriginalPayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2083,13 +1853,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
 
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalHeader;
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalHeader;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
             Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(originalMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(originalPayload));
+            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(OriginalMethod));
+            Assert.That(updatedDataSource.Payload, Is.EqualTo(OriginalPayload));
         }
 
         [RecordedTest]
@@ -2097,14 +1867,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalUsername = "username";
-            var originalPassword = "pass";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2124,14 +1888,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(originalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(originalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2139,14 +1903,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalUsername = "username";
-            var originalPassword = "pass";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2166,14 +1924,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(originalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(originalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2181,14 +1939,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalUsername = "username";
-            var originalPassword = "pass";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2207,14 +1959,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(originalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(originalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2222,14 +1974,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalUsername = "username";
-            var originalPassword = "pass";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new InfluxDbDataFeedSource(originalConnectionString, originalDatabase, originalUsername, originalPassword, originalQuery);
+            var dataSource = new InfluxDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalUsername, OriginalPassword, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2248,14 +1994,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(originalUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(originalPassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Username, Is.EqualTo(OriginalUsername));
+            Assert.That(updatedDataSource.Password, Is.EqualTo(OriginalPassword));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2263,12 +2009,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalCommand = "command";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2288,12 +2030,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(originalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
         }
 
         [RecordedTest]
@@ -2301,12 +2043,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalCommand = "command";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2326,12 +2064,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(originalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
         }
 
         [RecordedTest]
@@ -2339,12 +2077,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalCommand = "command";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2363,12 +2097,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(originalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
         }
 
         [RecordedTest]
@@ -2376,12 +2110,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalDatabase = "database";
-            var originalCommand = "command";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MongoDbDataFeedSource(originalConnectionString, originalDatabase, originalCommand);
+            var dataSource = new MongoDbDataFeedSource(OriginalConnectionString, OriginalDatabase, OriginalCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2400,12 +2130,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(originalDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(originalCommand));
+            Assert.That(updatedDataSource.Database, Is.EqualTo(OriginalDatabase));
+            Assert.That(updatedDataSource.Command, Is.EqualTo(OriginalCommand));
         }
 
         [RecordedTest]
@@ -2413,11 +2143,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2437,11 +2164,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2449,11 +2176,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2473,11 +2197,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2485,11 +2209,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2508,11 +2229,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2520,11 +2241,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new MySqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new MySqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2543,11 +2261,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2555,11 +2273,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2579,11 +2294,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2591,11 +2306,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2615,11 +2327,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2627,11 +2339,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2650,11 +2359,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2662,11 +2371,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new PostgreSqlDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new PostgreSqlDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2685,11 +2391,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2697,11 +2403,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2721,11 +2424,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2733,11 +2436,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -2757,11 +2457,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2769,11 +2469,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2792,11 +2489,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]
@@ -2804,11 +2501,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var originalConnectionString = "connectionStr";
-            var originalQuery = "query";
-
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSource = new SqlServerDataFeedSource(originalConnectionString, originalQuery);
+            var dataSource = new SqlServerDataFeedSource(OriginalConnectionString, OriginalQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -2827,11 +2521,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : originalConnectionString;
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : OriginalConnectionString;
 
             Assert.That(updatedDataSource, Is.Not.Null);
             Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(originalQuery));
+            Assert.That(updatedDataSource.Query, Is.EqualTo(OriginalQuery));
         }
 
         [RecordedTest]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         private const string DataSourceFile = "file";
         private const string DataSourceFileSystem = "fileSystem";
         private const string DataSourceHeader = "header";
-        private const string DataSourceHost = "host";
+        private const string DataSourceHost = "https://fakehost.com/";
         private const string DataSourceKey = "key";
         private const string DataSourceMethod = "method";
         private const string DataSourcePassword = "pass";
@@ -38,7 +38,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         private const string DataSourceTemplate = "template";
         private const string DataSourceUsername = "username";
 
-        public DataFeedLiveTests(bool isAsync) : base(isAsync)
+        public DataFeedLiveTests(bool isAsync) : base(isAsync, RecordedTestMode.Playback)
         {
         }
 
@@ -59,15 +59,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
-            Assert.That(createdDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureApplicationInsightsDataSource(createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource);
         }
 
         [RecordedTest]
@@ -87,15 +79,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
-            Assert.That(createdDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureApplicationInsightsDataSource(createdDataFeed.DataSource as AzureApplicationInsightsDataFeedSource);
         }
 
         [RecordedTest]
@@ -115,14 +99,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureBlobDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Container, Is.EqualTo(DataSourceContainer));
-            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
+            ValidateAzureBlobDataSource(createdDataFeed.DataSource as AzureBlobDataFeedSource);
         }
 
         [RecordedTest]
@@ -144,12 +121,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             var createdDataSource = createdDataFeed.DataSource as AzureBlobDataFeedSource;
 
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Container, Is.EqualTo(DataSourceContainer));
-            Assert.That(createdDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
+            ValidateAzureBlobDataSource(createdDataFeed.DataSource as AzureBlobDataFeedSource);
         }
 
         [RecordedTest]
@@ -169,15 +141,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureCosmosDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
-            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(createdDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
+            ValidateAzureCosmosDbDataSource(createdDataFeed.DataSource as AzureCosmosDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -197,15 +161,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureCosmosDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
-            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(createdDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
+            ValidateAzureCosmosDbDataSource(createdDataFeed.DataSource as AzureCosmosDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -225,13 +181,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureDataExplorerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureDataExplorerDataSource(createdDataFeed.DataSource as AzureDataExplorerDataFeedSource);
         }
 
         [RecordedTest]
@@ -251,13 +201,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureDataExplorerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureDataExplorerDataSource(createdDataFeed.DataSource as AzureDataExplorerDataFeedSource);
         }
 
         [RecordedTest]
@@ -277,16 +221,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.AccountName, Is.EqualTo(DataSourceAccount));
-            Assert.That(createdDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
-            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
-            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
+            ValidateAzureDataLakeStorageGen2DataSource(createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource);
         }
 
         [RecordedTest]
@@ -306,16 +241,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.AccountName, Is.EqualTo(DataSourceAccount));
-            Assert.That(createdDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(createdDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
-            Assert.That(createdDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
-            Assert.That(createdDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
+            ValidateAzureDataLakeStorageGen2DataSource(createdDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource);
         }
 
         [RecordedTest]
@@ -335,14 +261,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureTableDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Table, Is.EqualTo(DataSourceTable));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureTableDataSource(createdDataFeed.DataSource as AzureTableDataFeedSource);
         }
 
         [RecordedTest]
@@ -362,14 +281,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
-            var createdDataSource = createdDataFeed.DataSource as AzureTableDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Table, Is.EqualTo(DataSourceTable));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureTableDataSource(createdDataFeed.DataSource as AzureTableDataFeedSource);
         }
 
         [RecordedTest]
@@ -389,15 +301,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
-            var createdDataSource = createdDataFeed.DataSource as ElasticsearchDataFeedSource;
-
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Host, Is.EqualTo(DataSourceHost));
-            Assert.That(createdDataSource.Port, Is.EqualTo(DataSourcePort));
-            Assert.That(createdDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateElasticsearchDataSource(createdDataFeed.DataSource as ElasticsearchDataFeedSource);
         }
 
         [RecordedTest]
@@ -417,15 +321,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
-            var createdDataSource = createdDataFeed.DataSource as ElasticsearchDataFeedSource;
-
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Host, Is.EqualTo(DataSourceHost));
-            Assert.That(createdDataSource.Port, Is.EqualTo(DataSourcePort));
-            Assert.That(createdDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateElasticsearchDataSource(createdDataFeed.DataSource as ElasticsearchDataFeedSource);
         }
 
         [RecordedTest]
@@ -434,8 +330,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
+            var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -446,15 +341,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
 
-            var createdDataSource = createdDataFeed.DataSource as HttpRequestDataFeedSource;
-
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
-            Assert.That(createdDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
-            Assert.That(createdDataSource.Payload, Is.EqualTo(DataSourcePayload));
+            ValidateHttpRequestDataSource(createdDataFeed.DataSource as HttpRequestDataFeedSource);
         }
 
         [RecordedTest]
@@ -463,8 +350,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
+            var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithOptionalMembersSet(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -475,15 +361,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
 
-            var createdDataSource = createdDataFeed.DataSource as HttpRequestDataFeedSource;
-
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
-            Assert.That(createdDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(createdDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
-            Assert.That(createdDataSource.Payload, Is.EqualTo(DataSourcePayload));
+            ValidateHttpRequestDataSource(createdDataFeed.DataSource as HttpRequestDataFeedSource);
         }
 
         [RecordedTest]
@@ -503,16 +381,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
-            var createdDataSource = createdDataFeed.DataSource as InfluxDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(createdDataSource.Username, Is.EqualTo(DataSourceUsername));
-            Assert.That(createdDataSource.Password, Is.EqualTo(DataSourcePassword));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateInfluxDbDataSource(createdDataFeed.DataSource as InfluxDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -532,16 +401,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
-            var createdDataSource = createdDataFeed.DataSource as InfluxDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(createdDataSource.Username, Is.EqualTo(DataSourceUsername));
-            Assert.That(createdDataSource.Password, Is.EqualTo(DataSourcePassword));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateInfluxDbDataSource(createdDataFeed.DataSource as InfluxDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -561,14 +421,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
-            var createdDataSource = createdDataFeed.DataSource as MongoDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(createdDataSource.Command, Is.EqualTo(DataSourceCommand));
+            ValidateMongoDbDataSource(createdDataFeed.DataSource as MongoDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -588,14 +441,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
-            var createdDataSource = createdDataFeed.DataSource as MongoDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(createdDataSource.Command, Is.EqualTo(DataSourceCommand));
+            ValidateMongoDbDataSource(createdDataFeed.DataSource as MongoDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -615,13 +461,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
-            var createdDataSource = createdDataFeed.DataSource as MySqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateMySqlDataSource(createdDataFeed.DataSource as MySqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -641,13 +481,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
-            var createdDataSource = createdDataFeed.DataSource as MySqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateMySqlDataSource(createdDataFeed.DataSource as MySqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -667,13 +501,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
-            var createdDataSource = createdDataFeed.DataSource as PostgreSqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidatePostgreSqlDataSource(createdDataFeed.DataSource as PostgreSqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -693,13 +521,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
-            var createdDataSource = createdDataFeed.DataSource as PostgreSqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidatePostgreSqlDataSource(createdDataFeed.DataSource as PostgreSqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -719,13 +541,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
-            var createdDataSource = createdDataFeed.DataSource as SqlServerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateSqlServerDataSource(createdDataFeed.DataSource as SqlServerDataFeedSource);
         }
 
         [RecordedTest]
@@ -745,13 +561,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(createdDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
-            var createdDataSource = createdDataFeed.DataSource as SqlServerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(createdDataSource, Is.Not.Null);
-            Assert.That(createdDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(createdDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateSqlServerDataSource(createdDataFeed.DataSource as SqlServerDataFeedSource);
         }
 
         [RecordedTest]
@@ -779,15 +589,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
-            Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureApplicationInsightsDataSource(updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource);
         }
 
         [RecordedTest]
@@ -815,15 +617,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
-            Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureApplicationInsightsDataSource(updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource);
         }
 
         [RecordedTest]
@@ -850,15 +644,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
-            Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureApplicationInsightsDataSource(updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource);
         }
 
         [RecordedTest]
@@ -885,15 +671,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
-            Assert.That(updatedDataSource.ApiKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureApplicationInsightsDataSource(updatedDataFeed.DataSource as AzureApplicationInsightsDataFeedSource);
         }
 
         [RecordedTest]
@@ -920,14 +698,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
+            ValidateAzureBlobDataSource(updatedDataFeed.DataSource as AzureBlobDataFeedSource);
         }
 
         [RecordedTest]
@@ -954,14 +725,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
+            ValidateAzureBlobDataSource(updatedDataFeed.DataSource as AzureBlobDataFeedSource);
         }
 
         [RecordedTest]
@@ -987,14 +751,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
+            ValidateAzureBlobDataSource(updatedDataFeed.DataSource as AzureBlobDataFeedSource);
         }
 
         [RecordedTest]
@@ -1020,14 +777,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureBlobDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Container, Is.EqualTo(DataSourceContainer));
-            Assert.That(updatedDataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
+            ValidateAzureBlobDataSource(updatedDataFeed.DataSource as AzureBlobDataFeedSource);
         }
 
         [RecordedTest]
@@ -1055,15 +805,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
+            ValidateAzureCosmosDbDataSource(updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -1091,15 +833,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
+            ValidateAzureCosmosDbDataSource(updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -1126,15 +860,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
+            ValidateAzureCosmosDbDataSource(updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -1161,15 +887,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
+            ValidateAzureCosmosDbDataSource(updatedDataFeed.DataSource as AzureCosmosDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -1197,13 +915,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureDataExplorerDataSource(updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource);
         }
 
         [RecordedTest]
@@ -1231,13 +943,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureDataExplorerDataSource(updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource);
         }
 
         [RecordedTest]
@@ -1264,13 +970,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureDataExplorerDataSource(updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource);
         }
 
         [RecordedTest]
@@ -1297,13 +997,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureDataExplorerDataSource(updatedDataFeed.DataSource as AzureDataExplorerDataFeedSource);
         }
 
         [RecordedTest]
@@ -1330,16 +1024,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
-            Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
+            ValidateAzureDataLakeStorageGen2DataSource(updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource);
         }
 
         [RecordedTest]
@@ -1366,16 +1051,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
-            Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
+            ValidateAzureDataLakeStorageGen2DataSource(updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource);
         }
 
         [RecordedTest]
@@ -1401,16 +1077,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
-            Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
+            ValidateAzureDataLakeStorageGen2DataSource(updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource);
         }
 
         [RecordedTest]
@@ -1436,16 +1103,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource;
-
-            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.AccountName, Is.EqualTo(DataSourceAccount));
-            Assert.That(updatedDataSource.AccountKey, Is.EqualTo(expectedKey));
-            Assert.That(updatedDataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
-            Assert.That(updatedDataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
-            Assert.That(updatedDataSource.FileTemplate, Is.EqualTo(DataSourceFile));
+            ValidateAzureDataLakeStorageGen2DataSource(updatedDataFeed.DataSource as AzureDataLakeStorageGen2DataFeedSource);
         }
 
         [RecordedTest]
@@ -1472,14 +1130,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureTableDataSource(updatedDataFeed.DataSource as AzureTableDataFeedSource);
         }
 
         [RecordedTest]
@@ -1506,14 +1157,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureTableDataSource(updatedDataFeed.DataSource as AzureTableDataFeedSource);
         }
 
         [RecordedTest]
@@ -1539,14 +1183,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureTableDataSource(updatedDataFeed.DataSource as AzureTableDataFeedSource);
         }
 
         [RecordedTest]
@@ -1572,14 +1209,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
-            var updatedDataSource = updatedDataFeed.DataSource as AzureTableDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Table, Is.EqualTo(DataSourceTable));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateAzureTableDataSource(updatedDataFeed.DataSource as AzureTableDataFeedSource);
         }
 
         [RecordedTest]
@@ -1606,15 +1236,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
-            var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
-
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
-            Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateElasticsearchDataSource(updatedDataFeed.DataSource as ElasticsearchDataFeedSource);
         }
 
         [RecordedTest]
@@ -1641,15 +1263,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
-            var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
-
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
-            Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateElasticsearchDataSource(updatedDataFeed.DataSource as ElasticsearchDataFeedSource);
         }
 
         [RecordedTest]
@@ -1675,15 +1289,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
-            var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
-
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
-            Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateElasticsearchDataSource(updatedDataFeed.DataSource as ElasticsearchDataFeedSource);
         }
 
         [RecordedTest]
@@ -1709,15 +1315,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
-            var updatedDataSource = updatedDataFeed.DataSource as ElasticsearchDataFeedSource;
-
-            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Host, Is.EqualTo(DataSourceHost));
-            Assert.That(updatedDataSource.Port, Is.EqualTo(DataSourcePort));
-            Assert.That(updatedDataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateElasticsearchDataSource(updatedDataFeed.DataSource as ElasticsearchDataFeedSource);
         }
 
         [RecordedTest]
@@ -1726,8 +1324,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
+            var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1745,15 +1342,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
 
-            var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
-
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
-            Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
+            ValidateHttpRequestDataSource(updatedDataFeed.DataSource as HttpRequestDataFeedSource);
         }
 
         [RecordedTest]
@@ -1762,8 +1351,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
+            var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             var description = "This data feed was created to test the .NET client.";
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1781,15 +1369,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
 
-            var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
-
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
-            Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
+            ValidateHttpRequestDataSource(updatedDataFeed.DataSource as HttpRequestDataFeedSource);
         }
 
         [RecordedTest]
@@ -1798,8 +1378,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
+            var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1816,15 +1395,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
 
-            var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
-
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
-            Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
+            ValidateHttpRequestDataSource(updatedDataFeed.DataSource as HttpRequestDataFeedSource);
         }
 
         [RecordedTest]
@@ -1833,8 +1404,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
-            var dataSourceHost = new Uri("https://fakehost.com/");
-            var dataSource = new HttpRequestDataFeedSource(dataSourceHost, DataSourceHeader, DataSourceMethod, DataSourcePayload);
+            var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
@@ -1849,17 +1419,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
 
-            Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
-
-            var updatedDataSource = updatedDataFeed.DataSource as HttpRequestDataFeedSource;
-
-            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.Url.AbsoluteUri, Is.EqualTo(dataSourceHost.AbsoluteUri));
-            Assert.That(updatedDataSource.HttpHeader, Is.EqualTo(expectedHeader));
-            Assert.That(updatedDataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
-            Assert.That(updatedDataSource.Payload, Is.EqualTo(DataSourcePayload));
+            ValidateHttpRequestDataSource(updatedDataFeed.DataSource as HttpRequestDataFeedSource);
         }
 
         [RecordedTest]
@@ -1886,16 +1446,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateInfluxDbDataSource(updatedDataFeed.DataSource as InfluxDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -1922,16 +1473,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateInfluxDbDataSource(updatedDataFeed.DataSource as InfluxDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -1957,16 +1499,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateInfluxDbDataSource(updatedDataFeed.DataSource as InfluxDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -1992,16 +1525,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as InfluxDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Username, Is.EqualTo(DataSourceUsername));
-            Assert.That(updatedDataSource.Password, Is.EqualTo(DataSourcePassword));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateInfluxDbDataSource(updatedDataFeed.DataSource as InfluxDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -2028,14 +1552,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
+            ValidateMongoDbDataSource(updatedDataFeed.DataSource as MongoDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -2062,14 +1579,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
+            ValidateMongoDbDataSource(updatedDataFeed.DataSource as MongoDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -2095,14 +1605,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
+            ValidateMongoDbDataSource(updatedDataFeed.DataSource as MongoDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -2128,14 +1631,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MongoDbDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Database, Is.EqualTo(DataSourceDatabase));
-            Assert.That(updatedDataSource.Command, Is.EqualTo(DataSourceCommand));
+            ValidateMongoDbDataSource(updatedDataFeed.DataSource as MongoDbDataFeedSource);
         }
 
         [RecordedTest]
@@ -2162,13 +1658,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateMySqlDataSource(updatedDataFeed.DataSource as MySqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2195,13 +1685,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateMySqlDataSource(updatedDataFeed.DataSource as MySqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2227,13 +1711,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateMySqlDataSource(updatedDataFeed.DataSource as MySqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2259,13 +1737,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as MySqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateMySqlDataSource(updatedDataFeed.DataSource as MySqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2292,13 +1764,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidatePostgreSqlDataSource(updatedDataFeed.DataSource as PostgreSqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2325,13 +1791,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidatePostgreSqlDataSource(updatedDataFeed.DataSource as PostgreSqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2357,13 +1817,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidatePostgreSqlDataSource(updatedDataFeed.DataSource as PostgreSqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2389,13 +1843,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
-            var updatedDataSource = updatedDataFeed.DataSource as PostgreSqlDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidatePostgreSqlDataSource(updatedDataFeed.DataSource as PostgreSqlDataFeedSource);
         }
 
         [RecordedTest]
@@ -2422,13 +1870,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateSqlServerDataSource(updatedDataFeed.DataSource as SqlServerDataFeedSource);
         }
 
         [RecordedTest]
@@ -2455,13 +1897,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateSqlServerDataSource(updatedDataFeed.DataSource as SqlServerDataFeedSource);
         }
 
         [RecordedTest]
@@ -2487,13 +1923,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateSqlServerDataSource(updatedDataFeed.DataSource as SqlServerDataFeedSource);
         }
 
         [RecordedTest]
@@ -2519,13 +1949,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
-            var updatedDataSource = updatedDataFeed.DataSource as SqlServerDataFeedSource;
-
-            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
-
-            Assert.That(updatedDataSource, Is.Not.Null);
-            Assert.That(updatedDataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
-            Assert.That(updatedDataSource.Query, Is.EqualTo(DataSourceQuery));
+            ValidateSqlServerDataSource(updatedDataFeed.DataSource as SqlServerDataFeedSource);
         }
 
         [RecordedTest]
@@ -2793,6 +2217,140 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.IngestionSettings.IngestionRetryDelay, Is.EqualTo(TimeSpan.FromSeconds(90)));
             Assert.That(dataFeed.IngestionSettings.StopRetryAfter, Is.EqualTo(TimeSpan.FromMinutes(20)));
             Assert.That(dataFeed.IngestionSettings.DataSourceRequestConcurrency, Is.EqualTo(6));
+        }
+
+        private void ValidateAzureApplicationInsightsDataSource(AzureApplicationInsightsDataFeedSource dataSource)
+        {
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ApplicationId, Is.EqualTo(DataSourceAppId));
+            Assert.That(dataSource.ApiKey, Is.EqualTo(expectedKey));
+            Assert.That(dataSource.AzureCloud, Is.EqualTo(DataSourceCloud));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
+        }
+
+        private void ValidateAzureBlobDataSource(AzureBlobDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Container, Is.EqualTo(DataSourceContainer));
+            Assert.That(dataSource.BlobTemplate, Is.EqualTo(DataSourceTemplate));
+        }
+
+        private void ValidateAzureCosmosDbDataSource(AzureCosmosDbDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.SqlQuery, Is.EqualTo(DataSourceQuery));
+            Assert.That(dataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(dataSource.CollectionId, Is.EqualTo(DataSourceCollectionId));
+        }
+
+        private void ValidateAzureDataExplorerDataSource(AzureDataExplorerDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
+        }
+
+        private void ValidateAzureDataLakeStorageGen2DataSource(AzureDataLakeStorageGen2DataFeedSource dataSource)
+        {
+            var expectedKey = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceKey;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.AccountName, Is.EqualTo(DataSourceAccount));
+            Assert.That(dataSource.AccountKey, Is.EqualTo(expectedKey));
+            Assert.That(dataSource.FileSystemName, Is.EqualTo(DataSourceFileSystem));
+            Assert.That(dataSource.DirectoryTemplate, Is.EqualTo(DataSourceDirectory));
+            Assert.That(dataSource.FileTemplate, Is.EqualTo(DataSourceFile));
+        }
+
+        private void ValidateAzureTableDataSource(AzureTableDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Table, Is.EqualTo(DataSourceTable));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
+        }
+
+        private void ValidateElasticsearchDataSource(ElasticsearchDataFeedSource dataSource)
+        {
+            var expectedAuth = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceAuth;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.Host, Is.EqualTo(DataSourceHost));
+            Assert.That(dataSource.Port, Is.EqualTo(DataSourcePort));
+            Assert.That(dataSource.AuthorizationHeader, Is.EqualTo(expectedAuth));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
+        }
+
+        private void ValidateHttpRequestDataSource(HttpRequestDataFeedSource dataSource)
+        {
+            var expectedHeader = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceHeader;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.Url.AbsoluteUri, Is.EqualTo(DataSourceHost));
+            Assert.That(dataSource.HttpHeader, Is.EqualTo(expectedHeader));
+            Assert.That(dataSource.HttpMethod, Is.EqualTo(DataSourceMethod));
+            Assert.That(dataSource.Payload, Is.EqualTo(DataSourcePayload));
+        }
+
+        private void ValidateInfluxDbDataSource(InfluxDbDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(dataSource.Username, Is.EqualTo(DataSourceUsername));
+            Assert.That(dataSource.Password, Is.EqualTo(DataSourcePassword));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
+        }
+
+        private void ValidateMongoDbDataSource(MongoDbDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Database, Is.EqualTo(DataSourceDatabase));
+            Assert.That(dataSource.Command, Is.EqualTo(DataSourceCommand));
+        }
+
+        private void ValidateMySqlDataSource(MySqlDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
+        }
+
+        private void ValidatePostgreSqlDataSource(PostgreSqlDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
+        }
+
+        private void ValidateSqlServerDataSource(SqlServerDataFeedSource dataSource)
+        {
+            var expectedConnectStr = TestEnvironment.Mode == RecordedTestMode.Playback ? "Sanitized" : DataSourceConnectionString;
+
+            Assert.That(dataSource, Is.Not.Null);
+            Assert.That(dataSource.ConnectionString, Is.EqualTo(expectedConnectStr));
+            Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithMinimumSetup.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithMinimumSetup.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-05bfc2996fbfa24cbde36fa04c721646-0250cdfa257a2448-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9af39765e02f6441baabcf4cca9ca484-9129ef6943819946-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "47bb13ef83b42a39dfd3b72ad8623d92",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,25 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c06f4924-a3fc-438c-b8a9-3142624dfe3b",
+        "apim-request-id": "53b4f8a5-b47d-4c71-a2d1-b143b22e64ee",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6a1bc159-e1ea-4ef4-ae37-554467fba969",
+        "Date": "Wed, 06 Jan 2021 01:16:29 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2f56f6a-143b-44e8-97df-5fe53534c010",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "355",
-        "x-request-id": "c06f4924-a3fc-438c-b8a9-3142624dfe3b"
+        "x-envoy-upstream-service-time": "2567",
+        "x-request-id": "53b4f8a5-b47d-4c71-a2d1-b143b22e64ee"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6a1bc159-e1ea-4ef4-ae37-554467fba969",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2f56f6a-143b-44e8-97df-5fe53534c010",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a07edc8e0079f249b25422e92bc56129-f3313ac3b9af5042-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-105144e7fb79fa4b980e70d006b60e3a-a90c9a09caa0684d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1986a5cf274fbe6bdd8c8586a6fcf6f3",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "547fa428-cd3d-4a34-ae60-9f5200ecc242",
-        "Content-Length": "972",
+        "apim-request-id": "6f533167-0b98-455c-8a33-1f5fa42d608e",
+        "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:26 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "145",
-        "x-request-id": "547fa428-cd3d-4a34-ae60-9f5200ecc242"
+        "x-envoy-upstream-service-time": "347",
+        "x-request-id": "6f533167-0b98-455c-8a33-1f5fa42d608e"
       },
       "ResponseBody": {
-        "dataFeedId": "6a1bc159-e1ea-4ef4-ae37-554467fba969",
+        "dataFeedId": "b2f56f6a-143b-44e8-97df-5fe53534c010",
         "dataFeedName": "dataFeedNmL1hh6d",
         "metrics": [
           {
-            "metricId": "c23d2e27-0368-4c5f-a4ae-a0475418d295",
+            "metricId": "6373d1a2-96dd-4c6e-889e-595a6c2f2099",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,25 +104,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:27Z",
+        "createdTime": "2021-01-06T01:16:30Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6a1bc159-e1ea-4ef4-ae37-554467fba969",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2f56f6a-143b-44e8-97df-5fe53534c010",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5d60d1622de3d942a61d745cf98582c7-17a5b43ca6e5be4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9e2698e1795eb84a9c0b6a4f97b0c749-765cf73b3c1b364e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "925117ff88fbe1c4e8b6147960e3e6d2",
         "x-ms-return-client-request-id": "true"
@@ -130,19 +130,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "707a2db3-3fc3-4071-b383-652409f1bd2a",
+        "apim-request-id": "8ecf9ec0-ef8e-48fd-a726-55ec62aa401c",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:27 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "306",
-        "x-request-id": "707a2db3-3fc3-4071-b383-652409f1bd2a"
+        "x-envoy-upstream-service-time": "1244",
+        "x-request-id": "8ecf9ec0-ef8e-48fd-a726-55ec62aa401c"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:27.7723586-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:31.2488462-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithMinimumSetupAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithMinimumSetupAsync.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-423e741b1c9e1641811d8ece284355eb-2b384a5268103548-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-40f45572748bb64a99e2b325e02153cc-5c774a549cd6064d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "803a41bc02b9197fad305d2a64fbce1d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,25 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e1d61e80-26a3-4ab7-a073-a978337a7e03",
+        "apim-request-id": "9620169c-cbf2-4018-8c4e-6f5c7a68288d",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:07 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/885227c7-b6b0-4c87-affc-4362c74b9bb8",
+        "Date": "Wed, 06 Jan 2021 01:16:50 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5cb174d5-0fe5-4bad-8198-d0ee7bddc3a3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5603",
-        "x-request-id": "e1d61e80-26a3-4ab7-a073-a978337a7e03"
+        "x-envoy-upstream-service-time": "787",
+        "x-request-id": "9620169c-cbf2-4018-8c4e-6f5c7a68288d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/885227c7-b6b0-4c87-affc-4362c74b9bb8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5cb174d5-0fe5-4bad-8198-d0ee7bddc3a3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-10f4430e1983a34d9bdbf4fa172fd12b-e5a4f20a06005c4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-aec7cf5c3645024ab06fa80d44aa4a04-970e834a6ba45742-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "aea27b05bab7670b914670a7edc9730a",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "885caf6e-051c-4ede-abe8-bc4bdbb6df08",
-        "Content-Length": "972",
+        "apim-request-id": "448c227f-db28-4278-8f59-0423903e4638",
+        "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:07 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "142",
-        "x-request-id": "885caf6e-051c-4ede-abe8-bc4bdbb6df08"
+        "x-request-id": "448c227f-db28-4278-8f59-0423903e4638"
       },
       "ResponseBody": {
-        "dataFeedId": "885227c7-b6b0-4c87-affc-4362c74b9bb8",
+        "dataFeedId": "5cb174d5-0fe5-4bad-8198-d0ee7bddc3a3",
         "dataFeedName": "dataFeeddXPBUZuE",
         "metrics": [
           {
-            "metricId": "3467fbfa-8108-4134-a73d-bbc425bc30a6",
+            "metricId": "db03ce5f-2f44-4394-84aa-1c5a2992078b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,25 +104,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:07Z",
+        "createdTime": "2021-01-06T01:16:50Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/885227c7-b6b0-4c87-affc-4362c74b9bb8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5cb174d5-0fe5-4bad-8198-d0ee7bddc3a3",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9131c154441d2f48ba41c4104080b959-3eacb95644491546-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d3f34dc4f9bb624badcb461e6d270e07-3ec9d671e582ed4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a09abd499ef9b857dea19787ca178b48",
         "x-ms-return-client-request-id": "true"
@@ -130,19 +130,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2cdbe2fc-90cb-444c-9bec-09e01fa740cd",
+        "apim-request-id": "62847f29-f3f0-452d-9dd6-d916de5e15df",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:08 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "279",
-        "x-request-id": "2cdbe2fc-90cb-444c-9bec-09e01fa740cd"
+        "x-envoy-upstream-service-time": "290",
+        "x-request-id": "62847f29-f3f0-452d-9dd6-d916de5e15df"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:08.3323801-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:50.7757288-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembers.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "941",
+        "Content-Length": "958",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-349e2f38967f5b4e8b8e8b6f3f5d01e7-aa2a24a5effaf74a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-af040b5d97a68546a57ef307560f82d7-f9d74fa7cb29574e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "af2b7c7871b91bd4401c67ca0b5cb216",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -60,25 +60,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "db1d3279-2221-4bee-8724-8d3ea2457f3e",
+        "apim-request-id": "8f6b9c88-bcef-4f47-bb3b-c0b8367210e4",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a346370-9225-4ec0-9c01-00b4dbf6cd45",
+        "Date": "Wed, 06 Jan 2021 01:16:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "547",
-        "x-request-id": "db1d3279-2221-4bee-8724-8d3ea2457f3e"
+        "x-envoy-upstream-service-time": "617",
+        "x-request-id": "8f6b9c88-bcef-4f47-bb3b-c0b8367210e4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a346370-9225-4ec0-9c01-00b4dbf6cd45",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9d38578c4ede6499fcc686c3053cbab-aa4a81b339974a4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6b04d94007ed3c4892a995e3787e26b5-5c965c769a1f8b42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a593b2c625c77ac8c27845ca207e80d7",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +86,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e6b3771a-a05a-4149-a2e4-22cc1e66ca82",
-        "Content-Length": "1382",
+        "apim-request-id": "889b28fe-4841-4814-8384-a42644e05230",
+        "Content-Length": "1399",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:28 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "137",
-        "x-request-id": "e6b3771a-a05a-4149-a2e4-22cc1e66ca82"
+        "x-envoy-upstream-service-time": "188",
+        "x-request-id": "889b28fe-4841-4814-8384-a42644e05230"
       },
       "ResponseBody": {
-        "dataFeedId": "7a346370-9225-4ec0-9c01-00b4dbf6cd45",
+        "dataFeedId": "4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
         "dataFeedName": "dataFeedhbJW7QYR",
         "metrics": [
           {
-            "metricId": "d45b91a4-144f-4458-9db1-44131ebc1cd2",
+            "metricId": "b4f55d5a-d787-4c51-b254-c541c88dbd4c",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "216aeb1e-cf3e-4adb-872d-87dcd4574eb2",
+            "metricId": "e0d028be-f016-4ada-afec-b141d1270d55",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -146,25 +146,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:28Z",
+        "createdTime": "2021-01-06T01:16:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a346370-9225-4ec0-9c01-00b4dbf6cd45",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-62ff1742d60d5e408679dc93e1041148-7dd1165a12ea8c40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fb7d899af0a12d4cb1ccded4dfe26f27-d21881dc01405d46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "19edf8c3f813d79ac844236d00770864",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e5ede4e2-9610-46cb-8418-6e4ff185944b",
+        "apim-request-id": "93fe6b08-48cc-464a-90e0-65b1bec2d7ed",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:28 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "363",
-        "x-request-id": "e5ede4e2-9610-46cb-8418-6e4ff185944b"
+        "x-envoy-upstream-service-time": "406",
+        "x-request-id": "93fe6b08-48cc-464a-90e0-65b1bec2d7ed"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:28.9839955-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:33.7057747-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembersAsync.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "941",
+        "Content-Length": "958",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f0c7e2ee26187840952a946d54772441-8f8280916a96db4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2cdc87f1c3b22148b6a26544811b00b9-07377f662f324e44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3909fd4e55f30a9aa785e1bb36e7b39c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -60,25 +60,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2a72180f-dc83-4f5d-8a0e-4468975fedeb",
+        "apim-request-id": "287064a2-1d59-423e-886d-f920d34eb64e",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:08 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1f5a978-9456-4537-aea4-546396fd587f",
+        "Date": "Wed, 06 Jan 2021 01:16:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16313af2-1eff-498a-9374-d99c24fbeb8b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "723",
-        "x-request-id": "2a72180f-dc83-4f5d-8a0e-4468975fedeb"
+        "x-envoy-upstream-service-time": "821",
+        "x-request-id": "287064a2-1d59-423e-886d-f920d34eb64e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1f5a978-9456-4537-aea4-546396fd587f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16313af2-1eff-498a-9374-d99c24fbeb8b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21bbfab4162bed4fa7a29426fd5cfc50-9bfda73c4291914c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-61432dae6b4ba14ea3566952963435e8-7045888077b6c148-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f53c27492da1152d42d342afc31ea40c",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +86,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8dec7ee3-289f-447e-ac75-7eae075de902",
-        "Content-Length": "1382",
+        "apim-request-id": "1e91993e-09ae-42ac-96f8-7389e98384c1",
+        "Content-Length": "1399",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:09 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "176",
-        "x-request-id": "8dec7ee3-289f-447e-ac75-7eae075de902"
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "1e91993e-09ae-42ac-96f8-7389e98384c1"
       },
       "ResponseBody": {
-        "dataFeedId": "a1f5a978-9456-4537-aea4-546396fd587f",
+        "dataFeedId": "16313af2-1eff-498a-9374-d99c24fbeb8b",
         "dataFeedName": "dataFeedjYFWDipg",
         "metrics": [
           {
-            "metricId": "56201a12-21ee-453e-80eb-7c3fe401d940",
+            "metricId": "27d32bc7-2600-4540-b8d2-f77ce7f3ffe6",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "1fc24cca-ddac-46ff-9cdb-56323e3d5307",
+            "metricId": "9b2b6bb5-5f31-4206-bf9a-b403d44a120b",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -146,25 +146,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:09Z",
+        "createdTime": "2021-01-06T01:16:51Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1f5a978-9456-4537-aea4-546396fd587f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16313af2-1eff-498a-9374-d99c24fbeb8b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-faf8842b6d7e6f4bb12fdcd80235ac5b-ec41e6c4b8777f40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7634f94b45b3f14d8604e6b7ddf7d108-e80b5c4b2161ca49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "357356c832e57433690de79c0ed76146",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0b2dd220-6abc-48df-819e-a6f1a5970117",
+        "apim-request-id": "b02c7aa9-4b82-489b-8879-b7152d33c725",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:09 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "352",
-        "x-request-id": "0b2dd220-6abc-48df-819e-a6f1a5970117"
+        "x-envoy-upstream-service-time": "344",
+        "x-request-id": "b02c7aa9-4b82-489b-8879-b7152d33c725"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:09.8920237-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:52.6632029-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,277 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "268",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4bb2e9f36644e54aa8b50763a508d4af-c82fade3b317fd4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6d6e742fc64fdcfa864a5b0a67644d4b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedqF5usX2A",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "c3925ec6-f888-4f29-b3c7-5d1ae23b6905",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "1029",
+        "x-request-id": "c3925ec6-f888-4f29-b3c7-5d1ae23b6905"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-681739af23ea1a4984eaf30952716392-8bedbe526e5e254f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9ee5b684ac1ceb6943566b8bbff6179f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d8697900-1264-4667-b877-d693fbdda259",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "871",
+        "x-request-id": "d8697900-1264-4667-b877-d693fbdda259"
+      },
+      "ResponseBody": {
+        "dataFeedId": "0a556679-96b5-4b45-a58e-94cf7a7cadab",
+        "dataFeedName": "dataFeedqF5usX2A",
+        "metrics": [
+          {
+            "metricId": "239cb279-7eb6-4d71-8f28-886dad4e2f07",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureBlob",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:09Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "container": "container",
+          "connectionString": "Sanitized",
+          "blobTemplate": "template"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "694",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8786d0b11abd0c47934f2c378f5d1c27-c77809584320e94e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c81800b28ea2db73a565a51e0ea9d58a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedqF5usX2A",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "37703e64-199e-4949-85b9-9c7f9831f363",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "887",
+        "x-request-id": "37703e64-199e-4949-85b9-9c7f9831f363"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2b65daabfac7654983a9038eaee707a0-1a0b91d2fee78a40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "756c1b1bd0cc837a0a8329f95a6e1c8f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c529c7f6-464e-4d55-b85e-3bfac02af619",
+        "Content-Length": "1106",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:10 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "154",
+        "x-request-id": "c529c7f6-464e-4d55-b85e-3bfac02af619"
+      },
+      "ResponseBody": {
+        "dataFeedId": "0a556679-96b5-4b45-a58e-94cf7a7cadab",
+        "dataFeedName": "dataFeedqF5usX2A",
+        "metrics": [
+          {
+            "metricId": "239cb279-7eb6-4d71-8f28-886dad4e2f07",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureBlob",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:09Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "container": "container",
+          "connectionString": "Sanitized",
+          "blobTemplate": "template"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8eff262168a8b3428d0c877605838047-40ff5dcbd7f36d44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6657bb32854cf5a84209f9b7064bdc9a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "c839df07-b47f-4529-83eb-5e61a8704662",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "285",
+        "x-request-id": "c839df07-b47f-4529-83eb-5e61a8704662"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:11.7458807-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "2048713368"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,277 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "268",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9cb68e5d2c1e5140bfc9455e28a57262-92801c9a7e0a6e4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f9bdc89e03fc41c8e66c1c7e3737afee",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedUKzatqz4",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "e764178a-2433-442c-8f1c-c9e3dd287728",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "433",
+        "x-request-id": "e764178a-2433-442c-8f1c-c9e3dd287728"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ee249538e905b94baea2ddbfdf389557-7d317609acd24b4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f6ce5f57d4e9b4d0245ad529c5d00b4e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "479d60f5-654a-4c95-82fe-f6530b21d21b",
+        "Content-Length": "980",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "x-request-id": "479d60f5-654a-4c95-82fe-f6530b21d21b"
+      },
+      "ResponseBody": {
+        "dataFeedId": "55da68de-dd13-49b0-866c-88467b4760b4",
+        "dataFeedName": "dataFeedUKzatqz4",
+        "metrics": [
+          {
+            "metricId": "8a3f62a6-35a7-48bd-afd8-fd0e6c0c8cb0",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureBlob",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:50Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "container": "container",
+          "connectionString": "Sanitized",
+          "blobTemplate": "template"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "694",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6050e6212ebe46459970cc8ac2387f31-c0e2c35184f7dc49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d130277b2ee4c811f697245997503e69",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedUKzatqz4",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "8aa3ed9b-090d-4fb6-93f1-d939c2673a36",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "505",
+        "x-request-id": "8aa3ed9b-090d-4fb6-93f1-d939c2673a36"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8cafccb5e631bd439cb53c61941e854c-679e41b4ed518848-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b3756cfe8d7bc9e1f709d4a12d9e7b16",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "84a3b9ab-4443-4f2f-99f4-d4d48fbc2446",
+        "Content-Length": "1106",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "x-request-id": "84a3b9ab-4443-4f2f-99f4-d4d48fbc2446"
+      },
+      "ResponseBody": {
+        "dataFeedId": "55da68de-dd13-49b0-866c-88467b4760b4",
+        "dataFeedName": "dataFeedUKzatqz4",
+        "metrics": [
+          {
+            "metricId": "8a3f62a6-35a7-48bd-afd8-fd0e6c0c8cb0",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureBlob",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:50Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "container": "container",
+          "connectionString": "Sanitized",
+          "blobTemplate": "template"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-aa4b882ab3125b4c820aeaf3571562ff-7b871740bebfa947-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0f02cd60dd0728094d050052b0771dd3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ff5c855e-b730-4805-b71a-b3b5c85dc32b",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:51 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "304",
+        "x-request-id": "ff5c855e-b730-4805-b71a-b3b5c85dc32b"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:51.2031444-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "879095224"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,200 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "268",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-db3b7caa3fb2df4887e3c01b649eb775-84d5a1b30ae30c4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c45aab0de04a9efd5ac9427098b58dd7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedhmzpGlfW",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "082d1fe0-3cc1-402b-8fc6-c58b08e41fa0",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:11 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "347",
+        "x-request-id": "082d1fe0-3cc1-402b-8fc6-c58b08e41fa0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "582",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ea11a6f1a7c1c240968ffc0b8ef2f7e0-46254f3036329749-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "09af9614f017f813256973132d590ef0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedhmzpGlfW",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "38245667-0bd0-4a70-8e8c-3b8423c3706e",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "449",
+        "x-request-id": "38245667-0bd0-4a70-8e8c-3b8423c3706e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5c90877a6f89d24f991d7515cf9214c3-ee9a8495afde204c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f4239f0252cf055f46bab92c35ff5e42",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "24a8ce93-919d-4f80-8135-747b619cea6d",
+        "Content-Length": "1106",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "x-request-id": "24a8ce93-919d-4f80-8135-747b619cea6d"
+      },
+      "ResponseBody": {
+        "dataFeedId": "4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+        "dataFeedName": "dataFeedhmzpGlfW",
+        "metrics": [
+          {
+            "metricId": "0ab4098e-64fa-4af4-b284-5820651f9ee4",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureBlob",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:12Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "container": "container",
+          "connectionString": "Sanitized",
+          "blobTemplate": "template"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6649cab08d2a914b8d85398a5894925c-8342bc4851d71246-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0f7d320a9cd11c3397619fe06de97100",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "f36081e4-0119-453b-a16f-228815e6d56d",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "332",
+        "x-request-id": "f36081e4-0119-453b-a16f-228815e6d56d"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:13.3579759-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "2065298391"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,200 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "268",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c371515a9d0cea4f8ddb4ebc9e2f21dd-33a92a982fe8524a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "edbe7778cea33f93c9e673868c67afaf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedjowDOhD4",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "01fd1782-5774-40fc-b480-364f913806df",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "373",
+        "x-request-id": "01fd1782-5774-40fc-b480-364f913806df"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "582",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7c3fa1c69e235f4799f940b4f2744721-e9d6d8b4a7f58a49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1c11af763e8fe5cac941b0ed63aa68ff",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "container": "container",
+          "blobTemplate": "template"
+        },
+        "dataSourceType": "AzureBlob",
+        "dataFeedName": "dataFeedjowDOhD4",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b31fab53-8de8-4512-a6c9-df3b9742a9f1",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "450",
+        "x-request-id": "b31fab53-8de8-4512-a6c9-df3b9742a9f1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d07afbcb2a94ba459c4eda900912e6b2-e4d30c41bdd50148-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "889f4460539853159c926fe95d7cc6c7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "963d4607-bf17-4b58-b85f-b456d1833744",
+        "Content-Length": "1106",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "151",
+        "x-request-id": "963d4607-bf17-4b58-b85f-b456d1833744"
+      },
+      "ResponseBody": {
+        "dataFeedId": "e95a1309-2acb-497e-b88e-16ff9c9287cd",
+        "dataFeedName": "dataFeedjowDOhD4",
+        "metrics": [
+          {
+            "metricId": "ec7c0584-77d7-4dce-8a5b-d68d0a2bcdb2",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureBlob",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:51Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "container": "container",
+          "connectionString": "Sanitized",
+          "blobTemplate": "template"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7d412a4758ce7343a7904e15f1a58b55-178902b8146df34c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "15d9f8c3a2ca398dadd923621ea5dc1f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "e547520d-146b-4310-b14e-7e958ebfeb58",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:52 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "309",
+        "x-request-id": "e547520d-146b-4310-b14e-7e958ebfeb58"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:52.8032228-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1216453362"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,285 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "329",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-97a5da7b0f0e90478f79e701af2bd1fb-28ba38e9523ed844-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f053d72379e1480dc5202fe7cea0fb98",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeedoowhDb3K",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "8810e891-1533-4872-8401-438dc5f0ed77",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "368",
+        "x-request-id": "8810e891-1533-4872-8401-438dc5f0ed77"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4c8b06dd7bc051488dbf16e3ef45c3fd-056cf5facc5c6241-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "740de7bae6c71c05cc3fa7f9a3d5b98e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1a461423-23e9-464a-9c7a-8df922b64df3",
+        "Content-Length": "1041",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "151",
+        "x-request-id": "1a461423-23e9-464a-9c7a-8df922b64df3"
+      },
+      "ResponseBody": {
+        "dataFeedId": "2457caa0-03b0-4c07-9ff7-347b8995aecd",
+        "dataFeedName": "dataFeedoowhDb3K",
+        "metrics": [
+          {
+            "metricId": "e8e9f5db-d063-42a0-a3a0-145378b7767d",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:14Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "fileTemplate": "file",
+          "accountName": "account",
+          "directoryTemplate": "dir",
+          "fileSystemName": "fileSystem",
+          "accountKey": "Sanitized"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "755",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-48d860ee23f947438970eb3c853e43e1-85d9f15c32dae143-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8410b2209b4202c320076f6f6961f7a8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeedoowhDb3K",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "bef9e111-3b50-4a1f-b006-eec6cd9f7378",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "470",
+        "x-request-id": "bef9e111-3b50-4a1f-b006-eec6cd9f7378"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c643989cef5c4744ace3f67cd2dd8288-482e01cadc51614d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "047b95db0e1b3c8ed13624a1d214a5ef",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "1685ae02-c8b7-49a2-9492-8ec2787cebd5",
+        "Content-Length": "1167",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "147",
+        "x-request-id": "1685ae02-c8b7-49a2-9492-8ec2787cebd5"
+      },
+      "ResponseBody": {
+        "dataFeedId": "2457caa0-03b0-4c07-9ff7-347b8995aecd",
+        "dataFeedName": "dataFeedoowhDb3K",
+        "metrics": [
+          {
+            "metricId": "e8e9f5db-d063-42a0-a3a0-145378b7767d",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:14Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "fileTemplate": "file",
+          "accountName": "account",
+          "directoryTemplate": "dir",
+          "fileSystemName": "fileSystem",
+          "accountKey": "Sanitized"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d7c098caaeb78d4084a0a836fee13c1c-3db72a6add8de041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1cc6a06677901f55240b54c07795b36a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "23490b98-91ad-4e43-a011-4867ad6d1cb3",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "339",
+        "x-request-id": "23490b98-91ad-4e43-a011-4867ad6d1cb3"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:15.0128906-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1519731926"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,285 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "329",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-aabed615a3101c44a75dbd0403585c47-b11db76c2d5a8040-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e8338ea419d97e107e735ffbfa09de12",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeeddTt9Ks3M",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "5d9e63dc-471e-4361-8aba-29361cc01d6c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:53 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "406",
+        "x-request-id": "5d9e63dc-471e-4361-8aba-29361cc01d6c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4fd82a9690e4ff4d8adb6324377b1582-04707fe931687444-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6bbc6e336e07cae5b3cfbb29451b18cd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7c4593ff-ee90-4e55-946b-517209eabe56",
+        "Content-Length": "1041",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:53 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "181",
+        "x-request-id": "7c4593ff-ee90-4e55-946b-517209eabe56"
+      },
+      "ResponseBody": {
+        "dataFeedId": "b338e572-c6ff-4fa2-bb3f-901035743fe8",
+        "dataFeedName": "dataFeeddTt9Ks3M",
+        "metrics": [
+          {
+            "metricId": "7a126619-f8f8-4132-9201-ceefc0a4b9be",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:53Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "fileTemplate": "file",
+          "accountName": "account",
+          "directoryTemplate": "dir",
+          "fileSystemName": "fileSystem",
+          "accountKey": "Sanitized"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "755",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-90192f94911a264f8e923b36eca100d1-97e34491493c9943-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6dd05ee0b33f0732a71aadfadb66f67b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeeddTt9Ks3M",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b5cf2541-dc52-4239-bd86-7d5fb5c42d97",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "527",
+        "x-request-id": "b5cf2541-dc52-4239-bd86-7d5fb5c42d97"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0439e1df3a97f04f9306878fbfaa43b5-8ac4cdb18a702b42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "64596e3cc0a73540a969340a5de63862",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b9be27a4-bad6-4183-927f-5c4de825e65c",
+        "Content-Length": "1167",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "178",
+        "x-request-id": "b9be27a4-bad6-4183-927f-5c4de825e65c"
+      },
+      "ResponseBody": {
+        "dataFeedId": "b338e572-c6ff-4fa2-bb3f-901035743fe8",
+        "dataFeedName": "dataFeeddTt9Ks3M",
+        "metrics": [
+          {
+            "metricId": "7a126619-f8f8-4132-9201-ceefc0a4b9be",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:53Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "fileTemplate": "file",
+          "accountName": "account",
+          "directoryTemplate": "dir",
+          "fileSystemName": "fileSystem",
+          "accountKey": "Sanitized"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cb682ce5fbb13b408e2d0f25da90d242-a7629b4d42e60d4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9b1a925b70397fd23bb5c4edc1eaee4c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d1ce70dd-e756-4145-a258-6c1b8eda7553",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:54 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "325",
+        "x-request-id": "d1ce70dd-e756-4145-a258-6c1b8eda7553"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:54.6430576-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1628686579"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,206 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "329",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-84110c6f08b33740a840cd26b18d88f8-80084592b458fd49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "52c6924059bb021efd3d84a0c9f43f6f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeedR9uSeUfm",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "79ca435e-fd85-4ba2-81e2-90b284ebfb49",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "358",
+        "x-request-id": "79ca435e-fd85-4ba2-81e2-90b284ebfb49"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "643",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-554d21702927774db29051a47e40a649-27ae46557bddcc4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "48a37f1ff2c58e7b3a0405c1a98f22c3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeedR9uSeUfm",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "3c87c662-355e-4e08-af2a-2bf1e1b46cd0",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "497",
+        "x-request-id": "3c87c662-355e-4e08-af2a-2bf1e1b46cd0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9d472e2b39f77f408cd68f0ebdf56d1b-90de98e98e26f64a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f44be47805913aa05ab4e7680d7034f3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "03481a87-e803-40db-904d-1e3d796429c4",
+        "Content-Length": "1167",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "156",
+        "x-request-id": "03481a87-e803-40db-904d-1e3d796429c4"
+      },
+      "ResponseBody": {
+        "dataFeedId": "c28ff553-6534-4933-b364-64c3616a8666",
+        "dataFeedName": "dataFeedR9uSeUfm",
+        "metrics": [
+          {
+            "metricId": "5bc18261-eb9b-485a-8fe5-98b784021aca",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:15Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "fileTemplate": "file",
+          "accountName": "account",
+          "directoryTemplate": "dir",
+          "fileSystemName": "fileSystem",
+          "accountKey": "Sanitized"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e7614167bbd5db438bc4827ad38d14de-477d28d5ad8de442-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7765059627c24d41173717b6535c596e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "60df2f7d-6842-4f5c-bc8f-16a277f83180",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "333",
+        "x-request-id": "60df2f7d-6842-4f5c-bc8f-16a277f83180"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:16.5369509-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "435521816"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,206 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "329",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9a27a6dcd75ea944824796988ca7d2d6-503636c284a9ae45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b99024eb7d62fc8ccc1bed167b4f62f9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeedeNqX8GsA",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "73c7eb4a-25b1-41f2-97d9-76a04732afea",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "575",
+        "x-request-id": "73c7eb4a-25b1-41f2-97d9-76a04732afea"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "643",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c3272ea6cbae1b4d8044f0555a52da38-2c8299caf676394e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5fa144eaeab3e712b9d86cf08383bdf1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "accountName": "account",
+          "accountKey": "Sanitized",
+          "fileSystemName": "fileSystem",
+          "directoryTemplate": "dir",
+          "fileTemplate": "file"
+        },
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataFeedName": "dataFeedeNqX8GsA",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d3d47a63-49f4-4b0f-b26e-a07dc9eeba30",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "494",
+        "x-request-id": "d3d47a63-49f4-4b0f-b26e-a07dc9eeba30"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d484252d5dedc8499b2d8e2a6c4aba02-bf19544e6baa2140-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9b38f6b5975347f337269be11869a9c3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2710c093-a4ae-4be9-8bfc-d60106db5d96",
+        "Content-Length": "1167",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:55 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "2710c093-a4ae-4be9-8bfc-d60106db5d96"
+      },
+      "ResponseBody": {
+        "dataFeedId": "f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+        "dataFeedName": "dataFeedeNqX8GsA",
+        "metrics": [
+          {
+            "metricId": "bc6624a8-7571-4004-85ba-e984bd415f3f",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureDataLakeStorageGen2",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:55Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "fileTemplate": "file",
+          "accountName": "account",
+          "directoryTemplate": "dir",
+          "fileSystemName": "fileSystem",
+          "accountKey": "Sanitized"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c5b14e30261d3f469621b1c247189a67-b0babe1c1b3ed34d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ae8ad25d79a7005412a80089109b7849",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "f756bef9-d753-4f9d-a702-3c5b34cb6bb7",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:56 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "361",
+        "x-request-id": "f756bef9-d753-4f9d-a702-3c5b34cb6bb7"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:56.3896999-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "2033828863"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,277 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "251",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0612936691546041bda78ec4de2edf1b-55a3eed4fc4b2c49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f61cf5d2f683b04c43313fd09e441ddf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeedbvrHP8sF",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "3953a730-ae68-40f4-aeae-356a0ba4dca7",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:17 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "347",
+        "x-request-id": "3953a730-ae68-40f4-aeae-356a0ba4dca7"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0fcb5b880a15554595018674d6f551d5-ed401045096d8543-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fdb17db521f61146bfd3be1d9c505c6e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a2e3276d-0a06-4717-8081-ca7bcbbee0a0",
+        "Content-Length": "963",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "148",
+        "x-request-id": "a2e3276d-0a06-4717-8081-ca7bcbbee0a0"
+      },
+      "ResponseBody": {
+        "dataFeedId": "873ac113-6fce-4756-b096-bd8acf6ec45e",
+        "dataFeedName": "dataFeedbvrHP8sF",
+        "metrics": [
+          {
+            "metricId": "7b8342fa-c14e-4bc7-9a3a-f170cd51795d",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureTable",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:17Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query",
+          "table": "table"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "677",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a26fe626e51e514facafbb129570af1d-df188b245258854c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "79285bc202bd6e0cefed0f1b9199ebac",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeedbvrHP8sF",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b1219e19-f7ea-403c-ba60-322fdbe3adfd",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "456",
+        "x-request-id": "b1219e19-f7ea-403c-ba60-322fdbe3adfd"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4e3d2c2c31b34440a0213507a02cda78-c4f7edc15d87dc4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "30c5498141f6b103af0b36b0372f14f3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "80cc0c89-e445-4872-8889-2d3ccc60dcc3",
+        "Content-Length": "1089",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "141",
+        "x-request-id": "80cc0c89-e445-4872-8889-2d3ccc60dcc3"
+      },
+      "ResponseBody": {
+        "dataFeedId": "873ac113-6fce-4756-b096-bd8acf6ec45e",
+        "dataFeedName": "dataFeedbvrHP8sF",
+        "metrics": [
+          {
+            "metricId": "7b8342fa-c14e-4bc7-9a3a-f170cd51795d",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureTable",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:17Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query",
+          "table": "table"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-efdafb7649679d41a8fbb21f2ea82c80-621e84941d29854c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "420ed1d4a31cb32170430e08112a7f25",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "4520a83d-2b2e-46d7-a5b7-09b875aa900e",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "268",
+        "x-request-id": "4520a83d-2b2e-46d7-a5b7-09b875aa900e"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:18.2489515-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1454182824"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,277 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "251",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7772e34481aa9c4087cc46d3dc243564-dc48057e0ee53e49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b28681e140239fc41692acd9cd9ef894",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeedDnn54WoG",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "18660659-76a3-482b-810a-f126324af21f",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:56 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "578",
+        "x-request-id": "18660659-76a3-482b-810a-f126324af21f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c243431ec879324aaeca03de1bdfcfe0-cd01538124836d4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d3b147de9c6d27ba683446ee3490dc63",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "50a4fab7-82ed-44b8-bdd7-294ed7b89677",
+        "Content-Length": "963",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "50a4fab7-82ed-44b8-bdd7-294ed7b89677"
+      },
+      "ResponseBody": {
+        "dataFeedId": "13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+        "dataFeedName": "dataFeedDnn54WoG",
+        "metrics": [
+          {
+            "metricId": "0ff799c4-fa67-4f1c-afcb-a223392c13da",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureTable",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:57Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query",
+          "table": "table"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "677",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-be0531722f46d34ea4fe451bd9e9f921-a903fe06bed1d34b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "583939bff31676f370bee9f598506254",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeedDnn54WoG",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "6878ee72-97d1-4f60-9969-a61ea99b28e8",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:57 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "688",
+        "x-request-id": "6878ee72-97d1-4f60-9969-a61ea99b28e8"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-20295f05c2cd0742a9abb5624a204ced-406c994a5d54004a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e95d45b3e2a645b1c65f49eef9d56a86",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b867fbdd-cb4d-41d2-8799-9b868670d922",
+        "Content-Length": "1089",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "190",
+        "x-request-id": "b867fbdd-cb4d-41d2-8799-9b868670d922"
+      },
+      "ResponseBody": {
+        "dataFeedId": "13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+        "dataFeedName": "dataFeedDnn54WoG",
+        "metrics": [
+          {
+            "metricId": "0ff799c4-fa67-4f1c-afcb-a223392c13da",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureTable",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:57Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query",
+          "table": "table"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9011853ee574194686f0a62f6cf2c17e-2b975106e123c341-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "931949b69f65eb7d543b62afb2c58e18",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "e9dc5554-4c61-4ef5-937f-110dd3252dd6",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:58 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "283",
+        "x-request-id": "e9dc5554-4c61-4ef5-937f-110dd3252dd6"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:58.6800669-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "642859391"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,200 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "251",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-971fafe28e86ca49a71f626241c085eb-2abc96fb1d96344d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "260bbd058623fec9f18494cfd04f2165",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeed2to4oMyA",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "dfb1552c-81a4-49ba-b504-178d095ea652",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "510",
+        "x-request-id": "dfb1552c-81a4-49ba-b504-178d095ea652"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "565",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-28e99028e367e54a9f760b650257c2da-044d9dd288d9f043-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b5b2813160bb44e5702af33b14fec9ce",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeed2to4oMyA",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "75b82604-0a55-4819-9bf0-afb52d17d302",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "627",
+        "x-request-id": "75b82604-0a55-4819-9bf0-afb52d17d302"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-dc64b7445049c149a6d1c3a3970442ee-9198e8f78511a145-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1fa7953782403a7d5bd6eae27fe9bb46",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d38f2020-5d0c-4bd8-a8fc-12637a74c5ac",
+        "Content-Length": "1089",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "135",
+        "x-request-id": "d38f2020-5d0c-4bd8-a8fc-12637a74c5ac"
+      },
+      "ResponseBody": {
+        "dataFeedId": "8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+        "dataFeedName": "dataFeed2to4oMyA",
+        "metrics": [
+          {
+            "metricId": "5b390320-d6c0-4e50-ad56-3b5e1bdc1603",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureTable",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:19Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query",
+          "table": "table"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6ab14934b74fee4888ba1365c5350816-d0be8cdf2c5e1741-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fe31bae40517a50ed7c6b6f8938deaf2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "f9a54eee-bec2-4021-9010-53c5bfa64299",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "281",
+        "x-request-id": "f9a54eee-bec2-4021-9010-53c5bfa64299"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:19.9287241-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1327772396"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,200 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "251",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6e6f5350e2530745820fd3954357fc07-2781b437bc27e040-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "50e04808ced61567435a0c406948a355",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeedf4k9rJBM",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "54d7a3e8-70e5-40ea-b806-a0049e9ffb47",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:58 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "351",
+        "x-request-id": "54d7a3e8-70e5-40ea-b806-a0049e9ffb47"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "565",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-887137de5f0f6d4f974c49310fb2df99-3cb11ad5a2304348-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d049cfe3d324609d76c39dcead89f45b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "table": "table",
+          "query": "query"
+        },
+        "dataSourceType": "AzureTable",
+        "dataFeedName": "dataFeedf4k9rJBM",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "c937e8b7-0357-4052-beb6-58c8d74fe9d6",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "650",
+        "x-request-id": "c937e8b7-0357-4052-beb6-58c8d74fe9d6"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-22722f16fdfd354f99af863ef9c3d597-0d547719fc86d440-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b5b50280ea79e85060166fac21d635c6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "7ee0ee94-a657-4cfd-bd66-528fec855dc4",
+        "Content-Length": "1089",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:59 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "165",
+        "x-request-id": "7ee0ee94-a657-4cfd-bd66-528fec855dc4"
+      },
+      "ResponseBody": {
+        "dataFeedId": "9c49e989-b279-4a67-84e5-95d5086cca69",
+        "dataFeedName": "dataFeedf4k9rJBM",
+        "metrics": [
+          {
+            "metricId": "16a26ba0-8c76-4872-a41b-10d1d1d3a1cc",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "AzureTable",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:59Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query",
+          "table": "table"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-950306a936591c4dafcc6575297973ce-3c31f786fc991c4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7a65b859935b35c7aa80d912309968ba",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "0406a23a-a6f4-4a4c-b12d-b586773f17d4",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "290",
+        "x-request-id": "0406a23a-a6f4-4a4c-b12d-b586773f17d4"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:00.2686304-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "202598668"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ca19f75a7970f8408d4442f45ee941be-8c61b8ae0a6f6c45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6de39bdc4284a9498ece9640d7447235-bec3b96fc35ed64d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8d74123f5eff5d45789f511cc8c3fb12",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,25 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "656988c1-e301-4314-bd76-7552bc223416",
+        "apim-request-id": "88a9376e-fa76-43a3-8ab8-68892a9e9958",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+        "Date": "Wed, 06 Jan 2021 01:16:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "527",
-        "x-request-id": "656988c1-e301-4314-bd76-7552bc223416"
+        "x-envoy-upstream-service-time": "2509",
+        "x-request-id": "88a9376e-fa76-43a3-8ab8-68892a9e9958"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c271518563958e4a817c9adda082db28-9cea14e228b28448-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c8606364f506d246894ed21b8913bf29-1877aaf16abb4743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d709cb6bb7cdc50ae87c513d2debf4c7",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "df6d3038-16af-4f1b-aa99-fa77b0dfd840",
-        "Content-Length": "972",
+        "apim-request-id": "6f38fdce-a1e0-42c6-ba17-c05a29fe783b",
+        "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:20 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "df6d3038-16af-4f1b-aa99-fa77b0dfd840"
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "6f38fdce-a1e0-42c6-ba17-c05a29fe783b"
       },
       "ResponseBody": {
-        "dataFeedId": "7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+        "dataFeedId": "faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
         "dataFeedName": "dataFeedzAmjgdIi",
         "metrics": [
           {
-            "metricId": "d459f145-f5f9-4a0e-aac6-7a4e0a029e44",
+            "metricId": "d3111953-4b92-42aa-887a-1cda5fa1452f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,34 +104,34 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:20Z",
+        "createdTime": "2021-01-06T01:16:37Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "686",
+        "Content-Length": "703",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-01143e7d3875594590ec63bd55c912e6-46a3d54756bcdb4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2d66ca88f9cd414188d13a893fe4cb9d-7a6f3dcb98ac1d40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ab73eedd249d266f2921795eddda29c4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -161,24 +161,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fdb69aa8-a124-4ddf-81c0-7bb0fc15d77a",
+        "apim-request-id": "00151a61-8ab8-45a1-b8f9-008d560e9c84",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:21 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "667",
-        "x-request-id": "fdb69aa8-a124-4ddf-81c0-7bb0fc15d77a"
+        "x-envoy-upstream-service-time": "794",
+        "x-request-id": "00151a61-8ab8-45a1-b8f9-008d560e9c84"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09ffa0ada3f6284b90c0fa853fb88102-690d972f93c2ec47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d1209e6e6c3ec44d9805a999758bc550-bbe329133f84334e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4a8916307175877208aea4820c08308d",
         "x-ms-return-client-request-id": "true"
@@ -186,21 +186,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cfb5ec98-1063-49d0-8d13-549447fdcb8d",
-        "Content-Length": "1098",
+        "apim-request-id": "922c1100-3f04-4056-aae3-17f5c4165f0a",
+        "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:21 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "140",
-        "x-request-id": "cfb5ec98-1063-49d0-8d13-549447fdcb8d"
+        "x-envoy-upstream-service-time": "154",
+        "x-request-id": "922c1100-3f04-4056-aae3-17f5c4165f0a"
       },
       "ResponseBody": {
-        "dataFeedId": "7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+        "dataFeedId": "faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
         "dataFeedName": "dataFeedzAmjgdIi",
         "metrics": [
           {
-            "metricId": "d459f145-f5f9-4a0e-aac6-7a4e0a029e44",
+            "metricId": "d3111953-4b92-42aa-887a-1cda5fa1452f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -233,25 +233,25 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:20Z",
+        "createdTime": "2021-01-06T01:16:37Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a2506078c7474b4da83b4b14479dbfd6-4221d95cd9c5074b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e9a70797dffafb44b807092d95835397-8d32d1d00876c041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d93f89ab4f4f47745ce3aeab3eabe80e",
         "x-ms-return-client-request-id": "true"
@@ -259,19 +259,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "456067b6-10df-40cd-94ea-4d4e7551b771",
+        "apim-request-id": "92e6bec0-9125-40ba-9a60-452ab47a3fa1",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:22 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "290",
-        "x-request-id": "456067b6-10df-40cd-94ea-4d4e7551b771"
+        "x-envoy-upstream-service-time": "261",
+        "x-request-id": "92e6bec0-9125-40ba-9a60-452ab47a3fa1"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:21.8999484-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:39.3360876-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,281 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "260",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ca19f75a7970f8408d4442f45ee941be-8c61b8ae0a6f6c45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8d74123f5eff5d45789f511cc8c3fb12",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedzAmjgdIi",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "656988c1-e301-4314-bd76-7552bc223416",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:20 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "527",
+        "x-request-id": "656988c1-e301-4314-bd76-7552bc223416"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c271518563958e4a817c9adda082db28-9cea14e228b28448-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d709cb6bb7cdc50ae87c513d2debf4c7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "df6d3038-16af-4f1b-aa99-fa77b0dfd840",
+        "Content-Length": "972",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "x-request-id": "df6d3038-16af-4f1b-aa99-fa77b0dfd840"
+      },
+      "ResponseBody": {
+        "dataFeedId": "7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+        "dataFeedName": "dataFeedzAmjgdIi",
+        "metrics": [
+          {
+            "metricId": "d459f145-f5f9-4a0e-aac6-7a4e0a029e44",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "Elasticsearch",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:20Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "authHeader": "Sanitized",
+          "port": "port",
+          "query": "query",
+          "host": "host"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "686",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-01143e7d3875594590ec63bd55c912e6-46a3d54756bcdb4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ab73eedd249d266f2921795eddda29c4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedzAmjgdIi",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "fdb69aa8-a124-4ddf-81c0-7bb0fc15d77a",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "667",
+        "x-request-id": "fdb69aa8-a124-4ddf-81c0-7bb0fc15d77a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-09ffa0ada3f6284b90c0fa853fb88102-690d972f93c2ec47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "4a8916307175877208aea4820c08308d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "cfb5ec98-1063-49d0-8d13-549447fdcb8d",
+        "Content-Length": "1098",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "140",
+        "x-request-id": "cfb5ec98-1063-49d0-8d13-549447fdcb8d"
+      },
+      "ResponseBody": {
+        "dataFeedId": "7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+        "dataFeedName": "dataFeedzAmjgdIi",
+        "metrics": [
+          {
+            "metricId": "d459f145-f5f9-4a0e-aac6-7a4e0a029e44",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "Elasticsearch",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:20Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "authHeader": "Sanitized",
+          "port": "port",
+          "query": "query",
+          "host": "host"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e171d60-d1fd-4a0f-81e8-008ae02ea8f9",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a2506078c7474b4da83b4b14479dbfd6-4221d95cd9c5074b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d93f89ab4f4f47745ce3aeab3eabe80e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "456067b6-10df-40cd-94ea-4d4e7551b771",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:22 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "290",
+        "x-request-id": "456067b6-10df-40cd-94ea-4d4e7551b771"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:21.8999484-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "662718323"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c3b126fa2afb404a98d9649f6409c40b-ba1806b25115c647-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4a8b1ff696163f40b400071dab3b4fd1-b3a54dd93ca69c48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e2d8000ffbf43c0b0a4162bf2de6257b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,25 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f99f79fc-b8f5-40f5-9135-668e6ed05c22",
+        "apim-request-id": "832bd935-7abb-4b24-9322-f4dc4d09d674",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:00 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+        "Date": "Wed, 06 Jan 2021 01:16:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "344",
-        "x-request-id": "f99f79fc-b8f5-40f5-9135-668e6ed05c22"
+        "x-envoy-upstream-service-time": "722",
+        "x-request-id": "832bd935-7abb-4b24-9322-f4dc4d09d674"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-78ae133eadaeb4498b3556cbd60251ea-b5d0a2aeaad65c48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-953d6b02ac362540b6b9fa1937ba0192-4915964e1c068a40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bf6efa31a95a12eaa1e9253f3a4d5a64",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4acba8bc-5a6f-4bf3-8fc5-cc59d48594e3",
-        "Content-Length": "972",
+        "apim-request-id": "a87a1294-4fe4-4180-b0a6-c37c58f0101c",
+        "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:00 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "161",
-        "x-request-id": "4acba8bc-5a6f-4bf3-8fc5-cc59d48594e3"
+        "x-envoy-upstream-service-time": "155",
+        "x-request-id": "a87a1294-4fe4-4180-b0a6-c37c58f0101c"
       },
       "ResponseBody": {
-        "dataFeedId": "4bf755ea-8678-43a9-97eb-3c43cd24bace",
+        "dataFeedId": "0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
         "dataFeedName": "dataFeedVnhrJrLK",
         "metrics": [
           {
-            "metricId": "0a624099-f0f3-4199-bfaf-2ccf7ac0a2a6",
+            "metricId": "7fdb78ba-8ab4-419e-b3c2-8881d2dffaf8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,34 +104,34 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:00Z",
+        "createdTime": "2021-01-06T01:16:54Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "686",
+        "Content-Length": "703",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-80ee1dc93ce67b489ba3d796b1998946-b371ad1d2931f948-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f4b3d675614fd84180e6b7f6cf0efd1e-40068e9de1e5464f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e7ac2db23d949290698883d77c99e0c2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -161,24 +161,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ab4f53ca-ad4f-49a5-9419-bc561a413f23",
+        "apim-request-id": "98d35c79-3c9e-44ae-9334-a83cff0a285a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:01 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "713",
-        "x-request-id": "ab4f53ca-ad4f-49a5-9419-bc561a413f23"
+        "x-envoy-upstream-service-time": "505",
+        "x-request-id": "98d35c79-3c9e-44ae-9334-a83cff0a285a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-58272262a7178d48b3511fc992a57f17-0bbe43e689cb3e45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cf18038255986a439d4c556c925e5bf2-5dd7a863c8f19546-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "92cd326d0090652315c6410bd6cb01bc",
         "x-ms-return-client-request-id": "true"
@@ -186,21 +186,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4fe60c24-1287-42ef-99a6-51978013c27b",
-        "Content-Length": "1098",
+        "apim-request-id": "8ecd4dbd-4f79-44fd-aebd-914097b6c05c",
+        "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:01 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "145",
-        "x-request-id": "4fe60c24-1287-42ef-99a6-51978013c27b"
+        "x-envoy-upstream-service-time": "165",
+        "x-request-id": "8ecd4dbd-4f79-44fd-aebd-914097b6c05c"
       },
       "ResponseBody": {
-        "dataFeedId": "4bf755ea-8678-43a9-97eb-3c43cd24bace",
+        "dataFeedId": "0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
         "dataFeedName": "dataFeedVnhrJrLK",
         "metrics": [
           {
-            "metricId": "0a624099-f0f3-4199-bfaf-2ccf7ac0a2a6",
+            "metricId": "7fdb78ba-8ab4-419e-b3c2-8881d2dffaf8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -233,25 +233,25 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:00Z",
+        "createdTime": "2021-01-06T01:16:54Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90d6e722420f124dac0f4a9d0a28ec06-1a15759928cfc543-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d375f866ae020d4cbc1f152678890439-c6686c77459ea049-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "000cfde73e3af3e66adc55d126129607",
         "x-ms-return-client-request-id": "true"
@@ -259,19 +259,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fe87c04b-c685-466e-b02a-dd14c11effd9",
+        "apim-request-id": "3bb16972-efad-4c35-8913-4326bc1e9d5c",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:01 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "275",
-        "x-request-id": "fe87c04b-c685-466e-b02a-dd14c11effd9"
+        "x-envoy-upstream-service-time": "333",
+        "x-request-id": "3bb16972-efad-4c35-8913-4326bc1e9d5c"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:02.2262347-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:55.4302081-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,281 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "260",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c3b126fa2afb404a98d9649f6409c40b-ba1806b25115c647-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e2d8000ffbf43c0b0a4162bf2de6257b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedVnhrJrLK",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "f99f79fc-b8f5-40f5-9135-668e6ed05c22",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:00 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "344",
+        "x-request-id": "f99f79fc-b8f5-40f5-9135-668e6ed05c22"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-78ae133eadaeb4498b3556cbd60251ea-b5d0a2aeaad65c48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "bf6efa31a95a12eaa1e9253f3a4d5a64",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4acba8bc-5a6f-4bf3-8fc5-cc59d48594e3",
+        "Content-Length": "972",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:00 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "4acba8bc-5a6f-4bf3-8fc5-cc59d48594e3"
+      },
+      "ResponseBody": {
+        "dataFeedId": "4bf755ea-8678-43a9-97eb-3c43cd24bace",
+        "dataFeedName": "dataFeedVnhrJrLK",
+        "metrics": [
+          {
+            "metricId": "0a624099-f0f3-4199-bfaf-2ccf7ac0a2a6",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "Elasticsearch",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:00Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "authHeader": "Sanitized",
+          "port": "port",
+          "query": "query",
+          "host": "host"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "686",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-80ee1dc93ce67b489ba3d796b1998946-b371ad1d2931f948-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e7ac2db23d949290698883d77c99e0c2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedVnhrJrLK",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ab4f53ca-ad4f-49a5-9419-bc561a413f23",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "713",
+        "x-request-id": "ab4f53ca-ad4f-49a5-9419-bc561a413f23"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-58272262a7178d48b3511fc992a57f17-0bbe43e689cb3e45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "92cd326d0090652315c6410bd6cb01bc",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4fe60c24-1287-42ef-99a6-51978013c27b",
+        "Content-Length": "1098",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "145",
+        "x-request-id": "4fe60c24-1287-42ef-99a6-51978013c27b"
+      },
+      "ResponseBody": {
+        "dataFeedId": "4bf755ea-8678-43a9-97eb-3c43cd24bace",
+        "dataFeedName": "dataFeedVnhrJrLK",
+        "metrics": [
+          {
+            "metricId": "0a624099-f0f3-4199-bfaf-2ccf7ac0a2a6",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "Elasticsearch",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:00Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "authHeader": "Sanitized",
+          "port": "port",
+          "query": "query",
+          "host": "host"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4bf755ea-8678-43a9-97eb-3c43cd24bace",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-90d6e722420f124dac0f4a9d0a28ec06-1a15759928cfc543-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "000cfde73e3af3e66adc55d126129607",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "fe87c04b-c685-466e-b02a-dd14c11effd9",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:01 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "275",
+        "x-request-id": "fe87c04b-c685-466e-b02a-dd14c11effd9"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:02.2262347-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "308072523"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9928bc5a3284b41b2c9975cd2a771e3-cce1445bdcf05d4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-249e97995068284b9c3073add01af497-be7409cd7a18934a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "17f860f20c8c44386573122473ee4d90",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,34 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f8a06400-e0d8-4db7-a45b-12d8014c4aad",
+        "apim-request-id": "af224f5c-ab33-4c39-aefb-28a36b44ea50",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+        "Date": "Wed, 06 Jan 2021 01:16:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "518",
-        "x-request-id": "f8a06400-e0d8-4db7-a45b-12d8014c4aad"
+        "x-envoy-upstream-service-time": "584",
+        "x-request-id": "af224f5c-ab33-4c39-aefb-28a36b44ea50"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "574",
+        "Content-Length": "591",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-52bf026bdc8b824ba792d6472d2a4c56-06fdea1ae87a6c46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0787e5f52bfb304596a3921e6a79c559-7c740bb9d25e0449-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9cbb881ac730c435cefaa7376f1807b5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -83,24 +83,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4e68ab19-a614-43fa-a717-6d48489d9889",
+        "apim-request-id": "dabdfed1-5831-40ad-881c-a2b933b59d20",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:23 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "429",
-        "x-request-id": "4e68ab19-a614-43fa-a717-6d48489d9889"
+        "x-envoy-upstream-service-time": "1000",
+        "x-request-id": "dabdfed1-5831-40ad-881c-a2b933b59d20"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-49d123def4ae7340b160162f2397cc5b-21d44e707b60934e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b6f0170d5228774ba79f9e7b3bb343ca-2bf48c9dd5cb5447-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b0a81b7d3cc5b397cd06a10980e93068",
         "x-ms-return-client-request-id": "true"
@@ -108,21 +108,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "72ee413e-a11d-4476-b065-c316d7351ed7",
-        "Content-Length": "1098",
+        "apim-request-id": "8e83f614-933a-402b-96b8-a275926682fe",
+        "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:23 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "156",
-        "x-request-id": "72ee413e-a11d-4476-b065-c316d7351ed7"
+        "x-envoy-upstream-service-time": "144",
+        "x-request-id": "8e83f614-933a-402b-96b8-a275926682fe"
       },
       "ResponseBody": {
-        "dataFeedId": "f9568e30-e02b-4347-b5e3-115d71eac152",
+        "dataFeedId": "87104377-5f7f-402d-b247-49af361567d2",
         "dataFeedName": "dataFeedAii9hspN",
         "metrics": [
           {
-            "metricId": "c4d48d3d-a863-4b81-885c-d441e5812990",
+            "metricId": "3cc44bd8-9dc9-4e6f-af3f-8f31b030ac84",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -155,25 +155,25 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:22Z",
+        "createdTime": "2021-01-06T01:16:40Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d16dd6b26eb96c46a62aad9c7b500fc4-7fde0c723d6eed4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-83a76a7537bafd4f80e43f7106d9b44a-4cbc6f322eb5e642-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "75d7b091d6292bc72b3449916400d44d",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "672aa08a-4836-4aaf-87d7-c0c4d3433cdf",
+        "apim-request-id": "95477ed9-ea1f-4021-8326-1caff1558cbc",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:23 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "347",
-        "x-request-id": "672aa08a-4836-4aaf-87d7-c0c4d3433cdf"
+        "x-envoy-upstream-service-time": "280",
+        "x-request-id": "95477ed9-ea1f-4021-8326-1caff1558cbc"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:23.4609179-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:41.7754056-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,203 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "260",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c9928bc5a3284b41b2c9975cd2a771e3-cce1445bdcf05d4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "17f860f20c8c44386573122473ee4d90",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedAii9hspN",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "f8a06400-e0d8-4db7-a45b-12d8014c4aad",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:22 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "518",
+        "x-request-id": "f8a06400-e0d8-4db7-a45b-12d8014c4aad"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "574",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-52bf026bdc8b824ba792d6472d2a4c56-06fdea1ae87a6c46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9cbb881ac730c435cefaa7376f1807b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedAii9hspN",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "4e68ab19-a614-43fa-a717-6d48489d9889",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "429",
+        "x-request-id": "4e68ab19-a614-43fa-a717-6d48489d9889"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-49d123def4ae7340b160162f2397cc5b-21d44e707b60934e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b0a81b7d3cc5b397cd06a10980e93068",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "72ee413e-a11d-4476-b065-c316d7351ed7",
+        "Content-Length": "1098",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "156",
+        "x-request-id": "72ee413e-a11d-4476-b065-c316d7351ed7"
+      },
+      "ResponseBody": {
+        "dataFeedId": "f9568e30-e02b-4347-b5e3-115d71eac152",
+        "dataFeedName": "dataFeedAii9hspN",
+        "metrics": [
+          {
+            "metricId": "c4d48d3d-a863-4b81-885c-d441e5812990",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "Elasticsearch",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:22Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "authHeader": "Sanitized",
+          "port": "port",
+          "query": "query",
+          "host": "host"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f9568e30-e02b-4347-b5e3-115d71eac152",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d16dd6b26eb96c46a62aad9c7b500fc4-7fde0c723d6eed4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "75d7b091d6292bc72b3449916400d44d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "672aa08a-4836-4aaf-87d7-c0c4d3433cdf",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:23 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "347",
+        "x-request-id": "672aa08a-4836-4aaf-87d7-c0c4d3433cdf"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:23.4609179-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "693317099"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,203 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "260",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-43e8def112ca9c46bec3a80d9b4f623b-6e399705981a614d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ae40f5386870161b04ec893cb20c1391",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedCleLfrR1",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "5a55bd01-ac8a-4f77-8676-06e8110b31f4",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:02 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "612",
+        "x-request-id": "5a55bd01-ac8a-4f77-8676-06e8110b31f4"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "574",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-767355d8cc397c4aa8eb2e5a1ffffbdf-8c42fecd94c11745-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "65981d12dbf121699d71d6cd6b823ec6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "host": "host",
+          "port": "port",
+          "authHeader": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "Elasticsearch",
+        "dataFeedName": "dataFeedCleLfrR1",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "3d29bcbd-a2d7-4506-ba5a-9b5e7d2b08e0",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "667",
+        "x-request-id": "3d29bcbd-a2d7-4506-ba5a-9b5e7d2b08e0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-654a99ab7ec6d94d918500868f3a5f42-f09bf386b098f743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "02829e43e9991b4667f85c3bffc260d5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f835955b-53b6-4f2a-a8ba-b6c31b3d07ba",
+        "Content-Length": "1098",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "172",
+        "x-request-id": "f835955b-53b6-4f2a-a8ba-b6c31b3d07ba"
+      },
+      "ResponseBody": {
+        "dataFeedId": "aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+        "dataFeedName": "dataFeedCleLfrR1",
+        "metrics": [
+          {
+            "metricId": "ce141683-9769-4e6b-b050-1cdfdeb43957",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "Elasticsearch",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:03Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "authHeader": "Sanitized",
+          "port": "port",
+          "query": "query",
+          "host": "host"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2f288aea7f6df841b5d385a87b14b7fe-4010fb7e569ab64a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "03909ffd67d15c878b1e11fe914eab82",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "c38b5e6f-b268-47ba-804c-053b0f0f46f4",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:03 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "317",
+        "x-request-id": "c38b5e6f-b268-47ba-804c-053b0f0f46f4"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:04.1217943-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "294058770"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-43e8def112ca9c46bec3a80d9b4f623b-6e399705981a614d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-042dcb03a908c4438e0b27f9cdc2e590-a0047909e6ec3041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ae40f5386870161b04ec893cb20c1391",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,34 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5a55bd01-ac8a-4f77-8676-06e8110b31f4",
+        "apim-request-id": "9b79a1e2-553c-48f8-bfeb-64bb990e445c",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:02 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+        "Date": "Wed, 06 Jan 2021 01:16:56 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "612",
-        "x-request-id": "5a55bd01-ac8a-4f77-8676-06e8110b31f4"
+        "x-envoy-upstream-service-time": "695",
+        "x-request-id": "9b79a1e2-553c-48f8-bfeb-64bb990e445c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "574",
+        "Content-Length": "591",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-767355d8cc397c4aa8eb2e5a1ffffbdf-8c42fecd94c11745-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d948541ba9ba8a4bad92b2e4ef320309-fbbe479531b56c42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "65981d12dbf121699d71d6cd6b823ec6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -83,24 +83,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3d29bcbd-a2d7-4506-ba5a-9b5e7d2b08e0",
+        "apim-request-id": "1e92013b-fb81-4dd0-8185-29a7bc3a2b36",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:03 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "667",
-        "x-request-id": "3d29bcbd-a2d7-4506-ba5a-9b5e7d2b08e0"
+        "x-envoy-upstream-service-time": "545",
+        "x-request-id": "1e92013b-fb81-4dd0-8185-29a7bc3a2b36"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-654a99ab7ec6d94d918500868f3a5f42-f09bf386b098f743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c9699c8c3cf7c948bda5b2cec3e58f32-813596c3af2b4d41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "02829e43e9991b4667f85c3bffc260d5",
         "x-ms-return-client-request-id": "true"
@@ -108,21 +108,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f835955b-53b6-4f2a-a8ba-b6c31b3d07ba",
-        "Content-Length": "1098",
+        "apim-request-id": "2d153ad5-2e62-4a0a-a4e4-5046b180f6c5",
+        "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:03 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "172",
-        "x-request-id": "f835955b-53b6-4f2a-a8ba-b6c31b3d07ba"
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "2d153ad5-2e62-4a0a-a4e4-5046b180f6c5"
       },
       "ResponseBody": {
-        "dataFeedId": "aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+        "dataFeedId": "d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
         "dataFeedName": "dataFeedCleLfrR1",
         "metrics": [
           {
-            "metricId": "ce141683-9769-4e6b-b050-1cdfdeb43957",
+            "metricId": "38152a5d-6a90-48b1-836c-617601b460f6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -155,25 +155,25 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:03Z",
+        "createdTime": "2021-01-06T01:16:56Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafa0287-e255-4e8a-bc8a-dc24feffa89e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2f288aea7f6df841b5d385a87b14b7fe-4010fb7e569ab64a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e223186fb006564a920a83fa4c34a0e5-1bab2e2a7c380b4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "03909ffd67d15c878b1e11fe914eab82",
         "x-ms-return-client-request-id": "true"
@@ -181,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c38b5e6f-b268-47ba-804c-053b0f0f46f4",
+        "apim-request-id": "de2ee0df-c3ac-461a-a706-dd662aac84ce",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:03 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "317",
-        "x-request-id": "c38b5e6f-b268-47ba-804c-053b0f0f46f4"
+        "x-envoy-upstream-service-time": "295",
+        "x-request-id": "de2ee0df-c3ac-461a-a706-dd662aac84ce"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:04.1217943-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:57.6652980-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndGetInstance.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0844f5267bf76e4496f76d207b46888f-976a8fa9275baf4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5f6340cefd6426449ad230835a35a260-b5ed8207d3467243-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a839f886c17c3077113b55c02cdb02aa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,25 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f3ccd9d0-dc49-4774-bd93-738e3bbbbfd6",
+        "apim-request-id": "237ed90a-84e9-4586-95d0-e56bc5124caa",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3a87a6b-4859-4866-bd50-29c2511215d4",
+        "Date": "Wed, 06 Jan 2021 01:16:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41c1f14f-0315-49c7-8b77-c1574d8b5317",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "337",
-        "x-request-id": "f3ccd9d0-dc49-4774-bd93-738e3bbbbfd6"
+        "x-envoy-upstream-service-time": "574",
+        "x-request-id": "237ed90a-84e9-4586-95d0-e56bc5124caa"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3a87a6b-4859-4866-bd50-29c2511215d4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41c1f14f-0315-49c7-8b77-c1574d8b5317",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a31e90fe403af94e9e757686bbc9dbf3-4c75405228b22749-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4691d59ff18b11449d857f31ae81a886-adbd54325590cf4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "19440eea863f249ccb75473af7e276fe",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7e95c8d1-7c2b-4b8c-afae-d3cd69895250",
-        "Content-Length": "972",
+        "apim-request-id": "8bb98ab0-7b1a-4b94-b82f-c75ceb7370e6",
+        "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:19 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "7e95c8d1-7c2b-4b8c-afae-d3cd69895250"
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "8bb98ab0-7b1a-4b94-b82f-c75ceb7370e6"
       },
       "ResponseBody": {
-        "dataFeedId": "d3a87a6b-4859-4866-bd50-29c2511215d4",
+        "dataFeedId": "41c1f14f-0315-49c7-8b77-c1574d8b5317",
         "dataFeedName": "dataFeed9c6QIp5T",
         "metrics": [
           {
-            "metricId": "7282cdcd-307b-455e-a6b4-aa893f238811",
+            "metricId": "f5d11fc8-c4bc-495f-825f-6e543f08e228",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,34 +104,34 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:19Z",
+        "createdTime": "2021-01-06T01:16:42Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3a87a6b-4859-4866-bd50-29c2511215d4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41c1f14f-0315-49c7-8b77-c1574d8b5317",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "611",
+        "Content-Length": "628",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-20ab88dae6200d43a39abda54dac0f79-c974f36ef5665f40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7bbb2326a6795e48886ee0fdc05dd204-b035c021c4b1204a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2dadd2741316533dfc314502a68ee505",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -159,24 +159,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "bb7e326b-deef-4d21-bda9-f512a685f02b",
+        "apim-request-id": "bd7f8eb6-cf51-4d0a-a1ab-2a83bfcff5ca",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:19 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "448",
-        "x-request-id": "bb7e326b-deef-4d21-bda9-f512a685f02b"
+        "x-envoy-upstream-service-time": "877",
+        "x-request-id": "bd7f8eb6-cf51-4d0a-a1ab-2a83bfcff5ca"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3a87a6b-4859-4866-bd50-29c2511215d4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41c1f14f-0315-49c7-8b77-c1574d8b5317",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5e6522e8a14f1c43a39322df3f88be35-bf0808f9da567b45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1d2fac6141761e41a59a3a63de413e3d-95d47515e57aa64f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "49eeeac2cd5eff185c15dd07793c392e",
         "x-ms-return-client-request-id": "true"
@@ -184,21 +184,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "83d6aba5-15d5-46a0-b3b8-4ae3433cb5d6",
-        "Content-Length": "1023",
+        "apim-request-id": "d68f87f3-b6bd-4611-b6be-0b32b73fb34d",
+        "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:19 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "83d6aba5-15d5-46a0-b3b8-4ae3433cb5d6"
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "d68f87f3-b6bd-4611-b6be-0b32b73fb34d"
       },
       "ResponseBody": {
-        "dataFeedId": "d3a87a6b-4859-4866-bd50-29c2511215d4",
+        "dataFeedId": "41c1f14f-0315-49c7-8b77-c1574d8b5317",
         "dataFeedName": "dataFeed9c6QIp5T",
         "metrics": [
           {
-            "metricId": "7282cdcd-307b-455e-a6b4-aa893f238811",
+            "metricId": "f5d11fc8-c4bc-495f-825f-6e543f08e228",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -229,25 +229,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:19Z",
+        "createdTime": "2021-01-06T01:16:42Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3a87a6b-4859-4866-bd50-29c2511215d4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/41c1f14f-0315-49c7-8b77-c1574d8b5317",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3a055e950bc08042a349ffd3c1388a10-2e8bebbc933f2040-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0f081ee18f543344ab45185b28476a96-0bfa69589cc36544-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5a4b57c4d42ed694d1f01d0d41997d3c",
         "x-ms-return-client-request-id": "true"
@@ -255,19 +255,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "28af94f0-28e5-4af5-9da0-cc72f21a1b71",
+        "apim-request-id": "23dfc559-139f-44a1-bcc3-a50cd6be6fad",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:20 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "287",
-        "x-request-id": "28af94f0-28e5-4af5-9da0-cc72f21a1b71"
+        "x-envoy-upstream-service-time": "324",
+        "x-request-id": "23dfc559-139f-44a1-bcc3-a50cd6be6fad"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:20.7182662-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:44.4558546-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndGetInstanceAsync.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e4cd5dd66263f34fbfa9a72d4583b9bf-1dc6e1f1661ed842-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-35a9733020f9f54284c92bdd84aa7a31-75e602195864f943-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "00bbe17a44e2e7c7de3468b347f6023d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,25 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f1d8fc55-1073-42f4-8edb-83fda4c64f39",
+        "apim-request-id": "31e026b6-63da-4733-babf-443ebbcc0564",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:29 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/26b93799-7af1-424e-b38d-591b2afbc232",
+        "Date": "Wed, 06 Jan 2021 01:16:58 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964b686f-3516-45d8-9c67-98e11dac967f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "550",
-        "x-request-id": "f1d8fc55-1073-42f4-8edb-83fda4c64f39"
+        "x-envoy-upstream-service-time": "514",
+        "x-request-id": "31e026b6-63da-4733-babf-443ebbcc0564"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/26b93799-7af1-424e-b38d-591b2afbc232",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964b686f-3516-45d8-9c67-98e11dac967f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-411e38d317b29447ab513e73b2f6f0d6-681976248dcc4b44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-83e0bc92a624584fb5895bb2801c336a-a71005d6a4481344-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3af98b08657842473e300b49fb11ee9e",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7c4340cf-d309-4e08-b005-713535ffc846",
-        "Content-Length": "972",
+        "apim-request-id": "044cf665-f202-4394-ba30-e2e7b2297964",
+        "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:29 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "7c4340cf-d309-4e08-b005-713535ffc846"
+        "x-envoy-upstream-service-time": "149",
+        "x-request-id": "044cf665-f202-4394-ba30-e2e7b2297964"
       },
       "ResponseBody": {
-        "dataFeedId": "26b93799-7af1-424e-b38d-591b2afbc232",
+        "dataFeedId": "964b686f-3516-45d8-9c67-98e11dac967f",
         "dataFeedName": "dataFeedqOdtATNM",
         "metrics": [
           {
-            "metricId": "1c81164d-c613-4f28-b9a0-127abf00d5e0",
+            "metricId": "809d7b19-08df-4ac0-8c29-fb2fcd4ebded",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,34 +104,34 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:29Z",
+        "createdTime": "2021-01-06T01:16:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/26b93799-7af1-424e-b38d-591b2afbc232",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964b686f-3516-45d8-9c67-98e11dac967f",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "611",
+        "Content-Length": "628",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-370d8477747a6849921a69d6280ce197-ea1b91e85f3a694f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-75aec238a2f7c249b38764cab22755b0-559516d7c3abe240-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8a75ef743a97bdc1df27d500bd795045",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -159,24 +159,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "60031db1-2e6f-4a10-a1da-3f15c1009824",
+        "apim-request-id": "13d7e588-bdd9-406b-859a-b0b0a3eab818",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:30 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "706",
-        "x-request-id": "60031db1-2e6f-4a10-a1da-3f15c1009824"
+        "x-envoy-upstream-service-time": "690",
+        "x-request-id": "13d7e588-bdd9-406b-859a-b0b0a3eab818"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/26b93799-7af1-424e-b38d-591b2afbc232",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964b686f-3516-45d8-9c67-98e11dac967f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09cbb5684a44984d9d802faed140e6de-f140015076a35a4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b5e346371d6cfe45829fc7517c071ed0-3f43a3c9039a7f44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "35d75b0a628c14649978c1b2397eeccd",
         "x-ms-return-client-request-id": "true"
@@ -184,21 +184,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d41104e6-dfed-4600-be54-0d63a41b2a51",
-        "Content-Length": "1023",
+        "apim-request-id": "3e1c615a-17f1-4c32-90f7-c03f9d765581",
+        "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:30 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "d41104e6-dfed-4600-be54-0d63a41b2a51"
+        "x-envoy-upstream-service-time": "172",
+        "x-request-id": "3e1c615a-17f1-4c32-90f7-c03f9d765581"
       },
       "ResponseBody": {
-        "dataFeedId": "26b93799-7af1-424e-b38d-591b2afbc232",
+        "dataFeedId": "964b686f-3516-45d8-9c67-98e11dac967f",
         "dataFeedName": "dataFeedqOdtATNM",
         "metrics": [
           {
-            "metricId": "1c81164d-c613-4f28-b9a0-127abf00d5e0",
+            "metricId": "809d7b19-08df-4ac0-8c29-fb2fcd4ebded",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -229,25 +229,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:29Z",
+        "createdTime": "2021-01-06T01:16:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/26b93799-7af1-424e-b38d-591b2afbc232",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964b686f-3516-45d8-9c67-98e11dac967f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21daf5ece367234dbce8601cdb8a3ef2-3c83dde484ffe44f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ef60e77dfb6bd049b905fd6387195a05-2d29419c3e1cc843-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "583fc9457780cda6c93c5a51904685c4",
         "x-ms-return-client-request-id": "true"
@@ -255,19 +255,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "642830ae-6d15-49bc-8d34-c877a54225e2",
+        "apim-request-id": "deeb54e0-3c0b-47ba-82f5-9b6eb394b2cb",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:30 GMT",
+        "Date": "Wed, 06 Jan 2021 01:17:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "265",
-        "x-request-id": "642830ae-6d15-49bc-8d34-c877a54225e2"
+        "x-envoy-upstream-service-time": "401",
+        "x-request-id": "deeb54e0-3c0b-47ba-82f5-9b6eb394b2cb"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:30.4506028-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:17:00.1036612-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstance.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f5b84fc69658ec4f9c85612d319a74a8-869bffe432b5174b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-71290bed7828be4481bafc04f33db4a9-1d0faccbf2bac247-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d928acb952047ff4a78eaa975ee6072c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,34 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d9673148-1720-4bf1-864b-f25936eeca69",
+        "apim-request-id": "6b579bcf-308f-46c9-bb76-81d81acd5e74",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4360e18-1288-496f-885a-d55972cd1bc1",
+        "Date": "Wed, 06 Jan 2021 01:16:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "395",
-        "x-request-id": "d9673148-1720-4bf1-864b-f25936eeca69"
+        "x-envoy-upstream-service-time": "1018",
+        "x-request-id": "6b579bcf-308f-46c9-bb76-81d81acd5e74"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4360e18-1288-496f-885a-d55972cd1bc1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "276",
+        "Content-Length": "293",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b7e9bfd40b84d34cb71b21afdb1299ca-92b6dab240115747-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e99e5f697774ba44b1a31d251b116cc9-0a92b58db2da084f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d2391366ca03573b7ce47c596f91e362",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -72,24 +72,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "22a823a0-090b-433c-bce1-5b4730fbc793",
+        "apim-request-id": "88e633ad-f534-4f12-a9d4-2847269b0bb3",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:21 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "457",
-        "x-request-id": "22a823a0-090b-433c-bce1-5b4730fbc793"
+        "x-envoy-upstream-service-time": "753",
+        "x-request-id": "88e633ad-f534-4f12-a9d4-2847269b0bb3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4360e18-1288-496f-885a-d55972cd1bc1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-267a118c09bd3f41a0ad978abef56fa3-6857fe1a94e3714d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b7af3feff1b4d74d9c8396db11650df3-16e61d03f1296743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e82c0c1194992fc7691a34c99406b69e",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "220af502-4cca-44a4-b95f-11026e9be4e1",
-        "Content-Length": "1023",
+        "apim-request-id": "abc320df-ef05-4e33-9e8a-6b298e4579ce",
+        "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:21 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "220af502-4cca-44a4-b95f-11026e9be4e1"
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "abc320df-ef05-4e33-9e8a-6b298e4579ce"
       },
       "ResponseBody": {
-        "dataFeedId": "c4360e18-1288-496f-885a-d55972cd1bc1",
+        "dataFeedId": "bd1aa724-468b-4249-be0e-3ee7b8f964af",
         "dataFeedName": "dataFeedaa3Dg3AO",
         "metrics": [
           {
-            "metricId": "40b481c5-be92-41c3-9384-dbff41a70c50",
+            "metricId": "a745f6c4-2d5a-46f8-bbdc-eb3ab86ca740",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,25 +142,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:21Z",
+        "createdTime": "2021-01-06T01:16:45Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4360e18-1288-496f-885a-d55972cd1bc1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7ac4b6b642ddc4ca59ebf6438da5b7a-be1a57d775bd9440-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-befe8ec34f2be44ba4f126416f38dfc9-0e04885fc1dbe74d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "175a60259187ef2370d15d1fd59a1016",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "03c2fa44-86ab-43b5-98a5-9cfbecbcd400",
+        "apim-request-id": "ae955a3b-1afd-4f71-b150-2347dbdace18",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:21 GMT",
+        "Date": "Wed, 06 Jan 2021 01:16:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "296",
-        "x-request-id": "03c2fa44-86ab-43b5-98a5-9cfbecbcd400"
+        "x-envoy-upstream-service-time": "306",
+        "x-request-id": "ae955a3b-1afd-4f71-b150-2347dbdace18"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:22.2768946-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:16:47.6309983-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -5,18 +5,18 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "260",
+        "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-11ab951385051145a69cbf8b05422767-59e497c5af624141-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9634d5c87da3c844a86cc3b78109fec1-134355be3fac714f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "942b5b68e26e16925102f8c2eb608154",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -33,34 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b0ea5411-55b9-4e47-98d2-694f8baffa3a",
+        "apim-request-id": "bca9b8c4-42dd-4f18-9000-eab45219810a",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:31 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac1eb227-44d9-47df-af98-d0bd222049e2",
+        "Date": "Wed, 06 Jan 2021 01:17:00 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "541",
-        "x-request-id": "b0ea5411-55b9-4e47-98d2-694f8baffa3a"
+        "x-envoy-upstream-service-time": "491",
+        "x-request-id": "bca9b8c4-42dd-4f18-9000-eab45219810a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac1eb227-44d9-47df-af98-d0bd222049e2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "276",
+        "Content-Length": "293",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6a50641e15d0a048a82f5220234df230-4860f63a98fc3545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b46b2bee6020b640917d31434408a877-b2d549be2065d041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9b09ae620c055ece37c961b652a48414",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "dataSourceParameter": {
-          "host": "host",
+          "host": "https://fakehost.com/",
           "port": "port",
           "authHeader": "Sanitized",
           "query": "query"
@@ -72,24 +72,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9f2dfc0d-a533-4210-b21b-f678eb21a856",
+        "apim-request-id": "451ec77c-edf1-45ff-a35c-ee54d7bb61af",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:31 GMT",
+        "Date": "Wed, 06 Jan 2021 01:17:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "623",
-        "x-request-id": "9f2dfc0d-a533-4210-b21b-f678eb21a856"
+        "x-envoy-upstream-service-time": "714",
+        "x-request-id": "451ec77c-edf1-45ff-a35c-ee54d7bb61af"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac1eb227-44d9-47df-af98-d0bd222049e2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-768554eee63a2d4a921613276b612986-5d18b3922a387c4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7d41467f18c9274c95c7c20a2c96c85c-5443b34eb29a5741-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ccce69ccc2ddd518a94543b1d36bbe51",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "14ee0959-8f07-4df4-9672-aa4d4bcfbf93",
-        "Content-Length": "1023",
+        "apim-request-id": "4cc54b6b-da69-41e9-a16b-e950c817cbc3",
+        "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:32 GMT",
+        "Date": "Wed, 06 Jan 2021 01:17:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "14ee0959-8f07-4df4-9672-aa4d4bcfbf93"
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "4cc54b6b-da69-41e9-a16b-e950c817cbc3"
       },
       "ResponseBody": {
-        "dataFeedId": "ac1eb227-44d9-47df-af98-d0bd222049e2",
+        "dataFeedId": "51255a92-124d-4dd8-aa20-a5a0451bdc38",
         "dataFeedName": "dataFeedeoZ83UKE",
         "metrics": [
           {
-            "metricId": "497ce233-d937-45fc-a427-95941f9d0abc",
+            "metricId": "7f11588d-cf7e-4465-8245-814230d81022",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,25 +142,25 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:31Z",
+        "createdTime": "2021-01-06T01:17:01Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
           "authHeader": "Sanitized",
           "port": "port",
           "query": "query",
-          "host": "host"
+          "host": "https://fakehost.com/"
         }
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac1eb227-44d9-47df-af98-d0bd222049e2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-08a36668cd63a24b9ccd3738807747d7-5974edc8d6bfb344-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9464eccac721d94aa5c2c0c578452722-290be0f148c16041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1201f18d6dd25b1a8ccc5ca581dbc3ac",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d05c2116-4e6b-4d56-b9cf-d24489fb3ee1",
+        "apim-request-id": "23bf2f0a-6fdd-4210-830b-417c2b25865b",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:32 GMT",
+        "Date": "Wed, 06 Jan 2021 01:17:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "277",
-        "x-request-id": "d05c2116-4e6b-4d56-b9cf-d24489fb3ee1"
+        "x-envoy-upstream-service-time": "323",
+        "x-request-id": "23bf2f0a-6fdd-4210-830b-417c2b25865b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:32.4523376-08:00",
+    "DateTimeOffsetNow": "2021-01-05T17:17:02.7865686-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,281 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "286",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ad365564463cb44d87ee96e5a90f5045-1ec94998d1591c4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "52d25f5f8d38da8dadc137499e397eb7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeedFXglzsLV",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "7d328c08-33a8-4f80-8385-fd6fbabbb902",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "538",
+        "x-request-id": "7d328c08-33a8-4f80-8385-fd6fbabbb902"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-15ccddb670fda543836a8184dc093423-74e8f2a71b9bbf45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f12cf2419b1f14309361dcc9022df69b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "89941227-1eb7-4a53-a41c-8278f4fb0fe1",
+        "Content-Length": "998",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "89941227-1eb7-4a53-a41c-8278f4fb0fe1"
+      },
+      "ResponseBody": {
+        "dataFeedId": "5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+        "dataFeedName": "dataFeedFXglzsLV",
+        "metrics": [
+          {
+            "metricId": "69a96608-cb95-4513-b66e-12ccd35a4d75",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "HttpRequest",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:24Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "httpHeader": "Sanitized",
+          "payload": "payload",
+          "httpMethod": "method",
+          "url": "https://fakehost.com/"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "712",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c6ffb38546638a41af6149517ce1fb56-5c5ab9481542a547-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "874aa38c2c65f5295f28b0d6e0ff6669",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeedFXglzsLV",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "cee7edb1-894e-4875-b7b9-01225b1b10c3",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "634",
+        "x-request-id": "cee7edb1-894e-4875-b7b9-01225b1b10c3"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1562a8a81a0ca448a320bc759123d21c-37f43499b6744448-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f6200f1640cdc4332ebdbed7b0c4d780",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8f2b236e-e2b0-487a-82b6-b08d1d70359b",
+        "Content-Length": "1124",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "8f2b236e-e2b0-487a-82b6-b08d1d70359b"
+      },
+      "ResponseBody": {
+        "dataFeedId": "5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+        "dataFeedName": "dataFeedFXglzsLV",
+        "metrics": [
+          {
+            "metricId": "69a96608-cb95-4513-b66e-12ccd35a4d75",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "HttpRequest",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:24Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "httpHeader": "Sanitized",
+          "payload": "payload",
+          "httpMethod": "method",
+          "url": "https://fakehost.com/"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6980102ec62c814eae7ac8f09d25b4c6-2433e5f2f407cb4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fbbc9bcaf7ee1451c83691f6eb5a3394",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "480e6f5d-fb6e-4670-961a-16c1842a22cb",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "346",
+        "x-request-id": "480e6f5d-fb6e-4670-961a-16c1842a22cb"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:25.5656577-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1405218745"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,281 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "286",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c99e51c99375bf4fb2d869e8249f5917-778fef6b8135fe4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7829172c4c5b55e66d8182cc1cdf67cf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeedXUbS2vdX",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "27422785-8a9d-46ff-9ad7-3f2835540528",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "546",
+        "x-request-id": "27422785-8a9d-46ff-9ad7-3f2835540528"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-04207257a9db3844b70ec7344eb16e84-01195c50a8a5b442-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2f04852a93cb8b755de0561d5e5391d0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e1c64701-3576-4037-9a2f-ae1c20b44a45",
+        "Content-Length": "998",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:04 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "e1c64701-3576-4037-9a2f-ae1c20b44a45"
+      },
+      "ResponseBody": {
+        "dataFeedId": "00f57f43-9508-407c-b44e-3a3fa1f298c4",
+        "dataFeedName": "dataFeedXUbS2vdX",
+        "metrics": [
+          {
+            "metricId": "cd412711-50b7-4324-8af9-28b9a8cb445b",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "HttpRequest",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:05Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "httpHeader": "Sanitized",
+          "payload": "payload",
+          "httpMethod": "method",
+          "url": "https://fakehost.com/"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "712",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-128c21e12691dc4c8420b28ad60d3cc4-ed5d0df6ec0a0743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0d28399b91ba47fb927868a285246ec5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeedXUbS2vdX",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "e7ae7779-6026-4e36-a0f8-783dec853a9a",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "718",
+        "x-request-id": "e7ae7779-6026-4e36-a0f8-783dec853a9a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9ee84cbf69b8d24f8a85f8be4a0b3d2e-86c8719dd8493d4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5fa7266a19549895a29d1a7af6c9f719",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "0af0e6d1-a81e-4433-8d41-d2191040e770",
+        "Content-Length": "1124",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:05 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "x-request-id": "0af0e6d1-a81e-4433-8d41-d2191040e770"
+      },
+      "ResponseBody": {
+        "dataFeedId": "00f57f43-9508-407c-b44e-3a3fa1f298c4",
+        "dataFeedName": "dataFeedXUbS2vdX",
+        "metrics": [
+          {
+            "metricId": "cd412711-50b7-4324-8af9-28b9a8cb445b",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "HttpRequest",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:05Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "httpHeader": "Sanitized",
+          "payload": "payload",
+          "httpMethod": "method",
+          "url": "https://fakehost.com/"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-73bcd944494f2a43956fdfd2f123093a-a4ccf5b0f0286e48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e330b1ef5ab7981589bc9c522bd30639",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ef7cc843-9bde-4b3b-a93d-7e37fb956cad",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:06 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "332",
+        "x-request-id": "ef7cc843-9bde-4b3b-a93d-7e37fb956cad"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:06.3687870-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "624325975"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,203 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "286",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e61020782e5bde4d936408986edb8cba-794e909d8c70734c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b5bce963dc8e9cc4a6c5c6b17a5abe88",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeedrac2rFls",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "e5bd1c42-36d7-4d6a-a43f-fafc7316c270",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "547",
+        "x-request-id": "e5bd1c42-36d7-4d6a-a43f-fafc7316c270"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "600",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cf4ca23b19477242b436e9f09fb911cc-84ef17d939682f4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "36be81b27574f0e1d08d0a8cd8b5903b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeedrac2rFls",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "4dce7d37-f99c-48f3-843f-d6f21d821baa",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "676",
+        "x-request-id": "4dce7d37-f99c-48f3-843f-d6f21d821baa"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-7b08c2b4158b4b4f8a685339cbf26b29-1f420d1e1dbf5544-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fbe725edcbde88105b837054401e65c3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "f9644196-078e-4b44-ae91-f410a7b3a2c4",
+        "Content-Length": "1124",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "x-request-id": "f9644196-078e-4b44-ae91-f410a7b3a2c4"
+      },
+      "ResponseBody": {
+        "dataFeedId": "8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+        "dataFeedName": "dataFeedrac2rFls",
+        "metrics": [
+          {
+            "metricId": "b8a7ac6d-ff9b-4889-8048-e4f53d1c2244",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "HttpRequest",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:26Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "httpHeader": "Sanitized",
+          "payload": "payload",
+          "httpMethod": "method",
+          "url": "https://fakehost.com/"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-369f67c10767fc4ba68cd5c915772a19-545307b45e18cb45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2fcc8e41f776ed4007cce501d238c4f1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "ca77d3d3-63db-402a-bd78-ca3263f29d1d",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "274",
+        "x-request-id": "ca77d3d3-63db-402a-bd78-ca3263f29d1d"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:27.4403536-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1084445630"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,203 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "286",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e0fc9be5a4508e489d846b4bc5d348f5-68b5f607e5a34d47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e5fed9698cbd60f6ff7fe15af040d441",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeednOXZo4U6",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "07533a52-1229-41b7-b08b-97fe6e579b25",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "574",
+        "x-request-id": "07533a52-1229-41b7-b08b-97fe6e579b25"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "600",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0d463d0b342eab439d4910ebc13caffd-ccf974314a299f42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "10067a4602498582ae1a83534e41aef6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "url": "https://fakehost.com/",
+          "httpHeader": "Sanitized",
+          "httpMethod": "method",
+          "payload": "payload"
+        },
+        "dataSourceType": "HttpRequest",
+        "dataFeedName": "dataFeednOXZo4U6",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "40576f00-2d26-4582-955c-20efc833875c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "688",
+        "x-request-id": "40576f00-2d26-4582-955c-20efc833875c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3b9c17e22b5a9244bcd609eaa554b35f-60d7a4246a8a0749-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b1e808969f515102b30c5d27580ad386",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "00f8b323-95a4-4d17-9ebf-2826c1916eb6",
+        "Content-Length": "1124",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "x-request-id": "00f8b323-95a4-4d17-9ebf-2826c1916eb6"
+      },
+      "ResponseBody": {
+        "dataFeedId": "5e04f39a-1e56-4a34-8692-7f9aa9787279",
+        "dataFeedName": "dataFeednOXZo4U6",
+        "metrics": [
+          {
+            "metricId": "c50488c4-93d6-446f-bcd0-9472fd2b2496",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "HttpRequest",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:07Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "httpHeader": "Sanitized",
+          "payload": "payload",
+          "httpMethod": "method",
+          "url": "https://fakehost.com/"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9341d7567564434dabb6917a96540bba-be4c326e60749644-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "4b3192b875806603567937a208a211be",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b50b11e0-1f1b-44cc-ac36-65e59938d5fe",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:07 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "284",
+        "x-request-id": "b50b11e0-1f1b-44cc-ac36-65e59938d5fe"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:08.2853052-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1141864934"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,285 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "295",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9df4378980b17e418d1e54493e1e880d-13a179d36b7f7b4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0fbc272d3cbe1723edd086cc5d3bd2b4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeedplZVrok1",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d2dacc5b-b47f-42a8-98cf-94aee79162e4",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:28 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "572",
+        "x-request-id": "d2dacc5b-b47f-42a8-98cf-94aee79162e4"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5dad4576ced3214598c48d06f1b22fa0-2dd973652dbbfc44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e0d5ab78bf9faf36f8c237dd93d8a758",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fe87ae4a-36f7-4326-803d-5ad2a3fa92a2",
+        "Content-Length": "1007",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "145",
+        "x-request-id": "fe87ae4a-36f7-4326-803d-5ad2a3fa92a2"
+      },
+      "ResponseBody": {
+        "dataFeedId": "724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+        "dataFeedName": "dataFeedplZVrok1",
+        "metrics": [
+          {
+            "metricId": "c931eb3f-61fd-40ee-9aea-8d067087004b",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "InfluxDB",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:28Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "password": "pass",
+          "database": "database",
+          "query": "query",
+          "userName": "username"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "721",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e71ec3955f4748498d79acd167d9a3e7-6ef1ae6075dc4147-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "535f59dcfa3ab4ee30a311cc2da0fdb6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeedplZVrok1",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "a28f6798-d7be-4011-8418-ceec984fc9c0",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "644",
+        "x-request-id": "a28f6798-d7be-4011-8418-ceec984fc9c0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e82670e89b0142488c6df5cf04a0bc7c-2981e2164e82214f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "b49b234908a46dedf10d16fc05468415",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "4dabf14b-3a7f-4abb-bdba-36f3b4a723f7",
+        "Content-Length": "1133",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "4dabf14b-3a7f-4abb-bdba-36f3b4a723f7"
+      },
+      "ResponseBody": {
+        "dataFeedId": "724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+        "dataFeedName": "dataFeedplZVrok1",
+        "metrics": [
+          {
+            "metricId": "c931eb3f-61fd-40ee-9aea-8d067087004b",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "InfluxDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:28Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "password": "pass",
+          "database": "database",
+          "query": "query",
+          "userName": "username"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e433347f1cf25c4c9a7f788fc00ae9f8-175d37b3f650ad45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "03ef2e297fdc7e7abc20b0fbad698258",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "0273fb06-ee90-42f9-9693-0ca941bed223",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:29 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "311",
+        "x-request-id": "0273fb06-ee90-42f9-9693-0ca941bed223"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:29.5755922-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "2072844088"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,285 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "295",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-af30eb8c456b9743ace15d5545908777-9d42c038d513214e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0e7a2d4a9dbf6ec1c8c0a1ce0ad9a91e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeedYBU4mzwj",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "cb8cb168-1dc8-4374-995c-5772a2e1f0df",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "519",
+        "x-request-id": "cb8cb168-1dc8-4374-995c-5772a2e1f0df"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cbabc195d48fc04b8d7e2ab251ec0b08-f31174c8ce4f184e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9f8d10237e3d04001ad787fa7b59c83c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "d4373b2d-7c8a-46a2-9c7f-3de7d20a6138",
+        "Content-Length": "1007",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:08 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "176",
+        "x-request-id": "d4373b2d-7c8a-46a2-9c7f-3de7d20a6138"
+      },
+      "ResponseBody": {
+        "dataFeedId": "46dd08e9-574c-439e-99d0-ae3292011143",
+        "dataFeedName": "dataFeedYBU4mzwj",
+        "metrics": [
+          {
+            "metricId": "09c9656b-6cf6-49a4-975a-08b0697a6082",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "InfluxDB",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:09Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "password": "pass",
+          "database": "database",
+          "query": "query",
+          "userName": "username"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "721",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ab283b127f75fd49b91c56b24cad02ca-3e9506398e0f4f4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "35a5448ee5e00869bb68566c8eb9fec9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeedYBU4mzwj",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b6412c3f-1f5d-44a9-9a93-1ee633160623",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "683",
+        "x-request-id": "b6412c3f-1f5d-44a9-9a93-1ee633160623"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e7d13fdc823ff7498647e3b661f67bee-b6bf25e7f71a7247-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2b8227673224cb082c75f4e716c6f36f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5a64bb8b-472d-44e8-a0f6-0bfeb0565817",
+        "Content-Length": "1133",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "5a64bb8b-472d-44e8-a0f6-0bfeb0565817"
+      },
+      "ResponseBody": {
+        "dataFeedId": "46dd08e9-574c-439e-99d0-ae3292011143",
+        "dataFeedName": "dataFeedYBU4mzwj",
+        "metrics": [
+          {
+            "metricId": "09c9656b-6cf6-49a4-975a-08b0697a6082",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "InfluxDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:09Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "password": "pass",
+          "database": "database",
+          "query": "query",
+          "userName": "username"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cfa8c2cefb07d64cb87a06aa31b75e4a-829041c3ca896f4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c54064f874343e3da785e4d427947560",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "d0edea10-1070-4dc6-aeff-d5372fb1f28b",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:09 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "297",
+        "x-request-id": "d0edea10-1070-4dc6-aeff-d5372fb1f28b"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:10.3099084-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "940579427"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,206 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "295",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a64003231e99274e92787fca2ca2137a-1181506615a61840-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7c92fd6a7c39223397cee683319c3f2a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeed5eWbcxab",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "2d353b6b-eddd-4464-97e9-a18523a4a4f3",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "557",
+        "x-request-id": "2d353b6b-eddd-4464-97e9-a18523a4a4f3"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "609",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-48cadb117149554aad5779745890164b-53e148c6c7cc464a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c2e39f942a1da84349e5641383c5c47a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeed5eWbcxab",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "c0bfda5e-53a5-4b79-a4ce-b353953660cd",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "672",
+        "x-request-id": "c0bfda5e-53a5-4b79-a4ce-b353953660cd"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c7f797bf19859047b5dfce5177b9a541-b26f9c81a514774f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e31f29b008d1aede5237f251ff5e6177",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "10f661f5-4620-4d9e-b9ca-7e99dd08891d",
+        "Content-Length": "1133",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "138",
+        "x-request-id": "10f661f5-4620-4d9e-b9ca-7e99dd08891d"
+      },
+      "ResponseBody": {
+        "dataFeedId": "4e357182-011e-4373-b9f8-f9daa9632d54",
+        "dataFeedName": "dataFeed5eWbcxab",
+        "metrics": [
+          {
+            "metricId": "ac7c301b-1cf4-4e62-a9a4-c732bfd6a16f",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "InfluxDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:30Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "password": "pass",
+          "database": "database",
+          "query": "query",
+          "userName": "username"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e5f1d4142be8814696e224168361514d-0c3d2f477eff714c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a0258b9665c83f5bb9e9335417209ed1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "5ecd766d-56bc-4690-beea-9d964b9e263b",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:31 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "300",
+        "x-request-id": "5ecd766d-56bc-4690-beea-9d964b9e263b"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:31.4126660-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "442899400"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,206 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "295",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-61f25fb37c9f834b833daa0039b6ee86-f767af09be6f3b4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a3e9b3373b599d8c4f8f31fcae43283c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeedNbRJf0tc",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "bcea8290-7599-49f9-a490-bc00c0f6335c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "536",
+        "x-request-id": "bcea8290-7599-49f9-a490-bc00c0f6335c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "609",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9ce79c57b6638a48a30fbbec99a0529c-57fd0dcbdbdd9c47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "00af337d22ca1f881364dd67d9ec5eaf",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "userName": "username",
+          "password": "pass",
+          "query": "query"
+        },
+        "dataSourceType": "InfluxDB",
+        "dataFeedName": "dataFeedNbRJf0tc",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "420143d3-e9b3-4893-982a-1bcaa4c25ab1",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "615",
+        "x-request-id": "420143d3-e9b3-4893-982a-1bcaa4c25ab1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e9144ae825a54347a2c01dfdf81c5cbc-7b77399b765d0643-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6bfdbfc86c260cb18587b21da48d6bd4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e52c5577-dfa2-4993-9820-b700a3beedab",
+        "Content-Length": "1133",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "143",
+        "x-request-id": "e52c5577-dfa2-4993-9820-b700a3beedab"
+      },
+      "ResponseBody": {
+        "dataFeedId": "bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+        "dataFeedName": "dataFeedNbRJf0tc",
+        "metrics": [
+          {
+            "metricId": "db5a897b-aa54-47b2-8288-5c653cd94c58",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "InfluxDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:11Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "password": "pass",
+          "database": "database",
+          "query": "query",
+          "userName": "username"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-5c6249e6c6c2fe47994355ffadee7330-9430d521caa7db49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "09acafea3d5b14be2ac98ff55d24c462",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "af1dcecf-2a7c-4b39-adaa-a0908d410e4e",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:11 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "293",
+        "x-request-id": "af1dcecf-2a7c-4b39-adaa-a0908d410e4e"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:12.0551167-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1809490277"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,277 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "258",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a77eedcb224d09489cad27d9b8e24330-f57cac17ee48984a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7093ac4446e021fe7b493d8b86cc3feb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedK8TE7pob",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d5d6494d-d094-4ebf-bfc7-0b3c5b78e706",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "563",
+        "x-request-id": "d5d6494d-d094-4ebf-bfc7-0b3c5b78e706"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3c4b02e133d8f749924bc81036994360-09a4afb11c3a254a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "e726f0b394c3d93ceecb3ed721a0212c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "c9ed894b-1f9a-487c-942e-70104806dc88",
+        "Content-Length": "970",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "c9ed894b-1f9a-487c-942e-70104806dc88"
+      },
+      "ResponseBody": {
+        "dataFeedId": "f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+        "dataFeedName": "dataFeedK8TE7pob",
+        "metrics": [
+          {
+            "metricId": "cf302122-e219-461a-b840-510c6241d547",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MongoDB",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:32Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "684",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-445d465aaddc9c40b92fd1ac9027ecd8-8d0fe24483cf9f4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "998e46942d843ae2f8323ce1c68aead5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedK8TE7pob",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "848cfc42-8b48-42a6-a244-1a9ba6369c1c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:32 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "478",
+        "x-request-id": "848cfc42-8b48-42a6-a244-1a9ba6369c1c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-633a1ca536c59e43b0046c7d46a1db65-87580c6e6bceb04c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0289175b7a17af076fb982140826ffda",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "2bbcb217-a109-4b88-babb-6ba5738ff259",
+        "Content-Length": "1096",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "155",
+        "x-request-id": "2bbcb217-a109-4b88-babb-6ba5738ff259"
+      },
+      "ResponseBody": {
+        "dataFeedId": "f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+        "dataFeedName": "dataFeedK8TE7pob",
+        "metrics": [
+          {
+            "metricId": "cf302122-e219-461a-b840-510c6241d547",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MongoDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:32Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-310ebc5a02c9334ca3ff19d25d1bf7c6-3b5d29b86b70fa4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "40f61128a53d86670eecef91575b1364",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "a59cc77c-2048-47fb-9dd3-ca66a688a130",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:33 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "367",
+        "x-request-id": "a59cc77c-2048-47fb-9dd3-ca66a688a130"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:33.3032510-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "780257538"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,277 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "258",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2ad14c0deba5594cafe9e2713bb574ed-5c2db47545e71643-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3ad60d5a6186689c7073ef216e004139",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedXFOvZwlg",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "e78466da-0dd7-4828-b699-677ad9fd60f3",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "591",
+        "x-request-id": "e78466da-0dd7-4828-b699-677ad9fd60f3"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-64310c6f1d02624196777b910ba46fe5-8aa74cfd869df748-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3d9b10a04214e082480a65127ae3857b",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "6683a0e7-9dc1-45f5-9495-f8bc40504539",
+        "Content-Length": "970",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "6683a0e7-9dc1-45f5-9495-f8bc40504539"
+      },
+      "ResponseBody": {
+        "dataFeedId": "11e12cbd-2dba-4898-947c-a05b87270813",
+        "dataFeedName": "dataFeedXFOvZwlg",
+        "metrics": [
+          {
+            "metricId": "3672b32b-dadc-4bc2-9053-30912b620ea8",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MongoDB",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:12Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "684",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-cb40c762db84fc4abf68bd11809d57d6-5ab699431fadf646-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ae861133f75061f92195d3cbb81f4803",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedXFOvZwlg",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "1fec7879-ec63-4e3d-9558-2ad93b99fd9a",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "512",
+        "x-request-id": "1fec7879-ec63-4e3d-9558-2ad93b99fd9a"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a94db9f41cdd044dab118b4ee0c9d136-a4d1682af7265346-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fa83128ffd4318ca8af6f17bfb8aed8d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "509dfbf0-1027-484d-b746-438350535eaa",
+        "Content-Length": "1096",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "x-request-id": "509dfbf0-1027-484d-b746-438350535eaa"
+      },
+      "ResponseBody": {
+        "dataFeedId": "11e12cbd-2dba-4898-947c-a05b87270813",
+        "dataFeedName": "dataFeedXFOvZwlg",
+        "metrics": [
+          {
+            "metricId": "3672b32b-dadc-4bc2-9053-30912b620ea8",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MongoDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:12Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2a6e148a1b986a4188d80ec1aef12583-3d11ca0c574bf740-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "5dee73ee927aa8e916391c7e6eb62829",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "a358a695-ab05-4a98-92c9-8ffa8907b739",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:13 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "328",
+        "x-request-id": "a358a695-ab05-4a98-92c9-8ffa8907b739"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:14.0074860-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "186636522"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,200 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "258",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e6a3050a5dcac34abff9c35a5d74a5f2-7c8bc69bec635748-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d873d9648e4487a2ce4a359b5e0d1694",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedG6PQRZw4",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "3fd29476-717d-417a-887a-22c9a636f584",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "373",
+        "x-request-id": "3fd29476-717d-417a-887a-22c9a636f584"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "572",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-99cc9fc79a19044382f957d110cefaf0-7d4b059f1a92b341-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7b8032f9b82dc49b35796cd40a5b7c8e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedG6PQRZw4",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b76c8152-cdf8-422f-95fd-6053f1312e14",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:34 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "637",
+        "x-request-id": "b76c8152-cdf8-422f-95fd-6053f1312e14"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b5a597df8f6e0348a87d73942412e335-227d2af4dcd80d46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "1ebcef2f030c78d186290ae3df791963",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "56f18658-87ac-4f06-9829-64ba6892f080",
+        "Content-Length": "1096",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:35 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "637",
+        "x-request-id": "56f18658-87ac-4f06-9829-64ba6892f080"
+      },
+      "ResponseBody": {
+        "dataFeedId": "479cf661-e202-4085-8dcc-2847a0a3b4f5",
+        "dataFeedName": "dataFeedG6PQRZw4",
+        "metrics": [
+          {
+            "metricId": "0f25a8bb-10cc-4f0c-9049-35384dba109b",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MongoDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:34Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e436427cf5299e4986d26e5839857f85-5dfaab48ec31064b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "14a480178474acc53daea3cb22cd7d73",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "2c9b4efa-858d-4c45-bacb-f7cbd6cdb52c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:36 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "1073",
+        "x-request-id": "2c9b4efa-858d-4c45-bacb-f7cbd6cdb52c"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:35.5273499-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "878640460"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,200 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "258",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6599de23c32cb34cad922cf4b37adcfa-7b36c4ad81a1ef44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "98cbf441b9cd86670e7a17e34e02eb33",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedoMLI0uTw",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "8a371307-8e0a-4f11-807f-a2c1bd5aa198",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "531",
+        "x-request-id": "8a371307-8e0a-4f11-807f-a2c1bd5aa198"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "572",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9efefc995987b14e8ebaeee5257e04ae-1a7c24d9d16e2c42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3566ed3bd354ae857bb5929c3c395d59",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        },
+        "dataSourceType": "MongoDB",
+        "dataFeedName": "dataFeedoMLI0uTw",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "81837249-611b-4d33-a444-d82f795fca8c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:14 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "690",
+        "x-request-id": "81837249-611b-4d33-a444-d82f795fca8c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ee84f2b0f53d944084756a8e25061bf2-fe1f90f9878c3545-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "11906c5b5eba49d8895387c75e70152a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3f6ca674-f39d-460a-ab83-14adbd1a199b",
+        "Content-Length": "1096",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "192",
+        "x-request-id": "3f6ca674-f39d-460a-ab83-14adbd1a199b"
+      },
+      "ResponseBody": {
+        "dataFeedId": "a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+        "dataFeedName": "dataFeedoMLI0uTw",
+        "metrics": [
+          {
+            "metricId": "282165b9-dc24-4ae0-a4a8-aedad8d0a139",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MongoDB",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:14Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "database": "database",
+          "command": "command"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6729169fe1b9b9439666f9ec0e363f74-a23cc6193d601b42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "59c1a72861386e276f1d1d1726ca49d5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "e4c9b985-9a4b-4f34-864d-2e23b48fdaed",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:15 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "356",
+        "x-request-id": "e4c9b985-9a4b-4f34-864d-2e23b48fdaed"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:15.8884647-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1594191017"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "230",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f6e6f87e7da970489b35b88911fe109d-e3e477b2055ab948-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "695d7bcd8e298708dcd4a57dab9f60f4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedMjKRoDrV",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "a87dffde-5e9f-42ec-90ed-94f087bf0b48",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:37 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "1123",
+        "x-request-id": "a87dffde-5e9f-42ec-90ed-94f087bf0b48"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9977bbccff52bc4ba04ad6ef1b4e81ca-7b5a5ab0aa92214f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "960ed6cd3897007785452fc0b7f421bd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "b37271c7-7e57-42d8-b27d-848ba16ecc4a",
+        "Content-Length": "942",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:37 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "x-request-id": "b37271c7-7e57-42d8-b27d-848ba16ecc4a"
+      },
+      "ResponseBody": {
+        "dataFeedId": "c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+        "dataFeedName": "dataFeedMjKRoDrV",
+        "metrics": [
+          {
+            "metricId": "72f387ea-9d23-4eba-8e01-17d35048c761",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MySql",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:37Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "656",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b83626d8c082684f8b43c5672170b1c7-ed4c6b19088f1841-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "45150b1bb9b3312f6d13281db5ed6537",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedMjKRoDrV",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "07e23d89-325d-479e-9bb2-eb232bbf9784",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "657",
+        "x-request-id": "07e23d89-325d-479e-9bb2-eb232bbf9784"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f4af8790571d4c4e84ce440690e23d0b-ed261029bdbcdb41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8f3856c6c3429429045de3e35e48d0e7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3ce39036-94b5-4cab-ac70-310fe4c409ee",
+        "Content-Length": "1068",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:38 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "136",
+        "x-request-id": "3ce39036-94b5-4cab-ac70-310fe4c409ee"
+      },
+      "ResponseBody": {
+        "dataFeedId": "c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+        "dataFeedName": "dataFeedMjKRoDrV",
+        "metrics": [
+          {
+            "metricId": "72f387ea-9d23-4eba-8e01-17d35048c761",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MySql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:37Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c36f69f831c57b4897ced52470bafdb4-d5ed828a8fb52d4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a061e7b31a8a1440a7dd28840f594a98",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "0b39edef-4992-408a-ae22-59b65811c8d1",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:39 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "285",
+        "x-request-id": "0b39edef-4992-408a-ae22-59b65811c8d1"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:38.9616796-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1052066574"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "230",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-412c67f6fbff3040a6a776c70ca6f0d2-04ffe34f6765274b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3b1b52853f80a177823fdfd4e7cc2dc4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedbZHGE6Y9",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "312a5475-e269-4246-b9b6-e37497fdc6b8",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "394",
+        "x-request-id": "312a5475-e269-4246-b9b6-e37497fdc6b8"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-282fab40f4da2242b8e1c818542ec1cb-746bedc8dcc82e4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7fb32715551ff51793d2e9b5c2643715",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "e4e2085a-43f3-411a-9d43-8a7186c6c7a7",
+        "Content-Length": "942",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:16 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "e4e2085a-43f3-411a-9d43-8a7186c6c7a7"
+      },
+      "ResponseBody": {
+        "dataFeedId": "513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+        "dataFeedName": "dataFeedbZHGE6Y9",
+        "metrics": [
+          {
+            "metricId": "dd02b857-2e32-4b6f-ab1e-7a8faf2e5eca",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MySql",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:16Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "656",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-75cf4ce664da274e876d31f8bc8fb0fb-3b762b09f32fa942-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8a9e5c738d2c7b4c0c482c01a0e41bd0",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedbZHGE6Y9",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "a203a649-9121-462e-afde-80454a1ed322",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "684",
+        "x-request-id": "a203a649-9121-462e-afde-80454a1ed322"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9e070995af6a564dbcc1cc9259972cc9-587dc191fc856c41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c437126064b12fed3b25a8ae55c1de1d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8b116c53-6b8e-4166-9d94-85661af923af",
+        "Content-Length": "1068",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "8b116c53-6b8e-4166-9d94-85661af923af"
+      },
+      "ResponseBody": {
+        "dataFeedId": "513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+        "dataFeedName": "dataFeedbZHGE6Y9",
+        "metrics": [
+          {
+            "metricId": "dd02b857-2e32-4b6f-ab1e-7a8faf2e5eca",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MySql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:16Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-46c9a20b17ce0545b02e215f8198765a-8cfcd35391a25b4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8b60c908a22e8898db3772d7291555af",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "18d1e342-cf84-45ff-8e4b-800c6aa1cdab",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:17 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "340",
+        "x-request-id": "18d1e342-cf84-45ff-8e4b-800c6aa1cdab"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:18.1291730-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1573086331"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,197 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "230",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-aa7a558c2f06c54eae566dd6fecdd0f0-f3f8974d18f7754f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9fb2a4b57032eff9c7dea97f7f125c6a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedilGpZrKB",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "9b1c8396-0d7c-4782-a22c-5b17cb65943e",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "367",
+        "x-request-id": "9b1c8396-0d7c-4782-a22c-5b17cb65943e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "544",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1bd2426999150643aa84c811fac369bf-cf99fed970164949-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a40ac26ee66370c6a2e0d1d0a50f205d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedilGpZrKB",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "b7f48ea2-8fce-4458-b5f8-dd8942f7d7f0",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "680",
+        "x-request-id": "b7f48ea2-8fce-4458-b5f8-dd8942f7d7f0"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-80be70bf416746488f5be3743dc9bb21-c7559a6983d12b4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ffb834b5d8b509c61b02de74d67c7800",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "70cc2c32-00b2-498a-85d0-4579dd32be02",
+        "Content-Length": "1068",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "70cc2c32-00b2-498a-85d0-4579dd32be02"
+      },
+      "ResponseBody": {
+        "dataFeedId": "311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+        "dataFeedName": "dataFeedilGpZrKB",
+        "metrics": [
+          {
+            "metricId": "0b215087-fb37-4e59-be52-52994817ad58",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MySql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:39Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-8e67856b4397fd42a3a03e6feae43ae5-87bf0db65669f149-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "afeae9776161ce43de42fc519e2949b7",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "766bb71e-26b2-495f-b419-e860304afa86",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:40 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "300",
+        "x-request-id": "766bb71e-26b2-495f-b419-e860304afa86"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:40.7573988-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1068483484"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,197 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "230",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3e1dca6a21b7d44182ddd5d6f71b4998-4de631021ced1248-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c69fa038ed0d88696f14a0db93f68042",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedl7EhFK5o",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d0669b24-d8ee-478a-a080-6561a4c5b729",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "423",
+        "x-request-id": "d0669b24-d8ee-478a-a080-6561a4c5b729"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "544",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-ecbd1ac32d790046b8f9b9809ba8759b-18c04923a048ec4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "4464e4c46583f44278503faf05924a02",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "MySql",
+        "dataFeedName": "dataFeedl7EhFK5o",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "1bb3bdea-fdde-4dba-9481-b01e5e76d3bc",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:18 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "693",
+        "x-request-id": "1bb3bdea-fdde-4dba-9481-b01e5e76d3bc"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-edca074fce48f042a71595944c6d1877-ee4cae0e0e03f34d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "90d28914a5540874b02d54ab43f22174",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "49325df1-ff55-4b57-b564-2f384d0a6324",
+        "Content-Length": "1068",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "x-request-id": "49325df1-ff55-4b57-b564-2f384d0a6324"
+      },
+      "ResponseBody": {
+        "dataFeedId": "4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+        "dataFeedName": "dataFeedl7EhFK5o",
+        "metrics": [
+          {
+            "metricId": "dbb76588-30da-40c1-9d5c-88e7ebb273ae",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "MySql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:18Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-500f911148cff843953b87581672d450-d0674d952db63841-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "ee84adc0ca65d3435eab4dbcadb982dd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "29e48f55-950e-4efb-99c5-a17a83624cc6",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:19 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "313",
+        "x-request-id": "29e48f55-950e-4efb-99c5-a17a83624cc6"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:19.9872274-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1603685107"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "235",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-13be618805414e4380d5a37a2665c10f-b616da409572a347-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3b95a8f58d755d7640becf4b3bef0a34",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeedCMDMtCuM",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d85a17fd-cfab-4aeb-8e4a-b87fa0f1d1c1",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "539",
+        "x-request-id": "d85a17fd-cfab-4aeb-8e4a-b87fa0f1d1c1"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3682ff1f5de2ba45866fbdf3959e886c-04e61b648d27df4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2fab52674cc23f6fe2fb59b54e3908e9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "24e8371c-1d8c-4e9f-b2cc-cd47bcca3d40",
+        "Content-Length": "947",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:41 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "24e8371c-1d8c-4e9f-b2cc-cd47bcca3d40"
+      },
+      "ResponseBody": {
+        "dataFeedId": "7d433b14-94ef-40a2-811f-632c79eda68c",
+        "dataFeedName": "dataFeedCMDMtCuM",
+        "metrics": [
+          {
+            "metricId": "1c4874ad-0c4d-47cc-ae65-bcbcfe7e12e0",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "PostgreSql",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:41Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "661",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-be493ef3ca4fdd4fb3d032a563fa8a6e-157ea25f1316dc48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "4dd2ad599aee190e4bad12a6a4dd8962",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeedCMDMtCuM",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "5d71412b-00b8-423e-a181-7d3de606d234",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "511",
+        "x-request-id": "5d71412b-00b8-423e-a181-7d3de606d234"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1182ccb460bca840b6d5220597b5d5f9-7d773104bd260e4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "7a2f4cae7411a8ff3855597934c10f06",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a02c588c-6173-4bda-97c4-5cd35b1754fc",
+        "Content-Length": "1073",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "x-request-id": "a02c588c-6173-4bda-97c4-5cd35b1754fc"
+      },
+      "ResponseBody": {
+        "dataFeedId": "7d433b14-94ef-40a2-811f-632c79eda68c",
+        "dataFeedName": "dataFeedCMDMtCuM",
+        "metrics": [
+          {
+            "metricId": "1c4874ad-0c4d-47cc-ae65-bcbcfe7e12e0",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "PostgreSql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:41Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-fd0cf5cd0d782c4aa6bec9467b69aea2-4d137887e08f0b4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8ef2e5b6bd1ccc464492e3143ac99b05",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "28fb3173-f1dc-4ca7-8142-f9ede88eb17e",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:42 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "306",
+        "x-request-id": "28fb3173-f1dc-4ca7-8142-f9ede88eb17e"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:42.7299704-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "2012269413"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "235",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-3f9fba3634b83040a5032693a1665ddc-1067b27c65916649-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6b6dd1b2fb513ebe75ee95ba47135bab",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeeduZB2TS5C",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "63bd73e9-3d96-41ce-9f40-4986daf9e1db",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:20 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "538",
+        "x-request-id": "63bd73e9-3d96-41ce-9f40-4986daf9e1db"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d3f66ad2bf61254aba77bbff0ec87e23-519d26f7bc094b40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6b6fd968620ce047cc86c706c921b517",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "453fa463-8e48-497d-8df5-d1c9664f676d",
+        "Content-Length": "947",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "168",
+        "x-request-id": "453fa463-8e48-497d-8df5-d1c9664f676d"
+      },
+      "ResponseBody": {
+        "dataFeedId": "8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+        "dataFeedName": "dataFeeduZB2TS5C",
+        "metrics": [
+          {
+            "metricId": "25967e8e-2336-4216-96dc-f6ba62b93aa3",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "PostgreSql",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:20Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "661",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-73038eeae6523347b824573511e59632-275410b3e6cd484c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "19104f66d6aa97e90512c5e4842d993e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeeduZB2TS5C",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "4de45bb0-5ce0-4741-be02-e0453935043f",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:20 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "685",
+        "x-request-id": "4de45bb0-5ce0-4741-be02-e0453935043f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1e9a4244cc98f841b8f80867960c8a00-6ce31d0b42e30849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6da6ff1a829b4f5f8a8c9fcb33b77554",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "63eb88a8-16e3-4c71-8e5a-acdce5109a3c",
+        "Content-Length": "1073",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "187",
+        "x-request-id": "63eb88a8-16e3-4c71-8e5a-acdce5109a3c"
+      },
+      "ResponseBody": {
+        "dataFeedId": "8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+        "dataFeedName": "dataFeeduZB2TS5C",
+        "metrics": [
+          {
+            "metricId": "25967e8e-2336-4216-96dc-f6ba62b93aa3",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "PostgreSql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:20Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f025f21240386e4198fef3c1732e0f77-f01cf2dd6c56d54b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f8537e3941029100f0d865f99d635c9e",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "1fb64f66-1dbd-47c7-bfeb-83c98f83185c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:21 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "359",
+        "x-request-id": "1fb64f66-1dbd-47c7-bfeb-83c98f83185c"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:22.0699815-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1238299463"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,197 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "235",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f29bd62789dbc14396572c30c92b4318-0bb605904f25ba4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "6efb370f8e88b419b2f95ef94ec70cbd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeedc1AgktnD",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "0369079c-ab6e-4dd1-8ebd-b30adc161b3e",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "694",
+        "x-request-id": "0369079c-ab6e-4dd1-8ebd-b30adc161b3e"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "549",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-9a367762c83f9e4792a142cf82f3680e-b0b1381d2ed76b4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "59bb4eef5ddfdc4a62c75dcea1b7a6b5",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeedc1AgktnD",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "a72d8a04-4211-4434-a2f9-f6a49f276f3d",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "713",
+        "x-request-id": "a72d8a04-4211-4434-a2f9-f6a49f276f3d"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a308a2ec8334e44fb32df9e946a9d089-55b5bb9289f4064b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fdb236d64f9a2f9078432ff24d3e170c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "8fd0f3d6-7076-478c-87aa-a95cedc2cf5b",
+        "Content-Length": "1073",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "195",
+        "x-request-id": "8fd0f3d6-7076-478c-87aa-a95cedc2cf5b"
+      },
+      "ResponseBody": {
+        "dataFeedId": "a98986c7-34db-486b-90af-8164897a2c4c",
+        "dataFeedName": "dataFeedc1AgktnD",
+        "metrics": [
+          {
+            "metricId": "1f3bb1a0-db65-4118-9de0-5c862da351dc",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "PostgreSql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:43Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-16744d99c8843646b26efefca4df2aa2-87813933f7b1f84f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "0e5eb680d720b164ed1e0cc1314a12fb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "07171f8c-9afe-4be5-b9ba-0de20624d761",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:44 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "286",
+        "x-request-id": "07171f8c-9afe-4be5-b9ba-0de20624d761"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:44.8500181-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "501812333"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,197 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "235",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-1b6a66f5ce6e3e4093e0702ea7c3ba24-a3260c68d7abe24f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "fae0bb348ad536fee391cb1fb4d8a81c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeed1V6WOcCi",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "afade726-0f5d-46af-801f-16577aa9f4ee",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "594",
+        "x-request-id": "afade726-0f5d-46af-801f-16577aa9f4ee"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "549",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-823b07a21353644caf02c8630723c2cb-7309438bf5848b46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "141a862f101fb2e74ed3bcf7acec29d8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "PostgreSql",
+        "dataFeedName": "dataFeed1V6WOcCi",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "3fa912a1-51ce-49f2-8cda-55bc8e4dca5f",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "729",
+        "x-request-id": "3fa912a1-51ce-49f2-8cda-55bc8e4dca5f"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4ce992c40227dd4e9787aab37039e43b-46ae38ba62e97143-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "26081c185827da232b507f999e5e2202",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "efa85d07-639b-4fe7-a213-1d96dc258c7c",
+        "Content-Length": "1073",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:24 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "205",
+        "x-request-id": "efa85d07-639b-4fe7-a213-1d96dc258c7c"
+      },
+      "ResponseBody": {
+        "dataFeedId": "6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+        "dataFeedName": "dataFeed1V6WOcCi",
+        "metrics": [
+          {
+            "metricId": "e682af08-7311-4292-868e-c022fb134ff8",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "PostgreSql",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:23Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-2fdd7a9d71f0d9449acab7bcb9601071-3c705b7c9e1b8446-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2278b75923532469d32dab01cd078af6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "2508be45-b8e9-49a4-b141-8c5c25a4b5c6",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "413",
+        "x-request-id": "2508be45-b8e9-49a4-b141-8c5c25a4b5c6"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:24.6097858-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "648288582"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstance.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "234",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b2521a3ddd32ac48827ebc453aabd996-738c6cbc17245c43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "33efb7e67b644e78bf91efe1bb7aca24",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeeddo7sgZHb",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "8e158bb0-3b93-4343-952d-88c9d0273e11",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "402",
+        "x-request-id": "8e158bb0-3b93-4343-952d-88c9d0273e11"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-499e329e1ee0ed478458b47a74353776-6976d85037bd644e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "d55f0332cba437a718b4dde5815538fd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "a8452660-2c51-4968-b068-cb6f51b1abf4",
+        "Content-Length": "946",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:45 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "a8452660-2c51-4968-b068-cb6f51b1abf4"
+      },
+      "ResponseBody": {
+        "dataFeedId": "2bb9edf9-25be-4161-bdf7-194454ec7277",
+        "dataFeedName": "dataFeeddo7sgZHb",
+        "metrics": [
+          {
+            "metricId": "e79bfcc3-2fc6-408c-a168-4e31cec3d457",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:45Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "660",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-0dfd8aedd90912419aca7fde6dc3b3a4-7bf0184dbc809c4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f7c7aaf5c0acb03d10262fd519d1f4c8",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeeddo7sgZHb",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "a1f375eb-fe3f-4ffb-84fe-7070df072087",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "523",
+        "x-request-id": "a1f375eb-fe3f-4ffb-84fe-7070df072087"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-a22780ae59d1d043a43fe113e4127a64-74774e88c989474c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "9006535c36f01ac20fb71bb09e93cd6a",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "fc640722-7d0c-46d9-9bf5-30d561e9c140",
+        "Content-Length": "1072",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "168",
+        "x-request-id": "fc640722-7d0c-46d9-9bf5-30d561e9c140"
+      },
+      "ResponseBody": {
+        "dataFeedId": "2bb9edf9-25be-4161-bdf7-194454ec7277",
+        "dataFeedName": "dataFeeddo7sgZHb",
+        "metrics": [
+          {
+            "metricId": "e79bfcc3-2fc6-408c-a168-4e31cec3d457",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:45Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-b58a4a75edac504b8605e831c7634b68-951ed2ef1db4254c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "11ecf259d2b37177c6afc57e9cd21d47",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "1a605b95-46ec-47a7-af50-43133c658d55",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:46 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "328",
+        "x-request-id": "1a605b95-46ec-47a7-af50-43133c658d55"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:46.6491767-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "412923501"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -1,0 +1,273 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "234",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-44e48d991897a14690b749c29f62578d-5c9933e7628d3940-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f44edb11bd06e15ce1f0c47de6f53bae",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedYc3bmMvk",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "3a665559-9360-4224-a5d2-e482bc1c2b0c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:25 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "414",
+        "x-request-id": "3a665559-9360-4224-a5d2-e482bc1c2b0c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-279015fd33dee743b7f75c267ba0f2f1-676c33c4ea7e774c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f920813092315ccacba365f02dc878b6",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "3712eeb6-a906-467f-8871-953a1ebf2660",
+        "Content-Length": "946",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:25 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "176",
+        "x-request-id": "3712eeb6-a906-467f-8871-953a1ebf2660"
+      },
+      "ResponseBody": {
+        "dataFeedId": "b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+        "dataFeedName": "dataFeedYc3bmMvk",
+        "metrics": [
+          {
+            "metricId": "dd28f6cd-aaae-4d5f-96c1-f37225021cd6",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "",
+        "startOffsetInSeconds": 0,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "PreviousValue",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "",
+        "stopRetryAfterInSeconds": -1,
+        "minRetryIntervalInSeconds": -1,
+        "maxConcurrency": -1,
+        "viewMode": "Private",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:25Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "660",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-f8979225cd3d3a40979753802a3599d5-f391e1580c99eb41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "f26aaf3fe9146b3925941f31da6a9da3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedYc3bmMvk",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "needRollup": "NoRollup",
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "status": "Active",
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "2b2d3959-7f0c-4095-a28a-1654d775355c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "606",
+        "x-request-id": "2b2d3959-7f0c-4095-a28a-1654d775355c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-35c1a326cab389499cc947a87d113ce1-9ed09e57db03a147-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "240d3b1f2a587f2011f22863576cb419",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "54cbd674-39c4-4c9a-b102-47764ec8458b",
+        "Content-Length": "1072",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:26 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "182",
+        "x-request-id": "54cbd674-39c4-4c9a-b102-47764ec8458b"
+      },
+      "ResponseBody": {
+        "dataFeedId": "b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+        "dataFeedName": "dataFeedYc3bmMvk",
+        "metrics": [
+          {
+            "metricId": "dd28f6cd-aaae-4d5f-96c1-f37225021cd6",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:25Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-6e96cf90d60e82458a66b331a5a46065-a666bb7b9ebb9a44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "373e0e77498b469a48b5d49c72988160",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "fe40e1e2-3f73-489c-9464-2bd1fadaebfd",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:27 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "386",
+        "x-request-id": "fe40e1e2-3f73-489c-9464-2bd1fadaebfd"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:26.8109530-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "20756105"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
@@ -1,0 +1,197 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "234",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e6b72e8c6f995a4eb48300714b814136-da22bd87fdd62d4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "2be5ffdc3e0ef1aff109ae7d0dca60bb",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedCE4QcpDi",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "d2ee4abc-e45d-498d-a872-baa71f3ae95c",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "338",
+        "x-request-id": "d2ee4abc-e45d-498d-a872-baa71f3ae95c"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "548",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-d761d65928105241a5d967eeff361708-96b61be47dab554d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "49640726815f774fc728b7e332625672",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedCE4QcpDi",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "e4015276-0438-4be1-be16-5c9647fae007",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:47 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "644",
+        "x-request-id": "e4015276-0438-4be1-be16-5c9647fae007"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c1a7afbb687b2f439602145d3ddf30c0-26df3896c4a1fd4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "c9c7ed261d6fef5549be90e899e0ad59",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "df7e1563-215c-42df-bca4-a0ee5c4cddc4",
+        "Content-Length": "1072",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:50:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "df7e1563-215c-42df-bca4-a0ee5c4cddc4"
+      },
+      "ResponseBody": {
+        "dataFeedId": "0a0f5dff-945c-420e-80db-e6f1217ae828",
+        "dataFeedName": "dataFeedCE4QcpDi",
+        "metrics": [
+          {
+            "metricId": "36cc92e6-0717-4a79-89c6-0aa67cdd82e3",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:50:47Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-eda69a37bec1fd4a898360c30ae5acfc-034672d7e7e7b349-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "cbd9cab29ef75b1eb06e64e586ccbf8f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "2a9e87cf-0989-407a-b6ff-ffcda9b7105b",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:50:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "290",
+        "x-request-id": "2a9e87cf-0989-407a-b6ff-ffcda9b7105b"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:50:48.3329712-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1169437676"
+  }
+}

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -1,0 +1,197 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "234",
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-c9a2a8d60a68a24588a0ea2569778564-ae919a4dcb03e049-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "8db3021b53adb493bbbbbc48877f519f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedhxzk8laj",
+        "granularityName": "Daily",
+        "metrics": [
+          {
+            "metricName": "cost"
+          }
+        ],
+        "dataStartFrom": "2020-08-01T00:00:00Z"
+      },
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "apim-request-id": "0d57bcd4-8a4d-456f-a2ef-52e9d3d9bf90",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "556",
+        "x-request-id": "0d57bcd4-8a4d-456f-a2ef-52e9d3d9bf90"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+      "RequestMethod": "PATCH",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "548",
+        "Content-Type": "application/merge-patch\u002Bjson",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-e20dee2399d4d646924da70b90da0e13-98cf45f5ce8a9d4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "a8fd565f80d386ffcfb1bc96988ed0ec",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        },
+        "dataSourceType": "SqlServer",
+        "dataFeedName": "dataFeedhxzk8laj",
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "timestampColumn": "updatedTimestampColumn",
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "startOffsetInSeconds": 2400,
+        "maxConcurrency": 6,
+        "minRetryIntervalInSeconds": 90,
+        "stopRetryAfterInSeconds": 1200,
+        "fillMissingPointType": "NoFilling",
+        "viewMode": "Public",
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric"
+      },
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "951332ff-ad39-4a94-a815-3b9811f60459",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "527",
+        "x-request-id": "951332ff-ad39-4a94-a815-3b9811f60459"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-205b151900861c4195787b26ae6e503a-5540eed207b9fe42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "3b5451bca968268c814f9065a9183ce2",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "apim-request-id": "5edabdd9-5308-445c-9ab3-4983f26752ef",
+        "Content-Length": "1072",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 05 Jan 2021 04:51:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "191",
+        "x-request-id": "5edabdd9-5308-445c-9ab3-4983f26752ef"
+      },
+      "ResponseBody": {
+        "dataFeedId": "39b0f538-24d7-4609-9bad-61a05713eb22",
+        "dataFeedName": "dataFeedhxzk8laj",
+        "metrics": [
+          {
+            "metricId": "a7e2417d-3443-4928-8114-ad6d228d3dd2",
+            "metricName": "cost",
+            "metricDisplayName": "cost",
+            "metricDescription": ""
+          }
+        ],
+        "dimension": [],
+        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataSourceType": "SqlServer",
+        "timestampColumn": "updatedTimestampColumn",
+        "startOffsetInSeconds": 2400,
+        "maxQueryPerMinute": 30.0,
+        "granularityName": "Daily",
+        "granularityAmount": null,
+        "allUpIdentification": null,
+        "needRollup": "NoRollup",
+        "fillMissingPointType": "NoFilling",
+        "fillMissingPointValue": 0.0,
+        "rollUpMethod": "None",
+        "rollUpColumns": [],
+        "dataFeedDescription": "This data feed was updated to test the .NET client.",
+        "stopRetryAfterInSeconds": 1200,
+        "minRetryIntervalInSeconds": 90,
+        "maxConcurrency": 6,
+        "viewMode": "Public",
+        "admins": [
+          "foo@contoso.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
+        "creator": "foo@contoso.com",
+        "status": "Active",
+        "createdTime": "2021-01-05T04:51:27Z",
+        "isAdmin": true,
+        "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
+        "dataSourceParameter": {
+          "connectionString": "Sanitized",
+          "query": "query"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Ocp-Apim-Subscription-Key": "Sanitized",
+        "traceparent": "00-4f5907a130ef8947ba36a12101c6af3e-396296ebd824d34a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "x-api-key": "Sanitized",
+        "x-ms-client-request-id": "dba6b834884e9b86022cbefb97fd1b2d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "apim-request-id": "1a5f89f6-eb0a-409d-bc54-d2d8d51f5512",
+        "Content-Length": "0",
+        "Date": "Tue, 05 Jan 2021 04:51:28 GMT",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "360",
+        "x-request-id": "1a5f89f6-eb0a-409d-bc54-d2d8d51f5512"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DateTimeOffsetNow": "2021-01-04T20:51:28.6385236-08:00",
+    "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
+    "METRICSADVISOR_ENDPOINT_SUFFIX": null,
+    "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
+    "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
+    "RandomSeed": "1308822992"
+  }
+}


### PR DESCRIPTION
Part of https://github.com/Azure/azure-sdk-for-net/issues/15913.
This PR is part of a huge set of changes that fixes the issue mentioned above. These changes were separated into 4 chunks to reduce the review burden. This PR consists of:
- Live `DataFeed` tests for Update methods. Two tests were added for every possible type of data feed (13 types). The tests are pretty much the same, so the validation and setup logic could easily be extracted into separate methods.

The added tests only take into consideration updates for data feeds with all optional members set. Data Feeds with minimum setup configuration were already added in another PR.

Note: the git diff tool is not being helpful in this set of changes. No existing tests were modified: only new tests added. All added tests are named according to the `Update<DataFeedType>WithEveryMemberAnd<Get/New>Instance` pattern.