### PR TITLE
Change duplicate matrix name in live test template

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -80,7 +80,7 @@ parameters:
     Windows_Net50:
       OSVmImage: "windows-2019"
       TestTargetFramework: net5.0
-    Windows_NetCoreApp_ProjectReferences:
+    Windows_Net50_ProjectReferences:
       OSVmImage: "windows-2019"
       TestTargetFramework: net5.0
       AdditionalTestArguments: "/p:UseProjectReferenceToAzureClients=true"


### PR DESCRIPTION
This fixes a duplicate name entry in the test matrix.