### PR TITLE
Enable 1ES pools for live tests.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - ${{ parameters.PreSteps }}
 
-      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+#      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
       - ${{ each step in parameters.TestSetupSteps }}:
         - ${{ each pair in step }}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -60,6 +60,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
     pool:
+      name: $(Pool)
       vmImage: $(OSVmImage)
 
     ${{ if eq(parameters.UsePlatformContainer, 'true') }}:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -56,29 +56,36 @@ parameters:
   type: object
   default:
     Linux:
-      OSVmImage: "ubuntu-18.04"
+      Pool: azsdk-pool-mms-ubuntu-1804-general
+      OSVmImage: MMSUbuntu18.04
       TestTargetFramework: netcoreapp2.1
     Windows_NetCoreApp:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms-windows-2019-general
+      OSVmImage: MMS2019
       TestTargetFramework: netcoreapp2.1
       SupportsRecording: true
     Windows_NetCoreApp_ProjectReferences:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms-windows-2019-general
+      OSVmImage: MMS2019
       TestTargetFramework: netcoreapp2.1
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     Windows_NetFramework:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms-windows-2019-general
+      OSVmImage: MMS2019
       TestTargetFramework: net461
     Windows_NetFramework_ProjectReferences:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms-windows-2019-general
+      OSVmImage: MMS2019
       TestTargetFramework: net461
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     MacOS:
+      Pool: Azure Pipelines
       OSVmImage: "macOS-10.15"
       TestTargetFramework: netcoreapp2.1
       SupportedClouds: 'Public'
     Windows_Net50:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms-windows-2019-general
+      OSVmImage: MMS2019
       TestTargetFramework: net5.0
     Windows_Net50_ProjectReferences:
       OSVmImage: "windows-2019"

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -88,7 +88,8 @@ parameters:
       OSVmImage: MMS2019
       TestTargetFramework: net5.0
     Windows_Net50_ProjectReferences:
-      OSVmImage: "windows-2019"
+      Pool: azsdk-pool-mms-win-2019-general
+      OSVmImage: MMS2019
       TestTargetFramework: net5.0
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
 - name: PlatformPreSteps

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -70,7 +70,7 @@ parameters:
       TestTargetFramework: netcoreapp2.1
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
     Windows_NetFramework:
-      Pool: azsdk-pool-mms-windows-2019-general
+      Pool: azsdk-pool-mms-win-2019-general
       OSVmImage: MMS2019
       TestTargetFramework: net461
     Windows_NetFramework_ProjectReferences:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -60,12 +60,12 @@ parameters:
       OSVmImage: MMSUbuntu18.04
       TestTargetFramework: netcoreapp2.1
     Windows_NetCoreApp:
-      Pool: azsdk-pool-mms-windows-2019-general
+      Pool: azsdk-pool-mms-win-2019-general
       OSVmImage: MMS2019
       TestTargetFramework: netcoreapp2.1
       SupportsRecording: true
     Windows_NetCoreApp_ProjectReferences:
-      Pool: azsdk-pool-mms-windows-2019-general
+      Pool: azsdk-pool-mms-win-2019-general
       OSVmImage: MMS2019
       TestTargetFramework: netcoreapp2.1
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
@@ -74,7 +74,7 @@ parameters:
       OSVmImage: MMS2019
       TestTargetFramework: net461
     Windows_NetFramework_ProjectReferences:
-      Pool: azsdk-pool-mms-windows-2019-general
+      Pool: azsdk-pool-mms-win-2019-general
       OSVmImage: MMS2019
       TestTargetFramework: net461
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"
@@ -84,7 +84,7 @@ parameters:
       TestTargetFramework: netcoreapp2.1
       SupportedClouds: 'Public'
     Windows_Net50:
-      Pool: azsdk-pool-mms-windows-2019-general
+      Pool: azsdk-pool-mms-win-2019-general
       OSVmImage: MMS2019
       TestTargetFramework: net5.0
     Windows_Net50_ProjectReferences:

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -12,7 +12,8 @@ extends:
   parameters:
     AdditionalPlatforms:
       Linux_NetCore_Keyring:
-        OSVmImage: "ubuntu-18.04"
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage: MMSUbuntu18.04
         TestTargetFramework: 'netcoreapp2.1'
         Container: 'ubuntu_netcore_keyring'
         SupportedClouds: 'Public,Canary,Preview'


### PR DESCRIPTION
This PR adds support for 1ES pools on live test pipelines. It does this by adding a ```Pool``` parameter to platform entries which is then propagated down into the test job template as a variable in the matrix (which is then used in the ```pool:``` setting on jobs.