### PR TITLE
[Event Hubs Client] Preserve AMQP Exceptions

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
@@ -85,11 +85,13 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="response">The response to consider.</param>
         /// <param name="eventHubsResource">The Event Hubs resource associated with the request.</param>
+        /// <param name="innerException">The exception to embed in the newly created exception.</param>
         ///
         /// <returns>The exception that most accurately represents the response failure.</returns>
         ///
         public static Exception CreateExceptionForResponse(AmqpMessage response,
-                                                           string eventHubsResource)
+                                                           string eventHubsResource,
+                                                           Exception innerException = default)
         {
             if (response == null)
             {
@@ -101,7 +103,7 @@ namespace Azure.Messaging.EventHubs
                 description = Resources.UnknownCommunicationException;
             }
 
-            return CreateException(DetermineErrorCondition(response).Value, description, eventHubsResource);
+            return CreateException(DetermineErrorCondition(response).Value, description, eventHubsResource, innerException);
         }
 
         /// <summary>
@@ -110,18 +112,20 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="error">The AMQP error to consider.</param>
         /// <param name="eventHubsResource">The Event Hubs resource associated with the operation.</param>
+        /// <param name="innerException">The exception to embed in the newly created exception.</param>
         ///
         /// <returns>The exception that most accurately represents the error that was encountered.</returns>
         ///
         public static Exception CreateExceptionForError(Error error,
-                                                        string eventHubsResource)
+                                                        string eventHubsResource,
+                                                        Exception innerException = default)
         {
             if (error == null)
             {
                 return new EventHubsException(true, eventHubsResource, Resources.UnknownCommunicationException);
             }
 
-            return CreateException(error.Condition.Value, error.Description, eventHubsResource);
+            return CreateException(error.Condition.Value, error.Description, eventHubsResource, innerException);
         }
 
         /// <summary>
@@ -151,72 +155,74 @@ namespace Azure.Messaging.EventHubs
         /// <param name="condition">The error condition that represents the failure scenario.</param>
         /// <param name="description">The descriptive text to use for messaging the scenario.</param>
         /// <param name="eventHubsResource">The Event Hubs resource associated with the failure.</param>
+        /// <param name="innerException">The exception to embed in the newly created exception.</param>
         ///
         /// <returns>The exception that most accurately represents the failure scenario.</returns>
         ///
         private static Exception CreateException(string condition,
                                                  string description,
-                                                 string eventHubsResource)
+                                                 string eventHubsResource,
+                                                 Exception innerException = default)
         {
             // The request timed out.
 
             if (string.Equals(condition, TimeoutError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceTimeout);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceTimeout, innerException);
             }
 
             // The Event Hubs service was busy.
 
             if (string.Equals(condition, ServerBusyError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceBusy);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceBusy, innerException);
             }
 
             // An argument was rejected by the Event Hubs service.
 
             if (string.Equals(condition, ArgumentError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new ArgumentException(description);
+                return new ArgumentException(description, innerException);
             }
 
             if (string.Equals(condition, ArgumentOutOfRangeError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new ArgumentOutOfRangeException(description);
+                return new ArgumentOutOfRangeException(description, innerException);
             }
 
             // The consumer was superseded by one with a higher owner level.
 
             if (string.Equals(condition, AmqpErrorCode.Stolen.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ConsumerDisconnected);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ConsumerDisconnected, innerException);
             }
 
             // The producer was superseded by one with a higher owner level.
 
             if (string.Equals(condition, ProducerStolenError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ProducerDisconnected);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ProducerDisconnected, innerException);
             }
 
             // The client-supplied sequence number was not in the expected order.
 
             if (string.Equals(condition, SequenceOutOfOrderError.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.InvalidClientState);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.InvalidClientState, innerException);
             }
 
             // Authorization was denied.
 
             if (string.Equals(condition, AmqpErrorCode.UnauthorizedAccess.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new UnauthorizedAccessException(description);
+                return new UnauthorizedAccessException(description, innerException);
             }
 
             // Requests are being throttled due to exceeding the service quota.
 
             if (string.Equals(condition, AmqpErrorCode.ResourceLimitExceeded.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.QuotaExceeded);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.QuotaExceeded, innerException);
             }
 
             // The link was closed, generally this exception would be thrown for partition specific producers and would be caused by race conditions
