### PR TITLE
Disable InheritDocEnabled for KV samples

### DIFF
--- a/sdk/keyvault/samples/Directory.Build.props
+++ b/sdk/keyvault/samples/Directory.Build.props
@@ -8,4 +8,8 @@
   </PropertyGroup>
 
   <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <InheritDocEnabled>false</InheritDocEnabled>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The docs aren't published, so for sdk/keyvault/samples this should be fine to disable given the current issue with invalid XML in netstandard.library.xml for version 2.0.3.