### PR TITLE
Disable default HttpClient/HttpWebRequest timeouts

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.cs
@@ -134,7 +134,11 @@ namespace Azure.Core.Pipeline
             ServicePointHelpers.SetLimits(httpClientHandler);
 #endif
 
-            return new HttpClient(httpClientHandler);
+            return new HttpClient(httpClientHandler)
+            {
+                // Timeouts are handled by the pipeline
+                Timeout = Timeout.InfiniteTimeSpan
+            };
         }
 
         private static HttpRequestMessage BuildRequestMessage(HttpMessage message)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpWebRequestTransport.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Core.Pipeline
@@ -110,6 +111,11 @@ namespace Azure.Core.Pipeline
         private HttpWebRequest CreateRequest(Request messageRequest)
         {
             var request = WebRequest.CreateHttp(messageRequest.Uri.ToUri());
+
+            // Timeouts are handled by the pipeline
+            request.Timeout = Timeout.Infinite;
+            request.ReadWriteTimeout = Timeout.Infinite;
+
             // Don't disable the default proxy when there is no environment proxy configured
             if (_environmentProxy != null)
             {


### PR DESCRIPTION
I double check and all the cases handled by default timeouts are already handled by the Azure.Core pipeline, ResponseBodyPolicy in particular.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/18047