### PR TITLE
[Storage] Webjobs Storage Extension - review feedback vol 1.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -37,15 +37,31 @@ The connection string can be supplied through [AzureWebJobsStorage app setting](
 
 ## Key concepts
 
-### Using Blob binding
-
-Please follow the [input binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-input?tabs=csharp) and [output binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-output?tabs=csharp) to learn about using this extension for accessing Blobs.
-
 ### Using Blob trigger
 
 Please follow the [tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger?tabs=csharp) to learn about triggering an Azure Function when a blob is modified.
 
+### Using Blob binding
+
+Please follow the [input binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-input?tabs=csharp) and [output binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-output?tabs=csharp) to learn about using this extension for accessing Blobs.
+
 ## Examples
+
+### Reacting to blob change
+
+```C# Snippet:BlobFunction_ReactToBlobChange
+public static class BlobFunction_ReactToBlobChange
+{
+    [FunctionName("BlobFunction")]
+    public static void Run(
+        [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+        ILogger logger)
+    {
+        using var blobStreamReader = new StreamReader(blobStream);
+        logger.LogInformation("Blob sample-container/sample-blob has been updated with content: {content}", blobStreamReader.ReadToEnd());
+    }
+}
+```
 
 ### Reading from stream
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -120,6 +120,79 @@ public static class BlobFunction_String
 }
 ```
 
+### Writing string to blob
+
+```C# Snippet:BlobFunction_String_Write
+public static class BlobFunction_String_Write
+{
+    [FunctionName("BlobFunction")]
+    public static void Run(
+        [BlobTrigger("sample-container/sample-blob-1")] string blobContent1,
+        [Blob("sample-container/sample-blob-2")] out string blobContent2,
+        ILogger logger)
+    {
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobContent1);
+        blobContent2 = blobContent1;
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
+    }
+}
+```
+
+### Binding to byte array
+
+```C# Snippet:BlobFunction_ByteArray
+public static class BlobFunction_ByteArray
+{
+    [FunctionName("BlobFunction")]
+    public static void Run(
+        [BlobTrigger("sample-container/sample-blob-1")] byte[] blobContent1,
+        [Blob("sample-container/sample-blob-2")] byte[] blobContent2,
+        ILogger logger)
+    {
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", Encoding.UTF8.GetString(blobContent1));
+        logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", Encoding.UTF8.GetString(blobContent2));
+    }
+}
+```
+
+### Writing byte array to blob
+
+```C# Snippet:BlobFunction_ByteArray_Write
+public static class BlobFunction_ByteArray_Write
+{
+    [FunctionName("BlobFunction")]
+    public static void Run(
+        [BlobTrigger("sample-container/sample-blob-1")] byte[] blobContent1,
+        [Blob("sample-container/sample-blob-2")] out byte[] blobContent2,
+        ILogger logger)
+    {
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", Encoding.UTF8.GetString(blobContent1));
+        blobContent2 = blobContent1;
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
+    }
+}
+```
+
+### Binding to TextReader and TextWriter
+
+```C# Snippet:BlobFunction_TextReader_TextWriter
+public static class BlobFunction_TextReader_TextWriter
+{
+    [FunctionName("BlobFunction")]
+    public static async Task Run(
+        [BlobTrigger("sample-container/sample-blob-1")] TextReader blobContentReader1,
+        [Blob("sample-container/sample-blob-2")] TextWriter blobContentWriter2,
+        ILogger logger)
+    {
+        while (blobContentReader1.Peek() >= 0)
+        {
+            await blobContentWriter2.WriteLineAsync(await blobContentReader1.ReadLineAsync());
+        }
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
+    }
+}
+```
+
 ### Binding to Azure Storage Blob SDK types
 
 ```C# Snippet:BlobFunction_BlobClient

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -39,9 +39,13 @@ The connection string can be supplied through [AzureWebJobsStorage app setting](
 
 ### Using Blob trigger
 
+The Blob storage trigger starts a function when a new or updated blob is detected. The blob contents are provided as input to the function.
+
 Please follow the [tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger?tabs=csharp) to learn about triggering an Azure Function when a blob is modified.
 
 ### Using Blob binding
+
+The input binding allows you to read blob storage data as input to an Azure Function. The output binding allows you to modify and delete blob storage data in an Azure Function.
 
 Please follow the [input binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-input?tabs=csharp) and [output binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-output?tabs=csharp) to learn about using this extension for accessing Blobs.
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -212,6 +212,65 @@ public static class BlobFunction_BlobClient
 }
 ```
 
+### Accessing Blob container
+
+```C# Snippet:BlobFunction_AccessContainer
+public static class BlobFunction_AccessContainer
+{
+    [FunctionName("BlobFunction")]
+    public static async Task Run(
+        [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+        [Blob("sample-container")] BlobContainerClient blobContainerClient,
+        ILogger logger)
+    {
+        logger.LogInformation("Blobs within container:");
+        await foreach (BlobItem blobItem in blobContainerClient.GetBlobsAsync())
+        {
+            logger.LogInformation(blobItem.Name);
+        }
+    }
+}
+```
+
+### Enumerating blobs in container
+
+```C# Snippet:BlobFunction_EnumerateBlobs_Stream
+public static class BlobFunction_EnumerateBlobs_Stream
+{
+    [FunctionName("BlobFunction")]
+    public static async Task Run(
+        [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+        [Blob("sample-container")] IEnumerable<Stream> blobs,
+        ILogger logger)
+    {
+        logger.LogInformation("Blobs contents within container:");
+        foreach (Stream content in blobs)
+        {
+            using var blobStreamReader = new StreamReader(content);
+            logger.LogInformation(await blobStreamReader.ReadToEndAsync());
+        }
+    }
+}
+```
+
+```C# Snippet:BlobFunction_EnumerateBlobs_BlobClient
+public static class BlobFunction_EnumerateBlobs_BlobClient
+{
+    [FunctionName("BlobFunction")]
+    public static void Run(
+        [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+        [Blob("sample-container")] IEnumerable<BlobClient> blobs,
+        ILogger logger)
+    {
+        logger.LogInformation("Blobs within container:");
+        foreach (BlobClient blob in blobs)
+        {
+            logger.LogInformation(blob.Name);
+        }
+    }
+}
+```
+
 ## Troubleshooting
 
 Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for troubleshooting guidance.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/README.md
@@ -47,23 +47,6 @@ Please follow the [tutorial](https://docs.microsoft.com/azure/azure-functions/fu
 
 ## Examples
 
-### Binding to string
-
-```C# Snippet:BlobFunction_String
-public static class BlobFunction_String
-{
-    [FunctionName("BlobFunction")]
-    public static void Run(
-        [BlobTrigger("sample-container/sample-blob-1")] string blobTriggerContent,
-        [Blob("sample-container/sample-blob-2")] string blobContent,
-        ILogger logger)
-    {
-        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobTriggerContent);
-        logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobContent);
-    }
-}
-```
-
 ### Reading from stream
 
 ```C# Snippet:BlobFunction_ReadStream
@@ -71,14 +54,14 @@ public static class BlobFunction_ReadStream
 {
     [FunctionName("BlobFunction")]
     public static void Run(
-        [BlobTrigger("sample-container/sample-blob-1")] Stream blobTriggerStream,
-        [Blob("sample-container/sample-blob-2", FileAccess.Read)] Stream blobStream,
+        [BlobTrigger("sample-container/sample-blob-1")] Stream blobStream1,
+        [Blob("sample-container/sample-blob-2", FileAccess.Read)] Stream blobStream2,
         ILogger logger)
     {
-        using var blobTriggerStreamReader = new StreamReader(blobTriggerStream);
-        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobTriggerStreamReader.ReadToEnd());
-        using var blobStreamReader = new StreamReader(blobStream);
-        logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobStreamReader.ReadToEnd());
+        using var blobStreamReader1 = new StreamReader(blobStream1);
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobStreamReader1.ReadToEnd());
+        using var blobStreamReader2 = new StreamReader(blobStream2);
+        logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobStreamReader2.ReadToEnd());
     }
 }
 ```
@@ -90,12 +73,29 @@ public static class BlobFunction_WriteStream
 {
     [FunctionName("BlobFunction")]
     public static async Task Run(
-        [BlobTrigger("sample-container/sample-blob-1")] Stream blobTriggerStream,
-        [Blob("sample-container/sample-blob-2", FileAccess.Write)] Stream blobStream,
+        [BlobTrigger("sample-container/sample-blob-1")] Stream blobStream1,
+        [Blob("sample-container/sample-blob-2", FileAccess.Write)] Stream blobStream2,
         ILogger logger)
     {
-        await blobTriggerStream.CopyToAsync(blobStream);
+        await blobStream1.CopyToAsync(blobStream2);
         logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
+    }
+}
+```
+
+### Binding to string
+
+```C# Snippet:BlobFunction_String
+public static class BlobFunction_String
+{
+    [FunctionName("BlobFunction")]
+    public static void Run(
+        [BlobTrigger("sample-container/sample-blob-1")] string blobContent1,
+        [Blob("sample-container/sample-blob-2")] string blobContent2,
+        ILogger logger)
+    {
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobContent1);
+        logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobContent2);
     }
 }
 ```
