### PR TITLE
Document that DeletedSecret.Value is always null

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/KeyVaultSecret.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/KeyVaultSecret.cs
@@ -51,6 +51,7 @@ namespace Azure.Security.KeyVault.Secrets
         /// <summary>
         /// Gets the value of the secret.
         /// </summary>
+        /// <value>This property is always null for <see cref="DeletedSecret"/>.</value>
         public string Value { get; internal set; }
 
         internal virtual void ReadProperty(JsonProperty prop)


### PR DESCRIPTION
Resolves #17741

To note, I also checked if/how this applies to DeletedKey and DeletedCertificate. When retrieved individually, the public key portion of the JWK is retrieved and both the SecretId and KeyId on DeletedCertificate are present as well.