### PR TITLE
[Event Hubs Client] Idempotent Publishing Tweaks

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingOptions.cs
@@ -68,7 +68,12 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   The starting number that should be used for the automatic sequencing of events for the associated partition, when published by this producer.
         /// </summary>
         ///
-        /// <value>The starting sequence number to associate with the partition; if <c>null</c>, the Event Hubs service will control the value.</value>
+        /// <value>
+        ///     <para>The starting sequence number to associate with the partition; if <c>null</c>, the Event Hubs service will control the value.</para>
+        ///
+        ///     <para>The sequence number will be in the range of <c>0</c> - <see cref="int.MaxValue"/> (inclusive) and will increase as events are published.
+        ///     When more than <see cref="int.MaxValue" /> events have been published, the sequence number will roll over to <c>0</c>.</para>
+        /// </value>
         ///
         /// <remarks>
         ///   The starting sequence number is only recognized and relevant when certain features of the producer are enabled.  For example, it is used by

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingProperties.cs
@@ -11,6 +11,27 @@ namespace Azure.Messaging.EventHubs.Producer
     ///
     public class PartitionPublishingProperties
     {
+        /// <summary>An empty set of properties.</summary>
+        private static PartitionPublishingProperties s_emptyInstance;
+
+        /// <summary>
+        ///   Returns a set of properties that represents an empty set of properties
+        ///   suitable for use when partitions are not inherently stateful.
+        /// </summary>
+        ///
+        internal static PartitionPublishingProperties Empty
+        {
+            get
+            {
+                // The race condition here is benign; because the resulting properties
+                // are not mutable, there is not impact to having the reference updated after
+                // initial creation.
+
+                s_emptyInstance ??= new PartitionPublishingProperties(false, null, null, null);
+                return s_emptyInstance;
+            }
+        }
+
         /// <summary>
         ///   Indicates whether or not idempotent publishing is enabled for the producer and, by extension, the associated partition.
         /// </summary>
@@ -35,6 +56,12 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   The sequence number assigned to the event that was most recently published to the associated partition
         ///   successfully.
         /// </summary>
+        ///
+        /// <value>
+        ///   The sequence number will be in the range of <c>0</c> - <see cref="int.MaxValue"/> (inclusive) and will
+        ///   increase as events are published.  When more than <see cref="int.MaxValue" /> events have been published,
+        ///   the sequence number will roll over to <c>0</c>.
+        /// </value>
         ///
         public int? LastPublishedSequenceNumber { get; }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingState.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/PartitionPublishingState.cs
@@ -54,6 +54,12 @@ namespace Azure.Messaging.EventHubs.Producer
         ///   successfully.
         /// </summary>
         ///
+        /// <value>
+        ///   The sequence number will be in the range of <c>0</c> - <see cref="int.MaxValue"/> (inclusive) and will
+        ///   increase as events are published.  When more than <see cref="int.MaxValue" /> events have been published,
+        ///   the sequence number will roll over to <c>0</c>.
+        /// </value>
+        ///
         public int? LastPublishedSequenceNumber { get; set; }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -440,7 +440,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ReadPartitionPublishingPropertiesAsyncReturnsPartitionState()
+        public async Task ReadPartitionPublishingPropertiesAsyncReturnsPartitionStateWhenIdempotentPublishingEnabled()
         {
             var expectedPartition = "5";
             var expectedProperties = new PartitionPublishingProperties(true, 123, 456, 798);
@@ -477,6 +477,41 @@ namespace Azure.Messaging.EventHubs.Tests
                     It.IsAny<CancellationToken>()),
                 Times.Never,
                 "Partition state should not have been initialized twice.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerClient.GetPartitionPublishingPropertiesAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReadPartitionPublishingPropertiesAsyncReturnsEmptyPartitionStateWhenIdempotentPublishingDisabled()
+        {
+            var expectedPartition = "5";
+            var expectedProperties = PartitionPublishingProperties.Empty;
+            var mockTransport = new Mock<TransportProducer>();
+            var connection = new MockConnection(() => mockTransport.Object);
+
+            var producer = new EventHubProducerClient(connection, new EventHubProducerClientOptions
+            {
+                EnableIdempotentPartitions = false
+            });
+
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var readProperties = await producer.GetPartitionPublishingPropertiesAsync(expectedPartition, cancellationSource.Token);
+
+            Assert.That(readProperties, Is.Not.Null, "The read properties should have been created.");
+            Assert.That(readProperties.ProducerGroupId, Is.EqualTo(expectedProperties.ProducerGroupId), "The producer group should match.");
+            Assert.That(readProperties.OwnerLevel, Is.EqualTo(expectedProperties.OwnerLevel), "The owner level should match.");
+            Assert.That(readProperties.LastPublishedSequenceNumber, Is.EqualTo(expectedProperties.LastPublishedSequenceNumber), "The sequence number should match.");
+
+            mockTransport
+                .Verify(transportProducer => transportProducer.ReadInitializationPublishingPropertiesAsync(
+                    It.IsAny<CancellationToken>()),
+                Times.Never,
+                "Partition state should not have been initialized.");
         }
 
         /// <summary>
@@ -723,6 +758,8 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 EnableIdempotentPartitions = true
             });
+
+            Assert.That(async () => await producer.SendAsync(events), Throws.InstanceOf<InvalidOperationException>(), "Idempotent publishing requires the send options.");
 
             var sendOptions = new SendEventOptions();
             Assert.That(async () => await producer.SendAsync(events, sendOptions), Throws.InstanceOf<InvalidOperationException>(), "Automatic routing cannot be used with idempotent publishing.");


### PR DESCRIPTION
# Summary

The focus of these changes is to allow querying partition publishing properties when idempotent publishing is not enabled, returning an empty set of data with the feature flags.  Several areas of documentation were also enhanced to provide additional details and context.

# Last Upstream Rebase

Tuesday, December 12, 8:19am (EST)