### PR TITLE
Avoid exception in the OpenAsync when calling ReadLastEnqueuedEventProperties

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Processor/EventProcessorHost.cs
@@ -112,16 +112,19 @@ namespace Microsoft.Azure.WebJobs.EventHubs.Processor
             return partition.EventProcessor.ProcessEventsAsync(partition, events);
         }
 
-        protected override Task OnInitializingPartitionAsync(EventProcessorHostPartition partition, CancellationToken cancellationToken)
+        protected override async Task OnInitializingPartitionAsync(EventProcessorHostPartition partition, CancellationToken cancellationToken)
         {
             partition.ProcessorHost = this;
             partition.EventProcessor = _processorFactory.CreateEventProcessor();
-            partition.ReadLastEnqueuedEventPropertiesFunc = ReadLastEnqueuedEventProperties;
 
             // Since we are re-initializing this partition, any cached information we have about the partition will be incorrect.
             // Clear it out now, if there is any, we'll refresh it in ListCheckpointsAsync, which EventProcessor will call before starting to pump messages.
             partition.Checkpoint = null;
-            return partition.EventProcessor.OpenAsync(partition);
+            await partition.EventProcessor.OpenAsync(partition).ConfigureAwait(false);
+
+            // No ReadLastEnqueuedEventProperties information is available at this moment set the ReadLastEnqueuedEventPropertiesFunc last
+            // to avoid an exception in OpenAsync
+            partition.ReadLastEnqueuedEventPropertiesFunc = ReadLastEnqueuedEventProperties;
         }
 
         protected override Task OnPartitionProcessingStoppedAsync(EventProcessorHostPartition partition, ProcessingStoppedReason reason, CancellationToken cancellationToken)


### PR DESCRIPTION
Fewer exceptions in the startup path.