@@ -107,14 +107,14 @@ public static class BlobFunction_BlobClient
 {
     [FunctionName("BlobFunction")]
     public static async Task Run(
-        [BlobTrigger("sample-container/sample-blob-1")] BlobClient blobTriggerClient,
-        [Blob("sample-container/sample-blob-2")] BlobClient blobClient,
+        [BlobTrigger("sample-container/sample-blob-1")] BlobClient blobClient1,
+        [Blob("sample-container/sample-blob-2")] BlobClient blobClient2,
         ILogger logger)
     {
-        BlobProperties blobTriggerProperties = await blobTriggerClient.GetPropertiesAsync();
-        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated on: {datetime}", blobTriggerProperties.LastModified);
-        BlobProperties blobProperties = await blobClient.GetPropertiesAsync();
-        logger.LogInformation("Blob sample-container/sample-blob-2 has been updated on: {datetime}", blobProperties.LastModified);
+        BlobProperties blobProperties1 = await blobClient1.GetPropertiesAsync();
+        logger.LogInformation("Blob sample-container/sample-blob-1 has been updated on: {datetime}", blobProperties1.LastModified);
+        BlobProperties blobProperties2 = await blobClient2.GetPropertiesAsync();
+        logger.LogInformation("Blob sample-container/sample-blob-2 has been updated on: {datetime}", blobProperties2.LastModified);
     }
 }
 ```

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/api/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.netstandard2.0.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Azure.WebJobs.Host
     {
         public BlobsOptions() { }
         public int MaxDegreeOfParallelism { get { throw null; } set { } }
-        public string Format() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        string Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter.Format() { throw null; }
     }
 }
 namespace Microsoft.Extensions.Hosting

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
@@ -71,6 +71,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     }
     #endregion
 
+    // This doesn't work with Azurite so it's not run, just for compilation here.
+    #region Snippet:BlobFunction_ReactToBlobChange_EventGrid
+    public static class BlobFunction_ReactToBlobChange_EventGrid
+    {
+        [FunctionName("BlobFunction")]
+        public static void Run(
+            [BlobTrigger("sample-container/sample-blob", Source = BlobTriggerSource.EventGrid)] Stream blobStream,
+            ILogger logger)
+        {
+            using var blobStreamReader = new StreamReader(blobStream);
+            logger.LogInformation("Blob sample-container/sample-blob has been updated with content: {content}", blobStreamReader.ReadToEnd());
+        }
+    }
+    #endregion
+
     #region Snippet:BlobFunction_String
     public static class BlobFunction_String
     {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
 {
     public class BlobExtensionSamples
     {
+        [TestCase(typeof(BlobFunction_ReactToBlobChange))]
         [TestCase(typeof(BlobFunction_String))]
         [TestCase(typeof(BlobFunction_ReadStream))]
         [TestCase(typeof(BlobFunction_WriteStream))]
@@ -47,6 +48,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
             });
         }
     }
+
+    #region Snippet:BlobFunction_ReactToBlobChange
+    public static class BlobFunction_ReactToBlobChange
+    {
+        [FunctionName("BlobFunction")]
+        public static void Run(
+            [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+            ILogger logger)
+        {
+            using var blobStreamReader = new StreamReader(blobStream);
+            logger.LogInformation("Blob sample-container/sample-blob has been updated with content: {content}", blobStreamReader.ReadToEnd());
+        }
+    }
+    #endregion
 
     #region Snippet:BlobFunction_String
     public static class BlobFunction_String

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
@@ -53,12 +53,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     {
         [FunctionName("BlobFunction")]
         public static void Run(
-            [BlobTrigger("sample-container/sample-blob-1")] string blobTriggerContent,
-            [Blob("sample-container/sample-blob-2")] string blobContent,
+            [BlobTrigger("sample-container/sample-blob-1")] string blobContent1,
+            [Blob("sample-container/sample-blob-2")] string blobContent2,
             ILogger logger)
         {
-            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobTriggerContent);
-            logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobContent);
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobContent1);
+            logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobContent2);
         }
     }
     #endregion
@@ -68,14 +68,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     {
         [FunctionName("BlobFunction")]
         public static void Run(
-            [BlobTrigger("sample-container/sample-blob-1")] Stream blobTriggerStream,
-            [Blob("sample-container/sample-blob-2", FileAccess.Read)] Stream blobStream,
+            [BlobTrigger("sample-container/sample-blob-1")] Stream blobStream1,
+            [Blob("sample-container/sample-blob-2", FileAccess.Read)] Stream blobStream2,
             ILogger logger)
         {
-            using var blobTriggerStreamReader = new StreamReader(blobTriggerStream);
-            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobTriggerStreamReader.ReadToEnd());
-            using var blobStreamReader = new StreamReader(blobStream);
-            logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobStreamReader.ReadToEnd());
+            using var blobStreamReader1 = new StreamReader(blobStream1);
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobStreamReader1.ReadToEnd());
+            using var blobStreamReader2 = new StreamReader(blobStream2);
+            logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", blobStreamReader2.ReadToEnd());
         }
     }
     #endregion
@@ -85,11 +85,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     {
         [FunctionName("BlobFunction")]
         public static async Task Run(
-            [BlobTrigger("sample-container/sample-blob-1")] Stream blobTriggerStream,
-            [Blob("sample-container/sample-blob-2", FileAccess.Write)] Stream blobStream,
+            [BlobTrigger("sample-container/sample-blob-1")] Stream blobStream1,
+            [Blob("sample-container/sample-blob-2", FileAccess.Write)] Stream blobStream2,
             ILogger logger)
         {
-            await blobTriggerStream.CopyToAsync(blobStream);
+            await blobStream1.CopyToAsync(blobStream2);
             logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
         }
     }
@@ -100,14 +100,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     {
         [FunctionName("BlobFunction")]
         public static async Task Run(
-            [BlobTrigger("sample-container/sample-blob-1")] BlobClient blobTriggerClient,
-            [Blob("sample-container/sample-blob-2")] BlobClient blobClient,
+            [BlobTrigger("sample-container/sample-blob-1")] BlobClient blobClient1,
+            [Blob("sample-container/sample-blob-2")] BlobClient blobClient2,
             ILogger logger)
         {
-            BlobProperties blobTriggerProperties = await blobTriggerClient.GetPropertiesAsync();
-            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated on: {datetime}", blobTriggerProperties.LastModified);
-            BlobProperties blobProperties = await blobClient.GetPropertiesAsync();
-            logger.LogInformation("Blob sample-container/sample-blob-2 has been updated on: {datetime}", blobProperties.LastModified);
+            BlobProperties blobProperties1 = await blobClient1.GetPropertiesAsync();
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated on: {datetime}", blobProperties1.LastModified);
+            BlobProperties blobProperties2 = await blobClient2.GetPropertiesAsync();
+            logger.LogInformation("Blob sample-container/sample-blob-2 has been updated on: {datetime}", blobProperties2.LastModified);
         }
     }
     #endregion

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
         [TestCase(typeof(BlobFunction_WriteStream))]
         [TestCase(typeof(BlobFunction_BlobClient))]
         [TestCase(typeof(BlobFunction_TextReader_TextWriter))]
+        [TestCase(typeof(BlobFunction_AccessContainer))]
+        [TestCase(typeof(BlobFunction_EnumerateBlobs_Stream))]
+        [TestCase(typeof(BlobFunction_EnumerateBlobs_BlobClient))]
         public async Task Run_BlobFunction(Type programType)
         {
             var containerClient = AzuriteNUnitFixture.Instance.GetBlobServiceClient().GetBlobContainerClient("sample-container");
@@ -193,6 +196,61 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
             logger.LogInformation("Blob sample-container/sample-blob-1 has been updated on: {datetime}", blobProperties1.LastModified);
             BlobProperties blobProperties2 = await blobClient2.GetPropertiesAsync();
             logger.LogInformation("Blob sample-container/sample-blob-2 has been updated on: {datetime}", blobProperties2.LastModified);
+        }
+    }
+    #endregion
+
+    #region Snippet:BlobFunction_AccessContainer
+    public static class BlobFunction_AccessContainer
+    {
+        [FunctionName("BlobFunction")]
+        public static async Task Run(
+            [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+            [Blob("sample-container")] BlobContainerClient blobContainerClient,
+            ILogger logger)
+        {
+            logger.LogInformation("Blobs within container:");
+            await foreach (BlobItem blobItem in blobContainerClient.GetBlobsAsync())
+            {
+                logger.LogInformation(blobItem.Name);
+            }
+        }
+    }
+    #endregion
+
+    #region Snippet:BlobFunction_EnumerateBlobs_Stream
+    public static class BlobFunction_EnumerateBlobs_Stream
+    {
+        [FunctionName("BlobFunction")]
+        public static async Task Run(
+            [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+            [Blob("sample-container")] IEnumerable<Stream> blobs,
+            ILogger logger)
+        {
+            logger.LogInformation("Blobs contents within container:");
+            foreach (Stream content in blobs)
+            {
+                using var blobStreamReader = new StreamReader(content);
+                logger.LogInformation(await blobStreamReader.ReadToEndAsync());
+            }
+        }
+    }
+    #endregion
+
+    #region Snippet:BlobFunction_EnumerateBlobs_BlobClient
+    public static class BlobFunction_EnumerateBlobs_BlobClient
+    {
+        [FunctionName("BlobFunction")]
+        public static void Run(
+            [BlobTrigger("sample-container/sample-blob")] Stream blobStream,
+            [Blob("sample-container")] IEnumerable<BlobClient> blobs,
+            ILogger logger)
+        {
+            logger.LogInformation("Blobs within container:");
+            foreach (BlobClient blob in blobs)
+            {
+                logger.LogInformation(blob.Name);
+            }
         }
     }
     #endregion

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/samples/BlobExtensionSamples.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -20,9 +21,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     {
         [TestCase(typeof(BlobFunction_ReactToBlobChange))]
         [TestCase(typeof(BlobFunction_String))]
+        [TestCase(typeof(BlobFunction_ByteArray))]
+        [TestCase(typeof(BlobFunction_String_Write))]
+        [TestCase(typeof(BlobFunction_ByteArray_Write))]
         [TestCase(typeof(BlobFunction_ReadStream))]
         [TestCase(typeof(BlobFunction_WriteStream))]
         [TestCase(typeof(BlobFunction_BlobClient))]
+        [TestCase(typeof(BlobFunction_TextReader_TextWriter))]
         public async Task Run_BlobFunction(Type programType)
         {
             var containerClient = AzuriteNUnitFixture.Instance.GetBlobServiceClient().GetBlobContainerClient("sample-container");
@@ -78,6 +83,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
     }
     #endregion
 
+    #region Snippet:BlobFunction_ByteArray
+    public static class BlobFunction_ByteArray
+    {
+        [FunctionName("BlobFunction")]
+        public static void Run(
+            [BlobTrigger("sample-container/sample-blob-1")] byte[] blobContent1,
+            [Blob("sample-container/sample-blob-2")] byte[] blobContent2,
+            ILogger logger)
+        {
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", Encoding.UTF8.GetString(blobContent1));
+            logger.LogInformation("Blob sample-container/sample-blob-2 has content: {content}", Encoding.UTF8.GetString(blobContent2));
+        }
+    }
+    #endregion
+
+    #region Snippet:BlobFunction_ByteArray_Write
+    public static class BlobFunction_ByteArray_Write
+    {
+        [FunctionName("BlobFunction")]
+        public static void Run(
+            [BlobTrigger("sample-container/sample-blob-1")] byte[] blobContent1,
+            [Blob("sample-container/sample-blob-2")] out byte[] blobContent2,
+            ILogger logger)
+        {
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", Encoding.UTF8.GetString(blobContent1));
+            blobContent2 = blobContent1;
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
+        }
+    }
+    #endregion
+
     #region Snippet:BlobFunction_ReadStream
     public static class BlobFunction_ReadStream
     {
@@ -105,6 +141,40 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.Samples.Tests
             ILogger logger)
         {
             await blobStream1.CopyToAsync(blobStream2);
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
+        }
+    }
+    #endregion
+
+    #region Snippet:BlobFunction_String_Write
+    public static class BlobFunction_String_Write
+    {
+        [FunctionName("BlobFunction")]
+        public static void Run(
+            [BlobTrigger("sample-container/sample-blob-1")] string blobContent1,
+            [Blob("sample-container/sample-blob-2")] out string blobContent2,
+            ILogger logger)
+        {
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been updated with content: {content}", blobContent1);
+            blobContent2 = blobContent1;
+            logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
+        }
+    }
+    #endregion
+
+    #region Snippet:BlobFunction_TextReader_TextWriter
+    public static class BlobFunction_TextReader_TextWriter
+    {
+        [FunctionName("BlobFunction")]
+        public static async Task Run(
+            [BlobTrigger("sample-container/sample-blob-1")] TextReader blobContentReader1,
+            [Blob("sample-container/sample-blob-2")] TextWriter blobContentWriter2,
+            ILogger logger)
+        {
+            while (blobContentReader1.Peek() >= 0)
+            {
+                await blobContentWriter2.WriteLineAsync(await blobContentReader1.ReadLineAsync());
+            }
             logger.LogInformation("Blob sample-container/sample-blob-1 has been copied to sample-container/sample-blob-2");
         }
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/BlobAttribute.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs
     /// </item>
     /// </list>
     /// In addition to single blob bindings,  parameters can be bound to multiple blobs.
-    /// The parameter type can be CloudBlobContainer, CloudBlobDirectory or <see cref="IEnumerable{T}"/>
+    /// The parameter type can be <see cref="BlobContainerClient"/> or <see cref="IEnumerable{T}"/>
     /// of one of the following element types:
     /// <list type = "bullet" >
     /// <item><description><see cref="BlobClient"/></description></item>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/src/Config/BlobsOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
 using Microsoft.Azure.WebJobs.Hosting;
 using Newtonsoft.Json;
@@ -43,7 +44,8 @@ namespace Microsoft.Azure.WebJobs.Host
         }
 
         /// <inheritdoc/>
-        public string Format()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string IOptionsFormatter.Format()
         {
             JObject options = new JObject
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueuesOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using Azure.Storage.Queues;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common;
@@ -178,7 +179,8 @@ namespace Microsoft.Azure.WebJobs.Host
         }
 
         /// <inheritdoc/>
-        public string Format()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string IOptionsFormatter.Format()
         {
             JObject options = new JObject
             {

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.0.0-beta.2 (Unreleased)
 
+### Major changes and features 
+- This version Base64-encodes queue messages by default. This behavior can be changed by setting `QueuesOptions.MessageEncoding`.
+
 
 ## 5.0.0-beta.1 (2020-11-10)
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
@@ -37,13 +37,17 @@ The connection string can be supplied through [AzureWebJobsStorage app setting](
 
 ## Key concepts
 
-### Using Queue binding
-
-Please follow the [binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-output?tabs=csharp) to learn about using this extension for producing messages into queues in Azure Functions.
-
 ### Using Queue trigger
 
+The queue storage trigger runs a function as messages are added to Azure Queue storage.
+
 Please follow the [tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger?tabs=csharp) to learn about how to listen to queues in Azure Functions.
+
+### Using Queue binding
+
+Azure Functions can create new Azure Queue storage messages by setting up an output binding.
+
+Please follow the [binding tutorial](https://docs.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-output?tabs=csharp) to learn about using this extension for producing messages into queues in Azure Functions.
 
 ## Examples
 

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
@@ -53,6 +53,8 @@ Please follow the [binding tutorial](https://docs.microsoft.com/azure/azure-func
 
 ### Listening to queue
 
+The following set of examples shows how to receive and react to messages that are being added to the queue.
+
 #### Binding queue message to string
 
 ```C# Snippet:QueueTriggerFunction_String
