### PR TITLE
[Communication] - Common - Rename Id to UserId

### DIFF
--- a/sdk/communication/Azure.Communication.Common/api/Azure.Communication.Common.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.Common/api/Azure.Communication.Common.netstandard2.0.cs
@@ -29,8 +29,8 @@ namespace Azure.Communication
     public partial class MicrosoftTeamsUserIdentifier : Azure.Communication.CommunicationIdentifier
     {
         public MicrosoftTeamsUserIdentifier(string userId, bool isAnonymous = false) { }
-        public string Id { get { throw null; } }
         public bool IsAnonymous { get { throw null; } }
+        public string UserId { get { throw null; } }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("{Value}")]
     public partial class PhoneNumberIdentifier : Azure.Communication.CommunicationIdentifier

--- a/sdk/communication/Azure.Communication.Common/src/MicrosoftTeamsUserIdentifier.cs
+++ b/sdk/communication/Azure.Communication.Common/src/MicrosoftTeamsUserIdentifier.cs
@@ -9,7 +9,7 @@ namespace Azure.Communication
     public class MicrosoftTeamsUserIdentifier : CommunicationIdentifier
     {
         /// <summary>The id of the Microsoft Teams user. If the user isn't anonymous, the id is the AAD object id of the user.</summary>
-        public string Id { get; }
+        public string UserId { get; }
 
         /// <summary>True if the user is anonymous, for example when joining a meeting with a share link.</summary>
         public bool IsAnonymous { get; }
@@ -28,7 +28,7 @@ namespace Azure.Communication
         public MicrosoftTeamsUserIdentifier(string userId, bool isAnonymous = false)
         {
             Argument.AssertNotNullOrEmpty(userId, nameof(userId));
-            Id = userId;
+            UserId = userId;
             IsAnonymous = isAnonymous;
         }
     }


### PR DESCRIPTION
"Id" is reserved for future use so renaming to "UseId"