### PR TITLE
[Messaging Clients] Test Resource Cleanup

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal const string ServiceManagementUrlEnvironmentVariableName = "SERVICE_MANAGEMENT_URL";
         internal const string ResourceManagerEnvironmentVariableName = "RESOURCE_MANAGER_URL";
         internal const string StorageEndpointSuffixEnvironmentVariableName = "STORAGE_ENDPOINT_SUFFIX";
-        internal const string EventHubsNamespaceConnectionStringEnvironmentVariable = "EVENTHUB_T1_NAMESPACE_CONNECTION_STRING";
-        internal const string StorageConnectionStringEnvironmentVariable = "EVENTHUB_T1_STORAGE_CONNECTION_STRING";
+        internal const string EventHubsNamespaceConnectionStringEnvironmentVariable = "EVENTHUB_NAMESPACE_CONNECTION_STRING";
+        internal const string StorageConnectionStringEnvironmentVariable = "EVENTHUB_PROCESSOR_STORAGE_CONNECTION_STRING";
 
         // General
         internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(180);

--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -61,6 +61,13 @@
       "metadata": {
         "description": "The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung."
       }
+    },
+    "guidBaseValue": {
+      "type": "string",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "The base value to use as part of GUID generation for resources requiring them, such as RBAC rules."
+      }
     }
   },
   "variables": {
@@ -68,13 +75,9 @@
     "eventHubsDataOwnerRoleId": "f526a384-b230-433a-b45c-95f59c4a2dec",
     "eventHubsNamespace": "[concat('eh-', parameters('baseName'))]",
     "storageAccount": "[concat('blb', parameters('baseName'))]",
-    "eventHubsNamespace_T1": "[concat('t1-', variables('eventHubsNamespace'))]",
-    "storageAccount_T1": "[concat('t1', variables('storageAccount'))]",
     "defaultSASKeyName": "RootManageSharedAccessKey",
     "eventHubsAuthRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('eventHubsNamespace'), variables('defaultSASKeyName'))]",
-    "eventHubsAuthRuleResourceId_T1": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('eventHubsNamespace_T1'), variables('defaultSASKeyName'))]",
     "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount'))]",
-    "storageAccountId_T1": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount_T1'))]"
   },
   "resources": [
     {
@@ -91,48 +94,6 @@
       "type": "Microsoft.Storage/storageAccounts",
       "apiVersion": "2019-04-01",
       "name": "[variables('storageAccount')]",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Standard_LRS",
-        "tier": "Standard"
-      },
-      "kind": "BlobStorage",
-      "properties": {
-        "networkAcls": {
-          "bypass": "AzureServices",
-          "virtualNetworkRules": [],
-          "ipRules": [],
-          "defaultAction": "Allow"
-        },
-        "supportsHttpsTrafficOnly": true,
-        "encryption": {
-          "services": {
-            "file": {
-              "enabled": true
-            },
-            "blob": {
-              "enabled": true
-            }
-          },
-          "keySource": "Microsoft.Storage"
-        },
-        "accessTier": "Hot"
-      }
-    },
-    {
-      "apiVersion": "2015-08-01",
-      "name": "[variables('eventHubsNamespace_T1')]",
-      "type": "Microsoft.EventHub/Namespaces",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Standard",
-        "tier": "Standard"
-      }
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "2019-04-01",
-      "name": "[variables('storageAccount_T1')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Standard_LRS",
@@ -180,7 +141,7 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('eventHubsDataOwnerRoleId'), parameters('testApplicationOid'))]",
+      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('eventHubsDataOwnerRoleId'))]",
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('eventHubsDataOwnerRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",
@@ -190,7 +151,7 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(resourceGroup().id, deployment().name, parameters('baseName'), variables('contributorRoleId'), parameters('testApplicationOid'))]",
+      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('contributorRoleId'))]",
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",
@@ -210,14 +171,6 @@
     "EVENTHUB_PROCESSOR_STORAGE_CONNECTION_STRING": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccount'), ';AccountKey=', listKeys(variables('storageAccountId'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
-    },
-    "EVENTHUB_T1_NAMESPACE_CONNECTION_STRING": {
-        "type": "string",
-        "value": "[listkeys(variables('eventHubsAuthRuleResourceId_T1'), '2015-08-01').primaryConnectionString]"
-    },
-    "EVENTHUB_T1_STORAGE_CONNECTION_STRING": {
-      "type": "string",
-      "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccount_T1'), ';AccountKey=', listKeys(variables('storageAccountId_T1'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=', parameters('storageEndpointSuffix'))]"
     }
   }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestConstants.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestConstants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     static class TestConstants
     {
         // Environment Variables
-        internal const string ConnectionStringEnvironmentVariable = "SERVICEBUS_T1_CONNECTION_STRING";
+        internal const string ConnectionStringEnvironmentVariable = "SERVICEBUS_CONNECTION_STRING";
 
         // General
         internal const string SessionPrefix = "session";

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -47,14 +47,19 @@
       "metadata": {
         "description": "The location of the resources. By default, this is the same as the resource group."
       }
+    },
+    "guidBaseValue": {
+      "type": "string",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "The base value to use as part of GUID generation for resources requiring them, such as RBAC rules."
+      }
     }
   },
   "variables": {
     "serviceBusNamespace": "[concat('sb-', parameters('baseName'))]",
-    "serviceBusNamespace_T1": "[concat('t1-', variables('serviceBusNamespace'))]",
     "defaultSASKeyName": "RootManageSharedAccessKey",
     "authRuleResourceId": "[resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', variables('serviceBusNamespace'), variables('defaultSASKeyName'))]",
-    "authRuleResourceId_T1": "[resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', variables('serviceBusNamespace_T1'), variables('defaultSASKeyName'))]",
     "sbVersion": "2017-04-01",
     "contributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c",
     "serviceBusDataOwnerRoleId": "090c5cfd-751d-490a-894a-3ce6f1109419"
@@ -71,19 +76,9 @@
       "properties": {}
     },
     {
-      "apiVersion": "[variables('sbVersion')]",
-      "name": "[variables('serviceBusNamespace_T1')]",
-      "type": "Microsoft.ServiceBus/Namespaces",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Standard"
-      },
-      "properties": {}
-    },
-    {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(resourceGroup().id, deployment().name, variables('serviceBusDataOwnerRoleId'))]",
+      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('serviceBusDataOwnerRoleId'))]",
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('serviceBusDataOwnerRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",
@@ -93,7 +88,7 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(resourceGroup().id, deployment().name, variables('contributorRoleId'))]",
+      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('contributorRoleId'))]",
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",
@@ -105,10 +100,6 @@
     "SERVICEBUS_CONNECTION_STRING": {
       "type": "string",
       "value": "[listkeys(variables('authRuleResourceId'), variables('sbVersion')).primaryConnectionString]"
-    },
-    "SERVICEBUS_T1_CONNECTION_STRING": {
-      "type": "string",
-      "value": "[listkeys(variables('authRuleResourceId_T1'), variables('sbVersion')).primaryConnectionString]"
     }
   }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to cleanup the test resources now that the pipelines have been split; there is no longer a need to generate multiple namespaces and storage accounts so that T1 and T2 test didn't compete.

This will also to introduce another element into GUID generation for the RBAC rule names.  In the current form, we occasionally see collisions in parallel runs that require restarting to fix.

# Last Upstream Rebase

Wednesday, January 13, 10:35am (EST)