### PR TITLE
Add net5.0 to smoke tests

### DIFF
--- a/common/SmokeTests/SmokeTest/KeyVaultTest.cs
+++ b/common/SmokeTests/SmokeTest/KeyVaultTest.cs
@@ -14,10 +14,10 @@ namespace SmokeTest
     {
         private static Dictionary<string, Uri> authorityHostMap = new Dictionary<string, Uri>
         {
-            { "AzureCloud", KnownAuthorityHosts.AzureCloud },
-            { "AzureChinaCloud", KnownAuthorityHosts.AzureChinaCloud },
-            { "AzureGermanCloud", KnownAuthorityHosts.AzureGermanCloud },
-            { "AzureUSGovernment", KnownAuthorityHosts.AzureUSGovernment },
+            { "AzureCloud", AzureAuthorityHosts.AzurePublicCloud },
+            { "AzureChinaCloud", AzureAuthorityHosts.AzureChina },
+            { "AzureGermanCloud", AzureAuthorityHosts.AzureGermany },
+            { "AzureUSGovernment", AzureAuthorityHosts.AzureGovernment },
         };
 
         private static string SecretName = $"SmokeTestSecret-{Guid.NewGuid()}";
@@ -38,16 +38,16 @@ namespace SmokeTest
             Console.WriteLine("3.- Delete that Secret (Clean up)\n");
 
             string keyVaultUri = Environment.GetEnvironmentVariable("KEY_VAULT_URI");
-            var authorityHost = GetAuthorityHost(Environment.GetEnvironmentVariable("AZURE_CLOUD"), KnownAuthorityHosts.AzureCloud);
+            var authorityHost = GetAuthorityHost(Environment.GetEnvironmentVariable("AZURE_CLOUD"), AzureAuthorityHosts.AzurePublicCloud);
 
-            var defaultAzureCredentialOptions = new DefaultAzureCredentialOptions 
+            var defaultAzureCredentialOptions = new DefaultAzureCredentialOptions
             {
                 AuthorityHost = authorityHost
             };
 
 
             client = new SecretClient(
-                new Uri(keyVaultUri), 
+                new Uri(keyVaultUri),
                 new DefaultAzureCredential(defaultAzureCredentialOptions)
             );
 

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461;net5.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <StartupObject>SmokeTest.Program</StartupObject>
   </PropertyGroup>

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -4,6 +4,14 @@
     <TargetFrameworks>netcoreapp2.1;net461;net5.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <StartupObject>SmokeTest.Program</StartupObject>
+    <NoWarn>$(NoWarn);
+    <!--
+      Because we often ship packages with ***-beta.* dependency
+      forcing them to ***-alpha.* from the nightly feed is regarded as a downgrade
+      that's why the NU1605 warning is suppressed
+     -->
+      NU1605</NoWarn>
+    
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -14,11 +14,11 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.4.0-dev.*" />
     <PackageReference Include="Azure.Identity" Version="1.2.0-dev.*" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.1.0-dev.*" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.1.0-dev.*" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0-dev.*" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.0-dev.*" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.1.0-dev.*" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.5.0-dev.*" />
-    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.3" />
+    <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.9" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.20.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.0" />
   </ItemGroup>

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.4.0-dev.*" />
     <PackageReference Include="Azure.Identity" Version="1.2.0-dev.*" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0-dev.*" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.0-dev.*" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.1.0-dev.*" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.1.0-dev.*" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.1.0-dev.*" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.5.0-dev.*" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.9" />

--- a/common/SmokeTests/smoke-tests.yml
+++ b/common/SmokeTests/smoke-tests.yml
@@ -27,6 +27,11 @@ jobs:
           TestTargetFramework: net461
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           ArmTemplateParameters: $(azureCloudArmParameters)
+        Windows_Net50 (AzureCloud):
+          OSVmImage: "windows-2019"
+          TestTargetFramework: net5.0
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          ArmTemplateParameters: $(azureCloudArmParameters)
         MacOs (AzureCloud):
           OSVmImage: "macOS-10.15"
           TestTargetFramework: netcoreapp2.1


### PR DESCRIPTION
We recently misses a .net5 packaging issue. 