### PR TITLE
Avoid exception when setting the network stream timeout

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - `AzureSasCredential` and its respective policy.
 
+### Key Bug Fixes
+- Avoid a causing and ignoring an exception when setting network stream timeout on .NET Core 
+
 ## 1.7.0 (2020-12-14)
 
 ### New Features

--- a/sdk/core/Azure.Core/perf/Azure.Core.Perf.csproj
+++ b/sdk/core/Azure.Core/perf/Azure.Core.Perf.csproj
@@ -5,9 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../Azure.Core/src/Azure.Core.csproj" />
+    <ProjectReference Condition="'$(AzureCoreVersion)' == ''" Include="../../Azure.Core/src/Azure.Core.csproj" />
+    <PackageReference Condition="'$(AzureCoreVersion)' != ''" Include="Azure.Core" VersionOverride="$(AzureCoreVersion)" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
-    <ProjectReference Include="$(AzureCoreTestFramework)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
   </ItemGroup>
 

--- a/sdk/core/Azure.Core/perf/DownloadHttpClientTest.cs
+++ b/sdk/core/Azure.Core/perf/DownloadHttpClientTest.cs
@@ -6,8 +6,6 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core.Pipeline;
-using Azure.Identity;
 using Azure.Test.Perf;
 
 namespace Azure.Template.Perf

--- a/sdk/core/Azure.Core/perf/DownloadTest.cs
+++ b/sdk/core/Azure.Core/perf/DownloadTest.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Core.Pipeline;
-using Azure.Identity;
 using Azure.Test.Perf;
 
 namespace Azure.Template.Perf
@@ -21,7 +20,7 @@ namespace Azure.Template.Perf
         public DownloadTest(DownloadTestOptions options) : base(options)
         {
             _server ??= InProcTestServer.CreateStaticResponse(options.Size);
-            _pipeline ??= HttpPipelineBuilder.Build(new DefaultAzureCredentialOptions());
+            _pipeline ??= HttpPipelineBuilder.Build(new TestClientOptions());
         }
 
         public override void Run(CancellationToken cancellationToken)
@@ -48,5 +47,7 @@ namespace Azure.Template.Perf
             base.Dispose(disposing);
             _server.Dispose();
         }
+
+        public class TestClientOptions: ClientOptions {}
     }
 }

--- a/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Internal/ReadTimeoutStream.cs
@@ -138,7 +138,10 @@ namespace Azure.Core.Pipeline
         {
             try
             {
-                _stream.ReadTimeout = (int) _readTimeout.TotalMilliseconds;
+                if (_stream.CanTimeout)
+                {
+                    _stream.ReadTimeout = (int) _readTimeout.TotalMilliseconds;
+                }
             }
             catch
             {

--- a/sdk/core/Azure.Core/tests/ResponseBodyPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/ResponseBodyPolicyTests.cs
@@ -201,6 +201,8 @@ namespace Azure.Core.Tests
             }
 
             public override int ReadTimeout { get; set; }
+
+            public override bool CanTimeout { get; } = true;
         }
 
         private class ReadTrackingStream : TestReadStream


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17781

Also avoids an annoying exception that shows up in VS Debug Output windows constantly.

Before (using `dotnet run -c Release -f netcoreapp2.1 -- Download -s 10000`):
```

=== Test ===
Current         Total
3206            3206
3354            6560
3291            9851
3323            13174
3371            16545
3434            19979
3563            23542
3677            27219
3323            30542
3265            33807

=== Results ===
Completed 33807 operations in a weighted-average of 10.01s (3,378.15 ops/s, 0.000 s/op)
```

After:
```
=== Test ===
Current         Total
4182            4182
4169            8351
4153            12504
4268            16772
4246            21018
4158            25176
4195            29371
4199            33570
4270            37840
3851            41691

=== Results ===
Completed 41691 operations in a weighted-average of 10.02s (4,160.27 ops/s, 0.000 s/op)
```

**Azure.Core 1.0.2**

```
=== Test ===
Current         Total
4215            4215
4265            8480
4105            12585
4679            17264
4376            21640
4385            26025
4132            30157
4518            34675
4575            39250
3728            42978

=== Results ===
Completed 42978 operations in a weighted-average of 10.00s (4,296.94 ops/s, 0.000 s/op)
```