@@ -64,6 +66,36 @@ public static class QueueTriggerFunction_String
         ILogger logger)
     {
         logger.LogInformation("Received message from sample-queue, content={content}", message);
+    }
+}
+```
+
+#### Binding queue message to BinaryData
+
+```C# Snippet:QueueTriggerFunction_BinaryData
+public static class QueueTriggerFunction_BinaryData
+{
+    [FunctionName("QueueTriggerFunction")]
+    public static void Run(
+        [QueueTrigger("sample-queue")] BinaryData message,
+        ILogger logger)
+    {
+        logger.LogInformation("Received message from sample-queue, content={content}", message.ToString());
+    }
+}
+```
+
+#### Binding queue message to QueueMessage
+
+```C# Snippet:QueueTriggerFunction_QueueMessage
+public static class QueueTriggerFunction_QueueMessage
+{
+    [FunctionName("QueueTriggerFunction")]
+    public static void Run(
+        [QueueTrigger("sample-queue")] QueueMessage message,
+        ILogger logger)
+    {
+        logger.LogInformation("Received message from sample-queue, content={content}", message.Body.ToString());
     }
 }
 ```
@@ -105,6 +137,10 @@ public static class QueueTriggerFunction_JObject
 
 ### Publishing messages to queue
 
+The following set of examples shows how to add messages to queue by using `Queue` attribute.
+
+The `QueueTrigger` is used just for sample completeness, i.e. any other trigger mechanism can be used instead.
+
 #### Publishing message as string
 
 ```C# Snippet:QueueSenderFunction_String_Return
