### PR TITLE
[Storage] Capture azurite debug log before failing permanently.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
                     process.Kill();
                     process.WaitForExit();
                     var message = $"azurite process could not initialize within timeout with following output:\n{azuriteOutput}\nerror:\n{azuriteError}";
-                    if (includeDebugLog)
+                    if (includeDebugLog && File.Exists(debugLogPath))
                     {
                         using var fileStream = File.Open(debugLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                         using var streamReader = new StreamReader(fileStream);

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
         private int blobsPort;
         private int queuesPort;
 
-        public AzuriteFixture()
+        public AzuriteFixture(bool includeDebugLog = false)
         {
             // This is to force newer protocol on machines with older .NET Framework. Otherwise tests don't connect to Azurite with unsigned cert.
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
@@ -75,7 +75,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
             process = new Process();
             process.StartInfo.FileName = "node";
             process.StartInfo.WorkingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            process.StartInfo.Arguments = $"{azuriteScriptLocation} --oauth basic -l {tempDirectory} --blobPort 0 --queuePort 0 --cert cert.pem --key cert.pem --skipApiVersionCheck";
+            var arguments = $"{azuriteScriptLocation} --oauth basic -l {tempDirectory} --blobPort 0 --queuePort 0 --cert cert.pem --key cert.pem --skipApiVersionCheck";
+            string debugLogPath = null;
+            if (includeDebugLog)
+            {
+                debugLogPath = Path.GetTempFileName();
+                arguments += $" -d {debugLogPath}";
+            }
+            process.StartInfo.Arguments = arguments;
             process.StartInfo.EnvironmentVariables.Add("AZURITE_ACCOUNTS", $"{account.Name}:{account.Key}");
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
@@ -131,7 +138,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
                 {
                     process.Kill();
                     process.WaitForExit();
-                    throw new InvalidOperationException(ErrorMessage($"azurite process could not initialize within timeout with following output:\n{azuriteOutput}\nerror:\n{azuriteError}"));
+                    var message = $"azurite process could not initialize within timeout with following output:\n{azuriteOutput}\nerror:\n{azuriteError}";
+                    if (includeDebugLog)
+                    {
+                        var debugLog = new StreamReader(File.Open(debugLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)).ReadToEnd();
+                        message += $"\ndebug log:\n{debugLog}";
+                    }
+                    throw new InvalidOperationException(ErrorMessage(message));
                 }
             }
             account.BlobsPort = blobsPort;

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/AzuriteFixture.cs
@@ -141,7 +141,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests
                     var message = $"azurite process could not initialize within timeout with following output:\n{azuriteOutput}\nerror:\n{azuriteError}";
                     if (includeDebugLog)
                     {
-                        var debugLog = new StreamReader(File.Open(debugLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)).ReadToEnd();
+                        using var fileStream = File.Open(debugLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                        using var streamReader = new StreamReader(fileStream);
+                        var debugLog = streamReader.ReadToEnd();
                         message += $"\ndebug log:\n{debugLog}";
                     }
                     throw new InvalidOperationException(ErrorMessage(message));

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/Shared/AzuriteNUnitFixture.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/tests/Shared/AzuriteNUnitFixture.cs
@@ -33,6 +33,15 @@ public class AzuriteNUnitFixture
                 exceptions.Add(e);
             }
         }
+        try
+        {
+            // an extra attempt to capture azurite debug log.
+            return new AzuriteFixture(includeDebugLog: true);
+        }
+        catch (Exception e)
+        {
+            exceptions.Add(e);
+        }
         throw new AggregateException(exceptions);
     }
 


### PR DESCRIPTION
Another attempt to get more diagnostic information to troubleshoot azurite not starting correctly in pipelines.