### PR TITLE
[Service Bus Client] Documentation Updates

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 7.1.0-beta.1 (Unreleased)
 
+### Acknowledgments
+Thank you to our developer community members who helped to make the Service Bus client library better with their contributions to this release:
+
+- Aaron Dandy _([GitHub](https://github.com/aarondandy))_
+
+### Key Bug Fixes
+
+- Fixed an issue with the `ServiceBusProcessor` where closing and disposing or disposing multiple times resulted in an exception.  (A community contribution, courtesy of _[aarondandy](https://github.com/aarondandy)_)
+
 
 ## 7.0.1 (2021-01-12)
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -374,12 +374,18 @@ namespace Azure.Messaging.ServiceBus
             }
         }
 
-        /// <summary>Gets or sets the date and time in UTC at which the message will be enqueued. This
-        /// property returns the time in UTC; when setting the property, the supplied DateTime value must also be in UTC.</summary>
-        /// <value>The scheduled enqueue time in UTC. This value is for delayed message sending.
-        /// It is utilized to delay messages sending to a specific time in the future.</value>
-        /// <remarks> Message enqueuing time does not mean that the message will be sent at the same time. It will get enqueued, but the actual sending time
-        /// depends on the queue's workload and its state.</remarks>
+        /// <summary>
+        ///   Gets or sets the date and time in UTC at which the message will be enqueued. This
+        ///   property returns the time in UTC; when setting the property, the supplied DateTime value must also be in UTC.
+        /// </summary>
+        /// <value>
+        ///   The scheduled enqueue time in UTC. This value is for delayed message sending.
+        ///   It is utilized to delay messages sending to a specific time in the future.
+        /// </value>
+        /// <remarks>
+        ///   Message enqueuing time does not mean that the message will be sent at the same time. It will get enqueued, but the actual sending time
+        ///   depends on the queue's workload and its state.
+        /// </remarks>
         public DateTimeOffset ScheduledEnqueueTime
         {
             get


### PR DESCRIPTION
# Summary

The focus of these changes is to update the changelog with a recent community contribution and to reformat doc comments to try to fix a doc generation issue.

# Last Upstream Rebase

Friday, January 15, 2:56pm (EST)

# Related

- [Markup mistake in Remarks section](https://github.com/Azure/azure-sdk-for-net/issues/18025) ([#18025](https://github.com/Azure/azure-sdk-for-net/issues/18025))