@@ -224,19 +230,19 @@ namespace Azure.Messaging.EventHubs
 
             if (string.Equals(condition, AmqpErrorCode.IllegalState.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ClientClosed);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ClientClosed, innerException);
             }
 
             // The service does not understand how to process the request.
 
             if (string.Equals(condition, AmqpErrorCode.NotAllowed.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new InvalidOperationException(description);
+                return new InvalidOperationException(description, innerException);
             }
 
             if (string.Equals(condition, AmqpErrorCode.NotImplemented.Value, StringComparison.InvariantCultureIgnoreCase))
             {
-                return new NotSupportedException(description);
+                return new NotSupportedException(description, innerException);
             }
 
             // The Event Hubs resource was not valid or communication with the service was interrupted.
@@ -246,15 +252,15 @@ namespace Azure.Messaging.EventHubs
                 if (NotFoundExpression.IsMatch(description)
                     || (description.IndexOf(NotFoundStatusText, StringComparison.InvariantCultureIgnoreCase) >= 0))
                 {
-                    return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ResourceNotFound);
+                    return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ResourceNotFound, innerException);
                 }
 
-                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceCommunicationProblem);
+                return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceCommunicationProblem, innerException);
             }
 
             // There was no specific exception that could be determined; fall back to a generic one.
 
