### PR TITLE
Log x-ms-request-id for tests only

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AccessControlTestBase.cs
@@ -35,7 +35,16 @@ namespace Azure.Security.KeyVault.Administration.Tests
                 (new KeyVaultAccessControlClient(
                     Uri,
                     TestEnvironment.Credential,
-                    InstrumentClientOptions(new KeyVaultAdministrationClientOptions())));
+                    InstrumentClientOptions(new KeyVaultAdministrationClientOptions
+                    {
+                        Diagnostics =
+                        {
+                            LoggedHeaderNames =
+                            {
+                                "x-ms-request-id",
+                            },
+                        },
+                    })));
         }
 
         protected override void Start()

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AdministrationTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/AdministrationTestBase.cs
@@ -109,7 +109,16 @@ namespace Azure.Security.KeyVault.Administration.Tests
                 new KeyClient(
                     Uri,
                     TestEnvironment.Credential,
-                    InstrumentClientOptions(new KeyClientOptions())));
+                    InstrumentClientOptions(new KeyClientOptions
+                    {
+                        Diagnostics =
+                        {
+                            LoggedHeaderNames =
+                            {
+                                "x-ms-request-id",
+                            },
+                        },
+                    })));
 
             Start();
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/BackupRestoreTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/BackupRestoreTestBase.cs
@@ -30,7 +30,16 @@ namespace Azure.Security.KeyVault.Administration.Tests
             var client = new KeyVaultBackupClient(
                 Uri,
                 TestEnvironment.Credential,
-                InstrumentClientOptions(new KeyVaultAdministrationClientOptions()));
+                InstrumentClientOptions(new KeyVaultAdministrationClientOptions
+                {
+                    Diagnostics =
+                        {
+                            LoggedHeaderNames =
+                            {
+                                "x-ms-request-id",
+                            },
+                        },
+                }));
             return isInstrumented ? InstrumentClient(client) : client;
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
@@ -47,6 +47,10 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 Diagnostics =
                 {
                     IsLoggingContentEnabled = Debugger.IsAttached,
+                    LoggedHeaderNames =
+                    {
+                        "x-ms-request-id",
+                    },
                 }
             };
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -50,7 +50,17 @@ namespace Azure.Security.KeyVault.Keys.Tests
                 new KeyClient(
                     Uri,
                     TestEnvironment.Credential,
-                    InstrumentClientOptions(new KeyClientOptions(_serviceVersion))),
+                    InstrumentClientOptions(
+                        new KeyClientOptions(_serviceVersion)
+                        {
+                            Diagnostics =
+                            {
+                                LoggedHeaderNames =
+                                {
+                                    "x-ms-request-id",
+                                }
+                            },
+                        })),
                 interceptors);
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretsTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretsTestBase.cs
@@ -42,7 +42,17 @@ namespace Azure.Security.KeyVault.Secrets.Tests
                 (new SecretClient(
                     new Uri(TestEnvironment.KeyVaultUrl),
                     TestEnvironment.Credential,
-                    InstrumentClientOptions(new SecretClientOptions(_serviceVersion))));
+                    InstrumentClientOptions(
+                        new SecretClientOptions(_serviceVersion)
+                        {
+                            Diagnostics =
+                            {
+                                LoggedHeaderNames =
+                                {
+                                    "x-ms-request-id",
+                                }
+                            },
+                        })));
         }
 
         public override void StartTestRecording()


### PR DESCRIPTION
Helps follow up with the service team if any service issues occur during nightly live test runs.