### PR TITLE
Fix matrix dimension length bug for string values

### DIFF
--- a/eng/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/scripts/job-matrix/job-matrix-functions.ps1
@@ -73,7 +73,7 @@ function MatchesFilters([hashtable]$entry, [array]$filters) {
         # Default all regex checks to go against empty string when keys are missing.
         # This simplifies the filter syntax/interface to be regex only.
         $value = ""
-        if ($entry.parameters.Contains($key)) {
+        if ($null -ne $entry -and $entry.parameters.Contains($key)) {
             $value = $entry.parameters[$key]
         }
         if ($value -notmatch $regex) {
@@ -337,8 +337,10 @@ function GetMatrixDimensions([System.Collections.Specialized.OrderedDictionary]$
     foreach ($val in $parameters.Values) {
         if ($val -is [PSCustomObject]) {
             $dimensions += ($val.PSObject.Properties | Measure-Object).Count
-        } else {
+        } elseif ($val -is [Array]) {
             $dimensions += $val.Length
+        } else {
+            $dimensions += 1
         }
     }
 

--- a/eng/scripts/job-matrix/job-matrix-functions.tests.ps1
+++ b/eng/scripts/job-matrix/job-matrix-functions.tests.ps1
@@ -309,6 +309,9 @@ Describe "Platform Matrix Generation" -Tag "generate" {
 
     It "Should get matrix dimensions from Nd parameters" {
         GetMatrixDimensions $generateConfig.orderedMatrix | Should -Be 3, 2, 2
+
+        $generateConfig.orderedMatrix.Add("testStringParameter", "test")
+        GetMatrixDimensions $generateConfig.orderedMatrix | Should -Be 3, 2, 2, 1
     }
 
     It "Should use name overrides from displayNames" {


### PR DESCRIPTION
This fixes a bug introduced in the last update where we get the incorrect matrix dimension length when the value is a singular string (as opposed to an array or object grouping).

This also fixes an issue where a display name filter might make a matrix empty when passed to the regex filter step.