-            return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceCommunicationProblem);
+            return new EventHubsException(eventHubsResource, description, EventHubsException.FailureReason.ServiceCommunicationProblem, innerException);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/ExceptionExtensions.cs
@@ -33,16 +33,16 @@ namespace Azure.Messaging.EventHubs.Amqp
             switch (instance)
             {
                 case AmqpException amqpEx:
-                    return AmqpError.CreateExceptionForError(amqpEx.Error, eventHubName);
+                    return AmqpError.CreateExceptionForError(amqpEx.Error, eventHubName, amqpEx);
 
                 case OperationCanceledException operationEx when (operationEx.InnerException is AmqpException):
-                    return AmqpError.CreateExceptionForError(((AmqpException)operationEx.InnerException).Error, eventHubName);
+                    return AmqpError.CreateExceptionForError(((AmqpException)operationEx.InnerException).Error, eventHubName, operationEx.InnerException);
 
                 case OperationCanceledException operationEx when (operationEx.InnerException != null):
                     return operationEx.InnerException;
 
                 case OperationCanceledException operationEx when (!(operationEx is TaskCanceledException)):
-                    return new EventHubsException(eventHubName, operationEx.Message, EventHubsException.FailureReason.ServiceTimeout);
+                    return new EventHubsException(eventHubName, operationEx.Message, EventHubsException.FailureReason.ServiceTimeout, operationEx);
 
                 default:
                     return instance;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubsException.cs
@@ -114,33 +114,6 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="EventHubsException"/> class, using the <paramref name="reason"/>
-        ///   to detect whether or not it should be transient.
-        /// </summary>
-        ///
-        /// <param name="eventHubName">The name of the Event Hub to which the exception is associated.</param>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="reason">The reason for the failure that resulted in the exception.</param>
-        ///
-        public EventHubsException(string eventHubName,
-                                  string message,
-                                  FailureReason reason) : this(default, eventHubName, message, reason, null)
-        {
-            switch (reason)
-            {
-                case FailureReason.ServiceCommunicationProblem:
-                case FailureReason.ServiceTimeout:
-                case FailureReason.ServiceBusy:
-                    IsTransient = true;
-                    break;
-
-                default:
-                    IsTransient = false;
-                    break;
-            }
-        }
-
-        /// <summary>
         ///   Initializes a new instance of the <see cref="EventHubsException"/> class.
         /// </summary>
         ///
@@ -175,6 +148,50 @@ namespace Azure.Messaging.EventHubs
             IsTransient = isTransient;
             EventHubName = eventHubName;
             Reason = reason;
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsException"/> class, using the <paramref name="reason"/>
+        ///   to detect whether or not it should be transient.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="reason">The reason for the failure that resulted in the exception.</param>
+        ///
+        public EventHubsException(string eventHubName,
+                                  string message,
+                                  FailureReason reason) : this(eventHubName, message, reason, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsException"/> class, using the <paramref name="reason"/>
+        ///   to detect whether or not it should be transient.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the Event Hub to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="reason">The reason for the failure that resulted in the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal EventHubsException(string eventHubName,
+                                    string message,
+                                    FailureReason reason,
+                                    Exception innerException) : this(false, eventHubName, message, reason, innerException)
+        {
+            switch (reason)
+            {
+                case FailureReason.ServiceCommunicationProblem:
+                case FailureReason.ServiceTimeout:
+                case FailureReason.ServiceBusy:
+                    IsTransient = true;
+                    break;
+
+                default:
+                    IsTransient = false;
+                    break;
+            }
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpExceptionExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpExceptionExtensionsTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Amqp;
+using Microsoft.Azure.Amqp;
 using Microsoft.Azure.Amqp.Framing;
 using NUnit.Framework;
 
@@ -51,7 +52,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void TranslateServiceExceptionTranslatesAmqpExceptions()
         {
             var eventHub = "someHub";
-            var exception = AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, eventHub);
+            var exception = new AmqpException(new Error { Condition = AmqpError.ServerBusyError });
             var translated = exception.TranslateServiceException(eventHub);
 
             Assert.That(translated, Is.Not.Null, "An exception should have been returned.");
@@ -60,6 +61,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(eventHubsException, Is.Not.Null, "The exception type should be appropriate for the `Server Busy` scenario.");
             Assert.That(eventHubsException.Reason, Is.EqualTo(EventHubsException.FailureReason.ServiceBusy), "The exception reason should indicate `Server Busy`.");
             Assert.That(eventHubsException.EventHubName, Is.EqualTo(eventHub), "The Event Hub name should match.");
+            Assert.That(eventHubsException.InnerException, Is.EqualTo(exception), "The original exception should have been embedded.");
         }
 
         /// <summary>
@@ -80,6 +82,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(eventHubsException, Is.Not.Null, "The exception type should be appropriate for the `Server Busy` scenario.");
             Assert.That(eventHubsException.Reason, Is.EqualTo(EventHubsException.FailureReason.ServiceTimeout), "The exception reason should indicate a service timeout.");
             Assert.That(eventHubsException.EventHubName, Is.EqualTo(eventHub), "The Event Hub name should match.");
+            Assert.That(eventHubsException.InnerException, Is.EqualTo(exception), "The original exception should have been embedded.");
         }
 
         /// <summary>
@@ -91,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void TranslateServiceExceptionTranslatesOperationCanceledWithEmbeddedAmqpException()
         {
             var eventHub = "someHub";
-            var exception = new OperationCanceledException("oops", AmqpError.CreateExceptionForError(new Error { Condition = AmqpError.ServerBusyError }, eventHub));
+            var exception = new OperationCanceledException("oops", new AmqpException(new Error { Condition = AmqpError.ServerBusyError }));
             var translated = exception.TranslateServiceException(eventHub);
 
             Assert.That(translated, Is.Not.Null, "An exception should have been returned.");
@@ -100,6 +103,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(eventHubsException, Is.Not.Null, "The exception type should be appropriate for the `Server Busy` scenario.");
             Assert.That(eventHubsException.Reason, Is.EqualTo(EventHubsException.FailureReason.ServiceBusy), "The exception reason should indicate `Server Busy`.");
             Assert.That(eventHubsException.EventHubName, Is.EqualTo(eventHub), "The Event Hub name should match.");
+            Assert.That(eventHubsException.InnerException, Is.EqualTo(exception.InnerException), "The AMQP exception should have been embedded.");
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The focus of these changes is to preserve AMQP exceptions as inner exceptions after translating, to allow for deeper insight of service behavior and assist in debugging efforts.

# Last Upstream Rebase

Monday, January 19, 3:38pm (EST)