### PR TITLE
Distinguish the ASA variables so they don't clash with the ARR ones.

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/tests/MixedRealityTestEnvironment.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/tests/MixedRealityTestEnvironment.cs
@@ -11,24 +11,24 @@ namespace Azure.MixedReality.Authentication.Tests
         /// Gets the account domain.
         /// </summary>
         /// <remarks>
-        /// Set the MIXEDREALITY_ACCOUNT_DOMAIN environment variable.
+        /// Set the MIXEDREALITY_ASA_ACCOUNT_DOMAIN environment variable.
         /// </remarks>
-        public string AccountDomain => GetRecordedVariable("ACCOUNT_DOMAIN");
+        public string AccountDomain => GetRecordedVariable("ASA_ACCOUNT_DOMAIN");
 
         /// <summary>
         /// Gets the account identifier.
         /// </summary>
         /// <remarks>
-        /// Set the MIXEDREALITY_ACCOUNT_ID environment variable.
+        /// Set the MIXEDREALITY_ASA_ACCOUNT_ID environment variable.
         /// </remarks>
-        public string AccountId => GetRecordedVariable("ACCOUNT_ID");
+        public string AccountId => GetRecordedVariable("ASA_ACCOUNT_ID");
 
         /// <summary>
         /// Gets the account key.
         /// </summary>
         /// <remarks>
-        /// Set the MIXEDREALITY_ACCOUNT_KEY environment variable.
+        /// Set the MIXEDREALITY_ASA_ACCOUNT_KEY environment variable.
         /// </remarks>
-        public string AccountKey => GetRecordedVariable("ACCOUNT_KEY");
+        public string AccountKey => GetRecordedVariable("ASA_ACCOUNT_KEY");
     }
 }

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/tests/SessionRecords/MixedRealityStsClientLiveTests/GetToken.json
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/tests/SessionRecords/MixedRealityStsClientLiveTests/GetToken.json
@@ -31,9 +31,9 @@
     }
   ],
   "Variables": {
-    "ACCOUNT_DOMAIN": "mixedreality.azure.com",
-    "ACCOUNT_ID": "68321d5a-7978-4ceb-b880-0f49751daae9",
-    "ACCOUNT_KEY": "NjgzMjFkNWEtNzk3OC00Y2ViLWI4ODAtMGY0OTc1MWRhYWU5",
+    "ASA_ACCOUNT_DOMAIN": "mixedreality.azure.com",
+    "ASA_ACCOUNT_ID": "68321d5a-7978-4ceb-b880-0f49751daae9",
+    "ASA_ACCOUNT_KEY": "NjgzMjFkNWEtNzk3OC00Y2ViLWI4ODAtMGY0OTc1MWRhYWU5",
     "RandomSeed": "101086706"
   }
 }

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/tests/SessionRecords/MixedRealityStsClientLiveTests/GetTokenAsync.json
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/tests/SessionRecords/MixedRealityStsClientLiveTests/GetTokenAsync.json
@@ -31,9 +31,9 @@
     }
   ],
   "Variables": {
-    "ACCOUNT_DOMAIN": "mixedreality.azure.com",
-    "ACCOUNT_ID": "68321d5a-7978-4ceb-b880-0f49751daae9",
-    "ACCOUNT_KEY": "NjgzMjFkNWEtNzk3OC00Y2ViLWI4ODAtMGY0OTc1MWRhYWU5",
+    "ASA_ACCOUNT_DOMAIN": "mixedreality.azure.com",
+    "ASA_ACCOUNT_ID": "68321d5a-7978-4ceb-b880-0f49751daae9",
+    "ASA_ACCOUNT_KEY": "NjgzMjFkNWEtNzk3OC00Y2ViLWI4ODAtMGY0OTc1MWRhYWU5",
     "RandomSeed": "1748369871"
   }
 }

--- a/sdk/mixedreality/test-resources.json
+++ b/sdk/mixedreality/test-resources.json
@@ -38,15 +38,15 @@
         }
     ],
     "outputs": {
-        "MIXEDREALITY_ACCOUNT_ID": {
+        "MIXEDREALITY_ASA_ACCOUNT_ID": {
             "type": "string",
             "value": "[reference(variables('asaAccountName')).accountId]"
         },
-        "MIXEDREALITY_ACCOUNT_DOMAIN": {
+        "MIXEDREALITY_ASA_ACCOUNT_DOMAIN": {
             "type": "string",
             "value": "[reference(variables('asaAccountName')).accountDomain]"
         },
-        "MIXEDREALITY_ACCOUNT_KEY": {
+        "MIXEDREALITY_ASA_ACCOUNT_KEY": {
             "type": "string",
             "value": "[listKeys(resourceId('Microsoft.MixedReality/spatialAnchorsAccounts', variables('asaAccountName')), variables('apiVersion')).primaryKey]"
         }


### PR DESCRIPTION
The environment variables used in mixed reality are named generically, but it would be better if they were declared as ASA specific variables so when we add ARR ones, it's less confusing.