### PR TITLE
Updating the Mixed Reality test location

### DIFF
--- a/sdk/mixedreality/tests.yml
+++ b/sdk/mixedreality/tests.yml
@@ -4,3 +4,4 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: mixedreality
+    Location: eastus2


### PR DESCRIPTION
Azure Spatial Anchors doesn't currently support West US 2, so the tests fail when run against that region. This change configures the test location to be a specific location (`eastus2`). This should resolve #17715.