### PR TITLE
Add project reference NET5 test configuration

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -184,6 +184,11 @@ jobs:
           Pool: ${{ parameters.WindowsPool }} # Comment out to swap back to public hosted pool.
           OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
           TestTargetFramework: net5.0
+        Windows_Net50_ProjectReferences:
+          Pool: ${{ parameters.WindowsPool }} # Comment out to swap back to public hosted pool.
+          OSVmImage: # "windows-2019" # Comment back in to swap back to public hosted pool.
+          TestTargetFramework: net5.0
+          ConvertToProjectReferenceOption: /p:UseProjectReferenceToAzureClients=true
     pool:
       vmImage: "$(OSVmImage)"
       name: "$(Pool)"

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -80,6 +80,10 @@ parameters:
     Windows_Net50:
       OSVmImage: "windows-2019"
       TestTargetFramework: net5.0
+    Windows_NetCoreApp_ProjectReferences:
+      OSVmImage: "windows-2019"
+      TestTargetFramework: net5.0
+      AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
 - name: PlatformPreSteps
   type: object
   default:

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -12,7 +12,7 @@
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -12,7 +12,7 @@
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />


### PR DESCRIPTION
We've missed an Azure.Core packaging issue because we didn't have this configuration.