### PR TITLE
[communication] fix endpoint env var name

### DIFF
--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -54,6 +54,10 @@
             "type": "string",
             "value": "[concat('https://', parameters('baseName'), '-', parameters('endpointPrefix'), '.communication.azure.com')]"
         },
+        "COMMUNICATION_ACCESS_KEY": {
+            "type": "string",
+            "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').key1]"
+        },
         "RESOURCE_GROUP_NAME": {
             "type": "string",
             "value": "[resourceGroup().Name]"

--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -56,7 +56,7 @@
         },
         "COMMUNICATION_ACCESS_KEY": {
             "type": "string",
-            "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').key1]"
+            "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryKey]"
         },
         "RESOURCE_GROUP_NAME": {
             "type": "string",

--- a/sdk/communication/test-resources.json
+++ b/sdk/communication/test-resources.json
@@ -50,7 +50,7 @@
             "type": "string",
             "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2020-08-20-preview').primaryConnectionString]"
         },
-        "COMMUNICATION_ENDPOINT_STRING": {
+        "COMMUNICATION_ENDPOINT": {
             "type": "string",
             "value": "[concat('https://', parameters('baseName'), '-', parameters('endpointPrefix'), '.communication.azure.com')]"
         },


### PR DESCRIPTION
This PR updates the name of the endpoint environment var in `test-resources.json` to the correct one that is referenced in the tests.