### PR TITLE
[Messaging Clients] Test Resource RBAC Tweaks

### DIFF
--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -61,13 +61,6 @@
       "metadata": {
         "description": "The maximum duration, in minutes, that a single test is permitted to run before it is considered at-risk for being hung."
       }
-    },
-    "guidBaseValue": {
-      "type": "string",
-      "defaultValue": "[newGuid()]",
-      "metadata": {
-        "description": "The base value to use as part of GUID generation for resources requiring them, such as RBAC rules."
-      }
     }
   },
   "variables": {
@@ -141,7 +134,11 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('eventHubsDataOwnerRoleId'))]",
+      "name": "[guid(resourceGroup().id, parameters('testApplicationOid'), variables('eventHubsDataOwnerRoleId'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.EventHub/Namespaces', variables('eventHubsNamespace'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount'))]"
+      ],
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('eventHubsDataOwnerRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",
@@ -151,7 +148,11 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('contributorRoleId'))]",
+      "name": "[guid(resourceGroup().id, parameters('testApplicationOid'), variables('contributorRoleId'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.EventHub/Namespaces', variables('eventHubsNamespace'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount'))]"
+      ],
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -47,13 +47,6 @@
       "metadata": {
         "description": "The location of the resources. By default, this is the same as the resource group."
       }
-    },
-    "guidBaseValue": {
-      "type": "string",
-      "defaultValue": "[newGuid()]",
-      "metadata": {
-        "description": "The base value to use as part of GUID generation for resources requiring them, such as RBAC rules."
-      }
     }
   },
   "variables": {
@@ -78,7 +71,10 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('serviceBusDataOwnerRoleId'))]",
+      "name": "[guid(resourceGroup().id, parameters('testApplicationOid'), variables('serviceBusDataOwnerRoleId'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/Namespaces', variables('serviceBusNamespace'))]"
+      ],
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('serviceBusDataOwnerRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",
@@ -88,7 +84,10 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2019-04-01-preview",
-      "name": "[guid(parameters('guidBaseValue'), parameters('baseName'), parameters('testApplicationOid'), variables('contributorRoleId'))]",
+      "name": "[guid(resourceGroup().id, parameters('testApplicationOid'), variables('contributorRoleId'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/Namespaces', variables('serviceBusNamespace'))]"
+      ],
       "properties": {
         "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRoleId'))]",
         "principalId": "[parameters('testApplicationOid')]",


### PR DESCRIPTION
# Summary

The focus of these changes is to try and eliminate the potential for duplicate role assignments during retries of template deployment.  The previous approach attempted to randomize the name sufficiently to avoid collisions during retries; however, this increased failures because the same grant cannot exist in the same scope for the same principal - regardless of name.

This revision attempts to create a deterministic name based on the resource and principal that the grant is associated with and also limits creating the grant unless the key resources defined by the template were successful.

# Last Upstream Rebase

Saturday, January 16, 1:02pm (EST)