### PR TITLE
[Messaging Clients] Improve Batch `TryAdd` Doc Comments

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventDataBatch.cs
@@ -145,6 +145,12 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <returns><c>true</c> if the event was added; otherwise, <c>false</c>.</returns>
         ///
+        /// <exception cref="InvalidOperationException">
+        ///   When a batch is published, it will be locked for the duration of that operation.  During this time,
+        ///   no events may be added to the batch.  Calling <c>TryAdd</c> while the batch is being published will
+        ///   result in an <see cref="InvalidOperationException" /> until publishing has completed.
+        /// </exception>
+        ///
         public bool TryAdd(EventData eventData)
         {
             lock (SyncGuard)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Sender/ServiceBusMessageBatch.cs
@@ -76,9 +76,15 @@ namespace Azure.Messaging.ServiceBus
         ///   of the batch does not exceed its maximum.
         /// </summary>
         ///
-        /// <param name="message">Message to attempt to add to the batch.</param>
+        /// <param name="message">The message to attempt to add to the batch.</param>
         ///
         /// <returns><c>true</c> if the message was added; otherwise, <c>false</c>.</returns>
+        ///
+        /// <exception cref="InvalidOperationException">
+        ///   When a batch is sent, it will be locked for the duration of that operation.  During this time,
+        ///   no messages may be added to the batch.  Calling <c>TryAdd</c> while the batch is being sent will
+        ///   result in an <see cref="InvalidOperationException" /> until the send has completed.
+        /// </exception>
         ///
         public bool TryAddMessage(ServiceBusMessage message)
         {


### PR DESCRIPTION
# Summary

The focus of these changes is to improve the doc comments for the `TryAdd` method of the `EventDataBatch` and `ServiceBusMessageBatch` classes,, highlighting a known exception scenario.

# Last Upstream Rebase

Tuesday, January 26, 9:12am (EST)