### PR TITLE
[synapse] SparkBatchOperation should return if complete OR started

### DIFF
--- a/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Customization/SparkBatchOperation.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Spark/src/Customization/SparkBatchOperation.cs
@@ -143,6 +143,7 @@ namespace Azure.Analytics.Synapse.Spark
 
             switch (livyState)
             {
+                case "starting":
                 case "error":
                 case "dead":
                 case "success":


### PR DESCRIPTION
- We were blocking for the batch job to be complete, which was not the expected behavior outside of tests.