@@ -117,6 +153,42 @@ public static class QueueSenderFunction_String_Return
         ILogger logger)
     {
         logger.LogInformation("Received message from sample-queue-1, content={content}", message);
+        logger.LogInformation("Dispatching message to sample-queue-2");
+        return message;
+    }
+}
+```
+
+#### Publishing message as BinaryData
+
+```C# Snippet:QueueSenderFunction_BinaryData_Return
+public static class QueueSenderFunction_BinaryData_Return
+{
+    [FunctionName("QueueFunction")]
+    [return: Queue("sample-queue-2")]
+    public static BinaryData Run(
+        [QueueTrigger("sample-queue-1")] BinaryData message,
+        ILogger logger)
+    {
+        logger.LogInformation("Received message from sample-queue-1, content={content}", message.ToString());
+        logger.LogInformation("Dispatching message to sample-queue-2");
+        return message;
+    }
+}
+```
+
+#### Publishing message as QueueMessage
+
+```C# Snippet:QueueSenderFunction_QueueMessage_Return
+public static class QueueSenderFunction_QueueMessage_Return
+{
+    [FunctionName("QueueFunction")]
+    [return: Queue("sample-queue-2")]
+    public static QueueMessage Run(
+        [QueueTrigger("sample-queue-1")] QueueMessage message,
+        ILogger logger)
+    {
+        logger.LogInformation("Received message from sample-queue-1, content={content}", message.Body.ToString());
         logger.LogInformation("Dispatching message to sample-queue-2");
         return message;
     }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/README.md
@@ -241,6 +241,24 @@ public static class QueueSenderFunction_CustomObject_Collector
 }
 ```
 
+### Accessing queue properties
+
+```C# Snippet:Function_BindingToQueueClient
+public static class Function_BindingToQueueClient
+{
+    [FunctionName("QueueFunction")]
+    public static async Task Run(
+        [QueueTrigger("sample-queue")] string message,
+        [Queue("sample-queue")] QueueClient queueClient,
+        ILogger logger)
+    {
+        logger.LogInformation("Received message from sample-queue, content={content}", message);
+        QueueProperties queueProperties = await queueClient.GetPropertiesAsync();
+        logger.LogInformation("There are approximatelly {count} messages", queueProperties.ApproximateMessagesCount);
+    }
+}
+```
+
 ## Troubleshooting
 
 Please refer to [Monitor Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-monitoring) for troubleshooting guidance.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/api/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.netstandard2.0.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/api/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.netstandard2.0.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Azure.WebJobs.Host
         public Azure.Storage.Queues.QueueMessageEncoding MessageEncoding { get { throw null; } set { } }
         public int NewBatchThreshold { get { throw null; } set { } }
         public System.TimeSpan VisibilityTimeout { get { throw null; } set { } }
-        public string Format() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        string Microsoft.Azure.WebJobs.Hosting.IOptionsFormatter.Format() { throw null; }
     }
 }
 namespace Microsoft.Azure.WebJobs.Host.Queues

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/samples/QueueExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/samples/QueueExtensionSamples.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
 using Microsoft.Extensions.Azure;
@@ -26,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests
         [TestCase(typeof(QueueSenderFunction_QueueMessage_Return), "sample message")]
         [TestCase(typeof(QueueSenderFunction_CustomObject_OutParamter), "{ \"content\": \"sample message\"}")]
         [TestCase(typeof(QueueSenderFunction_CustomObject_Collector), "{ \"content\": \"sample message\"}")]
+        [TestCase(typeof(Function_BindingToQueueClient), "sample message")]
         public async Task Run_QueueFunction(Type programType, string message)
         {
             var queueServiceClient = AzuriteNUnitFixture.Instance.GetQueueServiceClient();
@@ -211,6 +213,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests
             logger.LogInformation("Received message from sample-queue-1, content={content}", incomingMessage.Content);
             logger.LogInformation("Dispatching message to sample-queue-2");
             collector.Add(incomingMessage);
+        }
+    }
+    #endregion
+
+    #region Snippet:Function_BindingToQueueClient
+    public static class Function_BindingToQueueClient
+    {
+        [FunctionName("QueueFunction")]
+        public static async Task Run(
+            [QueueTrigger("sample-queue")] string message,
+            [Queue("sample-queue")] QueueClient queueClient,
+            ILogger logger)
+        {
+            logger.LogInformation("Received message from sample-queue, content={content}", message);
+            QueueProperties queueProperties = await queueClient.GetPropertiesAsync();
+            logger.LogInformation("There are approximatelly {count} messages", queueProperties.ApproximateMessagesCount);
         }
     }
     #endregion

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/samples/QueueExtensionSamples.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/samples/QueueExtensionSamples.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Hosting;
@@ -16,9 +17,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests
     public class BlobExtensionSamples
     {
         [TestCase(typeof(QueueTriggerFunction_String), "sample message")]
+        [TestCase(typeof(QueueTriggerFunction_BinaryData), "sample message")]
+        [TestCase(typeof(QueueTriggerFunction_QueueMessage), "sample message")]
         [TestCase(typeof(QueueTriggerFunction_CustomObject), "{ \"content\": \"sample message\"}")]
         [TestCase(typeof(QueueTriggerFunction_JObject), "{ \"content\": \"sample message\"}")]
         [TestCase(typeof(QueueSenderFunction_String_Return), "sample message")]
+        [TestCase(typeof(QueueSenderFunction_BinaryData_Return), "sample message")]
+        [TestCase(typeof(QueueSenderFunction_QueueMessage_Return), "sample message")]
         [TestCase(typeof(QueueSenderFunction_CustomObject_OutParamter), "{ \"content\": \"sample message\"}")]
         [TestCase(typeof(QueueSenderFunction_CustomObject_Collector), "{ \"content\": \"sample message\"}")]
         public async Task Run_QueueFunction(Type programType, string message)
@@ -63,6 +68,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests
     }
     #endregion
 
+    #region Snippet:QueueTriggerFunction_BinaryData
+    public static class QueueTriggerFunction_BinaryData
+    {
+        [FunctionName("QueueTriggerFunction")]
+        public static void Run(
+            [QueueTrigger("sample-queue")] BinaryData message,
+            ILogger logger)
+        {
+            logger.LogInformation("Received message from sample-queue, content={content}", message.ToString());
+        }
+    }
+    #endregion
+
     #region Snippet:QueueTriggerFunction_CustomObject
     public static class QueueTriggerFunction_CustomObject
     {
@@ -94,6 +112,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests
     }
     #endregion
 
+    #region Snippet:QueueTriggerFunction_QueueMessage
+    public static class QueueTriggerFunction_QueueMessage
+    {
+        [FunctionName("QueueTriggerFunction")]
+        public static void Run(
+            [QueueTrigger("sample-queue")] QueueMessage message,
+            ILogger logger)
+        {
+            logger.LogInformation("Received message from sample-queue, content={content}", message.Body.ToString());
+        }
+    }
+    #endregion
+
     #region Snippet:QueueSenderFunction_String_Return
     public static class QueueSenderFunction_String_Return
     {
@@ -104,6 +135,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Samples.Tests
             ILogger logger)
         {
             logger.LogInformation("Received message from sample-queue-1, content={content}", message);
+            logger.LogInformation("Dispatching message to sample-queue-2");
+            return message;
+        }
+    }
+    #endregion
+
+    #region Snippet:QueueSenderFunction_BinaryData_Return
+    public static class QueueSenderFunction_BinaryData_Return
+    {
+        [FunctionName("QueueFunction")]
+        [return: Queue("sample-queue-2")]
+        public static BinaryData Run(
+            [QueueTrigger("sample-queue-1")] BinaryData message,
+            ILogger logger)
+        {
+            logger.LogInformation("Received message from sample-queue-1, content={content}", message.ToString());
+            logger.LogInformation("Dispatching message to sample-queue-2");
+            return message;
+        }
+    }
+    #endregion
+
+    #region Snippet:QueueSenderFunction_QueueMessage_Return
+    public static class QueueSenderFunction_QueueMessage_Return
+    {
+        [FunctionName("QueueFunction")]
+        [return: Queue("sample-queue-2")]
+        public static QueueMessage Run(
+            [QueueTrigger("sample-queue-1")] QueueMessage message,
+            ILogger logger)
+        {
+            logger.LogInformation("Received message from sample-queue-1, content={content}", message.Body.ToString());
             logger.LogInformation("Dispatching message to sample-queue-2");
             return message;
         }


### PR DESCRIPTION
This PR addresses the following items from https://github.com/Azure/azure-sdk/issues/2038 :
- Hide and explicit implement Format in BlobsOptions and QueuesOptions.
- Change order of blob samples, remove trigger from parameter name
- Explanation what's trigger
- Start blob readme with simple function that only has trigger
- Explain trigger strategies, how to enable analytic logs, event grid integration
- more queue samples, QueueMessage, BinaryData, QueueClient bindings
- More blob samples, container binding, enumeration of container, byte[], TextReader/Writer, etc.

Samples explaining configuration aspect will be added later as they seem to require creation of sample function apps.