### PR TITLE
Suppress ObjectDisposedException from SslStream during request cancellation

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RunOnlyOnPlatformsAttribute.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RunOnlyOnPlatformsAttribute.cs
@@ -18,13 +18,14 @@ namespace Azure.Core.TestFramework
         public bool OSX { get; set; }
         public bool Windows { get; set; }
         public string[] ContainerNames { get; set; }
+        public string Reason { get; set; }
 
         public void ApplyToTest(Test test)
         {
             if (test.RunState != RunState.NotRunnable && !CanRunOnPlatform())
             {
                 test.RunState = RunState.Ignored;
-                test.Properties.Set(PropertyNames.SkipReason, $"This test can't' run on {RuntimeInformation.OSDescription}.");
+                test.Properties.Set(PropertyNames.SkipReason, $"This test can't' run on {RuntimeInformation.OSDescription}. {Reason}");
             }
         }
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.9.0-beta.1 (Unreleased)
 
+### Key Bug Fixes
+
+- Avoid `ObjectDisposedException` when the request is cancelled during content upload over HTTPS.
 
 ## 1.8.1 (2020-01-11)
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -107,8 +107,12 @@ namespace Azure.Core.Pipeline
 #else
                     contentStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
-
                 }
+            }
+            // HttpClient on NET5 throws OperationCanceledException from sync call sites, normalize to TaskCanceledException
+            catch (OperationCanceledException)
+            {
+                throw new TaskCanceledException();
             }
             catch (HttpRequestException e)
             {

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -62,12 +62,6 @@ namespace Azure.Core.Pipeline
             {
                 if (message.Request.Content != null)
                 {
-                    if (request.ContentLength == -1 &&
-                        message.Request.Content.TryComputeLength(out var length))
-                    {
-                        request.ContentLength = length;
-                    }
-
                     using var requestStream = async ? await request.GetRequestStreamAsync().ConfigureAwait(false) : request.GetRequestStream();
 
                     if (async)
@@ -197,6 +191,13 @@ namespace Azure.Core.Pipeline
                 }
 
                 request.Headers.Add(messageRequestHeader.Name, messageRequestHeader.Value);
+            }
+
+            if (request.ContentLength == -1 &&
+                messageRequest.Content != null &&
+                messageRequest.Content.TryComputeLength(out var length))
+            {
+                request.ContentLength = length;
             }
 
             if (request.ContentLength != -1)

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
@@ -9,12 +9,15 @@ namespace Azure.Core.Tests
 {
     public class HttpClientTransportFunctionalTest : TransportFunctionalTests
     {
-        public HttpClientTransportFunctionalTest(bool isAsync) : base(isAsync)
+        static HttpClientTransportFunctionalTest()
         {
             // No way to disable SSL check per HttpClient on NET461
 #if NET461
             ServicePointManager.ServerCertificateValidationCallback += (_, _, _, _) => true;
 #endif
+        }
+        public HttpClientTransportFunctionalTest(bool isAsync) : base(isAsync)
+        {
         }
 
         protected override HttpPipelineTransport GetTransport(bool https = false)

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
@@ -17,9 +17,9 @@ namespace Azure.Core.Tests
 #endif
         }
 
-        protected override HttpPipelineTransport GetTransport(bool ssl = false)
+        protected override HttpPipelineTransport GetTransport(bool https = false)
         {
-            if (ssl)
+            if (https)
             {
 #if !NET461
                 return new HttpClientTransport(new HttpClientHandler()

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
@@ -27,7 +27,7 @@ namespace Azure.Core.Tests
 #if !NET461
                 return new HttpClientTransport(new HttpClientHandler()
                 {
-                    ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
                 });
 #endif
             }

--- a/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportFunctionalTest.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http;
+using Azure.Core.Pipeline;
+
+namespace Azure.Core.Tests
+{
+    public class HttpClientTransportFunctionalTest : TransportFunctionalTests
+    {
+        public HttpClientTransportFunctionalTest(bool isAsync) : base(isAsync)
+        {
+            // No way to disable SSL check per HttpClient on NET461
+#if NET461
+            ServicePointManager.ServerCertificateValidationCallback += (_, _, _, _) => true;
+#endif
+        }
+
+        protected override HttpPipelineTransport GetTransport(bool ssl = false)
+        {
+            if (ssl)
+            {
+#if !NET461
+                return new HttpClientTransport(new HttpClientHandler()
+                {
+                    ServerCertificateCustomValidationCallback = (_, _, _, _) => true
+                });
+#endif
+            }
+            return new HttpClientTransport();
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/HttpWebRequestTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpWebRequestTransportFunctionalTest.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using Azure.Core.Pipeline;
+
+namespace Azure.Core.Tests
+{
+#if NETFRAMEWORK
+    public class HttpWebRequestTransportFunctionalTest : TransportFunctionalTests
+    {
+        public HttpWebRequestTransportFunctionalTest(bool isAsync) : base(isAsync)
+        {
+        }
+
+        protected override HttpPipelineTransport GetTransport(bool ssl = false)
+        {
+            if (ssl)
+            {
+                return new HttpWebRequestTransport(request => request.ServerCertificateValidationCallback += (_, _, _, _) => true);
+            }
+
+            return new HttpWebRequestTransport();
+        }
+    }
+#endif
+}

--- a/sdk/core/Azure.Core/tests/HttpWebRequestTransportFunctionalTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpWebRequestTransportFunctionalTest.cs
@@ -13,9 +13,9 @@ namespace Azure.Core.Tests
         {
         }
 
-        protected override HttpPipelineTransport GetTransport(bool ssl = false)
+        protected override HttpPipelineTransport GetTransport(bool https = false)
         {
-            if (ssl)
+            if (https)
             {
                 return new HttpWebRequestTransport(request => request.ServerCertificateValidationCallback += (_, _, _, _) => true);
             }

--- a/sdk/core/Azure.Core/tests/TestServer.cs
+++ b/sdk/core/Azure.Core/tests/TestServer.cs
@@ -25,14 +25,20 @@ namespace Azure.Core.Tests
         {
         }
 
-        public TestServer(RequestDelegate app)
+        public TestServer(RequestDelegate app, bool ssl = false)
         {
             _app = app;
             _host = new WebHostBuilder()
                 .UseKestrel(options =>
                 {
                     options.Limits.MaxRequestBodySize = null;
-                    options.Listen(new IPEndPoint(IPAddress.Loopback, 0));
+                    options.Listen(new IPEndPoint(IPAddress.Loopback, 0), listenOptions =>
+                    {
+                        if (ssl)
+                        {
+                            listenOptions.UseHttps();
+                        }
+                    });
                 })
                 .ConfigureServices(services =>
                 {

--- a/sdk/core/Azure.Core/tests/TestServer.cs
+++ b/sdk/core/Azure.Core/tests/TestServer.cs
@@ -25,7 +25,7 @@ namespace Azure.Core.Tests
         {
         }
 
-        public TestServer(RequestDelegate app, bool ssl = false)
+        public TestServer(RequestDelegate app, bool https = false)
         {
             _app = app;
             _host = new WebHostBuilder()
@@ -34,7 +34,7 @@ namespace Azure.Core.Tests
                     options.Limits.MaxRequestBodySize = null;
                     options.Listen(new IPEndPoint(IPAddress.Loopback, 0), listenOptions =>
                     {
-                        if (ssl)
+                        if (https)
                         {
                             listenOptions.UseHttps();
                         }

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Core.Tests
         {
         }
 
-        protected abstract HttpPipelineTransport GetTransport(bool ssl = false);
+        protected abstract HttpPipelineTransport GetTransport(bool https = false);
 
         public static object[] ContentWithLength =>
             new object[]
@@ -789,7 +789,7 @@ namespace Azure.Core.Tests
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task ThrowsTaskCanceledExceptionWhenCancelled(bool ssl)
+        public async Task ThrowsTaskCanceledExceptionWhenCancelled(bool https)
         {
             var testDoneTcs = new CancellationTokenSource();
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -799,10 +799,10 @@ namespace Azure.Core.Tests
                 {
                     tcs.SetResult(null);
                     await Task.Delay(Timeout.Infinite, testDoneTcs.Token);
-                }, ssl);
+                }, https);
 
             var cts = new CancellationTokenSource();
-            var transport = GetTransport(ssl);
+            var transport = GetTransport(https);
             Request request = transport.CreateRequest();
             request.Uri.Reset(testServer.Address);
 
@@ -819,7 +819,7 @@ namespace Azure.Core.Tests
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task CanCancelContentUpload(bool ssl)
+        public async Task CanCancelContentUpload(bool https)
         {
             var testDoneTcs = new CancellationTokenSource();
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -834,10 +834,10 @@ namespace Azure.Core.Tests
                     await context.Request.Body.ReadAsync(buffer, 0, 100);
                     tcs.SetResult(null);
                     await Task.Delay(Timeout.Infinite, testDoneTcs.Token);
-                }, ssl);
+                }, https);
 
             var cts = new CancellationTokenSource();
-            var transport = GetTransport(ssl);
+            var transport = GetTransport(https);
             Request request = transport.CreateRequest();
             request.Method = RequestMethod.Post;
             request.Content = RequestContent.Create(buffer);

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -787,9 +787,14 @@ namespace Azure.Core.Tests
             }
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task ThrowsTaskCanceledExceptionWhenCancelled(bool https)
+        [Test]
+        public Task ThrowsTaskCanceledExceptionWhenCancelled() => ThrowsTaskCanceledExceptionWhenCancelled(false);
+
+        [Test]
+        [RunOnlyOnPlatforms(Linux = true, Windows = true, OSX = false, Reason = "https://github.com/Azure/azure-sdk-for-net/issues/17986")]
+        public Task ThrowsTaskCanceledExceptionWhenCancelledHttps() => ThrowsTaskCanceledExceptionWhenCancelled(true);
+
+        private async Task ThrowsTaskCanceledExceptionWhenCancelled(bool https)
         {
             var testDoneTcs = new CancellationTokenSource();
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -825,9 +830,14 @@ namespace Azure.Core.Tests
             testDoneTcs.Cancel();
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task CanCancelContentUpload(bool https)
+        [Test]
+        public Task CanCancelContentUpload() => CanCancelContentUpload(false);
+
+        [Test]
+        [RunOnlyOnPlatforms(Linux = true, Windows = true, OSX = false, Reason = "https://github.com/Azure/azure-sdk-for-net/issues/17986")]
+        public Task CanCancelContentUploadHttps() => CanCancelContentUpload(true);
+
+        private async Task CanCancelContentUpload(bool https)
         {
             var buffer = new byte[100];
             var testDoneTcs = new CancellationTokenSource();

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -809,11 +809,11 @@ namespace Azure.Core.Tests
             var task = Task.Run(async () => await ExecuteRequest(request, transport, cts.Token));
 
             // Wait for server to receive a request
-            await tcs.Task;
+            await tcs.Task.TimeoutAfterDefault();
 
             cts.Cancel();
 
-            Assert.ThrowsAsync(Is.InstanceOf<TaskCanceledException>(), async () => await task);
+            Assert.ThrowsAsync(Is.InstanceOf<TaskCanceledException>(), async () => await task.TimeoutAfterDefault());
             testDoneTcs.Cancel();
         }
 

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -808,8 +808,16 @@ namespace Azure.Core.Tests
 
             var task = Task.Run(async () => await ExecuteRequest(request, transport, cts.Token));
 
-            // Wait for server to receive a request
-            await tcs.Task.TimeoutAfterDefault();
+            try
+            {
+                // Wait for server to receive a request
+                await tcs.Task.TimeoutAfterDefault();
+            }
+            catch (TimeoutException)
+            {
+                // Try to observe the request failure
+                await task.TimeoutAfterDefault();
+            }
 
             cts.Cancel();
 
@@ -844,8 +852,17 @@ namespace Azure.Core.Tests
 
             var task = Task.Run(async () => await ExecuteRequest(request, transport, cts.Token));
 
-            // Wait for server to receive a request
-            await tcs.Task.TimeoutAfterDefault();
+            try
+            {
+                // Wait for server to receive a request
+                await tcs.Task.TimeoutAfterDefault();
+            }
+            catch (TimeoutException)
+            {
+                // Try to observe the request failure
+                await task.TimeoutAfterDefault();
+            }
+
             cts.Cancel();
 
             Assert.ThrowsAsync(Is.InstanceOf<TaskCanceledException>(), async () => await task.TimeoutAfterDefault());

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -33,7 +33,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: core
-    ServiceToTest: core
+    ServiceToTest: '*'
     ArtifactName: packages
     Artifacts:
     - name: Azure.Core

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -33,7 +33,7 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: core
-    ServiceToTest: '*'
+    ServiceToTest: core
     ArtifactName: packages
     Artifacts:
     - name: Azure.Core


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17527