### PR TITLE
SDK version 4.2.1 (Hotfix on 4.2.0): Update dependency of Microsoft.Azure.Amqp to version 2.4.9 and include ci.data.yml to trigger build from non-master branch

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -25,7 +25,7 @@
     <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.0.0" />
     <PackageReference Update="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
-    <PackageReference Update="Microsoft.Azure.Amqp" Version="[2.4.2, 3.0.0)" />
+    <PackageReference Update="Microsoft.Azure.Amqp" Version="2.4.9" />
     <PackageReference Update="Microsoft.Azure.Batch" Version="11.0.0" />
     <PackageReference Update="Microsoft.Azure.Graph.RBAC" Version="2.2.2-preview" />
     <PackageReference Update="Microsoft.Azure.KeyVault.Core" Version="3.0.3" />

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Release History
+
+## 4.2.1 (2021-01-14)
+- Update dependency of Microsoft.Azure.Amqp to version 2.4.9
+
 ## 4.2.0
 ### Improvements
 - Enable a way to Unregister Message Handler and Session Handler [PR 14021](https://github.com/Azure/azure-sdk-for-net/pull/14021)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/ci.data.yml
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/ci.data.yml
@@ -1,0 +1,34 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+
+trigger:
+  branches:
+    include:
+    - master
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/servicebus/ci.data.yml
+    - sdk/servicebus/Microsoft.Azure.ServiceBus
+
+pr:
+  branches:
+    include:
+    - master
+    - feature/*
+    - hotfix/*
+    - release/*
+  paths:
+    include:
+    - sdk/servicebus/ci.data.yml
+    - sdk/servicebus/Microsoft.Azure.ServiceBus
+
+extends:
+  template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    SdkType: data
+    ServiceDirectory: servicebus
+    ArtifactName: packages
+    Artifacts:
+    - name: Microsoft.Azure.ServiceBus
+      safeName: MicrosoftAzureServiceBus

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Azure ServiceBus SDK</AssemblyTitle>
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
-    <Version>4.2.0</Version>
+    <Version>4.2.1</Version>
     <PackageTags>Microsoft;Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic</PackageTags>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -32,7 +32,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Azure ServiceBus SDK</AssemblyTitle>
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
     <Version>4.2.1</Version>
     <PackageTags>Microsoft;Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic</PackageTags>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;CS1573;NU5125</NoWarn>
   </PropertyGroup>
@@ -32,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
-	<PackageReference Include="Microsoft.Azure.Amqp" />
+    <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -4,6 +4,7 @@
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
     <Version>4.2.1</Version>
     <PackageTags>Microsoft;Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic</PackageTags>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;CS1573;NU5125</NoWarn>
   </PropertyGroup>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
-	  <PackageReference Include="Microsoft.Azure.Amqp" />
+	<PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
-	<PackageReference Include="Microsoft.Azure.Amqp" />
+	  <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
+	<PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />


### PR DESCRIPTION
We need to release a new version of our Track 1 SDK Microsoft.Azure.ServiceBus with updated dependency on Microsoft.Azure.Amqp version 2.4.9.

