### PR TITLE
Include headers in the ExtractFailureContent partial methods

### DIFF
--- a/sdk/core/Azure.Core/generate_solution.ps1
+++ b/sdk/core/Azure.Core/generate_solution.ps1
@@ -27,7 +27,11 @@ try
         if (($_.Name.StartsWith("Azure.")) -or ($assets -Match "Azure.Core"))
         {
             $assetsJson = ConvertFrom-Json $assets;
-            return $assetsJson.project.restore.projectPath;
+            $projectPath = $assetsJson.project.restore.projectPath
+            if (Test-Path $projectPath)
+            {
+                return $projectPath;
+            }
         }
     }
 

--- a/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
+++ b/sdk/core/Azure.Core/src/Shared/ClientDiagnostics.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -36,12 +37,14 @@ namespace Azure.Core.Pipeline
         /// message, code, and details in a service specific manner.
         /// </summary>
         /// <param name="content">The error content.</param>
+        /// <param name="responseHeaders">The response headers.</param>
         /// <param name="message">The error message.</param>
         /// <param name="errorCode">The error code.</param>
         /// <param name="additionalInfo">Additional error details.</param>
 #pragma warning disable CA1822 // Member can be static
         partial void ExtractFailureContent(
             string? content,
+            ResponseHeaders responseHeaders,
             ref string? message,
             ref string? errorCode,
             ref IDictionary<string, string>? additionalInfo);
@@ -50,14 +53,14 @@ namespace Azure.Core.Pipeline
         public async ValueTask<RequestFailedException> CreateRequestFailedExceptionAsync(Response response, string? message = null, string? errorCode = null, IDictionary<string, string>? additionalInfo = null, Exception? innerException = null)
         {
             var content = await ReadContentAsync(response, true).ConfigureAwait(false);
-            ExtractFailureContent(content, ref message, ref errorCode, ref additionalInfo);
+            ExtractFailureContent(content, response.Headers, ref message, ref errorCode, ref additionalInfo);
             return CreateRequestFailedExceptionWithContent(response, message, content, errorCode, additionalInfo, innerException);
         }
 
         public RequestFailedException CreateRequestFailedException(Response response, string? message = null, string? errorCode = null, IDictionary<string, string>? additionalInfo = null, Exception? innerException = null)
         {
             string? content = ReadContentAsync(response, false).EnsureCompleted();
-            ExtractFailureContent(content, ref message, ref errorCode, ref additionalInfo);
+            ExtractFailureContent(content, response.Headers, ref message, ref errorCode, ref additionalInfo);
             return CreateRequestFailedExceptionWithContent(response, message, content, errorCode, additionalInfo, innerException);
         }
 

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientDiagnostics.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/ClientDiagnostics.cs
@@ -20,15 +20,17 @@ namespace Azure.Core.Pipeline
         /// attempting to parse them as <see cref="FormRecognizerError"/>s.
         /// </summary>
         /// <param name="content">The error content.</param>
+        /// <param name="responseHeaders">The response headers.</param>
         /// <param name="message">The error message.</param>
         /// <param name="errorCode">The error code.</param>
         /// <param name="additionalInfo">Additional error details.</param>
 #pragma warning disable CA1822 // Member can be static
+#pragma warning disable CA1801 // Remove unused parameter
         partial void ExtractFailureContent(
             string? content,
+            ResponseHeaders responseHeaders,
             ref string? message,
             ref string? errorCode,
-#pragma warning disable CA1801 // Remove unused parameter
             ref IDictionary<string, string>? additionalInfo)
 #pragma warning restore CA1801 // Remove unused parameter
 #pragma warning restore CA1822 // Member can be static

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ClientDiagnostics.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ClientDiagnostics.cs
@@ -11,11 +11,12 @@ namespace Azure.Core.Pipeline
     internal partial class ClientDiagnostics
     {
 #pragma warning disable CA1822 // Member can be static
+#pragma warning disable CA1801 // Remove unused parameter
         partial void ExtractFailureContent(
             string? content,
+            ResponseHeaders responseHeaders,
             ref string? message,
             ref string? errorCode,
-#pragma warning disable CA1801 // Remove unused parameter
             ref IDictionary<string, string>? additionalInfo)
 #pragma warning restore CA1801 // Remove unused parameter
 #pragma warning restore CA1822 // Member can be static

--- a/sdk/search/Azure.Search.Documents/src/Utilities/ClientDiagnostics.ExtractFailureContent.cs
+++ b/sdk/search/Azure.Search.Documents/src/Utilities/ClientDiagnostics.ExtractFailureContent.cs
@@ -22,15 +22,17 @@ namespace Azure.Core.Pipeline
         /// attempting to parse them as <see cref="SearchError"/>s.
         /// </summary>
         /// <param name="content">The error content.</param>
+        /// <param name="responseHeaders">The response headers.</param>
         /// <param name="message">The error message.</param>
         /// <param name="errorCode">The error code.</param>
         /// <param name="additionalInfo">Additional error details.</param>
 #pragma warning disable CA1822 // Member can be static
+#pragma warning disable CA1801 // Remove unused parameter
         partial void ExtractFailureContent(
             string? content,
+            ResponseHeaders responseHeaders,
             ref string? message,
             ref string? errorCode,
-#pragma warning disable CA1801 // Remove unused parameter
             ref IDictionary<string, string>? additionalInfo)
 #pragma warning restore CA1801 // Remove unused parameter
 #pragma warning restore CA1822 // Member can be static

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ClientDiagnostics.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Administration/ClientDiagnostics.cs
@@ -13,11 +13,12 @@ namespace Azure.Core.Pipeline
     internal sealed partial class ClientDiagnostics
     {
 #pragma warning disable CA1822 // Member can be static
+#pragma warning disable CA1801 // Remove unused parameter
         partial void ExtractFailureContent(
             string? content,
+            ResponseHeaders responseHeaders,
             ref string? message,
             ref string? errorCode,
-#pragma warning disable CA1801 // Remove unused parameter
             ref IDictionary<string, string>? additionalInfo)
 #pragma warning restore CA1801 // Remove unused parameter
 #pragma warning restore CA1822 // Member can be static

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClientDiagnostics.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/src/ClientDiagnostics.cs
@@ -21,15 +21,17 @@ namespace Azure.Core.Pipeline
         /// attempting to parse them as <see cref="TextAnalyticsError"/>s.
         /// </summary>
         /// <param name="content">The error content.</param>
+        /// <param name="responseHeaders">The response headers.</param>
         /// <param name="message">The error message.</param>
         /// <param name="errorCode">The error code.</param>
         /// <param name="additionalInfo">Additional error details.</param>
 #pragma warning disable CA1822 // Member can be static
+#pragma warning disable CA1801 // Remove unused parameter
         partial void ExtractFailureContent(
             string? content,
+            ResponseHeaders responseHeaders,
             ref string? message,
             ref string? errorCode,
-#pragma warning disable CA1801 // Remove unused parameter
             ref IDictionary<string, string>? additionalInfo)
 #pragma warning restore CA1801 // Remove unused parameter
 #pragma warning restore CA1822 // Member can be static


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/17979