### PR TITLE
[EngSys] Fixing CODEOWNERS Typo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -257,7 +257,7 @@
 # ServiceLabel: %Device Provisioning Service %Service Attention
 /sdk/deviceprovisioningservices/Microsoft.Azure.Management.DeviceProvisioningServices/            @nberdy
 
-# PRLabel: %DigitalTwins
+# PRLabel: %Digital Twins
 # ServiceLabel: %Digital Twins %Service Attention
 /sdk/digitaltwins/                              @drwill-ms @timtay-microsoft @abhipsaMisra @vinagesh @azabbasi @bikamani @barustum @jamdavi
 
@@ -496,7 +496,7 @@ sdk/trafficmanager/Microsoft.Azure.Management.TrafficManager/            @tmsupp
 
 # Client
 # PRLabel: %Service Bus
-/sdk/servicebus/                                @JoshLove-msft @ShivangiReja @jsquire
+/sdk/servicebus/                                @JoshLove-msft @jsquire
 
 # ServiceLabel: %Service Bus %Service Attention
 /sdk/servicebus/Microsoft.*/                    @axisc


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a typo in label application for the Digital Twins service.  The ownership of Service Bus has also been tweaked to reflect a change in areas of responsibility.

# Last Upstream Rebase

Monday, February 1, 9:53am (EST)