### PR TITLE
Move global variable to the pipeline level

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -31,8 +31,6 @@ parameters:
 
 jobs:
   - job: Build
-    variables:
-      - template: ../variables/globals.yml
     pool:
       name: ${{ parameters.WindowsPool }} # Comment this line back-out to switch to public pools.
       # vmImage: windows-2019 # Comment this line back-in to switch to public pools.
@@ -97,8 +95,6 @@ jobs:
 
   - job: "Analyze"
     condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
-    variables:
-      - template: ../variables/globals.yml
     pool:
       name: ${{ parameters.LinuxPool }}
       vmImage:
@@ -151,8 +147,6 @@ jobs:
   - job: "Test"
     timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
     condition: and(succeededOrFailed(), ne(variables['Skip.Test'], true))
-    variables:
-      - template: ../variables/globals.yml
     strategy:
       maxParallel: $[ variables['MaxParallelTestJobs'] ]
       matrix:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests-jobs.yml
@@ -53,7 +53,6 @@ jobs:
       matrix: $[ ${{ parameters.Matrix }} ]
 
     variables:
-      - template: ../variables/globals.yml
       # ServiceDirectory references must get passed down by the caller as variable references
       - name: ServiceDirectory
         value: ${{ parameters.ServiceDirectory }}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -43,6 +43,9 @@ parameters:
   type: number
   default: 60
 
+variables:
+  - template: ../variables/globals.yml
+
 stages:
   - stage: Build
     jobs:

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -85,6 +85,8 @@ parameters:
         pathToPublish: '$(Build.ArtifactStagingDirectory)/SessionRecords'
         artifactName: SessionRecords
 
+variables:
+  - template: ../variables/globals.yml
 
 stages:
 - ${{ each cloud in parameters.CloudConfig }}:


### PR DESCRIPTION
To ensure we always include the global variables in all
our pipeline jobs and stages we should import the variables
at the highest pipeline level to ensure we don't miss setting
these variables in any jobs.