### PR TITLE
[FR] Don't check error code for wrong region

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -526,8 +526,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             var operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
-            Assert.AreEqual("AuthorizationError", ex.ErrorCode);
+            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
         }
 
         [Test]


### PR DESCRIPTION
The error code here is not reliable as it can change depending on the load on the server. So deleting the check to avoid flakiness.
Example: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=688466&view=results