### PR TITLE
Skip empty checkpoints

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/CheckpointStore/BlobsCheckpointStoreTests.cs
@@ -621,7 +621,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         /// </summary>
         ///
         [Test]
-        public async Task ListCheckpointsUsesSequenceNumberAsTheStartingPositionWhenOffsetIsNullInLegacyCheckpoint()
+        public async Task ListCheckpointSkipsCheckpointsWhenOffsetIsNullInLegacyCheckpoint()
         {
             var blobList = new List<BlobItem>
             {
@@ -648,8 +648,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             var checkpoints = await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, new CancellationToken());
 
             Assert.That(checkpoints, Is.Not.Null, "A set of checkpoints should have been returned.");
-            Assert.That(checkpoints.Single().StartingPosition, Is.EqualTo(EventPosition.FromSequenceNumber(0, false)));
-            Assert.That(checkpoints.Single().PartitionId, Is.EqualTo("0"));
+            Assert.That(checkpoints, Is.Empty, "No valid checkpoints should exist.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
@@ -605,6 +605,7 @@ namespace Azure.Messaging.EventHubs.Processor
             offset = null;
             sequenceNumber = null;
 
+            var hadOffset = false;
             var jsonReader = new Utf8JsonReader(data);
 
             try
@@ -623,8 +624,10 @@ namespace Azure.Messaging.EventHubs.Processor
                                 return false;
                             }
 
+                            hadOffset = true;
+
                             var offsetString = jsonReader.GetString();
-                            if (offsetString != null)
+                            if (!string.IsNullOrEmpty(offsetString))
                             {
                                 if (long.TryParse(offsetString, out long offsetValue))
                                 {
@@ -657,7 +660,8 @@ namespace Azure.Messaging.EventHubs.Processor
                 // Ignore this because if the data is malformed, it will be treated as if the checkpoint didn't exist.
                 return false;
             }
-            return true;
+
+            return hadOffset && sequenceNumber != null;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobCheckpointStore/BlobsCheckpointStore.cs
@@ -370,18 +370,20 @@ namespace Azure.Messaging.EventHubs.Processor
                     using var memoryStream = new MemoryStream();
                     await blobClient.DownloadToAsync(memoryStream, listCheckpointsToken).ConfigureAwait(false);
 
-                    TryReadLegacyCheckpoint(
+                    if (TryReadLegacyCheckpoint(
                         memoryStream.GetBuffer().AsSpan(0, (int)memoryStream.Length),
                         out long? offset,
-                        out long? sequenceNumber);
-
-                    if (offset.HasValue)
+                        out long? sequenceNumber))
                     {
-                        startingPosition = EventPosition.FromOffset(offset.Value, false);
-                    }
-                    else if (sequenceNumber.HasValue)
-                    {
-                        startingPosition = EventPosition.FromSequenceNumber(sequenceNumber.Value, false);
+                        if (offset.HasValue)
+                        {
+                            startingPosition = EventPosition.FromOffset(offset.Value, false);
+                        }
+                        else
+                        {
+                            // Skip checkpoints without an offset without logging an error
+                            continue;
+                        }
                     }
 
                     if (startingPosition.HasValue)
@@ -598,7 +600,7 @@ namespace Azure.Messaging.EventHubs.Processor
         ///       "SequenceNumber":960180
         ///   }
         /// /// </remarks>
-        private static void TryReadLegacyCheckpoint(Span<byte> data, out long? offset, out long? sequenceNumber)
+        private static bool TryReadLegacyCheckpoint(Span<byte> data, out long? offset, out long? sequenceNumber)
         {
             offset = null;
             sequenceNumber = null;
@@ -607,7 +609,8 @@ namespace Azure.Messaging.EventHubs.Processor
 
             try
             {
-                if (!jsonReader.Read() || jsonReader.TokenType != JsonTokenType.StartObject) return;
+                if (!jsonReader.Read() || jsonReader.TokenType != JsonTokenType.StartObject)
+                    return false;
 
                 while (jsonReader.Read() && jsonReader.TokenType == JsonTokenType.PropertyName)
                 {
@@ -617,7 +620,7 @@ namespace Azure.Messaging.EventHubs.Processor
 
                             if (!jsonReader.Read())
                             {
-                                return;
+                                return false;
                             }
 
                             var offsetString = jsonReader.GetString();
@@ -629,7 +632,7 @@ namespace Azure.Messaging.EventHubs.Processor
                                 }
                                 else
                                 {
-                                    return;
+                                    return false;
                                 }
                             }
 
@@ -638,7 +641,7 @@ namespace Azure.Messaging.EventHubs.Processor
                             if (!jsonReader.Read() ||
                                 !jsonReader.TryGetInt64(out long sequenceNumberValue))
                             {
-                                return;
+                                return false;
                             }
 
                             sequenceNumber = sequenceNumberValue;
@@ -652,7 +655,9 @@ namespace Azure.Messaging.EventHubs.Processor
             catch (JsonException)
             {
                 // Ignore this because if the data is malformed, it will be treated as if the checkpoint didn't exist.
+                return false;
             }
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
T1 client can write checkpoints with a null offset and 0 sequenceNumber, they should be skipped.