### PR TITLE
[MetricsAdvisor] Made constructor of DataFeed parameterless

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -6,12 +6,23 @@
 - Added support for AAD authentication in `MetricsAdvisorClient` and `MetricsAdvisorAdministrationClient`.
 
 ### Breaking Changes
+- The constructor of the `DataFeed` class is now parameterless. Required properties should be set via setters.
+- The constructor of the `DataFeedSchema` class is now parameterless. Metrics can be added directly to `MetricColumns`.
+- The constructor of the `DataFeedIngestionSettings` class is now parameterless. Required properties should be set via setters.
+- In `DataFeed`, added property setters to `Name`, `DataSource`, `Granularity`, `IngestionSettings`, and `Schema`.
+- In `DataFeedIngestionSettings`, added a property setter to `IngestionStartTime`.
+- In `DataFeed`, removed the setters of the properties `Administrators` and `Viewers`.
+- In `DataFeedSchema`, removed the setter of the property `DimensionColumns`.
+- In `DataFeedRollupSettings`, removed the setter of the property `AutoRollupGroupByColumnNames`.
+- `DataFeed.SourceType` is now nullable. It will be null whenever `DataFeed.DataSource` is null.
+- `DataFeed.IngestionStartTime` is now nullable.
 - In `MetricsAdvisorKeyCredential`, renamed the parameter `key` to `subscriptionKey` in the method `UpdateSubscriptionKey`.
 - In `MetricsAdvisorKeyCredential`, renamed the parameter `key` to `apiKey` in the method `UpdateApiKey`.
 
 ### Key Bug Fixes
 - Fixed a bug in which setting `WebNotificationHook.CertificatePassword` would actually set the property `Username` instead.
 - Fixed a bug in which an `ArgumentNullException` was thrown when getting a `DataFeed` from the service as a Viewer.
+- Fixed a bug in which a data feed's administrators and viewers could not be set during creation.
 
 ## 1.0.0-beta.2 (2020-11-10)
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/README.md
@@ -186,29 +186,22 @@ Metrics Advisor supports multiple types of data sources. In this sample we'll il
 string sqlServerConnectionString = "<connectionString>";
 string sqlServerQuery = "<query>";
 
-var dataFeedName = "Sample data feed";
-var dataFeedSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
-var dataFeedGranularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
+var dataFeed = new DataFeed();
 
-var dataFeedMetrics = new List<DataFeedMetric>()
-{
-    new DataFeedMetric("cost"),
-    new DataFeedMetric("revenue")
-};
-var dataFeedDimensions = new List<DataFeedDimension>()
-{
-    new DataFeedDimension("category"),
-    new DataFeedDimension("city")
-};
-var dataFeedSchema = new DataFeedSchema(dataFeedMetrics)
-{
-    DimensionColumns = dataFeedDimensions
-};
+dataFeed.Name = "Sample data feed";
+dataFeed.DataSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
+dataFeed.Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
 
-var ingestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-var dataFeedIngestionSettings = new DataFeedIngestionSettings(ingestionStartTime);
+dataFeed.Schema = new DataFeedSchema();
+dataFeed.Schema.MetricColumns.Add(new DataFeedMetric("cost"));
+dataFeed.Schema.MetricColumns.Add(new DataFeedMetric("revenue"));
+dataFeed.Schema.DimensionColumns.Add(new DataFeedDimension("category"));
+dataFeed.Schema.DimensionColumns.Add(new DataFeedDimension("city"));
 
-var dataFeed = new DataFeed(dataFeedName, dataFeedSource, dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings);
+dataFeed.IngestionSettings = new DataFeedIngestionSettings()
+{
+    IngestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z")
+};
 
 Response<string> response = await adminClient.CreateDataFeedAsync(dataFeed);
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -507,26 +507,26 @@ namespace Azure.AI.MetricsAdvisor.Models
     }
     public partial class DataFeed
     {
-        public DataFeed(string dataFeedName, Azure.AI.MetricsAdvisor.Models.DataFeedSource dataSource, Azure.AI.MetricsAdvisor.Models.DataFeedGranularity dataFeedGranularity, Azure.AI.MetricsAdvisor.Models.DataFeedSchema dataFeedSchema, Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings dataFeedIngestionSettings) { }
+        public DataFeed() { }
         public Azure.AI.MetricsAdvisor.Models.DataFeedAccessMode? AccessMode { get { throw null; } set { } }
         public string ActionLinkTemplate { get { throw null; } set { } }
-        public System.Collections.Generic.IList<string> Administrators { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> Administrators { get { throw null; } }
         public System.DateTimeOffset? CreatedTime { get { throw null; } }
         public string Creator { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.DataFeedSource DataSource { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.DataFeedSource DataSource { get { throw null; } set { } }
         public string Description { get { throw null; } set { } }
-        public Azure.AI.MetricsAdvisor.Models.DataFeedGranularity Granularity { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.DataFeedGranularity Granularity { get { throw null; } set { } }
         public string Id { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings IngestionSettings { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.DataFeedIngestionSettings IngestionSettings { get { throw null; } set { } }
         public bool? IsAdministrator { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> MetricIds { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedMissingDataPointFillSettings MissingDataPointFillSettings { get { throw null; } set { } }
-        public string Name { get { throw null; } }
+        public string Name { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedRollupSettings RollupSettings { get { throw null; } set { } }
-        public Azure.AI.MetricsAdvisor.Models.DataFeedSchema Schema { get { throw null; } }
-        public Azure.AI.MetricsAdvisor.Models.DataFeedSourceType SourceType { get { throw null; } }
+        public Azure.AI.MetricsAdvisor.Models.DataFeedSchema Schema { get { throw null; } set { } }
+        public Azure.AI.MetricsAdvisor.Models.DataFeedSourceType? SourceType { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedStatus? Status { get { throw null; } }
-        public System.Collections.Generic.IList<string> Viewers { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> Viewers { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct DataFeedAccessMode : System.IEquatable<Azure.AI.MetricsAdvisor.Models.DataFeedAccessMode>
@@ -612,11 +612,11 @@ namespace Azure.AI.MetricsAdvisor.Models
     }
     public partial class DataFeedIngestionSettings
     {
-        public DataFeedIngestionSettings(System.DateTimeOffset ingestionStartTime) { }
+        public DataFeedIngestionSettings() { }
         public int? DataSourceRequestConcurrency { get { throw null; } set { } }
         public System.TimeSpan? IngestionRetryDelay { get { throw null; } set { } }
         public System.TimeSpan? IngestionStartOffset { get { throw null; } set { } }
-        public System.DateTimeOffset IngestionStartTime { get { throw null; } }
+        public System.DateTimeOffset? IngestionStartTime { get { throw null; } set { } }
         public System.TimeSpan? StopRetryAfter { get { throw null; } set { } }
     }
     public partial class DataFeedIngestionStatus
@@ -664,7 +664,7 @@ namespace Azure.AI.MetricsAdvisor.Models
     {
         public DataFeedRollupSettings() { }
         public string AlreadyRollupIdentificationValue { get { throw null; } set { } }
-        public System.Collections.Generic.IList<string> AutoRollupGroupByColumnNames { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> AutoRollupGroupByColumnNames { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedAutoRollupMethod? RollupMethod { get { throw null; } set { } }
         public Azure.AI.MetricsAdvisor.Models.DataFeedRollupType? RollupType { get { throw null; } set { } }
     }
@@ -689,8 +689,8 @@ namespace Azure.AI.MetricsAdvisor.Models
     }
     public partial class DataFeedSchema
     {
-        public DataFeedSchema(System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DataFeedMetric> metricColumns) { }
-        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DataFeedDimension> DimensionColumns { get { throw null; } set { } }
+        public DataFeedSchema() { }
+        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DataFeedDimension> DimensionColumns { get { throw null; } }
         public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DataFeedMetric> MetricColumns { get { throw null; } }
         public string TimestampColumn { get { throw null; } set { } }
     }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -279,13 +279,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <exception cref="ArgumentException"><paramref name="dataFeed"/>.Name is empty.</exception>
         public virtual async Task<Response<string>> CreateDataFeedAsync(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(dataFeed, nameof(dataFeed));
-            Argument.AssertNotNullOrEmpty(dataFeed.Name, $"{nameof(dataFeed)}.{nameof(dataFeed.Name)}");
-            Argument.AssertNotNull(dataFeed.DataSource, $"{nameof(dataFeed)}.{nameof(dataFeed.DataSource)}");
-            Argument.AssertNotNull(dataFeed.Granularity, $"{nameof(dataFeed)}.{nameof(dataFeed.Granularity)}");
-            Argument.AssertNotNull(dataFeed.Schema, $"{nameof(dataFeed)}.{nameof(dataFeed.Schema)}");
-            Argument.AssertNotNull(dataFeed.IngestionSettings, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}");
-            Argument.AssertNotNull(dataFeed.IngestionSettings.IngestionStartTime, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}.{nameof(dataFeed.IngestionSettings.IngestionStartTime)}");
+            ValidateDataFeedToCreate(dataFeed);
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();
@@ -317,13 +311,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <exception cref="ArgumentException"><paramref name="dataFeed"/>.Name is empty.</exception>
         public virtual Response<string> CreateDataFeed(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
-            Argument.AssertNotNull(dataFeed, nameof(dataFeed));
-            Argument.AssertNotNullOrEmpty(dataFeed.Name, $"{nameof(dataFeed)}.{nameof(dataFeed.Name)}");
-            Argument.AssertNotNull(dataFeed.DataSource, $"{nameof(dataFeed)}.{nameof(dataFeed.DataSource)}");
-            Argument.AssertNotNull(dataFeed.Granularity, $"{nameof(dataFeed)}.{nameof(dataFeed.Granularity)}");
-            Argument.AssertNotNull(dataFeed.Schema, $"{nameof(dataFeed)}.{nameof(dataFeed.Schema)}");
-            Argument.AssertNotNull(dataFeed.IngestionSettings, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}");
-            Argument.AssertNotNull(dataFeed.IngestionSettings.IngestionStartTime, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}.{nameof(dataFeed.IngestionSettings.IngestionStartTime)}");
+            ValidateDataFeedToCreate(dataFeed);
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();
@@ -690,6 +678,17 @@ namespace Azure.AI.MetricsAdvisor.Administration
             }
 
             return dataFeeds;
+        }
+
+        private static void ValidateDataFeedToCreate(DataFeed dataFeed)
+        {
+            Argument.AssertNotNull(dataFeed, nameof(dataFeed));
+            Argument.AssertNotNullOrEmpty(dataFeed.Name, $"{nameof(dataFeed)}.{nameof(dataFeed.Name)}");
+            Argument.AssertNotNull(dataFeed.DataSource, $"{nameof(dataFeed)}.{nameof(dataFeed.DataSource)}");
+            Argument.AssertNotNull(dataFeed.Granularity, $"{nameof(dataFeed)}.{nameof(dataFeed.Granularity)}");
+            Argument.AssertNotNull(dataFeed.Schema, $"{nameof(dataFeed)}.{nameof(dataFeed.Schema)}");
+            Argument.AssertNotNull(dataFeed.IngestionSettings, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}");
+            Argument.AssertNotNull(dataFeed.IngestionSettings.IngestionStartTime, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}.{nameof(dataFeed.IngestionSettings.IngestionStartTime)}");
         }
 
         #endregion DataFeed

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -275,7 +275,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// A <see cref="Response{T}"/> containing the result of the operation. The result is a <c>string</c>
         /// containing the ID of the newly created feed.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/>, <paramref name="dataFeed"/>.Name, <paramref name="dataFeed"/>.DataSource, <paramref name="dataFeed"/>.Granularity, <paramref name="dataFeed"/>.Schema, or <paramref name="dataFeed"/>.IngestionSettings is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/>, <paramref name="dataFeed"/>.Name, <paramref name="dataFeed"/>.DataSource, <paramref name="dataFeed"/>.Granularity, <paramref name="dataFeed"/>.Schema, <paramref name="dataFeed"/>.IngestionSettings, or <paramref name="dataFeed"/>.IngestionSettings.IngestionStartTime is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeed"/>.Name is empty.</exception>
         public virtual async Task<Response<string>> CreateDataFeedAsync(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
@@ -285,6 +285,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             Argument.AssertNotNull(dataFeed.Granularity, $"{nameof(dataFeed)}.{nameof(dataFeed.Granularity)}");
             Argument.AssertNotNull(dataFeed.Schema, $"{nameof(dataFeed)}.{nameof(dataFeed.Schema)}");
             Argument.AssertNotNull(dataFeed.IngestionSettings, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}");
+            Argument.AssertNotNull(dataFeed.IngestionSettings.IngestionStartTime, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}.{nameof(dataFeed.IngestionSettings.IngestionStartTime)}");
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();
@@ -312,7 +313,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// A <see cref="Response{T}"/> containing the result of the operation. The result is a <c>string</c> instance
         /// containing the ID of the newly created feed.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/>, <paramref name="dataFeed"/>.Name, <paramref name="dataFeed"/>.DataSource, <paramref name="dataFeed"/>.Granularity, <paramref name="dataFeed"/>.Schema, or <paramref name="dataFeed"/>.IngestionSettings is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/>, <paramref name="dataFeed"/>.Name, <paramref name="dataFeed"/>.DataSource, <paramref name="dataFeed"/>.Granularity, <paramref name="dataFeed"/>.Schema, <paramref name="dataFeed"/>.IngestionSettings, or <paramref name="dataFeed"/>.IngestionSettings.IngestionStartTime is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeed"/>.Name is empty.</exception>
         public virtual Response<string> CreateDataFeed(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
@@ -322,6 +323,7 @@ namespace Azure.AI.MetricsAdvisor.Administration
             Argument.AssertNotNull(dataFeed.Granularity, $"{nameof(dataFeed)}.{nameof(dataFeed.Granularity)}");
             Argument.AssertNotNull(dataFeed.Schema, $"{nameof(dataFeed)}.{nameof(dataFeed.Schema)}");
             Argument.AssertNotNull(dataFeed.IngestionSettings, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}");
+            Argument.AssertNotNull(dataFeed.IngestionSettings.IngestionStartTime, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}.{nameof(dataFeed.IngestionSettings.IngestionStartTime)}");
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -349,14 +349,12 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <returns>
         /// A <see cref="Response"/> containing the result of the operation.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/>, <paramref name="dataFeed"/>, or <paramref name="dataFeed"/>.SourceType is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> or <paramref name="dataFeed"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
         public virtual async Task<Response> UpdateDataFeedAsync(string dataFeedId, DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
             Argument.AssertNotNull(dataFeed, nameof(dataFeed));
-            Argument.AssertNotNull(dataFeed.SourceType, $"{nameof(dataFeed)}.{nameof(dataFeed.SourceType)}");
-
             if (!string.IsNullOrEmpty(dataFeed.Id) && !dataFeedId.Equals(dataFeed.Id, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException($"{nameof(dataFeedId)} does not match {nameof(dataFeed.Id)}");
@@ -385,14 +383,12 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <returns>
         /// A <see cref="Response"/> containing the result of the operation.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/>, <paramref name="dataFeed"/>, or <paramref name="dataFeed"/>.SourceType is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> or <paramref name="dataFeed"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
         public virtual Response UpdateDataFeed(string dataFeedId, DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
             Argument.AssertNotNull(dataFeed, nameof(dataFeed));
-            Argument.AssertNotNull(dataFeed.SourceType, $"{nameof(dataFeed)}.{nameof(dataFeed.SourceType)}");
-
             if (!string.IsNullOrEmpty(dataFeed.Id) && !dataFeedId.Equals(dataFeed.Id, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException($"{nameof(dataFeedId)} does not match {nameof(dataFeed.Id)}");

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -349,12 +349,14 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <returns>
         /// A <see cref="Response"/> containing the result of the operation.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> or <paramref name="dataFeed"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/>, <paramref name="dataFeed"/>, or <paramref name="dataFeed"/>.SourceType is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
         public virtual async Task<Response> UpdateDataFeedAsync(string dataFeedId, DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
             Argument.AssertNotNull(dataFeed, nameof(dataFeed));
+            Argument.AssertNotNull(dataFeed.SourceType, $"{nameof(dataFeed)}.{nameof(dataFeed.SourceType)}");
+
             if (!string.IsNullOrEmpty(dataFeed.Id) && !dataFeedId.Equals(dataFeed.Id, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException($"{nameof(dataFeedId)} does not match {nameof(dataFeed.Id)}");
@@ -383,12 +385,14 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// <returns>
         /// A <see cref="Response"/> containing the result of the operation.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/> or <paramref name="dataFeed"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeedId"/>, <paramref name="dataFeed"/>, or <paramref name="dataFeed"/>.SourceType is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="dataFeedId"/> is empty or not a valid GUID.</exception>
         public virtual Response UpdateDataFeed(string dataFeedId, DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
             Guid dataFeedGuid = ClientCommon.ValidateGuid(dataFeedId, nameof(dataFeedId));
             Argument.AssertNotNull(dataFeed, nameof(dataFeed));
+            Argument.AssertNotNull(dataFeed.SourceType, $"{nameof(dataFeed)}.{nameof(dataFeed.SourceType)}");
+
             if (!string.IsNullOrEmpty(dataFeed.Id) && !dataFeedId.Equals(dataFeed.Id, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException($"{nameof(dataFeedId)} does not match {nameof(dataFeed.Id)}");

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/MetricsAdvisorAdministrationClient.cs
@@ -275,10 +275,16 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// A <see cref="Response{T}"/> containing the result of the operation. The result is a <c>string</c>
         /// containing the ID of the newly created feed.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/>, <paramref name="dataFeed"/>.Name, <paramref name="dataFeed"/>.DataSource, <paramref name="dataFeed"/>.Granularity, <paramref name="dataFeed"/>.Schema, or <paramref name="dataFeed"/>.IngestionSettings is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="dataFeed"/>.Name is empty.</exception>
         public virtual async Task<Response<string>> CreateDataFeedAsync(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(dataFeed, nameof(dataFeed));
+            Argument.AssertNotNullOrEmpty(dataFeed.Name, $"{nameof(dataFeed)}.{nameof(dataFeed.Name)}");
+            Argument.AssertNotNull(dataFeed.DataSource, $"{nameof(dataFeed)}.{nameof(dataFeed.DataSource)}");
+            Argument.AssertNotNull(dataFeed.Granularity, $"{nameof(dataFeed)}.{nameof(dataFeed.Granularity)}");
+            Argument.AssertNotNull(dataFeed.Schema, $"{nameof(dataFeed)}.{nameof(dataFeed.Schema)}");
+            Argument.AssertNotNull(dataFeed.IngestionSettings, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}");
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();
@@ -306,10 +312,16 @@ namespace Azure.AI.MetricsAdvisor.Administration
         /// A <see cref="Response{T}"/> containing the result of the operation. The result is a <c>string</c> instance
         /// containing the ID of the newly created feed.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dataFeed"/>, <paramref name="dataFeed"/>.Name, <paramref name="dataFeed"/>.DataSource, <paramref name="dataFeed"/>.Granularity, <paramref name="dataFeed"/>.Schema, or <paramref name="dataFeed"/>.IngestionSettings is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="dataFeed"/>.Name is empty.</exception>
         public virtual Response<string> CreateDataFeed(DataFeed dataFeed, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNull(dataFeed, nameof(dataFeed));
+            Argument.AssertNotNullOrEmpty(dataFeed.Name, $"{nameof(dataFeed)}.{nameof(dataFeed.Name)}");
+            Argument.AssertNotNull(dataFeed.DataSource, $"{nameof(dataFeed)}.{nameof(dataFeed.DataSource)}");
+            Argument.AssertNotNull(dataFeed.Granularity, $"{nameof(dataFeed)}.{nameof(dataFeed.Granularity)}");
+            Argument.AssertNotNull(dataFeed.Schema, $"{nameof(dataFeed)}.{nameof(dataFeed.Schema)}");
+            Argument.AssertNotNull(dataFeed.IngestionSettings, $"{nameof(dataFeed)}.{nameof(dataFeed.IngestionSettings)}");
 
             using DiagnosticScope scope = _clientDiagnostics.CreateScope($"{nameof(MetricsAdvisorAdministrationClient)}.{nameof(CreateDataFeed)}");
             scope.Start();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -256,7 +256,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         internal DataFeedDetailPatch GetPatchModel()
         {
             DataFeedDetailPatch patch = DataSource?.InstantiateDataFeedDetailPatch()
-                ?? InstantiateDataFeedDetailPatchFromSourceType();
+                ?? new AzureApplicationInsightsDataFeedPatch();
 
             patch.DataFeedName = Name;
             patch.Status = Status.HasValue ? new DataFeedDetailPatchStatus(Status.ToString()) : default(DataFeedDetailPatchStatus?);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -14,10 +14,6 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// </summary>
     public class DataFeed
     {
-        private IList<string> _administrators;
-
-        private IList<string> _viewers;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DataFeed"/> class.
         /// </summary>
@@ -146,35 +142,13 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// data feed, being allowed to update, delete or pause them. They also have access to the
         /// credentials used to authenticate to the data source.
         /// </summary>
-        /// <exception cref="ArgumentNullException">The value assigned to <see cref="Administrators"/> is null.</exception>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public IList<string> Administrators
-        {
-            get => _administrators;
-            set
-            {
-                Argument.AssertNotNull(value, nameof(Administrators));
-                _administrators = value;
-            }
-        }
-#pragma warning restore CA2227 // Collection properties should be readonly
+        public IList<string> Administrators { get; }
 
         /// <summary>
         /// The emails of this data feed's viewers. Viewers have read-only access to a data feed, and
         /// do not have access to the credentials used to authenticate to the data source.
         /// </summary>
-        /// <exception cref="ArgumentNullException">The value assigned to <see cref="Viewers"/> is null.</exception>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public IList<string> Viewers
-        {
-            get => _viewers;
-            set
-            {
-                Argument.AssertNotNull(value, nameof(Viewers));
-                _viewers = value;
-            }
-        }
-#pragma warning restore CA2227 // Collection properties should be readonly
+        public IList<string> Viewers { get; }
 
         internal DataFeedDetail GetDataFeedDetail()
         {
@@ -214,8 +188,15 @@ namespace Azure.AI.MetricsAdvisor.Models
                 detail.FillMissingPointValue = MissingDataPointFillSettings.CustomFillValue;
             }
 
-            Administrators = detail.Admins;
-            Viewers = detail.Viewers;
+            foreach (var admin in Administrators)
+            {
+                detail.Admins.Add(admin);
+            }
+
+            foreach (var viewer in Viewers)
+            {
+                detail.Viewers.Add(viewer);
+            }
 
             return detail;
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -14,6 +14,10 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// </summary>
     public class DataFeed
     {
+        private DataFeedSource _dataSource;
+
+        private DataFeedSourceType? _sourceType;
+
         private IList<string> _administrators;
 
         private IList<string> _viewers;
@@ -89,12 +93,38 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The source from which data is consumed.
         /// </summary>
-        public DataFeedSource DataSource { get; set; }
+        public DataFeedSource DataSource
+        {
+            get => _dataSource;
+            set
+            {
+                _dataSource = value;
+
+                if (value != null)
+                {
+                    _sourceType = value.Type;
+                }
+            }
+        }
 
         /// <summary>
         /// The type of data source that ingests this <see cref="DataFeed"/> with data.
         /// </summary>
-        public DataFeedSourceType? SourceType => DataSource?.Type;
+        public DataFeedSourceType? SourceType
+        {
+            get => _sourceType;
+            set
+            {
+                var dataSource = _dataSource;
+
+                if (dataSource != null && dataSource.Type != value)
+                {
+                    throw new InvalidOperationException($"The source type cannot differ from the type of the set data source ({dataSource.Type}).");
+                }
+
+                _sourceType = value;
+            }
+        }
 
         /// <summary>
         /// Defines how this <see cref="DataFeed"/> structures the data ingested from the data source
@@ -225,18 +255,25 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// </summary>
         internal DataFeedDetailPatch GetPatchModel()
         {
-            DataFeedDetailPatch patch = DataSource.InstantiateDataFeedDetailPatch();
+            DataFeedDetailPatch patch = DataSource?.InstantiateDataFeedDetailPatch()
+                ?? InstantiateDataFeedDetailPatchFromSourceType();
 
             patch.DataFeedName = Name;
             patch.Status = Status.HasValue ? new DataFeedDetailPatchStatus(Status.ToString()) : default(DataFeedDetailPatchStatus?);
 
-            patch.TimestampColumn = Schema.TimestampColumn;
+            if (Schema != null)
+            {
+                patch.TimestampColumn = Schema.TimestampColumn;
+            }
 
-            patch.DataStartFrom = ClientCommon.NormalizeDateTimeOffset(IngestionSettings.IngestionStartTime);
-            patch.MaxConcurrency = IngestionSettings.DataSourceRequestConcurrency;
-            patch.MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds;
-            patch.StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds;
-            patch.StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds;
+            if (IngestionSettings != null)
+            {
+                patch.DataStartFrom = ClientCommon.NormalizeDateTimeOffset(IngestionSettings.IngestionStartTime);
+                patch.MaxConcurrency = IngestionSettings.DataSourceRequestConcurrency;
+                patch.MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds;
+                patch.StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds;
+                patch.StopRetryAfterInSeconds = (long?)IngestionSettings.StopRetryAfter?.TotalSeconds;
+            }
 
             patch.DataFeedDescription = Description;
             patch.ActionLinkTemplate = ActionLinkTemplate;
@@ -260,6 +297,71 @@ namespace Azure.AI.MetricsAdvisor.Models
             patch.Viewers = Viewers;
 
             return patch;
+        }
+
+        private DataFeedDetailPatch InstantiateDataFeedDetailPatchFromSourceType()
+        {
+            if (_sourceType == DataFeedSourceType.AzureApplicationInsights)
+            {
+                return new AzureApplicationInsightsDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.AzureBlob)
+            {
+                return new AzureBlobDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.AzureCosmosDb)
+            {
+                return new AzureCosmosDBDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.AzureDataLakeStorageGen2)
+            {
+                return new AzureDataLakeStorageGen2DataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.AzureTable)
+            {
+                return new AzureTableDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.Elasticsearch)
+            {
+                return new ElasticsearchDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.HttpRequest)
+            {
+                return new HttpRequestDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.InfluxDb)
+            {
+                return new InfluxDBDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.AzureDataExplorer)
+            {
+                return new AzureDataExplorerDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.MySql)
+            {
+                return new MySqlDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.PostgreSql)
+            {
+                return new PostgreSqlDataFeedPatch();
+            }
+
+            if (_sourceType == DataFeedSourceType.SqlServer)
+            {
+                return new SQLServerDataFeedPatch();
+            }
+
+            throw new InvalidOperationException("Invalid source type.");
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -14,10 +14,6 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// </summary>
     public class DataFeed
     {
-        private DataFeedSource _dataSource;
-
-        private DataFeedSourceType? _sourceType;
-
         private IList<string> _administrators;
 
         private IList<string> _viewers;
@@ -93,38 +89,12 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// The source from which data is consumed.
         /// </summary>
-        public DataFeedSource DataSource
-        {
-            get => _dataSource;
-            set
-            {
-                _dataSource = value;
-
-                if (value != null)
-                {
-                    _sourceType = value.Type;
-                }
-            }
-        }
+        public DataFeedSource DataSource { get; set; }
 
         /// <summary>
         /// The type of data source that ingests this <see cref="DataFeed"/> with data.
         /// </summary>
-        public DataFeedSourceType? SourceType
-        {
-            get => _sourceType;
-            set
-            {
-                var dataSource = _dataSource;
-
-                if (dataSource != null && dataSource.Type != value)
-                {
-                    throw new InvalidOperationException($"The source type cannot differ from the type of the set data source ({dataSource.Type}).");
-                }
-
-                _sourceType = value;
-            }
-        }
+        public DataFeedSourceType? SourceType => DataSource?.Type;
 
         /// <summary>
         /// Defines how this <see cref="DataFeed"/> structures the data ingested from the data source
@@ -297,71 +267,6 @@ namespace Azure.AI.MetricsAdvisor.Models
             patch.Viewers = Viewers;
 
             return patch;
-        }
-
-        private DataFeedDetailPatch InstantiateDataFeedDetailPatchFromSourceType()
-        {
-            if (_sourceType == DataFeedSourceType.AzureApplicationInsights)
-            {
-                return new AzureApplicationInsightsDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.AzureBlob)
-            {
-                return new AzureBlobDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.AzureCosmosDb)
-            {
-                return new AzureCosmosDBDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.AzureDataLakeStorageGen2)
-            {
-                return new AzureDataLakeStorageGen2DataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.AzureTable)
-            {
-                return new AzureTableDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.Elasticsearch)
-            {
-                return new ElasticsearchDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.HttpRequest)
-            {
-                return new HttpRequestDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.InfluxDb)
-            {
-                return new InfluxDBDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.AzureDataExplorer)
-            {
-                return new AzureDataExplorerDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.MySql)
-            {
-                return new MySqlDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.PostgreSql)
-            {
-                return new PostgreSqlDataFeedPatch();
-            }
-
-            if (_sourceType == DataFeedSourceType.SqlServer)
-            {
-                return new SQLServerDataFeedPatch();
-            }
-
-            throw new InvalidOperationException("Invalid source type.");
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -178,7 +178,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
         internal DataFeedDetail GetDataFeedDetail()
         {
-            DataFeedDetail detail = DataSource.InstantiateDataFeedDetail(Name, Granularity.GranularityType, Schema.MetricColumns, IngestionSettings.IngestionStartTime);
+            DataFeedDetail detail = DataSource.InstantiateDataFeedDetail(Name, Granularity.GranularityType, Schema.MetricColumns, IngestionSettings.IngestionStartTime.Value);
 
             foreach (var column in Schema.DimensionColumns)
             {
@@ -238,7 +238,7 @@ namespace Azure.AI.MetricsAdvisor.Models
 
             if (IngestionSettings != null)
             {
-                patch.DataStartFrom = ClientCommon.NormalizeDateTimeOffset(IngestionSettings.IngestionStartTime);
+                patch.DataStartFrom = IngestionSettings.IngestionStartTime.HasValue ? ClientCommon.NormalizeDateTimeOffset(IngestionSettings.IngestionStartTime.Value) : null;
                 patch.MaxConcurrency = IngestionSettings.DataSourceRequestConcurrency;
                 patch.MinRetryIntervalInSeconds = (long?)IngestionSettings.IngestionRetryDelay?.TotalSeconds;
                 patch.StartOffsetInSeconds = (long?)IngestionSettings.IngestionStartOffset?.TotalSeconds;

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -207,7 +207,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         internal DataFeedDetailPatch GetPatchModel()
         {
             DataFeedDetailPatch patch = DataSource?.InstantiateDataFeedDetailPatch()
-                ?? new AzureApplicationInsightsDataFeedPatch();
+                ?? new DataFeedDetailPatch();
 
             patch.DataFeedName = Name;
             patch.Status = Status.HasValue ? new DataFeedDetailPatchStatus(Status.ToString()) : default(DataFeedDetailPatchStatus?);

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeed.cs
@@ -21,27 +21,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="DataFeed"/> class.
         /// </summary>
-        /// <param name="dataFeedName">A custom name for the <see cref="DataFeed"/>.</param>
-        /// <param name="dataSource">The source from which data is consumed.</param>
-        /// <param name="dataFeedGranularity">The frequency with which ingestion from the data source occurs.</param>
-        /// <param name="dataFeedSchema">Defines how this <see cref="DataFeed"/> structures the data ingested from the data source in terms of metrics and dimensions.</param>
-        /// <param name="dataFeedIngestionSettings">Configures how a <see cref="DataFeed"/> behaves during data ingestion from its data source.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="dataFeedName"/>, <paramref name="dataSource"/>, <paramref name="dataFeedGranularity"/>, <paramref name="dataFeedSchema"/>, or <paramref name="dataFeedIngestionSettings"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="dataFeedName"/> is empty.</exception>
-        public DataFeed(string dataFeedName, DataFeedSource dataSource, DataFeedGranularity dataFeedGranularity, DataFeedSchema dataFeedSchema, DataFeedIngestionSettings dataFeedIngestionSettings)
+        public DataFeed()
         {
-            Argument.AssertNotNullOrEmpty(dataFeedName, nameof(dataFeedName));
-            Argument.AssertNotNull(dataSource, nameof(dataSource));
-            Argument.AssertNotNull(dataFeedGranularity, nameof(dataFeedGranularity));
-            Argument.AssertNotNull(dataFeedSchema, nameof(dataFeedSchema));
-            Argument.AssertNotNull(dataFeedIngestionSettings, nameof(dataFeedIngestionSettings));
-
-            Name = dataFeedName;
-            DataSource = dataSource;
-            SourceType = dataSource.Type;
-            Granularity = dataFeedGranularity;
-            Schema = dataFeedSchema;
-            IngestionSettings = dataFeedIngestionSettings;
             Administrators = new ChangeTrackingList<string>();
             Viewers = new ChangeTrackingList<string>();
         }
@@ -56,7 +37,6 @@ namespace Azure.AI.MetricsAdvisor.Models
             MetricIds = dataFeedDetail.Metrics.ToDictionary(metric => metric.MetricName, metric => metric.MetricId);
             Name = dataFeedDetail.DataFeedName;
             DataSource = DataFeedSource.GetDataFeedSource(dataFeedDetail);
-            SourceType = dataFeedDetail.DataSourceType;
             Schema = new DataFeedSchema(dataFeedDetail);
             Granularity = new DataFeedGranularity(dataFeedDetail);
             IngestionSettings = new DataFeedIngestionSettings(dataFeedDetail);
@@ -104,33 +84,33 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// A custom name for this <see cref="DataFeed"/> to be displayed on the web portal.
         /// </summary>
-        public string Name { get; }
+        public string Name { get; set; }
 
         /// <summary>
         /// The source from which data is consumed.
         /// </summary>
-        public DataFeedSource DataSource { get; }
+        public DataFeedSource DataSource { get; set; }
 
         /// <summary>
         /// The type of data source that ingests this <see cref="DataFeed"/> with data.
         /// </summary>
-        public DataFeedSourceType SourceType { get; }
+        public DataFeedSourceType? SourceType => DataSource?.Type;
 
         /// <summary>
         /// Defines how this <see cref="DataFeed"/> structures the data ingested from the data source
         /// in terms of metrics and dimensions.
         /// </summary>
-        public DataFeedSchema Schema { get; }
+        public DataFeedSchema Schema { get; set; }
 
         /// <summary>
         /// The frequency with which ingestion from the data source will happen.
         /// </summary>
-        public DataFeedGranularity Granularity { get; }
+        public DataFeedGranularity Granularity { get; set; }
 
         /// <summary>
         /// Configures how a <see cref="DataFeed"/> behaves during data ingestion from its data source.
         /// </summary>
-        public DataFeedIngestionSettings IngestionSettings { get; }
+        public DataFeedIngestionSettings IngestionSettings { get; set; }
 
         /// <summary>
         /// A description of this <see cref="DataFeed"/>.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
@@ -13,10 +13,8 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="DataFeedIngestionSettings"/> class.
         /// </summary>
-        /// <param name="ingestionStartTime">The starting point in time from which data will be ingested from the data source. Subsequent ingestions happen periodically according to the specified <see cref="DataFeedGranularity"/>.</param>
-        public DataFeedIngestionSettings(DateTimeOffset ingestionStartTime)
+        public DataFeedIngestionSettings()
         {
-            IngestionStartTime = ingestionStartTime;
         }
 
         internal DataFeedIngestionSettings(DataFeedDetail dataFeedDetail)
@@ -38,7 +36,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The starting point in time from which data will be ingested from the data source. Subsequent
         /// ingestions happen periodically according to the data feed's granularity.
         /// </summary>
-        public DateTimeOffset IngestionStartTime { get; set; }
+        public DateTimeOffset? IngestionStartTime { get; set; }
 
         /// <summary>
         /// If the specified data source supports limited concurrency, this can be set to specify the

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedIngestionSettings.cs
@@ -38,7 +38,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// The starting point in time from which data will be ingested from the data source. Subsequent
         /// ingestions happen periodically according to the data feed's granularity.
         /// </summary>
-        public DateTimeOffset IngestionStartTime { get; }
+        public DateTimeOffset IngestionStartTime { get; set; }
 
         /// <summary>
         /// If the specified data source supports limited concurrency, this can be set to specify the

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedRollupSettings.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedRollupSettings.cs
@@ -13,8 +13,6 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// </summary>
     public class DataFeedRollupSettings
     {
-        private IList<string> _autoRollupGroupByColumnNames;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DataFeedRollupSettings"/> class.
         /// </summary>
@@ -51,17 +49,6 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Defines the column names to which these <see cref="DataFeedRollupSettings"/> will apply.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><see cref="AutoRollupGroupByColumnNames"/> is null.</exception>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public IList<string> AutoRollupGroupByColumnNames
-        {
-            get => _autoRollupGroupByColumnNames;
-            set
-            {
-                Argument.AssertNotNull(value, nameof(AutoRollupGroupByColumnNames));
-                _autoRollupGroupByColumnNames = value;
-            }
-        }
-#pragma warning restore CA2227 // Collection properties should be readonly
+        public IList<string> AutoRollupGroupByColumnNames { get; }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSchema.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/DataFeed/DataFeedSchema.cs
@@ -14,18 +14,12 @@ namespace Azure.AI.MetricsAdvisor.Models
     /// </summary>
     public class DataFeedSchema
     {
-        private IList<DataFeedDimension> _dimensionColumns;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DataFeedSchema"/> class.
         /// </summary>
-        /// <param name="metricColumns">The metrics ingested from the data feed. The values of these metrics are monitored in search of anomalies. Cannot be empty.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="metricColumns"/> is null.</exception>
-        public DataFeedSchema(IList<DataFeedMetric> metricColumns)
+        public DataFeedSchema()
         {
-            Argument.AssertNotNull(metricColumns, nameof(metricColumns));
-
-            MetricColumns = metricColumns;
+            MetricColumns = new ChangeTrackingList<DataFeedMetric>();
             DimensionColumns = new ChangeTrackingList<DataFeedDimension>();
         }
 
@@ -47,18 +41,7 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// values this set of dimensions can assume, one time series is generated and
         /// monitored in search of anomalies.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><see cref="DimensionColumns"/> is null.</exception>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public IList<DataFeedDimension> DimensionColumns
-        {
-            get => _dimensionColumns;
-            set
-            {
-                Argument.AssertNotNull(value, nameof(DimensionColumns));
-                _dimensionColumns = value;
-            }
-        }
-#pragma warning restore CA2227 // Collection properties should be readonly
+        public IList<DataFeedDimension> DimensionColumns { get; }
 
         /// <summary>
         /// The name of the data source's column with date or string values to be used as timestamp.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -605,9 +605,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -713,9 +711,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -819,9 +815,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -925,9 +919,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1031,9 +1023,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1137,9 +1127,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1243,9 +1231,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1349,9 +1335,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1453,9 +1437,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1559,9 +1541,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1665,9 +1645,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1771,9 +1749,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
@@ -1877,9 +1853,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
-
-            dataFeedToUpdate.Description = description;
+            var dataFeedToUpdate = new DataFeed() { Description = description };
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -2078,7 +2078,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 DataSource = dataSource,
                 Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
                 Schema = new DataFeedSchema() { MetricColumns = { new ("cost") } },
-                IngestionSettings = new DataFeedIngestionSettings(ingestionStartTime)
+                IngestionSettings = new DataFeedIngestionSettings() { IngestionStartTime = ingestionStartTime }
             };
         }
 
@@ -2086,8 +2086,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
 
-            var ingestionSettings = new DataFeedIngestionSettings(ingestionStartTime)
+            var ingestionSettings = new DataFeedIngestionSettings()
             {
+                IngestionStartTime = ingestionStartTime,
                 IngestionStartOffset = TimeSpan.FromMinutes(30),
                 IngestionRetryDelay = TimeSpan.FromSeconds(80),
                 StopRetryAfter = TimeSpan.FromMinutes(10),

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -2126,6 +2126,17 @@ namespace Azure.AI.MetricsAdvisor.Tests
             dataFeed.Description = "This data feed was updated to test the .NET client.";
             dataFeed.AccessMode = DataFeedAccessMode.Public;
             dataFeed.ActionLinkTemplate = "https://fakeurl.com/%datafeed/%metric";
+
+            // If we're creating the data feed from scratch, we must be careful to not fully
+            // overwrite the admins list during the update, otherwise we can end up removing
+            // ourselves from the list. Doing so would cause permission errors during the next
+            // service calls.
+
+            if (dataFeed.Administrators.Count == 0)
+            {
+                dataFeed.Administrators.Add(dataFeed.Creator);
+            }
+
             dataFeed.Administrators.Add("fake@admin.com");
             dataFeed.Viewers.Add("fake@viewer.com");
 
@@ -2277,7 +2288,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
 
             Assert.That(dataFeed.Administrators, Is.Not.Null);
-            Assert.That(dataFeed.Administrators.Count, Is.EqualTo(1).Or.EqualTo(2));
+            Assert.That(dataFeed.Administrators.Count, Is.EqualTo(2));
+            Assert.That(dataFeed.Administrators, Contains.Item(dataFeed.Creator));
             Assert.That(dataFeed.Administrators, Contains.Item("fake@admin.com"));
             Assert.That(dataFeed.Viewers, Is.Not.Null);
             Assert.That(dataFeed.Viewers.Count, Is.EqualTo(1));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -2105,10 +2105,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Description = "This data feed was created to test the .NET client.",
                 AccessMode = DataFeedAccessMode.Public,
                 ActionLinkTemplate = "https://fakeurl.com/%metric/%datafeed",
-                Administrators = new List<string>() { "fake@admin.com" },
-                Viewers = new List<string>() { "fake@viewer.com" },
                 MissingDataPointFillSettings = new () { FillType = DataFeedMissingDataPointFillType.CustomValue, CustomFillValue = 45.0 }
             };
+
+            dataFeed.Administrators.Add("fake@admin.com");
+            dataFeed.Viewers.Add("fake@viewer.com");
 
             dataFeed.Schema.MetricColumns.Add(new ("cost") { MetricDisplayName = "costDisplayName", MetricDescription = "costDescription" });
             dataFeed.Schema.MetricColumns.Add(new ("revenue") { MetricDisplayName = "revenueDisplayName", MetricDescription = "revenueDescription" });

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -624,6 +624,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -631,13 +632,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
@@ -650,6 +651,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureApplicationInsightsDataFeedSource(DataSourceAppId, DataSourceKey, DataSourceCloud, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -657,13 +659,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureApplicationInsights));
 
@@ -730,6 +732,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -737,13 +740,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
@@ -756,6 +759,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureBlobDataFeedSource(DataSourceConnectionString, DataSourceContainer, DataSourceTemplate);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -763,13 +767,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureBlob));
 
@@ -834,6 +838,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -841,13 +846,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
@@ -860,6 +865,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureCosmosDbDataFeedSource(DataSourceConnectionString, DataSourceQuery, DataSourceDatabase, DataSourceCollectionId);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -867,13 +873,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureCosmosDb));
 
@@ -938,6 +944,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -945,13 +952,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
@@ -964,6 +971,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataExplorerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -971,13 +979,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataExplorer));
 
@@ -1042,6 +1050,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1049,13 +1058,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
@@ -1068,6 +1077,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureDataLakeStorageGen2DataFeedSource(DataSourceAccount, DataSourceKey, DataSourceFileSystem, DataSourceDirectory, DataSourceFile);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1075,13 +1085,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureDataLakeStorageGen2));
 
@@ -1146,6 +1156,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1153,13 +1164,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
@@ -1172,6 +1183,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new AzureTableDataFeedSource(DataSourceConnectionString, DataSourceTable, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1179,13 +1191,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.AzureTable));
 
@@ -1250,6 +1262,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1257,13 +1270,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
@@ -1276,6 +1289,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new ElasticsearchDataFeedSource(DataSourceHost, DataSourcePort, DataSourceAuth, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1283,13 +1297,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.Elasticsearch));
 
@@ -1354,6 +1368,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1361,13 +1376,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.HttpRequest));
 
@@ -1380,6 +1395,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new HttpRequestDataFeedSource(new Uri(DataSourceHost), DataSourceHeader, DataSourceMethod, DataSourcePayload);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1387,13 +1403,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             ValidateHttpRequestDataSource(updatedDataFeed.DataSource as HttpRequestDataFeedSource);
         }
@@ -1456,6 +1472,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1463,13 +1480,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
@@ -1482,6 +1499,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new InfluxDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceUsername, DataSourcePassword, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1489,13 +1507,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.InfluxDb));
 
@@ -1560,6 +1578,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1567,13 +1586,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
@@ -1586,6 +1605,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MongoDbDataFeedSource(DataSourceConnectionString, DataSourceDatabase, DataSourceCommand);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1593,13 +1613,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MongoDb));
 
@@ -1664,6 +1684,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1671,13 +1692,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
@@ -1690,6 +1711,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new MySqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1697,13 +1719,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.MySql));
 
@@ -1768,6 +1790,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1775,13 +1798,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
@@ -1794,6 +1817,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new PostgreSqlDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1801,13 +1825,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.PostgreSql));
 
@@ -1872,6 +1896,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1879,13 +1904,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
@@ -1898,6 +1923,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
             var dataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
+            var updatedDataFeedName = Recording.GenerateAlphaNumericId("dataFeed");
             var dataSource = new SqlServerDataFeedSource(DataSourceConnectionString, DataSourceQuery);
             DataFeed dataFeedToCreate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
@@ -1905,13 +1931,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
 
-            SetOptionalMembers(dataFeedToUpdate);
+            SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
             await adminClient.UpdateDataFeedAsync(disposableDataFeed.Id, dataFeedToUpdate);
 
             DataFeed updatedDataFeed = await adminClient.GetDataFeedAsync(disposableDataFeed.Id);
 
-            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, dataFeedName);
+            ValidateUpdatedDataFeedWithOptionalMembersSet(updatedDataFeed, disposableDataFeed.Id, updatedDataFeedName);
 
             Assert.That(updatedDataFeed.SourceType, Is.EqualTo(DataFeedSourceType.SqlServer));
 
@@ -2095,8 +2121,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
             };
         }
 
-        private void SetOptionalMembers(DataFeed dataFeed)
+        private void SetOptionalMembers(DataFeed dataFeed, string dataFeedName)
         {
+            dataFeed.Name = dataFeedName;
             dataFeed.Description = "This data feed was updated to test the .NET client.";
             dataFeed.AccessMode = DataFeedAccessMode.Public;
             dataFeed.ActionLinkTemplate = "https://fakeurl.com/%datafeed/%metric";
@@ -2105,6 +2132,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             dataFeed.Schema.TimestampColumn = "updatedTimestampColumn";
 
+            dataFeed.IngestionSettings.IngestionStartTime = DateTimeOffset.Parse("2020-09-21T00:00:00Z");
             dataFeed.IngestionSettings.IngestionStartOffset = TimeSpan.FromMinutes(40);
             dataFeed.IngestionSettings.IngestionRetryDelay = TimeSpan.FromSeconds(90);
             dataFeed.IngestionSettings.StopRetryAfter = TimeSpan.FromMinutes(20);
@@ -2235,7 +2263,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
         private void ValidateUpdatedDataFeedWithOptionalMembersSet(DataFeed dataFeed, string expectedId, string expectedName)
         {
-            var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
+            var ingestionStartTime = DateTimeOffset.Parse("2020-09-21T00:00:00Z");
 
             Assert.That(dataFeed.Id, Is.EqualTo(expectedId));
             Assert.That(dataFeed.Name, Is.EqualTo(expectedName));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -2073,11 +2073,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var metrics = new List<DataFeedMetric>() { new ("cost") };
             var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
 
-            var granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
-            var schema = new DataFeedSchema(metrics);
-            var ingestionSettings = new DataFeedIngestionSettings(ingestionStartTime);
-
-            return new DataFeed(name, dataSource, granularity, schema, ingestionSettings);
+            return new DataFeed()
+            {
+                Name = name,
+                DataSource = dataSource,
+                Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
+                Schema = new DataFeedSchema(metrics),
+                IngestionSettings = new DataFeedIngestionSettings(ingestionStartTime)
+            };
         }
 
         private DataFeed GetDataFeedWithOptionalMembersSet(string name, DataFeedSource dataSource)
@@ -2094,8 +2097,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
             };
             var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
 
-            var granularity = new DataFeedGranularity(DataFeedGranularityType.Custom) { CustomGranularityValue = 1360 };
-            var schema = new DataFeedSchema(metrics) { DimensionColumns = dimensionColumns, TimestampColumn = "timestamp" };
             var ingestionSettings = new DataFeedIngestionSettings(ingestionStartTime)
             {
                 IngestionStartOffset = TimeSpan.FromMinutes(30),
@@ -2104,8 +2105,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 DataSourceRequestConcurrency = 5
             };
 
-            return new DataFeed(name, dataSource, granularity, schema, ingestionSettings)
+            return new DataFeed()
             {
+                Name = name,
+                DataSource = dataSource,
+                Granularity = new DataFeedGranularity(DataFeedGranularityType.Custom) { CustomGranularityValue = 1360 },
+                Schema = new DataFeedSchema(metrics) { DimensionColumns = dimensionColumns, TimestampColumn = "timestamp" },
+                IngestionSettings = ingestionSettings,
                 Description = "This data feed was created to test the .NET client.",
                 AccessMode = DataFeedAccessMode.Public,
                 ActionLinkTemplate = "https://fakeurl.com/%metric/%datafeed",
@@ -2440,7 +2446,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataSource.Query, Is.EqualTo(DataSourceQuery));
         }
 
-        private void ValidateGenericDataSource(DataFeedSource dataSource, DataFeedSourceType sourceType, bool isAdmin)
+        private void ValidateGenericDataSource(DataFeedSource dataSource, DataFeedSourceType? sourceType, bool isAdmin)
         {
             if (sourceType == DataFeedSourceType.AzureApplicationInsights)
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -2070,7 +2070,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
         private DataFeed GetDataFeedWithMinimumSetup(string name, DataFeedSource dataSource)
         {
-            var metrics = new List<DataFeedMetric>() { new ("cost") };
             var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
 
             return new DataFeed()
@@ -2078,23 +2077,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Name = name,
                 DataSource = dataSource,
                 Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
-                Schema = new DataFeedSchema(metrics),
+                Schema = new DataFeedSchema() { MetricColumns = { new ("cost") } },
                 IngestionSettings = new DataFeedIngestionSettings(ingestionStartTime)
             };
         }
 
         private DataFeed GetDataFeedWithOptionalMembersSet(string name, DataFeedSource dataSource)
         {
-            var metrics = new List<DataFeedMetric>()
-            {
-                new ("cost") { MetricDisplayName = "costDisplayName", MetricDescription = "costDescription" },
-                new ("revenue") { MetricDisplayName = "revenueDisplayName", MetricDescription = "revenueDescription" }
-            };
-            var dimensionColumns = new List<DataFeedDimension>()
-            {
-                new ("city"),
-                new ("category") { DimensionDisplayName = "categoryDisplayName" }
-            };
             var ingestionStartTime = DateTimeOffset.Parse("2020-08-01T00:00:00Z");
 
             var ingestionSettings = new DataFeedIngestionSettings(ingestionStartTime)
@@ -2105,12 +2094,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 DataSourceRequestConcurrency = 5
             };
 
-            return new DataFeed()
+            var dataFeed = new DataFeed()
             {
                 Name = name,
                 DataSource = dataSource,
                 Granularity = new DataFeedGranularity(DataFeedGranularityType.Custom) { CustomGranularityValue = 1360 },
-                Schema = new DataFeedSchema(metrics) { DimensionColumns = dimensionColumns, TimestampColumn = "timestamp" },
+                Schema = new DataFeedSchema() { TimestampColumn = "timestamp" },
                 IngestionSettings = ingestionSettings,
                 Description = "This data feed was created to test the .NET client.",
                 AccessMode = DataFeedAccessMode.Public,
@@ -2119,6 +2108,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Viewers = new List<string>() { "fake@viewer.com" },
                 MissingDataPointFillSettings = new () { FillType = DataFeedMissingDataPointFillType.CustomValue, CustomFillValue = 45.0 }
             };
+
+            dataFeed.Schema.MetricColumns.Add(new ("cost") { MetricDisplayName = "costDisplayName", MetricDescription = "costDescription" });
+            dataFeed.Schema.MetricColumns.Add(new ("revenue") { MetricDisplayName = "revenueDisplayName", MetricDescription = "revenueDescription" });
+
+            dataFeed.Schema.DimensionColumns.Add(new ("city"));
+            dataFeed.Schema.DimensionColumns.Add(new ("category") { DimensionDisplayName = "categoryDisplayName" });
+
+            return dataFeed;
         }
 
         private void SetOptionalMembers(DataFeed dataFeed, string dataFeedName)

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedLiveTests.cs
@@ -657,7 +657,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -765,7 +765,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -871,7 +871,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -977,7 +977,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1083,7 +1083,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1189,7 +1189,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1295,7 +1295,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1401,7 +1401,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1505,7 +1505,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1611,7 +1611,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1717,7 +1717,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1823,7 +1823,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -1929,7 +1929,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             await using var disposableDataFeed = await DisposableDataFeed.CreateDataFeedAsync(adminClient, dataFeedToCreate);
 
-            DataFeed dataFeedToUpdate = GetDataFeedWithMinimumSetup(dataFeedName, dataSource);
+            var dataFeedToUpdate = new DataFeed();
 
             SetOptionalMembers(dataFeedToUpdate, updatedDataFeedName);
 
@@ -2126,11 +2126,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
             dataFeed.Description = "This data feed was updated to test the .NET client.";
             dataFeed.AccessMode = DataFeedAccessMode.Public;
             dataFeed.ActionLinkTemplate = "https://fakeurl.com/%datafeed/%metric";
-            // TODO: add administrator update validation. Related: https://github.com/Azure/azure-sdk-for-net/issues/17766
+            dataFeed.Administrators.Add("fake@admin.com");
             dataFeed.Viewers.Add("fake@viewer.com");
 
+            dataFeed.Schema = new DataFeedSchema();
             dataFeed.Schema.TimestampColumn = "updatedTimestampColumn";
 
+            dataFeed.IngestionSettings = new DataFeedIngestionSettings();
             dataFeed.IngestionSettings.IngestionStartTime = DateTimeOffset.Parse("2020-09-21T00:00:00Z");
             dataFeed.IngestionSettings.IngestionStartOffset = TimeSpan.FromMinutes(40);
             dataFeed.IngestionSettings.IngestionRetryDelay = TimeSpan.FromSeconds(90);
@@ -2204,11 +2206,13 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.ActionLinkTemplate, Is.EqualTo("https://fakeurl.com/%metric/%datafeed"));
             Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
 
-            // TODO: https://github.com/Azure/azure-sdk-for-net/issues/17719
             Assert.That(dataFeed.Administrators, Is.Not.Null);
-            Assert.That(dataFeed.Administrators.Count, Is.EqualTo(1));
+            Assert.That(dataFeed.Administrators.Count, Is.EqualTo(2));
             Assert.That(dataFeed.Administrators, Contains.Item(dataFeed.Creator));
-            Assert.That(dataFeed.Viewers, Is.Not.Null.And.Empty);
+            Assert.That(dataFeed.Administrators, Contains.Item("fake@admin.com"));
+            Assert.That(dataFeed.Viewers, Is.Not.Null);
+            Assert.That(dataFeed.Viewers.Count, Is.EqualTo(1));
+            Assert.That(dataFeed.Viewers, Contains.Item("fake@viewer.com"));
             Assert.That(dataFeed.IsAdministrator, Is.True);
 
             DateTimeOffset justNow = Recording.UtcNow.Subtract(TimeSpan.FromMinutes(5));
@@ -2273,9 +2277,8 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(dataFeed.Creator, Is.Not.Null.And.Not.Empty);
 
             Assert.That(dataFeed.Administrators, Is.Not.Null);
-            Assert.That(dataFeed.Administrators.Count, Is.EqualTo(1));
-            Assert.That(dataFeed.Administrators, Contains.Item(dataFeed.Creator));
-
+            Assert.That(dataFeed.Administrators.Count, Is.EqualTo(1).Or.EqualTo(2));
+            Assert.That(dataFeed.Administrators, Contains.Item("fake@admin.com"));
             Assert.That(dataFeed.Viewers, Is.Not.Null);
             Assert.That(dataFeed.Viewers.Count, Is.EqualTo(1));
             Assert.That(dataFeed.Viewers, Contains.Item("fake@viewer.com"));

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -114,7 +114,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataFeed = new DataFeed();
+            var dataFeed = new DataFeed()
+            {
+                SourceType = DataFeedSourceType.AzureApplicationInsights
+            };
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -96,7 +96,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataFeed = new DataFeed();
+            var dataFeed = new DataFeed() { SourceType = DataFeedSourceType.AzureApplicationInsights };
 
             Assert.That(() => adminClient.UpdateDataFeedAsync(null, dataFeed), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.UpdateDataFeedAsync("", dataFeed), Throws.InstanceOf<ArgumentException>());
@@ -107,6 +107,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(() => adminClient.UpdateDataFeed("", dataFeed), Throws.InstanceOf<ArgumentException>());
             Assert.That(() => adminClient.UpdateDataFeed("dataFeedId", dataFeed), Throws.InstanceOf<ArgumentException>().With.InnerException.TypeOf(typeof(FormatException)));
             Assert.That(() => adminClient.UpdateDataFeed(FakeGuid, null), Throws.InstanceOf<ArgumentNullException>());
+
+            dataFeed.SourceType = null;
+
+            Assert.That(() => adminClient.UpdateDataFeedAsync(FakeGuid, dataFeed), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => adminClient.UpdateDataFeed(FakeGuid, dataFeed), Throws.InstanceOf<ArgumentNullException>());
         }
 
         [Test]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -68,6 +68,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
             dataFeed.IngestionSettings = null;
             Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+
+            dataFeed.IngestionSettings = new DataFeedIngestionSettings();
+            Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
         }
 
         [Test]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -69,7 +69,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
 
-            dataFeed.IngestionSettings = new DataFeedIngestionSettings();
+            dataFeed.IngestionSettings = new DataFeedIngestionSettings() { IngestionStartTime = null };
             Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
         }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -28,7 +28,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var dataSource = new AzureTableDataFeedSource("connectionString", "table", "query");
             var granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
             var schema = new DataFeedSchema() { MetricColumns = { new ("metricName") } };
-            var ingestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow);
+            var ingestionSettings = new DataFeedIngestionSettings() { IngestionStartTime = DateTimeOffset.UtcNow };
 
             var dataFeed = new DataFeed()
             {
@@ -81,7 +81,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 DataSource = new AzureTableDataFeedSource("connectionString", "table", "query"),
                 Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
                 Schema = new DataFeedSchema() { MetricColumns = { new ("metricName") } },
-                IngestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow)
+                IngestionSettings = new DataFeedIngestionSettings() { IngestionStartTime = DateTimeOffset.UtcNow }
             };
 
             using var cancellationSource = new CancellationTokenSource();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -24,9 +24,50 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            Assert.That(() => adminClient.CreateDataFeedAsync(null), Throws.InstanceOf<ArgumentNullException>());
+            var name = "dataFeedName";
+            var dataSource = new AzureTableDataFeedSource("connectionString", "table", "query");
+            var granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
+            var schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") });
+            var ingestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow);
 
+            var dataFeed = new DataFeed()
+            {
+                Name = null,
+                DataSource = dataSource,
+                Granularity = granularity,
+                Schema = schema,
+                IngestionSettings = ingestionSettings
+            };
+
+            Assert.That(() => adminClient.CreateDataFeedAsync(null), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.CreateDataFeed(null), Throws.InstanceOf<ArgumentNullException>());
+
+            Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+
+            dataFeed.Name = "";
+            Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentException>());
+
+            dataFeed.Name = name;
+            dataFeed.DataSource = null;
+            Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+
+            dataFeed.DataSource = dataSource;
+            dataFeed.Granularity = null;
+            Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+
+            dataFeed.Granularity = granularity;
+            dataFeed.Schema = null;
+            Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+
+            dataFeed.Schema = schema;
+            dataFeed.IngestionSettings = null;
+            Assert.That(() => adminClient.CreateDataFeedAsync(dataFeed), Throws.InstanceOf<ArgumentNullException>());
+            Assert.That(() => adminClient.CreateDataFeed(dataFeed), Throws.InstanceOf<ArgumentNullException>());
         }
 
         [Test]
@@ -55,14 +96,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataFeed = new DataFeed()
-            {
-                Name = "dataFeedName",
-                DataSource = new AzureTableDataFeedSource("connectionString", "table", "query"),
-                Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
-                Schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") }),
-                IngestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow)
-            };
+            var dataFeed = new DataFeed();
 
             Assert.That(() => adminClient.UpdateDataFeedAsync(null, dataFeed), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.UpdateDataFeedAsync("", dataFeed), Throws.InstanceOf<ArgumentException>());
@@ -80,14 +114,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataFeed = new DataFeed()
-            {
-                Name = "dataFeedName",
-                DataSource = new AzureTableDataFeedSource("connectionString", "table", "query"),
-                Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
-                Schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") }),
-                IngestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow)
-            };
+            var dataFeed = new DataFeed();
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -34,11 +34,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataSource = new AzureTableDataFeedSource("connectionString", "table", "query");
-            var granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
-            var schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") });
-            var ingestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow);
-            var dataFeed = new DataFeed("dataFeedName", dataSource, granularity, schema, ingestionSettings);
+            var dataFeed = new DataFeed()
+            {
+                Name = "dataFeedName",
+                DataSource = new AzureTableDataFeedSource("connectionString", "table", "query"),
+                Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
+                Schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") }),
+                IngestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow)
+            };
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();
@@ -52,11 +55,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataSource = new AzureTableDataFeedSource("connectionString", "table", "query");
-            var granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
-            var schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") });
-            var ingestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow);
-            var dataFeed = new DataFeed("dataFeedName", dataSource, granularity, schema, ingestionSettings);
+            var dataFeed = new DataFeed()
+            {
+                Name = "dataFeedName",
+                DataSource = new AzureTableDataFeedSource("connectionString", "table", "query"),
+                Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
+                Schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") }),
+                IngestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow)
+            };
 
             Assert.That(() => adminClient.UpdateDataFeedAsync(null, dataFeed), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.UpdateDataFeedAsync("", dataFeed), Throws.InstanceOf<ArgumentException>());
@@ -74,11 +80,14 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataSource = new AzureTableDataFeedSource("connectionString", "table", "query");
-            var granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
-            var schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") });
-            var ingestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow);
-            var dataFeed = new DataFeed("dataFeedName", dataSource, granularity, schema, ingestionSettings);
+            var dataFeed = new DataFeed()
+            {
+                Name = "dataFeedName",
+                DataSource = new AzureTableDataFeedSource("connectionString", "table", "query"),
+                Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
+                Schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") }),
+                IngestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow)
+            };
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorAdministrationClient/DataFeedTests.cs
@@ -27,7 +27,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             var name = "dataFeedName";
             var dataSource = new AzureTableDataFeedSource("connectionString", "table", "query");
             var granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
-            var schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") });
+            var schema = new DataFeedSchema() { MetricColumns = { new ("metricName") } };
             var ingestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow);
 
             var dataFeed = new DataFeed()
@@ -80,7 +80,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 Name = "dataFeedName",
                 DataSource = new AzureTableDataFeedSource("connectionString", "table", "query"),
                 Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily),
-                Schema = new DataFeedSchema(new List<DataFeedMetric>() { new DataFeedMetric("metricName") }),
+                Schema = new DataFeedSchema() { MetricColumns = { new ("metricName") } },
                 IngestionSettings = new DataFeedIngestionSettings(DateTimeOffset.UtcNow)
             };
 
@@ -96,7 +96,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataFeed = new DataFeed() { SourceType = DataFeedSourceType.AzureApplicationInsights };
+            var dataFeed = new DataFeed();
 
             Assert.That(() => adminClient.UpdateDataFeedAsync(null, dataFeed), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => adminClient.UpdateDataFeedAsync("", dataFeed), Throws.InstanceOf<ArgumentException>());
@@ -107,11 +107,6 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(() => adminClient.UpdateDataFeed("", dataFeed), Throws.InstanceOf<ArgumentException>());
             Assert.That(() => adminClient.UpdateDataFeed("dataFeedId", dataFeed), Throws.InstanceOf<ArgumentException>().With.InnerException.TypeOf(typeof(FormatException)));
             Assert.That(() => adminClient.UpdateDataFeed(FakeGuid, null), Throws.InstanceOf<ArgumentNullException>());
-
-            dataFeed.SourceType = null;
-
-            Assert.That(() => adminClient.UpdateDataFeedAsync(FakeGuid, dataFeed), Throws.InstanceOf<ArgumentNullException>());
-            Assert.That(() => adminClient.UpdateDataFeed(FakeGuid, dataFeed), Throws.InstanceOf<ArgumentNullException>());
         }
 
         [Test]
@@ -119,10 +114,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorAdministrationClient adminClient = GetMetricsAdvisorAdministrationClient();
 
-            var dataFeed = new DataFeed()
-            {
-                SourceType = DataFeedSourceType.AzureApplicationInsights
-            };
+            var dataFeed = new DataFeed();
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
@@ -38,21 +38,11 @@ namespace Azure.AI.MetricsAdvisor.Samples
             dataFeed.DataSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
             dataFeed.Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
 
-            var dataFeedMetrics = new List<DataFeedMetric>()
-            {
-                new DataFeedMetric("cost"),
-                new DataFeedMetric("revenue")
-            };
-            var dataFeedDimensions = new List<DataFeedDimension>()
-            {
-                new DataFeedDimension("category"),
-                new DataFeedDimension("city")
-            };
-
-            dataFeed.Schema = new DataFeedSchema(dataFeedMetrics)
-            {
-                DimensionColumns = dataFeedDimensions
-            };
+            dataFeed.Schema = new DataFeedSchema();
+            dataFeed.Schema.MetricColumns.Add(new DataFeedMetric("cost"));
+            dataFeed.Schema.MetricColumns.Add(new DataFeedMetric("revenue"));
+            dataFeed.Schema.DimensionColumns.Add(new DataFeedDimension("category"));
+            dataFeed.Schema.DimensionColumns.Add(new DataFeedDimension("city"));
 
             var ingestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
@@ -44,9 +44,10 @@ namespace Azure.AI.MetricsAdvisor.Samples
             dataFeed.Schema.DimensionColumns.Add(new DataFeedDimension("category"));
             dataFeed.Schema.DimensionColumns.Add(new DataFeedDimension("city"));
 
-            var ingestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-
-            dataFeed.IngestionSettings = new DataFeedIngestionSettings(ingestionStartTime);
+            dataFeed.IngestionSettings = new DataFeedIngestionSettings()
+            {
+                IngestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z")
+            };
 
             Response<string> response = await adminClient.CreateDataFeedAsync(dataFeed);
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample01_DataFeedCrudOperations.cs
@@ -32,9 +32,11 @@ namespace Azure.AI.MetricsAdvisor.Samples
             //@@ string sqlServerConnectionString = "<connectionString>";
             //@@ string sqlServerQuery = "<query>";
 
-            var dataFeedName = "Sample data feed";
-            var dataFeedSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
-            var dataFeedGranularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
+            var dataFeed = new DataFeed();
+
+            dataFeed.Name = "Sample data feed";
+            dataFeed.DataSource = new SqlServerDataFeedSource(sqlServerConnectionString, sqlServerQuery);
+            dataFeed.Granularity = new DataFeedGranularity(DataFeedGranularityType.Daily);
 
             var dataFeedMetrics = new List<DataFeedMetric>()
             {
@@ -46,15 +48,15 @@ namespace Azure.AI.MetricsAdvisor.Samples
                 new DataFeedDimension("category"),
                 new DataFeedDimension("city")
             };
-            var dataFeedSchema = new DataFeedSchema(dataFeedMetrics)
+
+            dataFeed.Schema = new DataFeedSchema(dataFeedMetrics)
             {
                 DimensionColumns = dataFeedDimensions
             };
 
             var ingestionStartTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var dataFeedIngestionSettings = new DataFeedIngestionSettings(ingestionStartTime);
 
-            var dataFeed = new DataFeed(dataFeedName, dataFeedSource, dataFeedGranularity, dataFeedSchema, dataFeedIngestionSettings);
+            dataFeed.IngestionSettings = new DataFeedIngestionSettings(ingestionStartTime);
 
             Response<string> response = await adminClient.CreateDataFeedAsync(dataFeed);
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "965",
+        "Content-Length": "1023",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a071070686e72345a4b41d1f023e9278-fa45e9ea5220b14b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a3fa6b04e8255748b3373fda28350e07-edc44ffa57fcaf4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "62512a71a5bf9987e92de8b666087143",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +59,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a76d7bc2-f66f-41d4-b80c-deb8b268c098",
+        "apim-request-id": "5f0871ab-e7c2-4a9b-af73-0aa3a81e9465",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc87cd8-8439-437c-8d8f-f5c319342f1c",
+        "Date": "Mon, 01 Feb 2021 14:21:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/03ca2222-23ef-4227-8cd4-1f754a2a179b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "650",
-        "x-request-id": "a76d7bc2-f66f-41d4-b80c-deb8b268c098"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1159",
+        "X-Request-ID": "5f0871ab-e7c2-4a9b-af73-0aa3a81e9465"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc87cd8-8439-437c-8d8f-f5c319342f1c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/03ca2222-23ef-4227-8cd4-1f754a2a179b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b85b3f701bdf3a4c8c5029bd2409cab0-102d6848bd97934e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1ed6d8e7b1d3b94d8567b3c6df5c416d-45b3a56e1e7af941-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5c77a5558ae8596b20c3b205f031b707",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +98,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9de129bf-f127-40f2-aeb5-284f44f3abdc",
-        "Content-Length": "1406",
+        "apim-request-id": "a1da987f-9099-4fd8-88a7-056acc1810a6",
+        "Content-Length": "1440",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:12 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "9de129bf-f127-40f2-aeb5-284f44f3abdc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "864",
+        "X-Request-ID": "a1da987f-9099-4fd8-88a7-056acc1810a6"
       },
       "ResponseBody": {
-        "dataFeedId": "cdc87cd8-8439-437c-8d8f-f5c319342f1c",
+        "dataFeedId": "03ca2222-23ef-4227-8cd4-1f754a2a179b",
         "dataFeedName": "dataFeedbwkJ4tg1",
         "metrics": [
           {
-            "metricId": "858b1d2f-9c41-4d11-9e3c-f3d7eeb6bb8a",
+            "metricId": "d3b10f52-3261-4c00-9cf4-b3f4af6eb354",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "3c23455e-056e-470b-95d7-eed1882a4bea",
+            "metricId": "46a9fdde-c66d-460d-9f97-2d8229243961",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +153,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:12Z",
+        "createdTime": "2021-02-01T14:21:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +173,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc87cd8-8439-437c-8d8f-f5c319342f1c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/03ca2222-23ef-4227-8cd4-1f754a2a179b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cbe9b39f04fc1145a41a0c35442d7bd4-84f297a03d55fd41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-eb3a5a09de94674c81a2a5e5f9722215-0452340892774849-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bf4feeea1b7ec90c1dae84484ccea6e0",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +190,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "08456e1d-9f5d-4954-9827-568e9bb743ed",
+        "apim-request-id": "43d57096-7ee8-4d0d-9628-b6abbe85123b",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:13 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "414",
-        "x-request-id": "08456e1d-9f5d-4954-9827-568e9bb743ed"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1137",
+        "X-Request-ID": "43d57096-7ee8-4d0d-9628-b6abbe85123b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:13.3735246-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:19.9276097-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureApplicationInsightsDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "965",
+        "Content-Length": "1023",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0fc2caa30ff3f14093728af6690299e9-c0cb60b09d878249-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-640c77221dce1548b0a9fc5f6b2af7c1-a0e5df95fdd76e49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9acf4e3e24b889cdab8a8ea2f2a102cd",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +56,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b2601769-2b3b-4971-b2a5-c9a5befc5c7a",
+        "apim-request-id": "d211be91-370e-4345-88d4-2053a0190442",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:47 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/208bb871-6f6b-4562-9ca0-77c6cf3bdd64",
+        "Date": "Mon, 01 Feb 2021 15:40:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad5c4484-1259-4a7a-9a1a-fbaa56f500cb",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "694",
-        "x-request-id": "b2601769-2b3b-4971-b2a5-c9a5befc5c7a"
+        "x-envoy-upstream-service-time": "553",
+        "x-request-id": "d211be91-370e-4345-88d4-2053a0190442"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/208bb871-6f6b-4562-9ca0-77c6cf3bdd64",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad5c4484-1259-4a7a-9a1a-fbaa56f500cb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-84efda0a8fd1ae46861429e9525897fc-c553196bf4f09142-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ff9adc2148d65747ae382a46235bb3d4-b0ab586cb1856e45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f28d7b8b1f4f020bd4899c2737fd3420",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "12bc41f3-a244-41f6-bb99-fa83e7a9155f",
-        "Content-Length": "1406",
+        "apim-request-id": "e04d49a8-dc08-403a-92ea-c5d951774bfc",
+        "Content-Length": "1440",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:47 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "141",
-        "x-request-id": "12bc41f3-a244-41f6-bb99-fa83e7a9155f"
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "e04d49a8-dc08-403a-92ea-c5d951774bfc"
       },
       "ResponseBody": {
-        "dataFeedId": "208bb871-6f6b-4562-9ca0-77c6cf3bdd64",
+        "dataFeedId": "ad5c4484-1259-4a7a-9a1a-fbaa56f500cb",
         "dataFeedName": "dataFeedshoTrmTc",
         "metrics": [
           {
-            "metricId": "c790be8a-f914-4893-9d9c-460a0fbf15d4",
+            "metricId": "f006ba82-04c6-4633-b315-c4f4e0ba2104",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "7a6021a9-409f-4343-9dee-912711afb499",
+            "metricId": "d12533bc-d094-4391-a42e-69fffd4f0410",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +147,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:47Z",
+        "createdTime": "2021-02-01T15:40:32Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/208bb871-6f6b-4562-9ca0-77c6cf3bdd64",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad5c4484-1259-4a7a-9a1a-fbaa56f500cb",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9e2aaeae73171548af5d6d66f7615312-4fd6e4cd17afc24c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f6d0ab21356c304cbb728f0d83014e5c-7b8f54c64ee78e4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d7989347317ca8ab129a1157b6164b56",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2988cfa4-8047-41fc-8f88-8f3dcf49a5ff",
+        "apim-request-id": "9bf4e01e-349c-4fc7-be54-0cbe9e952085",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:47 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "380",
-        "x-request-id": "2988cfa4-8047-41fc-8f88-8f3dcf49a5ff"
+        "x-envoy-upstream-service-time": "375",
+        "x-request-id": "9bf4e01e-349c-4fc7-be54-0cbe9e952085"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:48.2122306-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:32.5606554-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "949",
+        "Content-Length": "1007",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7be8150b84648145bbf6d840aae1f4dc-3ba84d7687c17042-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-75596b8e4ae1894f8090961e69938f0f-a473cbc414235c49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f73179f69dbf3d5a5eb4c053afba517d",
         "x-ms-return-client-request-id": "true"
@@ -55,29 +58,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "91b90c03-ed72-4442-80c8-28830e2ad532",
+        "apim-request-id": "1184389f-a04d-492b-bb46-80c0db2a8517",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:15 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4e56ccb-e689-4738-9abd-1c4aecbf8e91",
+        "Date": "Mon, 01 Feb 2021 14:19:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4955b079-5488-47c5-b52b-d5c377272d24",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "513",
-        "x-request-id": "91b90c03-ed72-4442-80c8-28830e2ad532"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "755",
+        "X-Request-ID": "1184389f-a04d-492b-bb46-80c0db2a8517"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4e56ccb-e689-4738-9abd-1c4aecbf8e91",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4955b079-5488-47c5-b52b-d5c377272d24",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-84d048cdce578440ab9e225fe63d7285-55258ff442eecb4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8d72e227b729e9458b461128d8ddebe4-8eafbf728d3bb34b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c4d2fcfe5267a3f57b05762bb1fd1df7",
         "x-ms-return-client-request-id": "true"
@@ -85,27 +97,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d3570476-4b05-47b3-bdd5-c7a9a9040828",
-        "Content-Length": "1390",
+        "apim-request-id": "1570e730-21a4-4c2c-9fe7-41aff0df8735",
+        "Content-Length": "1424",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:15 GMT",
+        "Date": "Mon, 01 Feb 2021 14:19:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "d3570476-4b05-47b3-bdd5-c7a9a9040828"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "148",
+        "X-Request-ID": "1570e730-21a4-4c2c-9fe7-41aff0df8735"
       },
       "ResponseBody": {
-        "dataFeedId": "c4e56ccb-e689-4738-9abd-1c4aecbf8e91",
+        "dataFeedId": "4955b079-5488-47c5-b52b-d5c377272d24",
         "dataFeedName": "dataFeed1UfEswJZ",
         "metrics": [
           {
-            "metricId": "f1737b54-97ad-45fc-9b06-ac286e4d1e82",
+            "metricId": "6585381b-545e-404b-a058-cc573eed9b3a",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "0b23a3b3-10b0-48ee-9943-a99619b0341d",
+            "metricId": "0a22d499-4d7c-4b80-a78c-27add27b984c",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -140,12 +152,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:15Z",
+        "createdTime": "2021-02-01T14:19:31Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -156,13 +171,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4e56ccb-e689-4738-9abd-1c4aecbf8e91",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4955b079-5488-47c5-b52b-d5c377272d24",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7167c43d5689774c9d59e0886dc77d23-03a8c802ab078743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-42f59f276f2e3e49a7eeea9cc6b0b25f-c772714222f25e44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ed3931fc093326669636a505dbfd23e8",
         "x-ms-return-client-request-id": "true"
@@ -170,19 +188,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "52b1a769-dd38-48f9-a22b-be284574342c",
+        "apim-request-id": "986a825d-f7c4-4456-bad9-fedd98401399",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:15 GMT",
+        "Date": "Mon, 01 Feb 2021 14:19:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "367",
-        "x-request-id": "52b1a769-dd38-48f9-a22b-be284574342c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "366",
+        "X-Request-ID": "986a825d-f7c4-4456-bad9-fedd98401399"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:15.9929368-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:19:31.9145853-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureBlobDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "949",
+        "Content-Length": "1007",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-abf6d909d798be4bbd0c432c79e250ef-e4ee9d903063244b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b09dded6ef35ff4fb2fa273dc434fbdb-d81dc5e98cb5f44f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "59c734a90281eda0a7f7c4cc27af8d8b",
         "x-ms-return-client-request-id": "true"
@@ -55,29 +55,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c190a77a-446c-4c53-9727-6723744e82b0",
+        "apim-request-id": "d612f874-badb-44a5-b249-018e7dbf2161",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:50 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/abd83425-7842-4d19-916f-89bb1287cfec",
+        "Date": "Mon, 01 Feb 2021 15:40:33 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b534685-79a0-4688-a9a0-f1a29b388d73",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "438",
-        "x-request-id": "c190a77a-446c-4c53-9727-6723744e82b0"
+        "x-envoy-upstream-service-time": "859",
+        "x-request-id": "d612f874-badb-44a5-b249-018e7dbf2161"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/abd83425-7842-4d19-916f-89bb1287cfec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b534685-79a0-4688-a9a0-f1a29b388d73",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-293a53768a27bf44ad10e1030042d793-4e2dbedb9cee6b47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6f1591a37d3c2248ad606ebb115bbce5-08908a4467d5a442-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b6c6bb3b979a14821337bac1a3d3a4b5",
         "x-ms-return-client-request-id": "true"
@@ -85,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "68d19c00-ced5-46bd-acd9-6d6be9a83b62",
-        "Content-Length": "1390",
+        "apim-request-id": "7128e492-4e8b-4329-9213-d40eaf84fc33",
+        "Content-Length": "1424",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:50 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "137",
-        "x-request-id": "68d19c00-ced5-46bd-acd9-6d6be9a83b62"
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "7128e492-4e8b-4329-9213-d40eaf84fc33"
       },
       "ResponseBody": {
-        "dataFeedId": "abd83425-7842-4d19-916f-89bb1287cfec",
+        "dataFeedId": "3b534685-79a0-4688-a9a0-f1a29b388d73",
         "dataFeedName": "dataFeedB0kvnc8e",
         "metrics": [
           {
-            "metricId": "74209d80-738e-4e03-8ab8-bc33fd4a4946",
+            "metricId": "c2f76e4e-134f-43b9-9acb-fe3ea2497beb",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "3d07ea62-05f4-4820-9025-1bde7770c103",
+            "metricId": "3ca836cc-1a3b-42c3-b438-b599386e9ccb",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -140,12 +146,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:50Z",
+        "createdTime": "2021-02-01T15:40:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -156,13 +165,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/abd83425-7842-4d19-916f-89bb1287cfec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b534685-79a0-4688-a9a0-f1a29b388d73",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fc3cbe1ca5bf5b49b41090c21c6befc1-87f86aa297d51842-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-504778dfa7dc9247b65edcf3a5103df9-8252f56e4977914e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a74c58d39cc45c48069d663e86fb42cb",
         "x-ms-return-client-request-id": "true"
@@ -170,19 +179,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "78d284ff-e596-481b-9c1f-39c81f3e62fd",
+        "apim-request-id": "9fd00aa8-b56c-493a-899b-70c1e0feab1d",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:50 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "294",
-        "x-request-id": "78d284ff-e596-481b-9c1f-39c81f3e62fd"
+        "x-envoy-upstream-service-time": "421",
+        "x-request-id": "9fd00aa8-b56c-493a-899b-70c1e0feab1d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:50.7185980-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:34.0777590-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "971",
+        "Content-Length": "1029",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c911d84d1226e74087dbd4fff2b2c730-60d0b3b717bc6c43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-04d9cf1157b80a469f4037bd57800402-23c6cc322429354b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5d93cfe15d8f08b80fa08a606ba98f41",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +59,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "83ec9673-6070-4e8e-8d94-c48058ebe6fe",
+        "apim-request-id": "34864182-d665-4549-8fe8-ed0c17a41b20",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:17 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/92f61573-52c0-4427-93db-3d3bbb1443cc",
+        "Date": "Mon, 01 Feb 2021 14:21:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e7dc13c8-805e-495d-b4e2-f19a50e93ba2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "505",
-        "x-request-id": "83ec9673-6070-4e8e-8d94-c48058ebe6fe"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1246",
+        "X-Request-ID": "34864182-d665-4549-8fe8-ed0c17a41b20"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/92f61573-52c0-4427-93db-3d3bbb1443cc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e7dc13c8-805e-495d-b4e2-f19a50e93ba2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61fca7ef7ee72140b696e3dada66a238-9fa76e6a83f1094a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-71645b0eef2ada42a1d57e50d3764fa0-5de8a29b13a9ad40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7c55837cfb14e9e0869972e95154e801",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +98,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ed1d826f-be5b-4d06-b0f5-21ba10fe71a2",
-        "Content-Length": "1412",
+        "apim-request-id": "17811b7d-edfa-4d84-a031-c1e864698f1f",
+        "Content-Length": "1446",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:17 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "147",
-        "x-request-id": "ed1d826f-be5b-4d06-b0f5-21ba10fe71a2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "X-Request-ID": "17811b7d-edfa-4d84-a031-c1e864698f1f"
       },
       "ResponseBody": {
-        "dataFeedId": "92f61573-52c0-4427-93db-3d3bbb1443cc",
+        "dataFeedId": "e7dc13c8-805e-495d-b4e2-f19a50e93ba2",
         "dataFeedName": "dataFeedbDb3DlWr",
         "metrics": [
           {
-            "metricId": "61d418d8-b0bd-426d-9c94-e9a662dd925a",
+            "metricId": "c6555090-e2aa-4da6-8a02-db1fabf68746",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "4098e97a-389e-439e-b2e3-cd85d4402c6a",
+            "metricId": "4463cc0a-56a1-4561-a207-5b6ef76abfdd",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +153,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:17Z",
+        "createdTime": "2021-02-01T14:21:22Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +173,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/92f61573-52c0-4427-93db-3d3bbb1443cc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e7dc13c8-805e-495d-b4e2-f19a50e93ba2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f7af68150b68fd4ea18532561e6bf890-989010b00423824c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8c4ce146f3e9d344af89e3bbff0e14b9-47f91d81f191b640-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "67370370dcd72058523cb609f739e552",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +190,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2c8a09e1-2856-447f-ac71-49813a61f50b",
+        "apim-request-id": "b3749aa9-8383-4bee-a761-167b92dcdd5b",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:17 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "314",
-        "x-request-id": "2c8a09e1-2856-447f-ac71-49813a61f50b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "405",
+        "X-Request-ID": "b3749aa9-8383-4bee-a761-167b92dcdd5b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:18.1984547-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:22.6851387-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureCosmosDbDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "971",
+        "Content-Length": "1029",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0688dbf11efe8b4c95d6808f941e9318-1fe8370ee2ebe841-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-16544ec38cd4c346a4da4c4c5cd9e420-a73c2798f1389e43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1db4a731d83ef4e0de60626b59ddb018",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +56,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "aa1ffd0d-5654-4146-9dd8-ddc04f941487",
+        "apim-request-id": "5edd4a6d-9d80-4fb3-aeb3-9fbf4a2f0463",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:52 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/27de3087-2677-4750-810d-5460e5bc0c1d",
+        "Date": "Mon, 01 Feb 2021 15:40:40 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfeb6435-736e-4962-86c3-aa52c4bb0b0b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "701",
-        "x-request-id": "aa1ffd0d-5654-4146-9dd8-ddc04f941487"
+        "x-envoy-upstream-service-time": "5782",
+        "x-request-id": "5edd4a6d-9d80-4fb3-aeb3-9fbf4a2f0463"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/27de3087-2677-4750-810d-5460e5bc0c1d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfeb6435-736e-4962-86c3-aa52c4bb0b0b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-82232d05aba7ee4bb59ff92f9512d6ec-e20e6c6b30279a42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-250f4bc5330adf4a9608a2ee315a72fe-35ee2e2453bd6f42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c8afadc15bfa34a75c7fd9941bdcd610",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "43744f81-ef35-477e-82c7-92f6c73a7e46",
-        "Content-Length": "1412",
+        "apim-request-id": "d7400f24-9ccc-4376-ba82-ab4235ddafc0",
+        "Content-Length": "1446",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:53 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "x-request-id": "43744f81-ef35-477e-82c7-92f6c73a7e46"
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "d7400f24-9ccc-4376-ba82-ab4235ddafc0"
       },
       "ResponseBody": {
-        "dataFeedId": "27de3087-2677-4750-810d-5460e5bc0c1d",
+        "dataFeedId": "dfeb6435-736e-4962-86c3-aa52c4bb0b0b",
         "dataFeedName": "dataFeedpGfHCqUn",
         "metrics": [
           {
-            "metricId": "f3f2e88e-32b3-4f9e-9362-926b463a8f01",
+            "metricId": "82521a30-2fd6-4cf9-8176-10bc0b064b8f",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "8834e4fd-4184-411c-9876-5c65a13e8c32",
+            "metricId": "c9699cf7-427c-4525-ad1a-ffb8ca2bd32c",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +147,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:53Z",
+        "createdTime": "2021-02-01T15:40:40Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/27de3087-2677-4750-810d-5460e5bc0c1d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfeb6435-736e-4962-86c3-aa52c4bb0b0b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d6b1ab13089e6948a417921e16af4d48-c265e81013dd0949-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6c5e562a388d4b42a7b2bbe87672ab43-7a44c95088f8fa49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9d9145c93e1cd7078d3ce4a911e26d74",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "04e5834d-af6d-4345-bf31-f3a73bb215be",
+        "apim-request-id": "f7da1c8a-0169-4645-8716-9ae27a97c6e4",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:53 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "343",
-        "x-request-id": "04e5834d-af6d-4345-bf31-f3a73bb215be"
+        "x-envoy-upstream-service-time": "344",
+        "x-request-id": "f7da1c8a-0169-4645-8716-9ae27a97c6e4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:53.9359899-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:40.5183375-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "923",
+        "Content-Length": "981",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3957519d1bfabf4782b18719a7433441-b04bd0ef8218584d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bff7ea2183c6de47bf8b9994c96d3f0d-f217483bec14d146-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8ff259ac478ccc3cafac26cf42fbf4ec",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +57,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "efdfda28-21d5-408b-91ca-2da41e44c2b7",
+        "apim-request-id": "be4d1b6e-9418-46cd-accc-f81504732716",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e83bbbc4-82ce-43d4-85fc-194205c90ce8",
+        "Date": "Mon, 01 Feb 2021 14:21:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3dccf777-faf8-40b8-9d1a-98ab24830cc4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "444",
-        "x-request-id": "efdfda28-21d5-408b-91ca-2da41e44c2b7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "779",
+        "X-Request-ID": "be4d1b6e-9418-46cd-accc-f81504732716"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e83bbbc4-82ce-43d4-85fc-194205c90ce8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3dccf777-faf8-40b8-9d1a-98ab24830cc4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1c4aec4037a58a4c9a106a7e127c85ab-580d4234e9de5d4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b42f7f404c236648a93e74acfc63927d-181918b813899d47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3ca2bc475fcb4b8299b214c0373c25df",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +96,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4f0eac7a-e51c-4e9a-b470-ae7bfcd6aa08",
-        "Content-Length": "1364",
+        "apim-request-id": "8e288186-2cfa-4dac-b54f-70ad0d559304",
+        "Content-Length": "1398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:20 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "145",
-        "x-request-id": "4f0eac7a-e51c-4e9a-b470-ae7bfcd6aa08"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "158",
+        "X-Request-ID": "8e288186-2cfa-4dac-b54f-70ad0d559304"
       },
       "ResponseBody": {
-        "dataFeedId": "e83bbbc4-82ce-43d4-85fc-194205c90ce8",
+        "dataFeedId": "3dccf777-faf8-40b8-9d1a-98ab24830cc4",
         "dataFeedName": "dataFeedeKXWW1HR",
         "metrics": [
           {
-            "metricId": "9a6354ac-f5ee-4ffe-95f9-9930d48f57db",
+            "metricId": "c30748f7-69eb-43f4-b4bf-bb499cd81c94",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "c037840f-66c2-4543-9101-332be4967c0e",
+            "metricId": "2763ebbb-0755-45f3-911e-2fda51e1d70a",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +151,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:20Z",
+        "createdTime": "2021-02-01T14:21:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +169,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e83bbbc4-82ce-43d4-85fc-194205c90ce8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3dccf777-faf8-40b8-9d1a-98ab24830cc4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b529f5560739e244adae62365c796431-074560bc1c97d148-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8f4b3aff85440841988dcb0d2e9eaa60-b56fe630502f7246-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0b4805bcc2c934e36e8e50dd5ee4c2e7",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +186,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b89df9d5-3f5e-48aa-9dd7-73ae4ef19e9f",
+        "apim-request-id": "751db2f0-7f19-4154-bdcc-e05b03c5ba18",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:20 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "321",
-        "x-request-id": "b89df9d5-3f5e-48aa-9dd7-73ae4ef19e9f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "394",
+        "X-Request-ID": "751db2f0-7f19-4154-bdcc-e05b03c5ba18"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:20.8961846-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:24.1673473-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataExplorerDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "923",
+        "Content-Length": "981",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-11448c408f5e25429af866061fc4f0c3-206256eec0d0d340-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fdcdd5c9bdefa5458cf86d72fd19b596-ea2ae9f2c9e32145-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e80e9cbd169ba9b340aea27e67f86572",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +54,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "4eec5089-10c0-4527-a728-ad9f7699e939",
+        "apim-request-id": "1c596c7c-d54a-4c7a-ba34-4af5602daf3a",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6de70890-57f3-451c-885c-422f90aa8f75",
+        "Date": "Mon, 01 Feb 2021 15:40:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/82ff0a3d-3ca5-45e4-aeb2-c043e69fc3b0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "486",
-        "x-request-id": "4eec5089-10c0-4527-a728-ad9f7699e939"
+        "x-envoy-upstream-service-time": "744",
+        "x-request-id": "1c596c7c-d54a-4c7a-ba34-4af5602daf3a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6de70890-57f3-451c-885c-422f90aa8f75",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/82ff0a3d-3ca5-45e4-aeb2-c043e69fc3b0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e8da5639a784bc4ea9e06189e105e63b-9de13d19c4831048-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-312bd364b0be224a9ae2eb8891d802dd-4d4313995b8e4244-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "995a4a2935c6ccb57e97c69c71e6fa94",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "626a01cb-108a-4e19-9656-51ee49a139c6",
-        "Content-Length": "1364",
+        "apim-request-id": "10585d3b-eece-4d73-a5bd-b8a933d179b7",
+        "Content-Length": "1398",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "182",
-        "x-request-id": "626a01cb-108a-4e19-9656-51ee49a139c6"
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "10585d3b-eece-4d73-a5bd-b8a933d179b7"
       },
       "ResponseBody": {
-        "dataFeedId": "6de70890-57f3-451c-885c-422f90aa8f75",
+        "dataFeedId": "82ff0a3d-3ca5-45e4-aeb2-c043e69fc3b0",
         "dataFeedName": "dataFeedm7a4TvMx",
         "metrics": [
           {
-            "metricId": "49e943dc-3bf5-4384-bfcc-6cbd86f07883",
+            "metricId": "65b5128a-ed5b-4c20-9d0c-7dc9cf3e6645",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "b655a8a9-55b4-4c31-a6b4-507b53d06603",
+            "metricId": "d6df0302-59fb-4612-9c4e-6bd8a237d20c",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +145,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:56Z",
+        "createdTime": "2021-02-01T15:40:41Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6de70890-57f3-451c-885c-422f90aa8f75",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/82ff0a3d-3ca5-45e4-aeb2-c043e69fc3b0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0b12941d82bf2478a53c59d129c48af-8d48ae7658a82743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-39454d1836de804f9e8a50a66c03d1fa-043df811b51e1443-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "96c9a7e44dad54c16724ab1c108b8c60",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2cacfa28-cc25-4e55-aaac-58a27aa0d859",
+        "apim-request-id": "78701f1a-6196-47aa-8c80-0b2b58d8e720",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "315",
-        "x-request-id": "2cacfa28-cc25-4e55-aaac-58a27aa0d859"
+        "x-envoy-upstream-service-time": "393",
+        "x-request-id": "78701f1a-6196-47aa-8c80-0b2b58d8e720"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:56.6869062-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:41.8968854-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageGen2DataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageGen2DataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "1010",
+        "Content-Length": "1068",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d49a845295cb904ca4d6fc4f0cee9185-372c9f8fb15cc841-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ce44c7e17f46344aaf218ef1a669966e-5eb3c093f692ef4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b767ab3e417b47e9adbff30e210e2df0",
         "x-ms-return-client-request-id": "true"
@@ -57,29 +60,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "7bbcf2c0-2361-4479-897f-9de8a4f8ae1a",
+        "apim-request-id": "7449ba10-e49e-4b69-bf7e-6a1247ce9518",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/59d10d5b-f67e-41be-ad36-74ef6d26af3f",
+        "Date": "Mon, 01 Feb 2021 14:21:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fdfbaa22-63d8-4edf-9769-529b9eb03eb4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "459",
-        "x-request-id": "7bbcf2c0-2361-4479-897f-9de8a4f8ae1a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "780",
+        "X-Request-ID": "7449ba10-e49e-4b69-bf7e-6a1247ce9518"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/59d10d5b-f67e-41be-ad36-74ef6d26af3f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fdfbaa22-63d8-4edf-9769-529b9eb03eb4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3262333ebedbeb4095adae65ef31fd0d-a0b0e785f08c434b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c468a0e07f06b04f9a72a22e237b659d-bc0e97f4bfff8c42-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "61738f682f588fc798bcb625fdbfe036",
         "x-ms-return-client-request-id": "true"
@@ -87,27 +99,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fbbf534e-43ff-447b-ad7e-e247c964d501",
-        "Content-Length": "1451",
+        "apim-request-id": "cba96e40-e7f6-41a7-8eee-006d3457b781",
+        "Content-Length": "1485",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:22 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "138",
-        "x-request-id": "fbbf534e-43ff-447b-ad7e-e247c964d501"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "156",
+        "X-Request-ID": "cba96e40-e7f6-41a7-8eee-006d3457b781"
       },
       "ResponseBody": {
-        "dataFeedId": "59d10d5b-f67e-41be-ad36-74ef6d26af3f",
+        "dataFeedId": "fdfbaa22-63d8-4edf-9769-529b9eb03eb4",
         "dataFeedName": "dataFeed2ZTAxTdn",
         "metrics": [
           {
-            "metricId": "d3253eee-5564-44f2-b2f7-821b77b2942b",
+            "metricId": "37b0f836-e235-4e27-8642-063239c2c841",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "aba93017-b55a-40c2-84fc-c61d15b81ed7",
+            "metricId": "e05a3955-4911-4659-9dd2-b0778e1a7c75",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -142,12 +154,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:22Z",
+        "createdTime": "2021-02-01T14:21:25Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -160,13 +175,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/59d10d5b-f67e-41be-ad36-74ef6d26af3f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fdfbaa22-63d8-4edf-9769-529b9eb03eb4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-66db595919667f4e9157b304c02de214-c223043d18df8f48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4449b2063b3aac419a24317e719f3d95-be1c1dcabe2b6c4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8135ba773a9edd4f64a6bdaa52d33b16",
         "x-ms-return-client-request-id": "true"
@@ -174,19 +192,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f9abfeb9-a383-4a40-b652-0be3fbaff01e",
+        "apim-request-id": "91fe1ed9-0c24-499e-bb4c-cb8b20f51a17",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:22 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "355",
-        "x-request-id": "f9abfeb9-a383-4a40-b652-0be3fbaff01e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "433",
+        "X-Request-ID": "91fe1ed9-0c24-499e-bb4c-cb8b20f51a17"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:23.3493412-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:25.5686413-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageGen2DataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureDataLakeStorageGen2DataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "1010",
+        "Content-Length": "1068",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-04d337ee691148449c78c19e3a265224-c6b3aab89485f443-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-311a4fbad3206444a47ae7e0001777a4-9b7e93e2418ca44b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dffee865c239b8cba4f76ee47ec25f26",
         "x-ms-return-client-request-id": "true"
@@ -57,29 +57,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "99e76682-35ef-4835-b640-99bc38459638",
+        "apim-request-id": "a80f9e30-521e-4b5c-990e-06446f40f633",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:58 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cbf57a14-21c9-4bcc-b519-c174008cdab3",
+        "Date": "Mon, 01 Feb 2021 15:40:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e418d3d0-8cf4-41e5-800f-66d972ba27cc",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "502",
-        "x-request-id": "99e76682-35ef-4835-b640-99bc38459638"
+        "x-envoy-upstream-service-time": "498",
+        "x-request-id": "a80f9e30-521e-4b5c-990e-06446f40f633"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cbf57a14-21c9-4bcc-b519-c174008cdab3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e418d3d0-8cf4-41e5-800f-66d972ba27cc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3ec68193118885469a30e5dacb3a8e53-dd0f8c92efc92945-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e3fb1af64c8c8646af430f951f63bb09-ab02c478006c3c47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a3968a613c1cd124c04d3e57af5eb91a",
         "x-ms-return-client-request-id": "true"
@@ -87,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4a9b3167-ac51-4367-b71b-501bd665e2dd",
-        "Content-Length": "1451",
+        "apim-request-id": "a17b5a70-5b3c-4494-b8de-1bc6aec9f3ee",
+        "Content-Length": "1485",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:58 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "4a9b3167-ac51-4367-b71b-501bd665e2dd"
+        "x-envoy-upstream-service-time": "189",
+        "x-request-id": "a17b5a70-5b3c-4494-b8de-1bc6aec9f3ee"
       },
       "ResponseBody": {
-        "dataFeedId": "cbf57a14-21c9-4bcc-b519-c174008cdab3",
+        "dataFeedId": "e418d3d0-8cf4-41e5-800f-66d972ba27cc",
         "dataFeedName": "dataFeedyzWlsjAo",
         "metrics": [
           {
-            "metricId": "d2011c6d-c502-4fe4-9a53-f6c9a526fabb",
+            "metricId": "a521e7b2-a6a0-414e-a6e4-6af32ed635ca",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "2bfc65f4-75b9-47bf-a915-99ce862eacbe",
+            "metricId": "b12ef031-70ab-4824-8f9b-85610db69011",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -142,12 +148,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:58Z",
+        "createdTime": "2021-02-01T15:40:42Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -160,13 +169,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cbf57a14-21c9-4bcc-b519-c174008cdab3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e418d3d0-8cf4-41e5-800f-66d972ba27cc",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a69270e1b478234a8322571541e7235e-b2298a05731d8540-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-46ceb7f8b9649f46af030cf5f65f1ba6-cf0e50cb8010f946-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "54fa63dadbb594d78f7887b74eda96dd",
         "x-ms-return-client-request-id": "true"
@@ -174,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "eae8c406-b5f8-4bc3-b887-9e4cb818f9de",
+        "apim-request-id": "99fdf028-73e0-4a7e-8ef8-87d195e07ef6",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:58 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "378",
-        "x-request-id": "eae8c406-b5f8-4bc3-b887-9e4cb818f9de"
+        "x-envoy-upstream-service-time": "383",
+        "x-request-id": "99fdf028-73e0-4a7e-8ef8-87d195e07ef6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:59.0251188-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:43.0855982-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "932",
+        "Content-Length": "990",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-669719166a653c4da09d74508dba0bee-1d8106916637c14e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e57ea502fe06204989779b9074720d75-607cc3af216f0344-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7b541ec617384f29e42891ad533c507c",
         "x-ms-return-client-request-id": "true"
@@ -55,29 +58,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "bb6ac2f5-66e8-49c0-ba8a-a2b3505d636c",
+        "apim-request-id": "315a4d6c-f884-4400-b0fb-f434a8aac470",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:25 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c9c4675-8bd5-47f1-98bd-cde749521a06",
+        "Date": "Mon, 01 Feb 2021 14:21:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1524da4-4da4-4139-b994-3e2e52e4bfd9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "556",
-        "x-request-id": "bb6ac2f5-66e8-49c0-ba8a-a2b3505d636c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "726",
+        "X-Request-ID": "315a4d6c-f884-4400-b0fb-f434a8aac470"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c9c4675-8bd5-47f1-98bd-cde749521a06",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1524da4-4da4-4139-b994-3e2e52e4bfd9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5c0f29922028e345886d73e518c4ee21-3ee0eb158f55b14c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-aadc28a73bbae04a9de1e778d65c229c-16fca46ee4bfe24a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "735c82eef4b8afece104d4f875c81292",
         "x-ms-return-client-request-id": "true"
@@ -85,27 +97,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ac1480d3-4e12-4368-a8c7-ea5f7695f5a1",
-        "Content-Length": "1373",
+        "apim-request-id": "9b3d329f-5e1b-4765-b9de-6d9afe1cff7d",
+        "Content-Length": "1407",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:25 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158",
-        "x-request-id": "ac1480d3-4e12-4368-a8c7-ea5f7695f5a1"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "X-Request-ID": "9b3d329f-5e1b-4765-b9de-6d9afe1cff7d"
       },
       "ResponseBody": {
-        "dataFeedId": "8c9c4675-8bd5-47f1-98bd-cde749521a06",
+        "dataFeedId": "b1524da4-4da4-4139-b994-3e2e52e4bfd9",
         "dataFeedName": "dataFeedgoOWLhzw",
         "metrics": [
           {
-            "metricId": "f23850b3-5aac-482d-9c06-ec69b69480c1",
+            "metricId": "43580e62-43bc-407b-99b1-8b6a324ed617",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "0d9ad6e8-c486-458c-b62b-f9700447cd0a",
+            "metricId": "5db42991-4a65-4fb2-a4be-b8e69cf51d7e",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -140,12 +152,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:25Z",
+        "createdTime": "2021-02-01T14:21:26Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -156,13 +171,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c9c4675-8bd5-47f1-98bd-cde749521a06",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1524da4-4da4-4139-b994-3e2e52e4bfd9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bfdd9251ebd8c64ab73a3cd6d6c7c65c-931ca59fc125bd4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c7c86cf8453f8541b4fe047d0100168e-0c071ba154d0664d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "787aa66edcf6580eeb463b14dcba66be",
         "x-ms-return-client-request-id": "true"
@@ -170,19 +188,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "21f3b0cf-19e4-4d50-aa56-61b35d249714",
+        "apim-request-id": "1b9fe7bd-c040-433a-bd1f-2793297aadd6",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:25 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "335",
-        "x-request-id": "21f3b0cf-19e4-4d50-aa56-61b35d249714"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "388",
+        "X-Request-ID": "1b9fe7bd-c040-433a-bd1f-2793297aadd6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:26.3677858-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:27.0106640-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetAzureTableDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "932",
+        "Content-Length": "990",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b2f1b66acda5b49b4627ec7a6e6e62b-37c73d52a802d840-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-82e5c5b999668c44a5f9a79ee5cebd22-843075dcb16f1544-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "14dc436633c61796ce19383771675ea3",
         "x-ms-return-client-request-id": "true"
@@ -55,29 +55,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a9d929e9-31c2-4117-b2a0-977665b37759",
+        "apim-request-id": "6524a66c-0c9a-43d5-9cd4-a05e2bd05754",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:00 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d3df630-3faf-4fb1-a5b6-bcb0c58239ad",
+        "Date": "Mon, 01 Feb 2021 15:40:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/da1fa268-3233-48ce-bcea-ed36e8a63ea4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "484",
-        "x-request-id": "a9d929e9-31c2-4117-b2a0-977665b37759"
+        "x-envoy-upstream-service-time": "785",
+        "x-request-id": "6524a66c-0c9a-43d5-9cd4-a05e2bd05754"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d3df630-3faf-4fb1-a5b6-bcb0c58239ad",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/da1fa268-3233-48ce-bcea-ed36e8a63ea4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b234bd8e80e95446bfff003ce2717cc2-99bd46075116be40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-288890ba20c20c418b35815f9b2a7c3d-acd6960c0a4f3c49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3f967ef51b90d7390e7f116ccdaa8750",
         "x-ms-return-client-request-id": "true"
@@ -85,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b53dea4b-3f36-4cff-8f68-31ffa3751271",
-        "Content-Length": "1373",
+        "apim-request-id": "077ded51-39e5-436c-9fc5-87ad6a8142ee",
+        "Content-Length": "1407",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:00 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "b53dea4b-3f36-4cff-8f68-31ffa3751271"
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "077ded51-39e5-436c-9fc5-87ad6a8142ee"
       },
       "ResponseBody": {
-        "dataFeedId": "2d3df630-3faf-4fb1-a5b6-bcb0c58239ad",
+        "dataFeedId": "da1fa268-3233-48ce-bcea-ed36e8a63ea4",
         "dataFeedName": "dataFeedMKSbBurZ",
         "metrics": [
           {
-            "metricId": "176d33a1-75fd-4aba-a08a-d20900a701a1",
+            "metricId": "d85b6d2c-4f84-4160-950f-1978489b4db4",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "a86b9c8b-6577-42ea-bc3a-c87313bc192c",
+            "metricId": "629610ef-7794-4ae5-91cb-7fbe7f9240d5",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -140,12 +146,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:00Z",
+        "createdTime": "2021-02-01T15:40:44Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -156,13 +165,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d3df630-3faf-4fb1-a5b6-bcb0c58239ad",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/da1fa268-3233-48ce-bcea-ed36e8a63ea4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ef21bb5c127f154b91c3bb6f2a74f947-ce035eb01108884b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0dc4e76e7312db45aa4ed3cf17eb3034-aac9c9aa39829545-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a3c3d6ac58d11657dbaf588b357e796",
         "x-ms-return-client-request-id": "true"
@@ -170,19 +179,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6da49d12-c66b-49c5-a547-0b579af11227",
+        "apim-request-id": "f51e6bc8-77be-4983-817e-c4d8f5a0ae9b",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:01 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "358",
-        "x-request-id": "6da49d12-c66b-49c5-a547-0b579af11227"
+        "x-envoy-upstream-service-time": "383",
+        "x-request-id": "f51e6bc8-77be-4983-817e-c4d8f5a0ae9b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:01.4968966-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:44.5808954-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "958",
+        "Content-Length": "1016",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-af040b5d97a68546a57ef307560f82d7-f9d74fa7cb29574e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1f5e22ede2daf0468d4e4b9e51e14940-67dafd6f1172804e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "af2b7c7871b91bd4401c67ca0b5cb216",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +59,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8f6b9c88-bcef-4f47-bb3b-c0b8367210e4",
+        "apim-request-id": "cb7df967-17b5-4348-8033-76fb625146b8",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:32 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
+        "Date": "Mon, 01 Feb 2021 14:21:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ea89d266-07a1-4627-a8db-1e197e595a1b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "617",
-        "x-request-id": "8f6b9c88-bcef-4f47-bb3b-c0b8367210e4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "928",
+        "X-Request-ID": "cb7df967-17b5-4348-8033-76fb625146b8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ea89d266-07a1-4627-a8db-1e197e595a1b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6b04d94007ed3c4892a995e3787e26b5-5c965c769a1f8b42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-305026f088f8584dbc03beaaa2f094f4-93eb1f0a79e7a545-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a593b2c625c77ac8c27845ca207e80d7",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +98,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "889b28fe-4841-4814-8384-a42644e05230",
-        "Content-Length": "1399",
+        "apim-request-id": "c2251cdd-7e38-4a43-8e9a-268b3d3b3105",
+        "Content-Length": "1433",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:32 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "188",
-        "x-request-id": "889b28fe-4841-4814-8384-a42644e05230"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "135",
+        "X-Request-ID": "c2251cdd-7e38-4a43-8e9a-268b3d3b3105"
       },
       "ResponseBody": {
-        "dataFeedId": "4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
+        "dataFeedId": "ea89d266-07a1-4627-a8db-1e197e595a1b",
         "dataFeedName": "dataFeedhbJW7QYR",
         "metrics": [
           {
-            "metricId": "b4f55d5a-d787-4c51-b254-c541c88dbd4c",
+            "metricId": "092a98fb-61f7-495b-82a8-37ccb4386c9e",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "e0d028be-f016-4ada-afec-b141d1270d55",
+            "metricId": "26e0fbea-28bd-4cce-b76c-f6f9607cbb58",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +153,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:33Z",
+        "createdTime": "2021-02-01T14:21:28Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +173,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4b3048fc-33b4-43b3-ab2e-4bd58ad0c72b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ea89d266-07a1-4627-a8db-1e197e595a1b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fb7d899af0a12d4cb1ccded4dfe26f27-d21881dc01405d46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-753681eddfd53d48983b14053e8f1be1-eca877abe8b0a44d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "19edf8c3f813d79ac844236d00770864",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +190,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "93fe6b08-48cc-464a-90e0-65b1bec2d7ed",
+        "apim-request-id": "259feed1-57f9-4913-b340-0006c9bb9858",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:33 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "406",
-        "x-request-id": "93fe6b08-48cc-464a-90e0-65b1bec2d7ed"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "350",
+        "X-Request-ID": "259feed1-57f9-4913-b340-0006c9bb9858"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:16:33.7057747-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:28.5357858-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetElasticsearchDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "958",
+        "Content-Length": "1016",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2cdc87f1c3b22148b6a26544811b00b9-07377f662f324e44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-20002eb2a49690458c7208a174e8db93-5959665e6a572844-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3909fd4e55f30a9aa785e1bb36e7b39c",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +56,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "287064a2-1d59-423e-886d-f920d34eb64e",
+        "apim-request-id": "8b3fa665-74d3-4558-bafa-ddbbdf7c417d",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:51 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16313af2-1eff-498a-9374-d99c24fbeb8b",
+        "Date": "Mon, 01 Feb 2021 15:40:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/648a2884-f7d4-40bf-b51e-388b99f6167f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "821",
-        "x-request-id": "287064a2-1d59-423e-886d-f920d34eb64e"
+        "x-envoy-upstream-service-time": "590",
+        "x-request-id": "8b3fa665-74d3-4558-bafa-ddbbdf7c417d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16313af2-1eff-498a-9374-d99c24fbeb8b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/648a2884-f7d4-40bf-b51e-388b99f6167f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61432dae6b4ba14ea3566952963435e8-7045888077b6c148-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e1d5efe68a7a1b4da5eb7a3912048a85-194c35e484e47940-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f53c27492da1152d42d342afc31ea40c",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1e91993e-09ae-42ac-96f8-7389e98384c1",
-        "Content-Length": "1399",
+        "apim-request-id": "c1313851-6f76-4a1e-a123-a9a207e50c9c",
+        "Content-Length": "1433",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:52 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "1e91993e-09ae-42ac-96f8-7389e98384c1"
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "c1313851-6f76-4a1e-a123-a9a207e50c9c"
       },
       "ResponseBody": {
-        "dataFeedId": "16313af2-1eff-498a-9374-d99c24fbeb8b",
+        "dataFeedId": "648a2884-f7d4-40bf-b51e-388b99f6167f",
         "dataFeedName": "dataFeedjYFWDipg",
         "metrics": [
           {
-            "metricId": "27d32bc7-2600-4540-b8d2-f77ce7f3ffe6",
+            "metricId": "318f6f3b-1baf-4525-943d-ea953d759d34",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "9b2b6bb5-5f31-4206-bf9a-b403d44a120b",
+            "metricId": "d531d4e2-c695-4573-9d74-14acfa580be6",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +147,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:51Z",
+        "createdTime": "2021-02-01T15:40:45Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16313af2-1eff-498a-9374-d99c24fbeb8b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/648a2884-f7d4-40bf-b51e-388b99f6167f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7634f94b45b3f14d8604e6b7ddf7d108-e80b5c4b2161ca49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-eb317bfc96136740a5d547b455ab4612-1ba0ee809fd4fb4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "357356c832e57433690de79c0ed76146",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b02c7aa9-4b82-489b-8879-b7152d33c725",
+        "apim-request-id": "009edd8c-47a2-44d9-9a94-78127b8f3abc",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:52 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "344",
-        "x-request-id": "b02c7aa9-4b82-489b-8879-b7152d33c725"
+        "x-envoy-upstream-service-time": "415",
+        "x-request-id": "009edd8c-47a2-44d9-9a94-78127b8f3abc"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:16:52.6632029-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:45.8117013-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetHttpRequestDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetHttpRequestDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "967",
+        "Content-Length": "1025",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b086bd606901984d9c9ccd4f51017971-e93613ab14364e49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fd0c48f2ac326448b5da429afd305e4a-cb3a2bb994be6142-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0f972946397242c69a0aca31cb2a5a0d",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +59,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2d1756e6-ad76-434e-ba3c-75319b276e2f",
+        "apim-request-id": "114003f3-7cf5-4a74-b94c-be5a83a2f00a",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fabf01a5-393a-44fc-8e98-c226ce687526",
+        "Date": "Mon, 01 Feb 2021 14:21:28 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ec1cad0-2403-4ce6-a4c6-0ce3dcee46f2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "444",
-        "x-request-id": "2d1756e6-ad76-434e-ba3c-75319b276e2f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "734",
+        "X-Request-ID": "114003f3-7cf5-4a74-b94c-be5a83a2f00a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fabf01a5-393a-44fc-8e98-c226ce687526",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ec1cad0-2403-4ce6-a4c6-0ce3dcee46f2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-53674cf5464be044beae1388bd525756-2dcd97234d86874c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-00d12dc1a0a01a40a22ea44a3eeb4705-4b8ac4a2f3460d4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0e61866e875fb106c396424fb8a28921",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +98,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "844b9054-9c94-4542-b966-3a4a2d46d928",
-        "Content-Length": "1408",
+        "apim-request-id": "73d80b85-3471-4275-a76e-23c56bf2f1d3",
+        "Content-Length": "1442",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:31 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "157",
-        "x-request-id": "844b9054-9c94-4542-b966-3a4a2d46d928"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "131",
+        "X-Request-ID": "73d80b85-3471-4275-a76e-23c56bf2f1d3"
       },
       "ResponseBody": {
-        "dataFeedId": "fabf01a5-393a-44fc-8e98-c226ce687526",
+        "dataFeedId": "0ec1cad0-2403-4ce6-a4c6-0ce3dcee46f2",
         "dataFeedName": "dataFeedyPGQ0r3c",
         "metrics": [
           {
-            "metricId": "d038f53a-1b7f-47da-814c-15900b6fb6b1",
+            "metricId": "ba2a5aae-ab64-4f12-85af-0fa5ba7e2e16",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "0e679261-b22d-4144-82a4-eea060948eb8",
+            "metricId": "52fe2612-7ad2-4c50-b66e-f087a7b2e087",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +153,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:30Z",
+        "createdTime": "2021-02-01T14:21:29Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +173,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fabf01a5-393a-44fc-8e98-c226ce687526",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ec1cad0-2403-4ce6-a4c6-0ce3dcee46f2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e470d2778ff2184dba6117691ab707c9-abed5f26e3672743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5c8523acf66b1143b0b485eaca2def60-7dce958cb97ed14b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8858a3fd93a7158cf1ae21ee61e3959a",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +190,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4ebea704-6b54-4a94-87ae-d3309e08d42e",
+        "apim-request-id": "4d5e8f77-97d4-4c0e-b226-3b4e47ff4e56",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:31 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "326",
-        "x-request-id": "4ebea704-6b54-4a94-87ae-d3309e08d42e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "359",
+        "X-Request-ID": "4d5e8f77-97d4-4c0e-b226-3b4e47ff4e56"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:31.2882298-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:29.9142435-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetHttpRequestDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetHttpRequestDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "967",
+        "Content-Length": "1025",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d0068fbe2a908d47a24127548ac4e0bd-04ffc8176f8a934c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-48354171c9c8cb439be9182eb684f93c-9111d187c6353746-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "72d6f41da8777ab252751f6bea27ac0b",
         "x-ms-return-client-request-id": "true"
@@ -56,29 +56,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8742dc76-9353-452b-b88f-4375ef5206de",
+        "apim-request-id": "e3414dc2-3aff-48aa-b80b-f9e221d79235",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4084d034-6af3-4497-92a5-9f4117c641ba",
+        "Date": "Mon, 01 Feb 2021 15:40:46 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fdee4956-d555-46e5-b1af-71b5a77428ee",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "689",
-        "x-request-id": "8742dc76-9353-452b-b88f-4375ef5206de"
+        "x-envoy-upstream-service-time": "687",
+        "x-request-id": "e3414dc2-3aff-48aa-b80b-f9e221d79235"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4084d034-6af3-4497-92a5-9f4117c641ba",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fdee4956-d555-46e5-b1af-71b5a77428ee",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-77d96ef3542cb44aaee8973aebb30bbb-3bbf1bf3de56304b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ddbddf80daf47642a9ca946ef841b2ac-6138aa1cbaf4a14c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "75340af7a9c5efb82dd4b4bb8108d417",
         "x-ms-return-client-request-id": "true"
@@ -86,27 +92,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5bb4eeaf-d3b7-4e70-87e3-f303d71dc401",
-        "Content-Length": "1408",
+        "apim-request-id": "631b4a17-ba84-4c91-8dac-557cd5b3c07c",
+        "Content-Length": "1442",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "5bb4eeaf-d3b7-4e70-87e3-f303d71dc401"
+        "x-envoy-upstream-service-time": "149",
+        "x-request-id": "631b4a17-ba84-4c91-8dac-557cd5b3c07c"
       },
       "ResponseBody": {
-        "dataFeedId": "4084d034-6af3-4497-92a5-9f4117c641ba",
+        "dataFeedId": "fdee4956-d555-46e5-b1af-71b5a77428ee",
         "dataFeedName": "dataFeed4HARQp7I",
         "metrics": [
           {
-            "metricId": "f1fd93fe-1023-4c45-af4f-aa00b4862187",
+            "metricId": "6ca9685a-a6fc-487a-84e5-3f363e7ce45f",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "e328df33-7470-4e39-9063-f8c8c449a235",
+            "metricId": "7149459b-f2d5-42a0-8c67-b90ab9878b4b",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -141,12 +147,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:12Z",
+        "createdTime": "2021-02-01T15:40:46Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -158,13 +167,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4084d034-6af3-4497-92a5-9f4117c641ba",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fdee4956-d555-46e5-b1af-71b5a77428ee",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a20caf477c6fb2409d89c8359f0d4000-44f2b7812c21f841-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bb7c5c0325d6bf4a8d63a8e92270895b-44f749bdce315843-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f277cf6a8511a6d3d9a8e678eb76351f",
         "x-ms-return-client-request-id": "true"
@@ -172,19 +181,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f3690499-7c22-4afe-87ac-dc9532ad106f",
+        "apim-request-id": "2397e28b-5522-4d28-933c-df97722258d7",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "337",
-        "x-request-id": "f3690499-7c22-4afe-87ac-dc9532ad106f"
+        "x-envoy-upstream-service-time": "405",
+        "x-request-id": "2397e28b-5522-4d28-933c-df97722258d7"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:12.6564957-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:47.2226510-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "976",
+        "Content-Length": "1034",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c683004ae7afef41af177dad903741ab-4f449d689e4f5348-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d570c0bc8535b04fbd5bccd143b5f8a5-7dd4b92050668c4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9d041078b1e3a7e73e7f0c61fc6a0ba5",
         "x-ms-return-client-request-id": "true"
@@ -57,29 +60,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "1a3d5c74-0476-4a44-9ed7-59b8f77561f9",
+        "apim-request-id": "2d0114e4-d149-484b-b144-6707d195994a",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:33 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73f080ad-4982-46aa-bb05-ca895c8fe7d9",
+        "Date": "Mon, 01 Feb 2021 14:21:35 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ffcff58-9238-4e82-88d4-981ae924c253",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "455",
-        "x-request-id": "1a3d5c74-0476-4a44-9ed7-59b8f77561f9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5826",
+        "X-Request-ID": "2d0114e4-d149-484b-b144-6707d195994a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73f080ad-4982-46aa-bb05-ca895c8fe7d9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ffcff58-9238-4e82-88d4-981ae924c253",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c084873b5625ca43850ef1a04071af2e-3537d3828e63de42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-29653e1592ee5146b740451d2b43a251-d2336e541f984a49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4d557079890c486dd931d4fd34d89ef4",
         "x-ms-return-client-request-id": "true"
@@ -87,27 +99,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "882dd576-30fb-4df6-90f9-7e98f3757e4f",
-        "Content-Length": "1417",
+        "apim-request-id": "0afdc3ac-65e8-462a-ab36-30c91d80e953",
+        "Content-Length": "1451",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:34 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "178",
-        "x-request-id": "882dd576-30fb-4df6-90f9-7e98f3757e4f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "X-Request-ID": "0afdc3ac-65e8-462a-ab36-30c91d80e953"
       },
       "ResponseBody": {
-        "dataFeedId": "73f080ad-4982-46aa-bb05-ca895c8fe7d9",
+        "dataFeedId": "5ffcff58-9238-4e82-88d4-981ae924c253",
         "dataFeedName": "dataFeedinA3Na3s",
         "metrics": [
           {
-            "metricId": "bcbd1b86-beb3-46c1-8827-5c16a7dd4e00",
+            "metricId": "b855236b-cc1f-49b8-950d-848027390cee",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "4c40d384-7416-404d-be5b-9f181c90e3f0",
+            "metricId": "11d0d4aa-e3ac-45ce-a62e-1ed436602c99",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -142,12 +154,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:34Z",
+        "createdTime": "2021-02-01T14:21:35Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -160,13 +175,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73f080ad-4982-46aa-bb05-ca895c8fe7d9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ffcff58-9238-4e82-88d4-981ae924c253",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61c5b359c58db740968527aeec7991c9-a1087401f826074c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-958dd1b42da86744a825fb250bcc5df6-54c9d42de456cc4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8780e974466a4acc05a84f2a3a546c4b",
         "x-ms-return-client-request-id": "true"
@@ -174,19 +192,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "82dfa89c-2655-4193-ba75-00d4c028b8db",
+        "apim-request-id": "92386180-68ce-4b9c-84fb-0a58b9dd41bc",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:34 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "318",
-        "x-request-id": "82dfa89c-2655-4193-ba75-00d4c028b8db"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "408",
+        "X-Request-ID": "92386180-68ce-4b9c-84fb-0a58b9dd41bc"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:34.5639907-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:36.4160688-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetInfluxDbDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "976",
+        "Content-Length": "1034",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f3936ccebeaa6e44aa6a17c248e12d44-fd2dc4da6758f941-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-04c72448140efa47910dabbaa4898ab7-dadcfdbc6a26c942-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6252c472d46e4a19cdab563ce87e761a",
         "x-ms-return-client-request-id": "true"
@@ -57,29 +57,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "79aa1824-9702-46d1-ab65-fb69abeb7e98",
+        "apim-request-id": "1c33fc3c-8b30-42b4-be14-d19794de7a64",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:14 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1acc024b-ed53-405b-850a-094551ef6523",
+        "Date": "Mon, 01 Feb 2021 15:40:48 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b482a09-d47a-4d2d-88c5-de5125d2cc19",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "503",
-        "x-request-id": "79aa1824-9702-46d1-ab65-fb69abeb7e98"
+        "x-envoy-upstream-service-time": "801",
+        "x-request-id": "1c33fc3c-8b30-42b4-be14-d19794de7a64"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1acc024b-ed53-405b-850a-094551ef6523",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b482a09-d47a-4d2d-88c5-de5125d2cc19",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ace572abe756e848b93e8eee15b2401c-b3230c7b59c0d647-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6c052b5406f5a34386a1e021199fa139-feb382f3467a4a4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "54fddd90ef48400529fbfbfe7ae94084",
         "x-ms-return-client-request-id": "true"
@@ -87,27 +93,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "56d267e5-6bd5-4566-94f6-cb791deafd66",
-        "Content-Length": "1417",
+        "apim-request-id": "331da57a-ab9a-40e4-b7e0-8a9155eb6840",
+        "Content-Length": "1451",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:14 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "172",
-        "x-request-id": "56d267e5-6bd5-4566-94f6-cb791deafd66"
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "331da57a-ab9a-40e4-b7e0-8a9155eb6840"
       },
       "ResponseBody": {
-        "dataFeedId": "1acc024b-ed53-405b-850a-094551ef6523",
+        "dataFeedId": "8b482a09-d47a-4d2d-88c5-de5125d2cc19",
         "dataFeedName": "dataFeedby5qOJIr",
         "metrics": [
           {
-            "metricId": "f5281439-c324-4f52-a54f-cca01c81a3e4",
+            "metricId": "875bcdc9-5f06-4e0b-9dbf-84878fb4b5bc",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "18638066-ddbb-4330-93aa-d48d4f968408",
+            "metricId": "84bc9f5e-e353-40af-82b6-10b26df93630",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -142,12 +148,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:14Z",
+        "createdTime": "2021-02-01T15:40:48Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -160,13 +169,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1acc024b-ed53-405b-850a-094551ef6523",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b482a09-d47a-4d2d-88c5-de5125d2cc19",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a6b5d42854088848943b1ebe771fcdee-4746aae1cd72f64f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ee7c09f57c667c45a8d1792534c55771-8e260a604d38be4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "95e68dedd826cee89b6fe292722f9845",
         "x-ms-return-client-request-id": "true"
@@ -174,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "323c1b1e-7e8f-40e1-919e-0a6983b68ea7",
+        "apim-request-id": "c2c0c7a2-0580-4a1c-97c7-5cb626f42d13",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:15 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "405",
-        "x-request-id": "323c1b1e-7e8f-40e1-919e-0a6983b68ea7"
+        "x-envoy-upstream-service-time": "373",
+        "x-request-id": "c2c0c7a2-0580-4a1c-97c7-5cb626f42d13"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:15.2352186-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:48.7679863-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "939",
+        "Content-Length": "997",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-25bd55a7583ce94998cd044b11465f8b-51acebba97cca14e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1156da473cd5ac448b25e361327e4446-227ab420520b6b47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a3d43c7745a4a24592be10940793c8c7",
         "x-ms-return-client-request-id": "true"
@@ -55,29 +58,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "20132eb5-6c23-49b8-aa33-1d66a8bbef78",
+        "apim-request-id": "5fd5a39b-0b62-4688-beff-06a00492af05",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6340f0ea-3c25-4587-834c-4d7d9dea306b",
+        "Date": "Mon, 01 Feb 2021 14:21:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64235387-4451-4488-ac0a-9bdade4766e6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "511",
-        "x-request-id": "20132eb5-6c23-49b8-aa33-1d66a8bbef78"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "840",
+        "X-Request-ID": "5fd5a39b-0b62-4688-beff-06a00492af05"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6340f0ea-3c25-4587-834c-4d7d9dea306b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64235387-4451-4488-ac0a-9bdade4766e6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-eb9728a57fba3f4fbe4fd208d118a8ba-c1289c5ad8b04f40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-92a000568c164a4995d10f021f7d6b54-86dd14deb1a13e49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "40b6c8316da078e7396b4d6494e8a1c1",
         "x-ms-return-client-request-id": "true"
@@ -85,27 +97,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cc4f7a7a-ecd9-48da-8c94-af671e9eaab7",
-        "Content-Length": "1380",
+        "apim-request-id": "e3f53db0-7865-425b-b1e8-90fd7a7a42ae",
+        "Content-Length": "1414",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:36 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
-        "x-request-id": "cc4f7a7a-ecd9-48da-8c94-af671e9eaab7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "170",
+        "X-Request-ID": "e3f53db0-7865-425b-b1e8-90fd7a7a42ae"
       },
       "ResponseBody": {
-        "dataFeedId": "6340f0ea-3c25-4587-834c-4d7d9dea306b",
+        "dataFeedId": "64235387-4451-4488-ac0a-9bdade4766e6",
         "dataFeedName": "dataFeedsR6T7Z02",
         "metrics": [
           {
-            "metricId": "e099b4be-227b-469d-b3e0-6eb54c5cbcf2",
+            "metricId": "72dbc44d-084e-4e0c-b18f-c0799742ef1f",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "c7e6b49f-e6e3-49b6-b82e-fed31626da9b",
+            "metricId": "f0f050aa-7cb9-46e1-bce9-bf2d9d1cf957",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -140,12 +152,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:36Z",
+        "createdTime": "2021-02-01T14:21:37Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -156,13 +171,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6340f0ea-3c25-4587-834c-4d7d9dea306b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64235387-4451-4488-ac0a-9bdade4766e6",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90ed46b2bdc2cc4da6468d7371c06801-5cd5b2be15538240-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-77f26e026cec6449a03072132b9f0f2f-5b0a40ea25d3b546-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8167193d7b9fbd03e6d2724fa4381163",
         "x-ms-return-client-request-id": "true"
@@ -170,19 +188,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b3b800c1-9d01-480b-b4ad-d98a97db6173",
+        "apim-request-id": "ac60fbed-a7d3-4d53-bfbf-8f7c0247eeab",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:37 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "302",
-        "x-request-id": "b3b800c1-9d01-480b-b4ad-d98a97db6173"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "360",
+        "X-Request-ID": "ac60fbed-a7d3-4d53-bfbf-8f7c0247eeab"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:37.1894092-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:37.9800533-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMongoDbDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "939",
+        "Content-Length": "997",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0d7bb9744732a24e97c50eca3691c4ce-47b88567968e6242-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-001dec671cb8d04aa2ca4a20edf7887f-6fa93a6b1490c645-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fc27be14c3879258a02f968a2d50ed27",
         "x-ms-return-client-request-id": "true"
@@ -55,29 +55,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "931b6f43-1e00-46da-a456-cfcee24ca8a0",
+        "apim-request-id": "7b041adf-05a1-42b5-b7ef-dc0e1e38e421",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:17 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73525441-9d85-4656-97da-8122f5216fc7",
+        "Date": "Mon, 01 Feb 2021 15:40:49 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cf2c045-fcfd-4b0c-9cbd-b84ced288cd6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "469",
-        "x-request-id": "931b6f43-1e00-46da-a456-cfcee24ca8a0"
+        "x-envoy-upstream-service-time": "552",
+        "x-request-id": "7b041adf-05a1-42b5-b7ef-dc0e1e38e421"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73525441-9d85-4656-97da-8122f5216fc7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cf2c045-fcfd-4b0c-9cbd-b84ced288cd6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c102886628383347af579768f25b2616-d0ca462efb54fd44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7a3becadd2b98c44ab44fb404d75e4f2-182c64eb0da0124f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0b19e60ffedc993d8eb2bf5d48e86834",
         "x-ms-return-client-request-id": "true"
@@ -85,27 +91,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9ff89a36-2490-4c09-b5c3-dbf667205609",
-        "Content-Length": "1380",
+        "apim-request-id": "55d54529-6909-4898-a7e9-a04a3dbacb5d",
+        "Content-Length": "1414",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "9ff89a36-2490-4c09-b5c3-dbf667205609"
+        "x-envoy-upstream-service-time": "144",
+        "x-request-id": "55d54529-6909-4898-a7e9-a04a3dbacb5d"
       },
       "ResponseBody": {
-        "dataFeedId": "73525441-9d85-4656-97da-8122f5216fc7",
+        "dataFeedId": "1cf2c045-fcfd-4b0c-9cbd-b84ced288cd6",
         "dataFeedName": "dataFeedLS0fekdV",
         "metrics": [
           {
-            "metricId": "1ad2ccba-7de2-43da-a1b2-8062cc5e5611",
+            "metricId": "81ce6f0f-62d4-4273-9475-13e10f8258ca",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "5a27dd51-8a08-4b37-97ad-c68e1ad76e48",
+            "metricId": "9cffee9a-24b5-42b7-866b-d70b4932718d",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -140,12 +146,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:17Z",
+        "createdTime": "2021-02-01T15:40:49Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -156,13 +165,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73525441-9d85-4656-97da-8122f5216fc7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cf2c045-fcfd-4b0c-9cbd-b84ced288cd6",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-872f225219c74143a3515b9cf1cff756-085672285e347a41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9cb470ec947ad74e9c6da46078407032-4be4b9ee17a6c74f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cc62f72efeebda40a8930ed2bb234980",
         "x-ms-return-client-request-id": "true"
@@ -170,19 +179,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "588607a9-b469-467f-9edc-f2f84bb7a410",
+        "apim-request-id": "720af540-e86b-44e7-b020-a70be47c63a0",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "298",
-        "x-request-id": "588607a9-b469-467f-9edc-f2f84bb7a410"
+        "x-envoy-upstream-service-time": "385",
+        "x-request-id": "720af540-e86b-44e7-b020-a70be47c63a0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:18.1541341-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:50.0243857-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "911",
+        "Content-Length": "969",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c2f4ca604f49fa4db31f2882162793f6-ba0ec701adf5d244-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b9a54c8a7ae6a844aa77be35304837a7-4e478177b698d044-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9ac4891ef145b15dfe07db041d5dc281",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +57,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "85f0f4fb-d775-415a-93d5-b66a6238e246",
+        "apim-request-id": "8281fc1a-d349-4af6-8331-75f212d41bbf",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:38 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cac88662-a31d-42bf-980c-90e946f711d0",
+        "Date": "Mon, 01 Feb 2021 14:21:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/144ab68e-55ca-406f-b5b6-58269584200f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "499",
-        "x-request-id": "85f0f4fb-d775-415a-93d5-b66a6238e246"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "724",
+        "X-Request-ID": "8281fc1a-d349-4af6-8331-75f212d41bbf"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cac88662-a31d-42bf-980c-90e946f711d0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/144ab68e-55ca-406f-b5b6-58269584200f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ec27f133604f454282f80c995cfb0911-7d2794405b8bf440-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2f9b3449b9a100478165503266562727-2533cfbc7e37ac4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "49fe086974f57d567a21c51fd8605f46",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +96,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b1996c68-545e-4eb2-a837-235870384954",
-        "Content-Length": "1352",
+        "apim-request-id": "cf0d3a7c-6c2b-4532-a97e-7392986dc4b1",
+        "Content-Length": "1386",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:39 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "138",
-        "x-request-id": "b1996c68-545e-4eb2-a837-235870384954"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "154",
+        "X-Request-ID": "cf0d3a7c-6c2b-4532-a97e-7392986dc4b1"
       },
       "ResponseBody": {
-        "dataFeedId": "cac88662-a31d-42bf-980c-90e946f711d0",
+        "dataFeedId": "144ab68e-55ca-406f-b5b6-58269584200f",
         "dataFeedName": "dataFeed4J2AWNot",
         "metrics": [
           {
-            "metricId": "fa2b6e8d-0a21-48b9-878f-728ae40177cc",
+            "metricId": "7471a01d-3c5e-43df-9522-652032712e76",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "fe2689d8-a9d2-4222-8e31-b080b44379e5",
+            "metricId": "af4366a5-7c4d-4f16-8311-5b164b62d3f3",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +151,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:39Z",
+        "createdTime": "2021-02-01T14:21:38Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +169,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cac88662-a31d-42bf-980c-90e946f711d0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/144ab68e-55ca-406f-b5b6-58269584200f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-409058077045db429306b39eb1d13eaa-e4fd84626a9cb345-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3382483156b7824db710e7ec92a6b834-64707007d9226144-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3c99d52a0aa7f1180d2646e9e27d1ae0",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +186,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "86048001-789b-4f87-be57-96107230f41b",
+        "apim-request-id": "fed5a781-912b-425b-ba3f-2f93e5cfab21",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:39 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "318",
-        "x-request-id": "86048001-789b-4f87-be57-96107230f41b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "390",
+        "X-Request-ID": "fed5a781-912b-425b-ba3f-2f93e5cfab21"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:39.5339482-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:39.2918875-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetMySqlDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "911",
+        "Content-Length": "969",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-31e435ba69ca4b43972b3e7a244b8d20-efc865fc14680545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c58cd2fa30e983419eaf800fe0b2e8d4-74490be2cc1eac48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9e702109323119494ec56a4f8b9494db",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +54,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8e06650d-6c3e-4de8-9b2f-0b9155f53725",
+        "apim-request-id": "7a14b77d-c578-4ec8-93a6-68b33960efb7",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c0875962-a4cf-4aef-95f6-f6b480bd1bde",
+        "Date": "Mon, 01 Feb 2021 15:40:50 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fb41bd2-d95c-410b-9e02-d643b3329218",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "512",
-        "x-request-id": "8e06650d-6c3e-4de8-9b2f-0b9155f53725"
+        "x-envoy-upstream-service-time": "776",
+        "x-request-id": "7a14b77d-c578-4ec8-93a6-68b33960efb7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c0875962-a4cf-4aef-95f6-f6b480bd1bde",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fb41bd2-d95c-410b-9e02-d643b3329218",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-32e50a9d46b451439c2c27a8e2dc7416-fa02595d1fb7274e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-755764c47302c74eada458eca4769375-28a2b8f0caae6e4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "eba95d2cd342a5963911b433617ee200",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b0e0a60a-32e9-46eb-997b-5e1eee451830",
-        "Content-Length": "1352",
+        "apim-request-id": "dad9fed0-b9bb-4da3-9c77-7fa94dcdc80f",
+        "Content-Length": "1386",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
-        "x-request-id": "b0e0a60a-32e9-46eb-997b-5e1eee451830"
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "dad9fed0-b9bb-4da3-9c77-7fa94dcdc80f"
       },
       "ResponseBody": {
-        "dataFeedId": "c0875962-a4cf-4aef-95f6-f6b480bd1bde",
+        "dataFeedId": "0fb41bd2-d95c-410b-9e02-d643b3329218",
         "dataFeedName": "dataFeedk7wnLUbS",
         "metrics": [
           {
-            "metricId": "fd9f5e0a-1d8f-43f2-96d4-92ff389130ef",
+            "metricId": "c1c82ffc-52d1-4607-9181-0f1c4b2e806e",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "2ed3c72c-0483-48a4-bde6-956673663c8c",
+            "metricId": "bdec0693-b384-4141-9379-37a333d20f47",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +145,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:20Z",
+        "createdTime": "2021-02-01T15:40:50Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c0875962-a4cf-4aef-95f6-f6b480bd1bde",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fb41bd2-d95c-410b-9e02-d643b3329218",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aaab7e66c5c3de4cbc4c72ddbf379791-0ab25b2088dfe24f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6ba09c294528aa429e0655f822d8111a-db406d3843206144-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "30a15f015ea302b019442594bbcd9e12",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ec2fe0bc-fe95-42b5-a204-3f376c204e7b",
+        "apim-request-id": "a95d613c-ea67-44d3-bdc6-a5f733bfd2a8",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "324",
-        "x-request-id": "ec2fe0bc-fe95-42b5-a204-3f376c204e7b"
+        "x-envoy-upstream-service-time": "350",
+        "x-request-id": "a95d613c-ea67-44d3-bdc6-a5f733bfd2a8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:20.9096659-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:51.4677813-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "916",
+        "Content-Length": "974",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1a28d1e7f247b640924b973a4766fa3d-1da359a695635647-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f52effba9d5b9e46b75603866359161a-04664684298daa4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "051b7626a9142028f6f00e9ad56b9615",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +57,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "67986721-7100-4b60-bb43-8287d64ae632",
+        "apim-request-id": "85f5d781-aa3b-4f22-a298-ac15afced41b",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:41 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e021e57b-7b45-4f46-b97b-5bbc29e083dc",
+        "Date": "Mon, 01 Feb 2021 14:21:40 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1656f723-60cf-468b-b1e5-24ebd0a1bc55",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "466",
-        "x-request-id": "67986721-7100-4b60-bb43-8287d64ae632"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "714",
+        "X-Request-ID": "85f5d781-aa3b-4f22-a298-ac15afced41b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e021e57b-7b45-4f46-b97b-5bbc29e083dc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1656f723-60cf-468b-b1e5-24ebd0a1bc55",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c0aefbe0cefc044585660c30563a3842-6508f318c2f4cb4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-466d511a7147194fba65f0e990aba630-8acad29589ae6947-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4e3642bb69b6d1ef9041c21785e9eb14",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +96,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8f90a0b9-5908-4be9-94ff-103b372a9669",
-        "Content-Length": "1357",
+        "apim-request-id": "b15d5331-d1cf-4863-a292-4e330569d133",
+        "Content-Length": "1391",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:41 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "8f90a0b9-5908-4be9-94ff-103b372a9669"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "X-Request-ID": "b15d5331-d1cf-4863-a292-4e330569d133"
       },
       "ResponseBody": {
-        "dataFeedId": "e021e57b-7b45-4f46-b97b-5bbc29e083dc",
+        "dataFeedId": "1656f723-60cf-468b-b1e5-24ebd0a1bc55",
         "dataFeedName": "dataFeedzyytIbjH",
         "metrics": [
           {
-            "metricId": "54ddfc1d-691c-4537-96a1-017029efa233",
+            "metricId": "ce5ca500-052a-413e-b2fa-bf7b4da87d5d",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "2aa3bf9d-5291-4428-8cc5-7f4b8ca0abef",
+            "metricId": "f19d8173-2029-4c3b-a1cb-0fac4fed0953",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +151,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:41Z",
+        "createdTime": "2021-02-01T14:21:40Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +169,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e021e57b-7b45-4f46-b97b-5bbc29e083dc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1656f723-60cf-468b-b1e5-24ebd0a1bc55",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-97c746a3aec81045901041d049dafe64-e7fdc384f6d02a44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-52398f39fac0b04ab67fd01ffcab1271-f62f1612ff1e4941-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d328cdf5145aaa205cc97670b7a50f7e",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +186,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "772ae65a-3e33-422d-952a-dd0fec74dbb6",
+        "apim-request-id": "8ec89ccb-6beb-47f3-8c70-cf815e4ff276",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:42 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "336",
-        "x-request-id": "772ae65a-3e33-422d-952a-dd0fec74dbb6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "338",
+        "X-Request-ID": "8ec89ccb-6beb-47f3-8c70-cf815e4ff276"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:42.2448099-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:40.6839721-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetPostgreSqlDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "916",
+        "Content-Length": "974",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-481bc6bc867f7d47acac9d23b72b8e70-ff43841e8a74e648-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fbca9fb0e02d5146ac18607e74b6ea05-de9410eaae2dcd4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fb5ff9a17356a5f50d9e9fbe2f10a2f4",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +54,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c58d54d1-2012-442f-92cb-aecc22f6e368",
+        "apim-request-id": "567344d0-f1d0-487e-baea-976da75abd6d",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e7bb215c-0bc8-44ff-bfc4-ec53f671806f",
+        "Date": "Mon, 01 Feb 2021 15:40:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/441fbc43-d96e-4eac-b49b-390446c5f479",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "640",
-        "x-request-id": "c58d54d1-2012-442f-92cb-aecc22f6e368"
+        "x-envoy-upstream-service-time": "536",
+        "x-request-id": "567344d0-f1d0-487e-baea-976da75abd6d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e7bb215c-0bc8-44ff-bfc4-ec53f671806f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/441fbc43-d96e-4eac-b49b-390446c5f479",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-36ad22a0f564404f8adf799bf407bd38-38f0618034111745-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1bd5a73156e74f429e0e325f8e0850ff-0744f1593928de4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "79ad770bba1d3760ff157f7ab63e5bf1",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f5a84979-b152-4f3b-940c-6c29e4c8530b",
-        "Content-Length": "1357",
+        "apim-request-id": "4ccf9e8a-7d37-4549-96f4-39b035a64f65",
+        "Content-Length": "1391",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:22 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "192",
-        "x-request-id": "f5a84979-b152-4f3b-940c-6c29e4c8530b"
+        "x-envoy-upstream-service-time": "140",
+        "x-request-id": "4ccf9e8a-7d37-4549-96f4-39b035a64f65"
       },
       "ResponseBody": {
-        "dataFeedId": "e7bb215c-0bc8-44ff-bfc4-ec53f671806f",
+        "dataFeedId": "441fbc43-d96e-4eac-b49b-390446c5f479",
         "dataFeedName": "dataFeedffsJE0BR",
         "metrics": [
           {
-            "metricId": "38747517-34d9-42b2-b4bb-23558cbbd889",
+            "metricId": "252e99b1-ef43-4128-8824-83f01dc56723",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "67e3a67c-4607-441d-9693-ca59050f9b08",
+            "metricId": "e4f52931-59bc-4428-be4c-bbf2a64df6d4",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +145,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:23Z",
+        "createdTime": "2021-02-01T15:40:52Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e7bb215c-0bc8-44ff-bfc4-ec53f671806f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/441fbc43-d96e-4eac-b49b-390446c5f479",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6e4d843f69933945a2cc3632c7ac6223-e9affa148076e343-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5712f57e5b8e3541aa8da16b8a6eb419-6e747d9957bdf840-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "91dc330bf653f0a370bd5f171f7bbb25",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a3962450-1202-49e9-8a08-a361d11a0510",
+        "apim-request-id": "da64e319-058c-48c4-8f52-d8b76159e0f8",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "386",
-        "x-request-id": "a3962450-1202-49e9-8a08-a361d11a0510"
+        "x-envoy-upstream-service-time": "397",
+        "x-request-id": "da64e319-058c-48c4-8f52-d8b76159e0f8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:23.9176661-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:52.7379078-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembers.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembers.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "915",
+        "Content-Length": "973",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8170578839633143b95b3871d94b1f4a-775f092b8bdfbb4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-562256f83806af409963a8ecf385eb3f-8d7a7acd63bf6344-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9506268ea80a218e20797da422fde083",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +57,38 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "9402cf64-bfb9-49cc-aa9d-e1c73e555421",
+        "apim-request-id": "396d40f5-96c0-4770-8521-ec63ca994608",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:44 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfd0b063-6810-4341-b392-617a9f7cd67b",
+        "Date": "Mon, 01 Feb 2021 14:21:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97f0f9a9-491e-44cd-b508-e025a76cbac7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "505",
-        "x-request-id": "9402cf64-bfb9-49cc-aa9d-e1c73e555421"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "751",
+        "X-Request-ID": "396d40f5-96c0-4770-8521-ec63ca994608"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfd0b063-6810-4341-b392-617a9f7cd67b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97f0f9a9-491e-44cd-b508-e025a76cbac7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-770642cf71c7a6488c5e35a03597c16c-9aa88903559e7a41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9855a72f65bef04987e46b201d6be34f-51ff27c8dcae2544-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "69e2e68fe7210dcae10286033f839142",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +96,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ba49bd3-b94a-41a5-aefc-f104b93ede4f",
-        "Content-Length": "1356",
+        "apim-request-id": "9ff9dd17-25c7-4c0c-a187-213306611928",
+        "Content-Length": "1390",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:40:44 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "1ba49bd3-b94a-41a5-aefc-f104b93ede4f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "151",
+        "X-Request-ID": "9ff9dd17-25c7-4c0c-a187-213306611928"
       },
       "ResponseBody": {
-        "dataFeedId": "dfd0b063-6810-4341-b392-617a9f7cd67b",
+        "dataFeedId": "97f0f9a9-491e-44cd-b508-e025a76cbac7",
         "dataFeedName": "dataFeed5atufFei",
         "metrics": [
           {
-            "metricId": "747706e3-4777-4a4c-b020-2850eb52880a",
+            "metricId": "d925d511-9ad5-4a71-80a0-9f482cf737c7",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "abd5c3cd-0975-40c0-88ff-4c8730eff851",
+            "metricId": "49456360-ddaf-468b-ad65-c7591a4695c8",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +151,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:40:44Z",
+        "createdTime": "2021-02-01T14:21:41Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +169,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfd0b063-6810-4341-b392-617a9f7cd67b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/97f0f9a9-491e-44cd-b508-e025a76cbac7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ac070756825dc047b706bfc00d213d73-7abb09fd472fec4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-38d55fea48db6646b8ee4f8a53b2b666-46a35bfa3bd0784f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ec81eab9ca01446e43b47aab8df25752",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +186,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "33d932a4-4755-4109-820a-e35e490c55aa",
+        "apim-request-id": "4c294b6f-26d0-4ceb-8373-d8559fa617e4",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:40:45 GMT",
+        "Date": "Mon, 01 Feb 2021 14:21:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "354",
-        "x-request-id": "33d932a4-4755-4109-820a-e35e490c55aa"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "375",
+        "X-Request-ID": "4c294b6f-26d0-4ceb-8373-d8559fa617e4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:40:45.3134675-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:21:42.0089784-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembersAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/CreateAndGetSqlServerDataFeedWithOptionalMembersAsync.json
@@ -5,11 +5,11 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "915",
+        "Content-Length": "973",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cbcb6e1e129b1e48ab49fbcea3f6f502-7a36cd3e32c62840-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-50ab6e70198c4b41b1de87045c9de514-f283cbc6d1cd6148-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9534f4446271ed34e922df1675e21907",
         "x-ms-return-client-request-id": "true"
@@ -54,29 +54,35 @@
         "fillMissingPointType": "CustomValue",
         "fillMissingPointValue": 45,
         "viewMode": "Public",
+        "admins": [
+          "fake@admin.com"
+        ],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed"
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "31635992-7658-4875-a9f2-09f56ed4a13c",
+        "apim-request-id": "12e79dbe-c946-4528-b9ee-c972c01ad840",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a68f3cf-f819-4807-abdf-6c7117c9382f",
+        "Date": "Mon, 01 Feb 2021 15:40:52 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0858ee7d-cf67-4975-bdda-d701c1d3df8a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "697",
-        "x-request-id": "31635992-7658-4875-a9f2-09f56ed4a13c"
+        "x-envoy-upstream-service-time": "586",
+        "x-request-id": "12e79dbe-c946-4528-b9ee-c972c01ad840"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a68f3cf-f819-4807-abdf-6c7117c9382f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0858ee7d-cf67-4975-bdda-d701c1d3df8a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f4e37c5177a63e418ab24534d8b3fc45-40b21f3bdd6d964e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d1113310cffda84ebe1b1104c52cf836-5f0b9db51b244542-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2fd5808ac9b1909764cc43d88a3d83a1",
         "x-ms-return-client-request-id": "true"
@@ -84,27 +90,27 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2d2b0e9e-a2a7-47f0-b002-323b1ea1ee59",
-        "Content-Length": "1356",
+        "apim-request-id": "88c66c15-9848-446d-af07-d6d9af58b545",
+        "Content-Length": "1390",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 29 Dec 2020 21:41:26 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "172",
-        "x-request-id": "2d2b0e9e-a2a7-47f0-b002-323b1ea1ee59"
+        "x-envoy-upstream-service-time": "148",
+        "x-request-id": "88c66c15-9848-446d-af07-d6d9af58b545"
       },
       "ResponseBody": {
-        "dataFeedId": "7a68f3cf-f819-4807-abdf-6c7117c9382f",
+        "dataFeedId": "0858ee7d-cf67-4975-bdda-d701c1d3df8a",
         "dataFeedName": "dataFeedP9n9URW6",
         "metrics": [
           {
-            "metricId": "16ee2a05-47cf-4acd-9cf4-003ff13a53e6",
+            "metricId": "41cd9de6-8086-410e-8c0a-16d2e7862ef2",
             "metricName": "cost",
             "metricDisplayName": "costDisplayName",
             "metricDescription": "costDescription"
           },
           {
-            "metricId": "ae927a79-0557-4ef1-a36e-355b1f2b83b1",
+            "metricId": "bcce4f4a-9a13-4e64-8dfd-5b252f9f3102",
             "metricName": "revenue",
             "metricDisplayName": "revenueDisplayName",
             "metricDescription": "revenueDescription"
@@ -139,12 +145,15 @@
         "maxConcurrency": 5,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
-        "viewers": [],
+        "viewers": [
+          "fake@viewer.com"
+        ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-29T21:41:26Z",
+        "createdTime": "2021-02-01T15:40:53Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%metric/%datafeed",
         "dataSourceParameter": {
@@ -154,13 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a68f3cf-f819-4807-abdf-6c7117c9382f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0858ee7d-cf67-4975-bdda-d701c1d3df8a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21c5194e62e13f49a03ce3c25a9a0dab-572fdb0d28e75a4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9250b2166e55884eb0dcd62a09386eed-f39ddf4aba02674b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c6589d421c17f0f97de1835868666960",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7a16dbef-8146-409f-af5f-1448693f0dda",
+        "apim-request-id": "6ad2fd90-2f07-40b9-bc0a-6d82a5ea5613",
         "Content-Length": "0",
-        "Date": "Tue, 29 Dec 2020 21:41:27 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "342",
-        "x-request-id": "7a16dbef-8146-409f-af5f-1448693f0dda"
+        "x-envoy-upstream-service-time": "431",
+        "x-request-id": "6ad2fd90-2f07-40b9-bc0a-6d82a5ea5613"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-29T13:41:26.8889642-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:53.9864679-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9845d326c705b34e94caf86df50f72ef-dd8b632a1bf10041-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7bee5bd096e7124388a5b01aeaa7d7f1-fdff40b9294a9942-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2b253105568840e019a295c200bb7121",
+        "x-ms-client-request-id": "c295a219bb0021710ded21845d78bc41",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +33,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5aa31fa5-1aa1-4574-9c2c-64c90f95c069",
+        "apim-request-id": "85a3ac7c-5139-4203-b69f-d940ad67fa85",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:37 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/08ce41f1-e870-40aa-9651-f32437c1d597",
+        "Date": "Mon, 01 Feb 2021 13:12:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "742",
-        "x-request-id": "5aa31fa5-1aa1-4574-9c2c-64c90f95c069"
+        "x-envoy-upstream-service-time": "942",
+        "x-request-id": "85a3ac7c-5139-4203-b69f-d940ad67fa85"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/08ce41f1-e870-40aa-9651-f32437c1d597",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-acbb7899e372dc4b9d1839235923069b-178b682d9852da45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4707e79c7f31fb49b927bf82960a9761-f837bde535e77845-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8421ed0d785d41bcbb4d02b481a5ff14",
+        "x-ms-client-request-id": "b4024dbba58114ff5713be9155053f82",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d5508fe8-8e9b-4c87-80b8-45e01e2b66af",
+        "apim-request-id": "754ece27-ca81-4591-b45c-2bd9643d7de6",
         "Content-Length": "996",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:37 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "312",
-        "x-request-id": "d5508fe8-8e9b-4c87-80b8-45e01e2b66af"
+        "x-envoy-upstream-service-time": "297",
+        "x-request-id": "754ece27-ca81-4591-b45c-2bd9643d7de6"
       },
       "ResponseBody": {
-        "dataFeedId": "08ce41f1-e870-40aa-9651-f32437c1d597",
+        "dataFeedId": "7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
         "dataFeedName": "dataFeedJ3xXSPId",
         "metrics": [
           {
-            "metricId": "49aec553-9b8e-44ae-a460-1c46ad7863bf",
+            "metricId": "fd4c3511-fc3b-4f68-9062-a29103946a3d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:37Z",
+        "createdTime": "2021-02-01T13:12:16Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +116,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/08ce41f1-e870-40aa-9651-f32437c1d597",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "710",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2abec30f74acb94ca2dec76b0ef81f34-5ab83f492d4a784c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fb1082b306158c49a2848508fb3efb72-1d61388f804da940-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "91be13570555823f039ae73816968c5a",
+        "x-ms-client-request-id": "38e79a0396165a8ce192a49e4da9898d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +137,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeedJ3xXSPId",
+        "dataFeedName": "dataFeedoAOYoy3P",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +161,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8b016ccc-0827-4474-b0ee-719853a97ab5",
+        "apim-request-id": "b9ca62d5-26ad-4a6a-8ada-af44bd37c196",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:38 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "864",
-        "x-request-id": "8b016ccc-0827-4474-b0ee-719853a97ab5"
+        "x-envoy-upstream-service-time": "855",
+        "x-request-id": "b9ca62d5-26ad-4a6a-8ada-af44bd37c196"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/08ce41f1-e870-40aa-9651-f32437c1d597",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fb8a1134bf34474e886fa05c95e91b53-9007e8ec2946f54a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c49f61f2cc738744ac8f70d98ee1bf1c-363088426c805f4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9ea492e1a94d8d8974e3703a532cbe74",
+        "x-ms-client-request-id": "3a70e3742c5374bea2816bedfde0cc08",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "686cb356-feb8-4330-a607-c81c4f1a0afc",
+        "apim-request-id": "5704e8b9-0185-48a6-a5b5-ef679f70ca6e",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:38 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "196",
-        "x-request-id": "686cb356-feb8-4330-a607-c81c4f1a0afc"
+        "x-envoy-upstream-service-time": "186",
+        "x-request-id": "5704e8b9-0185-48a6-a5b5-ef679f70ca6e"
       },
       "ResponseBody": {
-        "dataFeedId": "08ce41f1-e870-40aa-9651-f32437c1d597",
-        "dataFeedName": "dataFeedJ3xXSPId",
+        "dataFeedId": "7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+        "dataFeedName": "dataFeedoAOYoy3P",
         "metrics": [
           {
-            "metricId": "49aec553-9b8e-44ae-a460-1c46ad7863bf",
+            "metricId": "fd4c3511-fc3b-4f68-9062-a29103946a3d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureApplicationInsights",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +233,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:37Z",
+        "createdTime": "2021-02-01T13:12:16Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +245,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/08ce41f1-e870-40aa-9651-f32437c1d597",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d6e2a58a29f0f94bb8c7ba532dc1de49-35e1585a9be2dd40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6646b2f45080444ea485b84dc6ed5359-41642293fe9c634e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ed6b81a2e0fd08ccad9e80c391842b24",
+        "x-ms-client-request-id": "c3809ead8491242bc1a8d3ef0060c6ad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0b9e3852-3be6-47ef-9797-359705a41397",
+        "apim-request-id": "aa3dd47b-e4cc-40be-a7dd-570952fb2f92",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:39 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "329",
-        "x-request-id": "0b9e3852-3be6-47ef-9797-359705a41397"
+        "x-envoy-upstream-service-time": "324",
+        "x-request-id": "aa3dd47b-e4cc-40be-a7dd-570952fb2f92"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:39.4174216-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:17.6509850-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7bee5bd096e7124388a5b01aeaa7d7f1-fdff40b9294a9942-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1630a2b5dbbf7f479f0af1257a36b6ec-77600ff16c03ae49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c295a219bb0021710ded21845d78bc41",
         "x-ms-return-client-request-id": "true"
@@ -33,25 +36,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "85a3ac7c-5139-4203-b69f-d940ad67fa85",
+        "apim-request-id": "898fa0d1-1001-4c8e-814b-ba6bd125cf6f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+        "Date": "Mon, 01 Feb 2021 14:24:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e200cbff-1b80-495c-af23-539cb6330442",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "942",
-        "x-request-id": "85a3ac7c-5139-4203-b69f-d940ad67fa85"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "927",
+        "X-Request-ID": "898fa0d1-1001-4c8e-814b-ba6bd125cf6f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e200cbff-1b80-495c-af23-539cb6330442",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4707e79c7f31fb49b927bf82960a9761-f837bde535e77845-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5faced0845ba5f4a93b6c63fdbbddcc2-ac647d5c7effac46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b4024dbba58114ff5713be9155053f82",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "754ece27-ca81-4591-b45c-2bd9643d7de6",
+        "apim-request-id": "b0384244-df92-4a0f-a50e-bd5047db6bac",
         "Content-Length": "996",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:16 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "297",
-        "x-request-id": "754ece27-ca81-4591-b45c-2bd9643d7de6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1226",
+        "X-Request-ID": "b0384244-df92-4a0f-a50e-bd5047db6bac"
       },
       "ResponseBody": {
-        "dataFeedId": "7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+        "dataFeedId": "e200cbff-1b80-495c-af23-539cb6330442",
         "dataFeedName": "dataFeedJ3xXSPId",
         "metrics": [
           {
-            "metricId": "fd4c3511-fc3b-4f68-9062-a29103946a3d",
+            "metricId": "5d87c9a5-95ac-48cc-800a-0310b47dbb86",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:16Z",
+        "createdTime": "2021-02-01T14:24:30Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,15 +122,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e200cbff-1b80-495c-af23-539cb6330442",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "710",
+        "Content-Length": "727",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fb1082b306158c49a2848508fb3efb72-1d61388f804da940-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7ebf1aba2fcabc4b92c98d7902b2eb78-bfd0275a6d6dc148-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "38e79a0396165a8ce192a49e4da9898d",
         "x-ms-return-client-request-id": "true"
@@ -151,7 +160,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -161,24 +171,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b9ca62d5-26ad-4a6a-8ada-af44bd37c196",
+        "apim-request-id": "02fca53f-1160-43cf-a994-f2ea11a1b715",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:17 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "855",
-        "x-request-id": "b9ca62d5-26ad-4a6a-8ada-af44bd37c196"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "793",
+        "X-Request-ID": "02fca53f-1160-43cf-a994-f2ea11a1b715"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e200cbff-1b80-495c-af23-539cb6330442",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c49f61f2cc738744ac8f70d98ee1bf1c-363088426c805f4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2915f5ed9c96234cba96ba1fb0ddea98-38aa13343477314d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3a70e3742c5374bea2816bedfde0cc08",
         "x-ms-return-client-request-id": "true"
@@ -186,21 +199,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5704e8b9-0185-48a6-a5b5-ef679f70ca6e",
-        "Content-Length": "1122",
+        "apim-request-id": "ab0dff5c-23c4-4b67-b741-c7f8be2569c3",
+        "Content-Length": "1139",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:17 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "186",
-        "x-request-id": "5704e8b9-0185-48a6-a5b5-ef679f70ca6e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "269",
+        "X-Request-ID": "ab0dff5c-23c4-4b67-b741-c7f8be2569c3"
       },
       "ResponseBody": {
-        "dataFeedId": "7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+        "dataFeedId": "e200cbff-1b80-495c-af23-539cb6330442",
         "dataFeedName": "dataFeedoAOYoy3P",
         "metrics": [
           {
-            "metricId": "fd4c3511-fc3b-4f68-9062-a29103946a3d",
+            "metricId": "5d87c9a5-95ac-48cc-800a-0310b47dbb86",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -226,6 +239,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -233,7 +247,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:16Z",
+        "createdTime": "2021-02-01T14:24:30Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,13 +259,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7808d3fe-27ea-4cd7-a4f7-bd1b1fee97a9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e200cbff-1b80-495c-af23-539cb6330442",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6646b2f45080444ea485b84dc6ed5359-41642293fe9c634e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-73cbc9796cd55946a416ce4d3333cb66-7d4e998f1cfd414c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c3809ead8491242bc1a8d3ef0060c6ad",
         "x-ms-return-client-request-id": "true"
@@ -259,19 +276,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "aa3dd47b-e4cc-40be-a7dd-570952fb2f92",
+        "apim-request-id": "77f8324a-22b9-4171-8deb-4f526495d7cd",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:17 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "324",
-        "x-request-id": "aa3dd47b-e4cc-40be-a7dd-570952fb2f92"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "341",
+        "X-Request-ID": "77f8324a-22b9-4171-8deb-4f526495d7cd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:17.6509850-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:24:32.9608367-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-03ab1fa909cb7c49ae52f29426cd57a3-4874ca6587fdbe47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f60c5237b026a54f800e629a1d73231c-8cb54374ad52834e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c330beeee630bbd65d56432aa45adfe0",
+        "x-ms-client-request-id": "2a43565d5aa4e0dfa3428ca0e9d351b6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +36,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "60285bfc-afb7-483a-b592-ec5984c216c8",
+        "apim-request-id": "4d9b6f7e-bc6a-4e4f-8a09-77625c665688",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:02 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b1bbcef-b5ab-49e6-8c73-a1bb410d004a",
+        "Date": "Mon, 01 Feb 2021 13:41:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "619",
-        "x-request-id": "60285bfc-afb7-483a-b592-ec5984c216c8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1332",
+        "X-Request-ID": "4d9b6f7e-bc6a-4e4f-8a09-77625c665688"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b1bbcef-b5ab-49e6-8c73-a1bb410d004a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9bb9f3372574144c9c5adaabab0da822-99ccc0d2d72eaf4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-820a5e37c9d60640aaaabda663835ef9-cde12d8c6479574b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a08c42a3d3e9b6512db7fb6816b0cf7e",
+        "x-ms-client-request-id": "68fbb72db0167ecf7323ee9aa760fe33",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9d5cdcec-f73e-4411-afd5-a1f9f816184d",
+        "apim-request-id": "2e8434d9-2392-4b6a-913e-fcd8780013db",
         "Content-Length": "996",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:02 GMT",
+        "Date": "Mon, 01 Feb 2021 13:41:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "232",
-        "x-request-id": "9d5cdcec-f73e-4411-afd5-a1f9f816184d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "307",
+        "X-Request-ID": "2e8434d9-2392-4b6a-913e-fcd8780013db"
       },
       "ResponseBody": {
-        "dataFeedId": "8b1bbcef-b5ab-49e6-8c73-a1bb410d004a",
+        "dataFeedId": "8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
         "dataFeedName": "dataFeedZ3Hd3Bor",
         "metrics": [
           {
-            "metricId": "2854fceb-3bf1-4b0e-afdd-af9a532222ef",
+            "metricId": "17256f3a-19d2-4266-b648-19ccf6b4884f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:02Z",
+        "createdTime": "2021-02-01T13:41:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +122,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b1bbcef-b5ab-49e6-8c73-a1bb410d004a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "710",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9db75105ce594647935a0295658d42cc-30f7ba1bc5ff1c40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-733003d853ee764ebcb65980c0e06ffe-b675a5ff2175a54e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9aee237360a733fee1311b329f53cdc0",
+        "x-ms-client-request-id": "321b31e1539fc0cd1418adcec5fd271a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +146,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeedZ3Hd3Bor",
+        "dataFeedName": "dataFeedD7i9pDil",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +170,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6f4ed443-1568-48cb-b3aa-714f3b1a855e",
+        "apim-request-id": "71b82ab1-c7f0-4910-b903-3425e3d3bba9",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:03 GMT",
+        "Date": "Mon, 01 Feb 2021 13:41:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "750",
-        "x-request-id": "6f4ed443-1568-48cb-b3aa-714f3b1a855e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "834",
+        "X-Request-ID": "71b82ab1-c7f0-4910-b903-3425e3d3bba9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b1bbcef-b5ab-49e6-8c73-a1bb410d004a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61ff3d0a03fa8645aeb412fb507ad1f0-835a6fcc3bc1d04f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-012e6ab4810542488b8c4000cc008ce6-a21bbedb19ccec4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "cead1814fdc51a276d7a9679ea6da4ac",
+        "x-ms-client-request-id": "79967a6d6deaaca487c4b7816c443943",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e08d2cb7-a578-4597-a63f-b33668b4b8db",
+        "apim-request-id": "c3786627-9922-4887-b519-1f1d2632bc9b",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:03 GMT",
+        "Date": "Mon, 01 Feb 2021 13:41:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "e08d2cb7-a578-4597-a63f-b33668b4b8db"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "191",
+        "X-Request-ID": "c3786627-9922-4887-b519-1f1d2632bc9b"
       },
       "ResponseBody": {
-        "dataFeedId": "8b1bbcef-b5ab-49e6-8c73-a1bb410d004a",
-        "dataFeedName": "dataFeedZ3Hd3Bor",
+        "dataFeedId": "8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+        "dataFeedName": "dataFeedD7i9pDil",
         "metrics": [
           {
-            "metricId": "2854fceb-3bf1-4b0e-afdd-af9a532222ef",
+            "metricId": "17256f3a-19d2-4266-b648-19ccf6b4884f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureApplicationInsights",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +245,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:02Z",
+        "createdTime": "2021-02-01T13:41:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +257,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b1bbcef-b5ab-49e6-8c73-a1bb410d004a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3990874fc3263847a914ea79b2f17aa2-eed88ff6fe75cd46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b19f96747f578a4ca8d7991af7be3f43-46f662e7ab09c746-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "81b7c487446c43394358bfb7b81f16da",
+        "x-ms-client-request-id": "b7bf58431fb8da16ea3a54fe0201b975",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0a95f7d8-3a21-4de7-b3c4-9649b13434e8",
+        "apim-request-id": "f316e2b4-6839-45da-83ab-5baf5faaf83e",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:03 GMT",
+        "Date": "Mon, 01 Feb 2021 13:41:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "440",
-        "x-request-id": "0a95f7d8-3a21-4de7-b3c4-9649b13434e8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "372",
+        "X-Request-ID": "f316e2b4-6839-45da-83ab-5baf5faaf83e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:04.2589608-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:41:57.0771168-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f60c5237b026a54f800e629a1d73231c-8cb54374ad52834e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a19419e3c9c55640b28e0544f2903d6d-73124333bfaa4a4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2a43565d5aa4e0dfa3428ca0e9d351b6",
         "x-ms-return-client-request-id": "true"
@@ -36,28 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "4d9b6f7e-bc6a-4e4f-8a09-77625c665688",
+        "apim-request-id": "ffc127a1-f750-41bb-a1db-965339494d98",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:41:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+        "Date": "Mon, 01 Feb 2021 15:40:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00245112-e2b7-4fcd-b691-9a286189f14b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1332",
-        "X-Request-ID": "4d9b6f7e-bc6a-4e4f-8a09-77625c665688"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "524",
+        "x-request-id": "ffc127a1-f750-41bb-a1db-965339494d98"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00245112-e2b7-4fcd-b691-9a286189f14b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-820a5e37c9d60640aaaabda663835ef9-cde12d8c6479574b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ad1f970aec570646b3c4997d8ca94d3d-180a3488a2306942-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "68fbb72db0167ecf7323ee9aa760fe33",
         "x-ms-return-client-request-id": "true"
@@ -65,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2e8434d9-2392-4b6a-913e-fcd8780013db",
+        "apim-request-id": "3b49b292-2d26-4e91-a77e-f8569c7d5581",
         "Content-Length": "996",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:41:55 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "307",
-        "X-Request-ID": "2e8434d9-2392-4b6a-913e-fcd8780013db"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "168",
+        "x-request-id": "3b49b292-2d26-4e91-a77e-f8569c7d5581"
       },
       "ResponseBody": {
-        "dataFeedId": "8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+        "dataFeedId": "00245112-e2b7-4fcd-b691-9a286189f14b",
         "dataFeedName": "dataFeedZ3Hd3Bor",
         "metrics": [
           {
-            "metricId": "17256f3a-19d2-4266-b648-19ccf6b4884f",
+            "metricId": "c190f49e-7031-4a5e-a13e-d1a501495a6e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -110,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:41:55Z",
+        "createdTime": "2021-02-01T15:40:54Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -122,18 +116,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00245112-e2b7-4fcd-b691-9a286189f14b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "710",
+        "Content-Length": "727",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-733003d853ee764ebcb65980c0e06ffe-b675a5ff2175a54e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-20544ad599db5b41b625fe199fbc6e69-6bd79e9bdc8a164b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "321b31e1539fc0cd1418adcec5fd271a",
         "x-ms-return-client-request-id": "true"
@@ -160,7 +151,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -170,27 +162,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "71b82ab1-c7f0-4910-b903-3425e3d3bba9",
+        "apim-request-id": "0a79f5cc-d916-4957-ab7a-0198bede5c09",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:41:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "834",
-        "X-Request-ID": "71b82ab1-c7f0-4910-b903-3425e3d3bba9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "600",
+        "x-request-id": "0a79f5cc-d916-4957-ab7a-0198bede5c09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00245112-e2b7-4fcd-b691-9a286189f14b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-012e6ab4810542488b8c4000cc008ce6-a21bbedb19ccec4d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-63479e4e9aae1f458a0b87fa5dec14af-115b3abcc086ac4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "79967a6d6deaaca487c4b7816c443943",
         "x-ms-return-client-request-id": "true"
@@ -198,21 +187,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c3786627-9922-4887-b519-1f1d2632bc9b",
-        "Content-Length": "1122",
+        "apim-request-id": "fe17084b-4818-400b-ba3f-0bc04d42f5e8",
+        "Content-Length": "1139",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:41:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "X-Request-ID": "c3786627-9922-4887-b519-1f1d2632bc9b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "173",
+        "x-request-id": "fe17084b-4818-400b-ba3f-0bc04d42f5e8"
       },
       "ResponseBody": {
-        "dataFeedId": "8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+        "dataFeedId": "00245112-e2b7-4fcd-b691-9a286189f14b",
         "dataFeedName": "dataFeedD7i9pDil",
         "metrics": [
           {
-            "metricId": "17256f3a-19d2-4266-b648-19ccf6b4884f",
+            "metricId": "c190f49e-7031-4a5e-a13e-d1a501495a6e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -238,6 +227,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -245,7 +235,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:41:55Z",
+        "createdTime": "2021-02-01T15:40:54Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -257,16 +247,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8fe7d56d-4a3b-4a06-aa80-bf90882d7d58",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00245112-e2b7-4fcd-b691-9a286189f14b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b19f96747f578a4ca8d7991af7be3f43-46f662e7ab09c746-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-5170157e7e3ad2409f867c02656dd7ed-3ded6b76290d3e4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b7bf58431fb8da16ea3a54fe0201b975",
         "x-ms-return-client-request-id": "true"
@@ -274,19 +261,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f316e2b4-6839-45da-83ab-5baf5faaf83e",
+        "apim-request-id": "1e176b9c-4e29-45c8-9946-3e045d9030d2",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:41:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "372",
-        "X-Request-ID": "f316e2b4-6839-45da-83ab-5baf5faaf83e"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "314",
+        "x-request-id": "1e176b9c-4e29-45c8-9946-3e045d9030d2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:41:57.0771168-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:56.0780602-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ea96263924d7044683c1df249574bfc4-51aac1fd289dce4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b2ab2497a837724a89df8fcc5d09b90a-d4f1e70077a0b148-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1b2827badc19724f265bc77e35bff52e",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "64d4ab9b-fd22-489a-878d-cf07e286ae09",
+        "apim-request-id": "ae44fa58-34c8-4044-98a0-61d6cde599b0",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
+        "Date": "Mon, 01 Feb 2021 15:52:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/50f3eafc-5813-4721-8b5f-29bf92047418",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "673",
-        "x-request-id": "64d4ab9b-fd22-489a-878d-cf07e286ae09"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "5903",
+        "X-Request-ID": "ae44fa58-34c8-4044-98a0-61d6cde599b0"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/50f3eafc-5813-4721-8b5f-29bf92047418",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5a1be716eb705740801924fbb1df6691-8169db0efd2ab84f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-badd10bf1a2835449361358481c78602-b0d618719466a64b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "63db7d2d6a081c6d1dd880eac78a86af",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedmvyQGbvf",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9278c905-df35-4d23-9162-e763b10dccf1",
+        "apim-request-id": "951f3cd4-327f-43d9-a82b-2364b694ae5b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:21 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "871",
-        "x-request-id": "9278c905-df35-4d23-9162-e763b10dccf1"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "304",
+        "X-Request-ID": "951f3cd4-327f-43d9-a82b-2364b694ae5b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/50f3eafc-5813-4721-8b5f-29bf92047418",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21ca5f5900313142ae6729154b1235e4-0da5cb264140f54e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c6329b8e1164864eb1e9f98f00b7b7a5-0515ad28edf14b40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2613fe2daf552508aa5bb9506efbc1b5",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "42d0c767-1ba6-4ebd-8b74-ed2b756e3c75",
+        "apim-request-id": "b431d14c-449d-4833-a0ee-952f834af58d",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:21 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "251",
-        "x-request-id": "42d0c767-1ba6-4ebd-8b74-ed2b756e3c75"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "280",
+        "X-Request-ID": "b431d14c-449d-4833-a0ee-952f834af58d"
       },
       "ResponseBody": {
-        "dataFeedId": "d199033c-ecb4-4f73-8365-134477a3b226",
+        "dataFeedId": "50f3eafc-5813-4721-8b5f-29bf92047418",
         "dataFeedName": "dataFeedmvyQGbvf",
         "metrics": [
           {
-            "metricId": "5d67198c-2f60-4df1-b78b-19624631b3e8",
+            "metricId": "72a0a66c-e332-4024-afde-5f0f2e135768",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:21Z",
+        "createdTime": "2021-02-01T15:52:19Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/50f3eafc-5813-4721-8b5f-29bf92047418",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1bc03b6ced8e9947b06d0d165a6a79ea-043e704164edc443-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c73ba5b23db5ef4bbd188d81239b11d4-82be286ee13e1243-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dc2a38cbd48f4f7dba0cfe415c64ab9c",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "13c5741b-51b4-4efa-ba9f-be9bb8691045",
+        "apim-request-id": "0ca4b96b-d2d5-4e3b-b3d2-1e7b5406f18b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:22 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "356",
-        "x-request-id": "13c5741b-51b4-4efa-ba9f-be9bb8691045"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "385",
+        "X-Request-ID": "0ca4b96b-d2d5-4e3b-b3d2-1e7b5406f18b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:22.5235782-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:20.4432490-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-28c501d870a44447b605ff778defdbaf-e2cc1acd7e56e74d-00",
+        "traceparent": "00-ea96263924d7044683c1df249574bfc4-51aac1fd289dce4c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d3a8d9dc83f3a28eaccf087a6cd85735",
+        "x-ms-client-request-id": "1b2827badc19724f265bc77e35bff52e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,7 +22,7 @@
           "query": "query"
         },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeedugsxlZFc",
+        "dataFeedName": "dataFeed1IlWlJRN",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -33,40 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b48118af-6aa7-481c-858c-d7b7eba322a8",
+        "apim-request-id": "64d4ab9b-fd22-489a-878d-cf07e286ae09",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
+        "Date": "Mon, 01 Feb 2021 15:45:20 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "583",
-        "x-request-id": "b48118af-6aa7-481c-858c-d7b7eba322a8"
+        "x-envoy-upstream-service-time": "673",
+        "x-request-id": "64d4ab9b-fd22-489a-878d-cf07e286ae09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "598",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0c87db19312f9b40aa2346114785ae2f-2bb7237801acb049-00",
+        "traceparent": "00-5a1be716eb705740801924fbb1df6691-8169db0efd2ab84f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7ebf58a14b9a42924b9ec585011005aa",
+        "x-ms-client-request-id": "63db7d2d6a081c6d1dd880eac78a86af",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "azureCloud": "cloud",
-          "applicationId": "appId",
-          "apiKey": "Sanitized",
-          "query": "query"
-        },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeedvcLRzREy",
+        "dataFeedName": "dataFeedmvyQGbvf",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -83,46 +77,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d2e11854-8848-4360-bde9-52256fd55e6b",
+        "apim-request-id": "9278c905-df35-4d23-9162-e763b10dccf1",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:19 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "671",
-        "x-request-id": "d2e11854-8848-4360-bde9-52256fd55e6b"
+        "x-envoy-upstream-service-time": "871",
+        "x-request-id": "9278c905-df35-4d23-9162-e763b10dccf1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3b0952f275b99c4db2ca01b14279f2f7-ca0338020be0e74f-00",
+        "traceparent": "00-21ca5f5900313142ae6729154b1235e4-0da5cb264140f54e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "adec920b8c172339e968e75e5a2ea082",
+        "x-ms-client-request-id": "2613fe2daf552508aa5bb9506efbc1b5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb369669-16f3-4d4c-9f4e-37cc11d21b1c",
+        "apim-request-id": "42d0c767-1ba6-4ebd-8b74-ed2b756e3c75",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:19 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "bb369669-16f3-4d4c-9f4e-37cc11d21b1c"
+        "x-envoy-upstream-service-time": "251",
+        "x-request-id": "42d0c767-1ba6-4ebd-8b74-ed2b756e3c75"
       },
       "ResponseBody": {
-        "dataFeedId": "6d01f4f0-656e-426b-bb91-6ced024564e4",
-        "dataFeedName": "dataFeedvcLRzREy",
+        "dataFeedId": "d199033c-ecb4-4f73-8365-134477a3b226",
+        "dataFeedName": "dataFeedmvyQGbvf",
         "metrics": [
           {
-            "metricId": "caadb266-ec3d-42e6-865a-13ed2b62cbf2",
+            "metricId": "5d67198c-2f60-4df1-b78b-19624631b3e8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -155,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:18Z",
+        "createdTime": "2021-02-01T15:45:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,37 +161,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d199033c-ecb4-4f73-8365-134477a3b226",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c6ce7126eaa93e4aaadbc753654b338f-344bc6f9c0fa384e-00",
+        "traceparent": "00-1bc03b6ced8e9947b06d0d165a6a79ea-043e704164edc443-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f051cbf2ef4e91be47668754bd09a09b",
+        "x-ms-client-request-id": "dc2a38cbd48f4f7dba0cfe415c64ab9c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "bc81ea8d-e3bb-4c0d-ae26-073f8af449b0",
+        "apim-request-id": "13c5741b-51b4-4efa-ba9f-be9bb8691045",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:19 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "341",
-        "x-request-id": "bc81ea8d-e3bb-4c0d-ae26-073f8af449b0"
+        "x-envoy-upstream-service-time": "356",
+        "x-request-id": "13c5741b-51b4-4efa-ba9f-be9bb8691045"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:19.6036880-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:22.5235782-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "1942079703"
+    "RandomSeed": "2131770228"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dbbc8ebba445e648a4229750dbde4aab-1971ccce7c1d144e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-28c501d870a44447b605ff778defdbaf-e2cc1acd7e56e74d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f301495b0d48586edcd9a8d3f3838ea2",
+        "x-ms-client-request-id": "d3a8d9dc83f3a28eaccf087a6cd85735",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +33,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "803c9a62-5673-4e05-95db-6503649b66bf",
+        "apim-request-id": "b48118af-6aa7-481c-858c-d7b7eba322a8",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fde9976-6693-4858-897e-baf6b2ac4531",
+        "Date": "Mon, 01 Feb 2021 13:12:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "631",
-        "x-request-id": "803c9a62-5673-4e05-95db-6503649b66bf"
+        "x-envoy-upstream-service-time": "583",
+        "x-request-id": "b48118af-6aa7-481c-858c-d7b7eba322a8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fde9976-6693-4858-897e-baf6b2ac4531",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "598",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c722cd20dbae3847b95dd6d35f21f3de-b07af7a55357174f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0c87db19312f9b40aa2346114785ae2f-2bb7237801acb049-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7a08cfacd86c3557a158bf7e9a4b9242",
+        "x-ms-client-request-id": "7ebf58a14b9a42924b9ec585011005aa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +66,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeedugsxlZFc",
+        "dataFeedName": "dataFeedvcLRzREy",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +83,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5e185517-ca83-46fe-97ce-39fcdb52c6f1",
+        "apim-request-id": "d2e11854-8848-4360-bde9-52256fd55e6b",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "654",
-        "x-request-id": "5e185517-ca83-46fe-97ce-39fcdb52c6f1"
+        "x-envoy-upstream-service-time": "671",
+        "x-request-id": "d2e11854-8848-4360-bde9-52256fd55e6b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fde9976-6693-4858-897e-baf6b2ac4531",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-40e1c1e89bf0014bbc7309b47bdebab3-a4c7c52034871b45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3b0952f275b99c4db2ca01b14279f2f7-ca0338020be0e74f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "85c59e4b1001aa050b92ecad178c3923",
+        "x-ms-client-request-id": "adec920b8c172339e968e75e5a2ea082",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3e1f5252-c5bb-4328-9387-cf3258f418cc",
+        "apim-request-id": "bb369669-16f3-4d4c-9f4e-37cc11d21b1c",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "182",
-        "x-request-id": "3e1f5252-c5bb-4328-9387-cf3258f418cc"
+        "x-envoy-upstream-service-time": "151",
+        "x-request-id": "bb369669-16f3-4d4c-9f4e-37cc11d21b1c"
       },
       "ResponseBody": {
-        "dataFeedId": "0fde9976-6693-4858-897e-baf6b2ac4531",
-        "dataFeedName": "dataFeedugsxlZFc",
+        "dataFeedId": "6d01f4f0-656e-426b-bb91-6ced024564e4",
+        "dataFeedName": "dataFeedvcLRzREy",
         "metrics": [
           {
-            "metricId": "e6d045c2-fff0-46d3-a69a-3acb1fa996d4",
+            "metricId": "caadb266-ec3d-42e6-865a-13ed2b62cbf2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureApplicationInsights",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +155,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:40Z",
+        "createdTime": "2021-02-01T13:12:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +167,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0fde9976-6693-4858-897e-baf6b2ac4531",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6d01f4f0-656e-426b-bb91-6ced024564e4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-77cf8b5b89d35644aca062820aa6bfc5-5efdabc3b5bc0945-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c6ce7126eaa93e4aaadbc753654b338f-344bc6f9c0fa384e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5ee768e92e5a82a0f2cb51f04eefbe91",
+        "x-ms-client-request-id": "f051cbf2ef4e91be47668754bd09a09b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4b3189cf-7fa7-419e-879a-b4827a00fb4a",
+        "apim-request-id": "bc81ea8d-e3bb-4c0d-ae26-073f8af449b0",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:41 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "343",
-        "x-request-id": "4b3189cf-7fa7-419e-879a-b4827a00fb4a"
+        "x-envoy-upstream-service-time": "341",
+        "x-request-id": "bc81ea8d-e3bb-4c0d-ae26-073f8af449b0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:41.6051096-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:19.6036880-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d7ccfdc6b302c74aa06ec5118a1c64cd-a5d446ddc8c32446-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c1332dec69c18b40a78e82b307bc40c4-33823d75a1efcc48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "19779c0844b7646fb0357df753266ec9",
         "x-ms-return-client-request-id": "true"
@@ -36,41 +33,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "06ee5f2f-0ee2-46f0-8913-b7e99f2f2361",
+        "apim-request-id": "91d45388-7d4c-4bb6-a325-877b231cd271",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:41:58 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
+        "Date": "Mon, 01 Feb 2021 15:40:56 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1949",
-        "X-Request-ID": "06ee5f2f-0ee2-46f0-8913-b7e99f2f2361"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "447",
+        "x-request-id": "91d45388-7d4c-4bb6-a325-877b231cd271"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "598",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f05e3dcc061f784db7bb355b3189d0eb-372bc72928305c41-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-2639e1ba1b0eaf45b5b32f2ac9dcecb3-3959cc1783ceae41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5c74fa795a62c84fc005b175be262b33",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "azureCloud": "cloud",
-          "applicationId": "appId",
-          "apiKey": "Sanitized",
-          "query": "query"
-        },
         "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedkJ1Wdoj9",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
@@ -89,27 +77,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d5e5db0f-910c-400c-8453-467cc4a0691a",
+        "apim-request-id": "f413d5b2-2f1c-40ea-8fd0-4d26f6e89962",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:41:59 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "568",
-        "X-Request-ID": "d5e5db0f-910c-400c-8453-467cc4a0691a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "181",
+        "x-request-id": "f413d5b2-2f1c-40ea-8fd0-4d26f6e89962"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f9c49f5f1ecbdd4ab994b181ae4d47db-ddc9027de0305b4e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-b31384723b0e2c47980cf7d5c47b9fbb-e199473cdfd7b44f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5015229b8e97710b49b80595dca1388c",
         "x-ms-return-client-request-id": "true"
@@ -117,21 +102,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cfd56cd2-6ec7-46e9-8d6f-24075d53cd17",
+        "apim-request-id": "7c9744d5-108a-47ff-9cca-c7c169a18c74",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:41:59 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "192",
-        "X-Request-ID": "cfd56cd2-6ec7-46e9-8d6f-24075d53cd17"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "7c9744d5-108a-47ff-9cca-c7c169a18c74"
       },
       "ResponseBody": {
-        "dataFeedId": "78176d5b-7514-4756-90b1-434f28776eaf",
+        "dataFeedId": "052379a0-88ae-406a-87ea-0a47a3990569",
         "dataFeedName": "dataFeedkJ1Wdoj9",
         "metrics": [
           {
-            "metricId": "35d1391c-4653-417b-b97f-f3eaf016576c",
+            "metricId": "1d714e8b-bded-454a-bf45-e784b18fd0b9",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -164,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:41:58Z",
+        "createdTime": "2021-02-01T15:40:56Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -176,16 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c38de6618cb2b44ea5b5751aaa970cb4-f765266ada19f44b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-de4e4bee960f7443af11189f4dbe0516-92a6f9abb94d0a41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d4464c32fe15ad0c4cae58b192faa58a",
         "x-ms-return-client-request-id": "true"
@@ -193,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c4551e03-0756-4059-ac7b-e6362aed2aa0",
+        "apim-request-id": "d11753b7-bd41-4708-bc07-fc96383adde4",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:41:59 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "342",
-        "X-Request-ID": "c4551e03-0756-4059-ac7b-e6362aed2aa0"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "313",
+        "x-request-id": "d11753b7-bd41-4708-bc07-fc96383adde4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:00.3518710-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:57.3771260-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee38995df903374990fe9cce14538fe3-2a69d7da0ef72948-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d7ccfdc6b302c74aa06ec5118a1c64cd-a5d446ddc8c32446-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c015a1b289cf6e5b089c7719b7446f64",
+        "x-ms-client-request-id": "19779c0844b7646fb0357df753266ec9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +36,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2c99b68a-7d25-4c50-b028-33ca2469e6d7",
+        "apim-request-id": "06ee5f2f-0ee2-46f0-8913-b7e99f2f2361",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:04 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1238b101-d481-4d37-b690-79d6e5492252",
+        "Date": "Mon, 01 Feb 2021 13:41:58 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "746",
-        "x-request-id": "2c99b68a-7d25-4c50-b028-33ca2469e6d7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1949",
+        "X-Request-ID": "06ee5f2f-0ee2-46f0-8913-b7e99f2f2361"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1238b101-d481-4d37-b690-79d6e5492252",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "598",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f06ff37959f48d418c95e2953fcac38f-23f1c76f22da2449-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f05e3dcc061f784db7bb355b3189d0eb-372bc72928305c41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f77d35b02653c96e79fa745c625a4fc8",
+        "x-ms-client-request-id": "5c74fa795a62c84fc005b175be262b33",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +72,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeed5qDFtNKp",
+        "dataFeedName": "dataFeedkJ1Wdoj9",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +89,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "76487bfe-bcd9-43c8-84da-472036f9d6bc",
+        "apim-request-id": "d5e5db0f-910c-400c-8453-467cc4a0691a",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:05 GMT",
+        "Date": "Mon, 01 Feb 2021 13:41:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "706",
-        "x-request-id": "76487bfe-bcd9-43c8-84da-472036f9d6bc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "568",
+        "X-Request-ID": "d5e5db0f-910c-400c-8453-467cc4a0691a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1238b101-d481-4d37-b690-79d6e5492252",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-55f19242cfb2584aada616bcc7289922-f7dd59b1ff7c9f45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f9c49f5f1ecbdd4ab994b181ae4d47db-ddc9027de0305b4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "75b105c026be332b9b221550978e0b71",
+        "x-ms-client-request-id": "5015229b8e97710b49b80595dca1388c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae906e6b-c619-4517-be98-8d734801dd48",
+        "apim-request-id": "cfd56cd2-6ec7-46e9-8d6f-24075d53cd17",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:05 GMT",
+        "Date": "Mon, 01 Feb 2021 13:41:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "186",
-        "x-request-id": "ae906e6b-c619-4517-be98-8d734801dd48"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "192",
+        "X-Request-ID": "cfd56cd2-6ec7-46e9-8d6f-24075d53cd17"
       },
       "ResponseBody": {
-        "dataFeedId": "1238b101-d481-4d37-b690-79d6e5492252",
-        "dataFeedName": "dataFeed5qDFtNKp",
+        "dataFeedId": "78176d5b-7514-4756-90b1-434f28776eaf",
+        "dataFeedName": "dataFeedkJ1Wdoj9",
         "metrics": [
           {
-            "metricId": "9c4e1749-ffbd-4f79-aff5-68651099fa28",
+            "metricId": "35d1391c-4653-417b-b97f-f3eaf016576c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureApplicationInsights",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +164,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:05Z",
+        "createdTime": "2021-02-01T13:41:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +176,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1238b101-d481-4d37-b690-79d6e5492252",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78176d5b-7514-4756-90b1-434f28776eaf",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fdc92abbb4078743a7fdf4ef09700a00-2df0eaf49717bf48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c38de6618cb2b44ea5b5751aaa970cb4-f765266ada19f44b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9505b849a1dc8c38324c46d415fe0cad",
+        "x-ms-client-request-id": "d4464c32fe15ad0c4cae58b192faa58a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "222d4dcb-095f-4fe3-bfa4-0d5af6adaa1a",
+        "apim-request-id": "c4551e03-0756-4059-ac7b-e6362aed2aa0",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:05 GMT",
+        "Date": "Mon, 01 Feb 2021 13:41:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "341",
-        "x-request-id": "222d4dcb-095f-4fe3-bfa4-0d5af6adaa1a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "342",
+        "X-Request-ID": "c4551e03-0756-4059-ac7b-e6362aed2aa0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:06.5562607-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:00.3518710-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c1332dec69c18b40a78e82b307bc40c4-33823d75a1efcc48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ba92fd4169cc7d419188cc939a0efaa5-a0c9a18fbf580243-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "19779c0844b7646fb0357df753266ec9",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "91d45388-7d4c-4bb6-a325-877b231cd271",
+        "apim-request-id": "15b353d5-ef1c-49f4-a8a1-0509833b1f34",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:40:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
+        "Date": "Mon, 01 Feb 2021 15:52:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df4684e3-d924-47c5-b134-a0703027fae9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "447",
-        "x-request-id": "91d45388-7d4c-4bb6-a325-877b231cd271"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "470",
+        "X-Request-ID": "15b353d5-ef1c-49f4-a8a1-0509833b1f34"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df4684e3-d924-47c5-b134-a0703027fae9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2639e1ba1b0eaf45b5b32f2ac9dcecb3-3959cc1783ceae41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-866f1e2b3c84f14085fb856c9d04396a-d499ae1881ddc340-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5c74fa795a62c84fc005b175be262b33",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedkJ1Wdoj9",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f413d5b2-2f1c-40ea-8fd0-4d26f6e89962",
+        "apim-request-id": "ee25e8b4-41a5-45c0-88b2-83282c103c1b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:40:57 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "181",
-        "x-request-id": "f413d5b2-2f1c-40ea-8fd0-4d26f6e89962"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "X-Request-ID": "ee25e8b4-41a5-45c0-88b2-83282c103c1b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df4684e3-d924-47c5-b134-a0703027fae9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b31384723b0e2c47980cf7d5c47b9fbb-e199473cdfd7b44f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0eece3a360c5f14abe32b256444ba1a1-1e3e412d8ed43348-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5015229b8e97710b49b80595dca1388c",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7c9744d5-108a-47ff-9cca-c7c169a18c74",
+        "apim-request-id": "ffd0fb40-0ae2-4f55-bcb6-feff01a28273",
         "Content-Length": "1122",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:40:57 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "157",
-        "x-request-id": "7c9744d5-108a-47ff-9cca-c7c169a18c74"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "147",
+        "X-Request-ID": "ffd0fb40-0ae2-4f55-bcb6-feff01a28273"
       },
       "ResponseBody": {
-        "dataFeedId": "052379a0-88ae-406a-87ea-0a47a3990569",
+        "dataFeedId": "df4684e3-d924-47c5-b134-a0703027fae9",
         "dataFeedName": "dataFeedkJ1Wdoj9",
         "metrics": [
           {
-            "metricId": "1d714e8b-bded-454a-bf45-e784b18fd0b9",
+            "metricId": "2a4ac9c3-3843-4837-9bc8-4d9c8adcdbae",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:40:56Z",
+        "createdTime": "2021-02-01T15:52:51Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/052379a0-88ae-406a-87ea-0a47a3990569",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df4684e3-d924-47c5-b134-a0703027fae9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-de4e4bee960f7443af11189f4dbe0516-92a6f9abb94d0a41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d9e5718f1979f141b72ea6bf3505d830-fb594d60787b0440-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d4464c32fe15ad0c4cae58b192faa58a",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d11753b7-bd41-4708-bc07-fc96383adde4",
+        "apim-request-id": "6447b22d-35b9-42e6-949c-379f2b968549",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:40:57 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "313",
-        "x-request-id": "d11753b7-bd41-4708-bc07-fc96383adde4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "285",
+        "X-Request-ID": "6447b22d-35b9-42e6-949c-379f2b968549"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:40:57.3771260-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:52.4565491-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e6f0493f0e7f934e8b686ef959c21f63-246e395f6b231c47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d494fec56f248645a34a32f31d54ecd3-50b4d83d76b1a04b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "140824e99fa52887c308d2bcf5a933df",
         "x-ms-return-client-request-id": "true"
@@ -33,55 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e4be6b4f-326e-4736-b60c-cb8698488070",
+        "apim-request-id": "adef1944-a8f3-4098-bdaa-be934c312a25",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:40:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
+        "Date": "Mon, 01 Feb 2021 15:52:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19431fea-be0d-4fb4-a506-e1dbdf24d7e0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "765",
-        "x-request-id": "e4be6b4f-326e-4736-b60c-cb8698488070"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "473",
+        "X-Request-ID": "adef1944-a8f3-4098-bdaa-be934c312a25"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19431fea-be0d-4fb4-a506-e1dbdf24d7e0",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a9d73868e897cf46af90d556c3b5ee24-e510f81b609d3c40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5180d2abeb3bc247992a176c90dc83ac-a51d23d2abf9a94f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "de28f8eb928d00b3c78591ae88cc5b6f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2066d3a0-6c86-4640-8f07-afc6d50cb8dd",
+        "apim-request-id": "fa71a2d6-a2ed-4602-b608-bf6c103b54e5",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:40:55 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "242",
-        "x-request-id": "2066d3a0-6c86-4640-8f07-afc6d50cb8dd"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "X-Request-ID": "fa71a2d6-a2ed-4602-b608-bf6c103b54e5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19431fea-be0d-4fb4-a506-e1dbdf24d7e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7f69288e1aa20b44a3a8000d7b3d6983-4c321e2066cb0540-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4c1b5c04e7726f4c9836c061515daf2e-af329bde7a119b44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ecc0dcc51b9d3e68ad61fe72969abc0e",
         "x-ms-return-client-request-id": "true"
@@ -89,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fa6758c2-56e9-4b72-8a75-8bb1d1dd4e47",
+        "apim-request-id": "091d061d-525f-484c-b814-0307ecfe28f8",
         "Content-Length": "1047",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:40:55 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "217",
-        "x-request-id": "fa6758c2-56e9-4b72-8a75-8bb1d1dd4e47"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "X-Request-ID": "091d061d-525f-484c-b814-0307ecfe28f8"
       },
       "ResponseBody": {
-        "dataFeedId": "726afd0d-5366-4aaf-a281-02f2c0e622b4",
+        "dataFeedId": "19431fea-be0d-4fb4-a506-e1dbdf24d7e0",
         "dataFeedName": "dataFeedzIoAIA4x",
         "metrics": [
           {
-            "metricId": "0e35649c-8c24-4e6a-9014-0e1d553bc27e",
+            "metricId": "335266c8-13ad-4bdd-ba6f-fbb3f4535da9",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -134,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:40:55Z",
+        "createdTime": "2021-02-01T15:52:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -146,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19431fea-be0d-4fb4-a506-e1dbdf24d7e0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-deda1a13d6fc9a47990212ddb95ffb98-6e565bcdfd6ef746-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ef1d309770e1c54cbda6c9741ee5c96e-8823d899bf7a5e4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "501d09e4e36e569e70074d1f0dd99ff7",
         "x-ms-return-client-request-id": "true"
@@ -160,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3b5ffeaa-fded-4c91-804b-71535445792d",
+        "apim-request-id": "fc47acfc-bdd1-4b21-8dc0-4e7a73237872",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:40:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "411",
-        "x-request-id": "3b5ffeaa-fded-4c91-804b-71535445792d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "289",
+        "X-Request-ID": "fc47acfc-bdd1-4b21-8dc0-4e7a73237872"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:40:55.9893092-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:21.7936109-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-40f165993a2d024d97893299c8fd6203-df6aaef1c3dd9b48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e6f0493f0e7f934e8b686ef959c21f63-246e395f6b231c47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "140824e99fa52887c308d2bcf5a933df",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +33,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0d4f1b9a-2683-48cb-8dfa-9f8b2016d139",
+        "apim-request-id": "e4be6b4f-326e-4736-b60c-cb8698488070",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:42 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/61fe0286-a72a-4bc9-a69f-c15364a87efd",
+        "Date": "Mon, 01 Feb 2021 12:40:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "937",
-        "x-request-id": "0d4f1b9a-2683-48cb-8dfa-9f8b2016d139"
+        "x-envoy-upstream-service-time": "765",
+        "x-request-id": "e4be6b4f-326e-4736-b60c-cb8698488070"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/61fe0286-a72a-4bc9-a69f-c15364a87efd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "300",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3fedd9b4cdcc1e4f9a85afde1fcaf10a-2c06ad9c67ea844c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a9d73868e897cf46af90d556c3b5ee24-e510f81b609d3c40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "de28f8eb928d00b3c78591ae88cc5b6f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "azureCloud": "cloud",
-          "applicationId": "appId",
-          "apiKey": "Sanitized",
-          "query": "query"
-        },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeedzIoAIA4x",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f6326813-ce86-42ca-bb5c-c196a86b7f10",
+        "apim-request-id": "2066d3a0-6c86-4640-8f07-afc6d50cb8dd",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:42 GMT",
+        "Date": "Mon, 01 Feb 2021 12:40:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "503",
-        "x-request-id": "f6326813-ce86-42ca-bb5c-c196a86b7f10"
+        "x-envoy-upstream-service-time": "242",
+        "x-request-id": "2066d3a0-6c86-4640-8f07-afc6d50cb8dd"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/61fe0286-a72a-4bc9-a69f-c15364a87efd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c00409286f911946ac25ea4e0222815f-9ee0c1fb2ec03545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7f69288e1aa20b44a3a8000d7b3d6983-4c321e2066cb0540-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ecc0dcc51b9d3e68ad61fe72969abc0e",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +89,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "30aafa4b-976f-4deb-91df-e5074653d6f1",
+        "apim-request-id": "fa6758c2-56e9-4b72-8a75-8bb1d1dd4e47",
         "Content-Length": "1047",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:42 GMT",
+        "Date": "Mon, 01 Feb 2021 12:40:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "224",
-        "x-request-id": "30aafa4b-976f-4deb-91df-e5074653d6f1"
+        "x-envoy-upstream-service-time": "217",
+        "x-request-id": "fa6758c2-56e9-4b72-8a75-8bb1d1dd4e47"
       },
       "ResponseBody": {
-        "dataFeedId": "61fe0286-a72a-4bc9-a69f-c15364a87efd",
+        "dataFeedId": "726afd0d-5366-4aaf-a281-02f2c0e622b4",
         "dataFeedName": "dataFeedzIoAIA4x",
         "metrics": [
           {
-            "metricId": "bc45f24a-f2c8-4dce-941b-a41e2896193b",
+            "metricId": "0e35649c-8c24-4e6a-9014-0e1d553bc27e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +134,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:42Z",
+        "createdTime": "2021-02-01T12:40:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +146,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/61fe0286-a72a-4bc9-a69f-c15364a87efd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/726afd0d-5366-4aaf-a281-02f2c0e622b4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b2e993258b1e43469930f53071d041f6-a0846b4abe86ce44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-deda1a13d6fc9a47990212ddb95ffb98-6e565bcdfd6ef746-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "501d09e4e36e569e70074d1f0dd99ff7",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +160,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "138c4011-06b4-43c8-a07f-e3c304d440ee",
+        "apim-request-id": "3b5ffeaa-fded-4c91-804b-71535445792d",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:43 GMT",
+        "Date": "Mon, 01 Feb 2021 12:40:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "345",
-        "x-request-id": "138c4011-06b4-43c8-a07f-e3c304d440ee"
+        "x-envoy-upstream-service-time": "411",
+        "x-request-id": "3b5ffeaa-fded-4c91-804b-71535445792d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:43.7903131-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:40:55.9893092-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-da15132379b10c46af1fb7ad9267aeba-17e79f2c843ee34b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-43713f830090d94e8286ed8aa4dab0b1-4e0cb34bb9feb14d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "208258805194964d6e8bd9937612175d",
         "x-ms-return-client-request-id": "true"
@@ -33,55 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b63e7b22-6194-436a-93e7-466eb055a3da",
+        "apim-request-id": "f3124ee4-32a1-425c-9049-e855fc7fb288",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:40:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
+        "Date": "Mon, 01 Feb 2021 15:52:53 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c666e157-3721-4da6-bfa1-1027981e242e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "449",
-        "x-request-id": "b63e7b22-6194-436a-93e7-466eb055a3da"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "619",
+        "X-Request-ID": "f3124ee4-32a1-425c-9049-e855fc7fb288"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c666e157-3721-4da6-bfa1-1027981e242e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cea125285966fd42bd0795326b320aea-ed7a3bdf22323d47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fd2e64b9fb0ebd45b83b61427a218ce0-ef1190801c95bc4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6151095886eb00ac7a0c70e2fa7f5810",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "514440ea-eca7-48f1-a111-aaef86b022ad",
+        "apim-request-id": "d127e0d6-4aae-4ae5-92f5-029b81075aae",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:40:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "514440ea-eca7-48f1-a111-aaef86b022ad"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "X-Request-ID": "d127e0d6-4aae-4ae5-92f5-029b81075aae"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c666e157-3721-4da6-bfa1-1027981e242e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0c8d3fbd08b9dc418dda15c461a1e25b-701bc25ce19ba34c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a678a8176a95ce459b5342fdb230b500-8c4f13cff9f21d4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "da1db1e7c1536911c48c0ad0f9e797a8",
         "x-ms-return-client-request-id": "true"
@@ -89,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b7513af3-6593-44b0-a7c0-1d3387383d7d",
+        "apim-request-id": "ce30081b-e65a-4e28-acdc-bdd7ea55c5e4",
         "Content-Length": "1047",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:40:57 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "b7513af3-6593-44b0-a7c0-1d3387383d7d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "156",
+        "X-Request-ID": "ce30081b-e65a-4e28-acdc-bdd7ea55c5e4"
       },
       "ResponseBody": {
-        "dataFeedId": "b815d495-875d-457b-af0c-558f3d5f0418",
+        "dataFeedId": "c666e157-3721-4da6-bfa1-1027981e242e",
         "dataFeedName": "dataFeedMd99mopz",
         "metrics": [
           {
-            "metricId": "f06c67d5-7f5a-40d8-b9d8-445600429078",
+            "metricId": "87dfcf57-66c2-4298-a79c-5f6fbd45aaac",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -134,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:40:56Z",
+        "createdTime": "2021-02-01T15:52:53Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -146,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c666e157-3721-4da6-bfa1-1027981e242e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0f6521d39254d45b5805a304d115fee-65f184e532187b41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5ea73b4d24cb494e84ec172a5ec3cc87-a0fb3e1e2ddce942-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b9055052a3c8faefab81a687e16b9bef",
         "x-ms-return-client-request-id": "true"
@@ -160,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d90c4206-7af9-4ec6-bef2-c7e103a46175",
+        "apim-request-id": "76f9f31f-5ab5-42eb-9014-00cd50929887",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:40:57 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "384",
-        "x-request-id": "d90c4206-7af9-4ec6-bef2-c7e103a46175"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "309",
+        "X-Request-ID": "76f9f31f-5ab5-42eb-9014-00cd50929887"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:40:57.5146646-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:53.8664643-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureApplicationInsightsDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,8 @@
         "Content-Length": "284",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cf9d357d0437ef4588cfb5a811da734e-91ee31eed889e340-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-da15132379b10c46af1fb7ad9267aeba-17e79f2c843ee34b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "208258805194964d6e8bd9937612175d",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +33,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a3cf218c-7563-4448-8601-1f9518a379ad",
+        "apim-request-id": "b63e7b22-6194-436a-93e7-466eb055a3da",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:07 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1df9a87-5d85-4616-b05e-c31dc62fb0d8",
+        "Date": "Mon, 01 Feb 2021 12:40:56 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "570",
-        "x-request-id": "a3cf218c-7563-4448-8601-1f9518a379ad"
+        "x-envoy-upstream-service-time": "449",
+        "x-request-id": "b63e7b22-6194-436a-93e7-466eb055a3da"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1df9a87-5d85-4616-b05e-c31dc62fb0d8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "300",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-333517036662b844929d2bf268cbb6d8-a91072379c474b40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cea125285966fd42bd0795326b320aea-ed7a3bdf22323d47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6151095886eb00ac7a0c70e2fa7f5810",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "azureCloud": "cloud",
-          "applicationId": "appId",
-          "apiKey": "Sanitized",
-          "query": "query"
-        },
         "dataSourceType": "AzureApplicationInsights",
-        "dataFeedName": "dataFeedMd99mopz",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d3194c85-da21-4996-bc24-b5cce1d3805f",
+        "apim-request-id": "514440ea-eca7-48f1-a111-aaef86b022ad",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:08 GMT",
+        "Date": "Mon, 01 Feb 2021 12:40:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "691",
-        "x-request-id": "d3194c85-da21-4996-bc24-b5cce1d3805f"
+        "x-envoy-upstream-service-time": "177",
+        "x-request-id": "514440ea-eca7-48f1-a111-aaef86b022ad"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1df9a87-5d85-4616-b05e-c31dc62fb0d8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b984f3c634989d42be8fb2dde6b41f72-b42079c2d67e454e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0c8d3fbd08b9dc418dda15c461a1e25b-701bc25ce19ba34c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "da1db1e7c1536911c48c0ad0f9e797a8",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +89,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c1877dc1-7d64-4760-bde8-0632823e8c19",
+        "apim-request-id": "b7513af3-6593-44b0-a7c0-1d3387383d7d",
         "Content-Length": "1047",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:08 GMT",
+        "Date": "Mon, 01 Feb 2021 12:40:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "201",
-        "x-request-id": "c1877dc1-7d64-4760-bde8-0632823e8c19"
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "b7513af3-6593-44b0-a7c0-1d3387383d7d"
       },
       "ResponseBody": {
-        "dataFeedId": "a1df9a87-5d85-4616-b05e-c31dc62fb0d8",
+        "dataFeedId": "b815d495-875d-457b-af0c-558f3d5f0418",
         "dataFeedName": "dataFeedMd99mopz",
         "metrics": [
           {
-            "metricId": "db2a55ae-082c-4da8-ab7f-772090b8c4af",
+            "metricId": "f06c67d5-7f5a-40d8-b9d8-445600429078",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +134,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:07Z",
+        "createdTime": "2021-02-01T12:40:56Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +146,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1df9a87-5d85-4616-b05e-c31dc62fb0d8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b815d495-875d-457b-af0c-558f3d5f0418",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-81519b364a89be41bb3a4bcaa6b39f76-5840b02ed2bf4649-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e0f6521d39254d45b5805a304d115fee-65f184e532187b41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b9055052a3c8faefab81a687e16b9bef",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +160,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e698d08d-8260-4174-9929-ca8effad53e4",
+        "apim-request-id": "d90c4206-7af9-4ec6-bef2-c7e103a46175",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:08 GMT",
+        "Date": "Mon, 01 Feb 2021 12:40:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "371",
-        "x-request-id": "e698d08d-8260-4174-9929-ca8effad53e4"
+        "x-envoy-upstream-service-time": "384",
+        "x-request-id": "d90c4206-7af9-4ec6-bef2-c7e103a46175"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:08.6425457-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:40:57.5146646-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c199cad18653734c8d9b0a5a6a5355c2-08273dd0a6b75b41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-94314a003f528e408655047ff15a6a14-b21b1f1cf69f7c4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a5b4a8664674b4d84b6e59e1cac69eb",
         "x-ms-return-client-request-id": "true"
@@ -32,25 +35,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "05bf8244-9b14-4c92-a0dd-b9b62090fded",
+        "apim-request-id": "cd8a566d-8df6-49fb-98f2-22f84663e2c7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+        "Date": "Mon, 01 Feb 2021 14:24:35 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ddc8be57-9760-4ce2-9f7c-4c5243a0f705",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "508",
-        "x-request-id": "05bf8244-9b14-4c92-a0dd-b9b62090fded"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "600",
+        "X-Request-ID": "cd8a566d-8df6-49fb-98f2-22f84663e2c7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ddc8be57-9760-4ce2-9f7c-4c5243a0f705",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-db1868bd35ef2947b71aa18522995a57-05945da594c0ea44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e9395d23b2d52d44a1e43f5a009367fb-8020a2c2c34bda48-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8b6b5643f6bf9f17b20018c8a28e73db",
         "x-ms-return-client-request-id": "true"
@@ -58,21 +64,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "be78e426-b09e-4683-84f2-72d207a031d2",
+        "apim-request-id": "6d96f5c7-bdf8-4876-9197-3561489363a0",
         "Content-Length": "980",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:20 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "156",
-        "x-request-id": "be78e426-b09e-4683-84f2-72d207a031d2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "196",
+        "X-Request-ID": "6d96f5c7-bdf8-4876-9197-3561489363a0"
       },
       "ResponseBody": {
-        "dataFeedId": "8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+        "dataFeedId": "ddc8be57-9760-4ce2-9f7c-4c5243a0f705",
         "dataFeedName": "dataFeedqF5usX2A",
         "metrics": [
           {
-            "metricId": "f7a1f495-6393-4208-8d1d-cc5df1df82c8",
+            "metricId": "004f008d-0e5a-4694-928d-97201f67d084",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +109,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:20Z",
+        "createdTime": "2021-02-01T14:24:35Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,15 +120,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ddc8be57-9760-4ce2-9f7c-4c5243a0f705",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "694",
+        "Content-Length": "711",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-68233bbe8a365a4fa8036ddf91e2ded7-135a2f7256a3ac4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-06ba1cd8a56ead40bdd198d1fac4526b-2bc1faa86100ff44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1ea565a5a90e8ad51b1b6c75ccd07a83",
         "x-ms-return-client-request-id": "true"
@@ -148,7 +157,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -158,24 +168,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "649b00b8-0477-4def-b6b5-60447ba53e9a",
+        "apim-request-id": "260347b9-6540-40a6-902f-5f3f1657b57a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:21 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "885",
-        "x-request-id": "649b00b8-0477-4def-b6b5-60447ba53e9a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "673",
+        "X-Request-ID": "260347b9-6540-40a6-902f-5f3f1657b57a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ddc8be57-9760-4ce2-9f7c-4c5243a0f705",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ce4084e5e0e9c47b390dbde44072560-3cba25bce0c4ac4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-138bdc632a76db4486b5970573e706ec-eb1319a1223dbf4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f929830a6e5a8f1c32bb57664c85a8f5",
         "x-ms-return-client-request-id": "true"
@@ -183,21 +196,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "050d55c2-11fe-4c63-809d-9dbc231b7021",
-        "Content-Length": "1106",
+        "apim-request-id": "f3f0a0cf-f586-4aba-89ba-8457b1b28f8d",
+        "Content-Length": "1123",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:21 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "050d55c2-11fe-4c63-809d-9dbc231b7021"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "194",
+        "X-Request-ID": "f3f0a0cf-f586-4aba-89ba-8457b1b28f8d"
       },
       "ResponseBody": {
-        "dataFeedId": "8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+        "dataFeedId": "ddc8be57-9760-4ce2-9f7c-4c5243a0f705",
         "dataFeedName": "dataFeed7de3uXf1",
         "metrics": [
           {
-            "metricId": "f7a1f495-6393-4208-8d1d-cc5df1df82c8",
+            "metricId": "004f008d-0e5a-4694-928d-97201f67d084",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -223,6 +236,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -230,7 +244,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:20Z",
+        "createdTime": "2021-02-01T14:24:35Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,13 +255,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ddc8be57-9760-4ce2-9f7c-4c5243a0f705",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6c516992a5462e4b931a5faea2282613-a28febd51dcc0041-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4d870f244424c34abd842811c846d116-df16a0bb6518ae43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b7f909424b069adc80e070a48aa1d2e2",
         "x-ms-return-client-request-id": "true"
@@ -255,19 +272,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "344ecb3f-ed73-44d1-9ed4-80d3c3e4c240",
+        "apim-request-id": "3a15d548-f0b3-4ec4-927c-01d2baf7371f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:22 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "318",
-        "x-request-id": "344ecb3f-ed73-44d1-9ed4-80d3c3e4c240"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "331",
+        "X-Request-ID": "3a15d548-f0b3-4ec4-927c-01d2baf7371f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:21.8688742-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:24:36.9855058-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4bb2e9f36644e54aa8b50763a508d4af-c82fade3b317fd4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c199cad18653734c8d9b0a5a6a5355c2-08273dd0a6b75b41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6d6e742fc64fdcfa864a5b0a67644d4b",
+        "x-ms-client-request-id": "0a5b4a8664674b4d84b6e59e1cac69eb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,47 +32,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c3925ec6-f888-4f29-b3c7-5d1ae23b6905",
+        "apim-request-id": "05bf8244-9b14-4c92-a0dd-b9b62090fded",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:08 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+        "Date": "Mon, 01 Feb 2021 13:12:20 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1029",
-        "x-request-id": "c3925ec6-f888-4f29-b3c7-5d1ae23b6905"
+        "x-envoy-upstream-service-time": "508",
+        "x-request-id": "05bf8244-9b14-4c92-a0dd-b9b62090fded"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-681739af23ea1a4984eaf30952716392-8bedbe526e5e254f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-db1868bd35ef2947b71aa18522995a57-05945da594c0ea44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9ee5b684ac1ceb6943566b8bbff6179f",
+        "x-ms-client-request-id": "8b6b5643f6bf9f17b20018c8a28e73db",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d8697900-1264-4667-b877-d693fbdda259",
+        "apim-request-id": "be78e426-b09e-4683-84f2-72d207a031d2",
         "Content-Length": "980",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:09 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "871",
-        "x-request-id": "d8697900-1264-4667-b877-d693fbdda259"
+        "x-envoy-upstream-service-time": "156",
+        "x-request-id": "be78e426-b09e-4683-84f2-72d207a031d2"
       },
       "ResponseBody": {
-        "dataFeedId": "0a556679-96b5-4b45-a58e-94cf7a7cadab",
+        "dataFeedId": "8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
         "dataFeedName": "dataFeedqF5usX2A",
         "metrics": [
           {
-            "metricId": "239cb279-7eb6-4d71-8f28-886dad4e2f07",
+            "metricId": "f7a1f495-6393-4208-8d1d-cc5df1df82c8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +103,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:09Z",
+        "createdTime": "2021-02-01T13:12:20Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,17 +114,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "694",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8786d0b11abd0c47934f2c378f5d1c27-c77809584320e94e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-68233bbe8a365a4fa8036ddf91e2ded7-135a2f7256a3ac4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c81800b28ea2db73a565a51e0ea9d58a",
+        "x-ms-client-request-id": "1ea565a5a90e8ad51b1b6c75ccd07a83",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -134,10 +134,10 @@
           "blobTemplate": "template"
         },
         "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedqF5usX2A",
+        "dataFeedName": "dataFeed7de3uXf1",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -158,53 +158,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "37703e64-199e-4949-85b9-9c7f9831f363",
+        "apim-request-id": "649b00b8-0477-4def-b6b5-60447ba53e9a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:10 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "887",
-        "x-request-id": "37703e64-199e-4949-85b9-9c7f9831f363"
+        "x-envoy-upstream-service-time": "885",
+        "x-request-id": "649b00b8-0477-4def-b6b5-60447ba53e9a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2b65daabfac7654983a9038eaee707a0-1a0b91d2fee78a40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9ce4084e5e0e9c47b390dbde44072560-3cba25bce0c4ac4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "756c1b1bd0cc837a0a8329f95a6e1c8f",
+        "x-ms-client-request-id": "f929830a6e5a8f1c32bb57664c85a8f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c529c7f6-464e-4d55-b85e-3bfac02af619",
+        "apim-request-id": "050d55c2-11fe-4c63-809d-9dbc231b7021",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:10 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "154",
-        "x-request-id": "c529c7f6-464e-4d55-b85e-3bfac02af619"
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "050d55c2-11fe-4c63-809d-9dbc231b7021"
       },
       "ResponseBody": {
-        "dataFeedId": "0a556679-96b5-4b45-a58e-94cf7a7cadab",
-        "dataFeedName": "dataFeedqF5usX2A",
+        "dataFeedId": "8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
+        "dataFeedName": "dataFeed7de3uXf1",
         "metrics": [
           {
-            "metricId": "239cb279-7eb6-4d71-8f28-886dad4e2f07",
+            "metricId": "f7a1f495-6393-4208-8d1d-cc5df1df82c8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -230,7 +230,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:09Z",
+        "createdTime": "2021-02-01T13:12:20Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,33 +241,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a556679-96b5-4b45-a58e-94cf7a7cadab",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8e30aa6b-eaef-4488-8c85-1df9f6298fb3",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8eff262168a8b3428d0c877605838047-40ff5dcbd7f36d44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6c516992a5462e4b931a5faea2282613-a28febd51dcc0041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6657bb32854cf5a84209f9b7064bdc9a",
+        "x-ms-client-request-id": "b7f909424b069adc80e070a48aa1d2e2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c839df07-b47f-4529-83eb-5e61a8704662",
+        "apim-request-id": "344ecb3f-ed73-44d1-9ed4-80d3c3e4c240",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:11 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "285",
-        "x-request-id": "c839df07-b47f-4529-83eb-5e61a8704662"
+        "x-envoy-upstream-service-time": "318",
+        "x-request-id": "344ecb3f-ed73-44d1-9ed4-80d3c3e4c240"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:11.7458807-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:21.8688742-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4ff4e1d39f599c458830bb93a76d17fe-58981a6d5d67074f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-9c2d4fd1d406b044ae411e521734eb77-8a89440196d6b643-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7e1c6ce63737eeaf575fcef6e9d4d0b4",
         "x-ms-return-client-request-id": "true"
@@ -35,28 +32,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a0ce15fc-20f7-4c24-8acf-b066ad5fd384",
+        "apim-request-id": "4c7ff473-bf30-451c-89bf-fe751abdeb7b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:01 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
+        "Date": "Mon, 01 Feb 2021 15:40:58 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3ac1650-91b4-4385-8f2d-3bbed8a81e34",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1106",
-        "X-Request-ID": "a0ce15fc-20f7-4c24-8acf-b066ad5fd384"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "594",
+        "x-request-id": "4c7ff473-bf30-451c-89bf-fe751abdeb7b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3ac1650-91b4-4385-8f2d-3bbed8a81e34",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0ad5c75ed5502d49a18ed5ed42612a99-fd883ac2feb43244-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-1bb7756c4aab694aa331112c8ec9f7d4-0000723d37c54641-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "29d55a24d0c54e0b7b2730d1e42e11c8",
         "x-ms-return-client-request-id": "true"
@@ -64,21 +58,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "83de0575-c21a-43ae-ac23-90ebab311e65",
+        "apim-request-id": "41b95aae-1b61-4525-b6d8-ba42631f3386",
         "Content-Length": "980",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:02 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "183",
-        "X-Request-ID": "83de0575-c21a-43ae-ac23-90ebab311e65"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "x-request-id": "41b95aae-1b61-4525-b6d8-ba42631f3386"
       },
       "ResponseBody": {
-        "dataFeedId": "936f22c2-4046-490d-b597-035dea2a3a84",
+        "dataFeedId": "c3ac1650-91b4-4385-8f2d-3bbed8a81e34",
         "dataFeedName": "dataFeedUKzatqz4",
         "metrics": [
           {
-            "metricId": "3d9fa26e-aba2-4eb1-8618-6d3b94378e1b",
+            "metricId": "5bd738c2-4423-4865-96a4-31b7c4eb6793",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -109,7 +103,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:01Z",
+        "createdTime": "2021-02-01T15:40:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -120,18 +114,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3ac1650-91b4-4385-8f2d-3bbed8a81e34",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "694",
+        "Content-Length": "711",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6341c5cfd720ef4aba5cd0e689f5aa3c-4f14c89efa1ead4b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ed55e2e09d8a6f4fa3fd34388ce36423-142653aabec68c44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "592497f65097693efe6c75b37b8de1c9",
         "x-ms-return-client-request-id": "true"
@@ -157,7 +148,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -167,27 +159,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4b1efa31-087d-4bfd-b5bf-fb3552dfc7c7",
+        "apim-request-id": "a5c9b3e3-e5de-45fb-8102-b16479eda0d7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:03 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "987",
-        "X-Request-ID": "4b1efa31-087d-4bfd-b5bf-fb3552dfc7c7"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "493",
+        "x-request-id": "a5c9b3e3-e5de-45fb-8102-b16479eda0d7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3ac1650-91b4-4385-8f2d-3bbed8a81e34",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3643c0bac1c1a948b405acd974aa80f7-c3f125e46002a945-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-36fa1290da660f4ca3a5e002679bc2f2-31c135818946a14e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a1d409f79e2d167b60cd020f07dd0928",
         "x-ms-return-client-request-id": "true"
@@ -195,21 +184,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ad87bcf4-c55f-471d-9c32-b2b7ab919a69",
-        "Content-Length": "1106",
+        "apim-request-id": "4ffdfce8-f761-431b-8e97-47049c0b9667",
+        "Content-Length": "1123",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:03 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "190",
-        "X-Request-ID": "ad87bcf4-c55f-471d-9c32-b2b7ab919a69"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "148",
+        "x-request-id": "4ffdfce8-f761-431b-8e97-47049c0b9667"
       },
       "ResponseBody": {
-        "dataFeedId": "936f22c2-4046-490d-b597-035dea2a3a84",
+        "dataFeedId": "c3ac1650-91b4-4385-8f2d-3bbed8a81e34",
         "dataFeedName": "dataFeedbDwhM6EP",
         "metrics": [
           {
-            "metricId": "3d9fa26e-aba2-4eb1-8618-6d3b94378e1b",
+            "metricId": "5bd738c2-4423-4865-96a4-31b7c4eb6793",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -235,6 +224,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -242,7 +232,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:01Z",
+        "createdTime": "2021-02-01T15:40:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -253,16 +243,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3ac1650-91b4-4385-8f2d-3bbed8a81e34",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ec9ba0deea72b5499845d79c5cdba4a1-c655252a016ef74d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-700bae9e05bdc74ba09ff9520becd259-bff771208347124b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5200054d77b0d31d1b6c2a595b58d3ee",
         "x-ms-return-client-request-id": "true"
@@ -270,19 +257,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fd7a3c87-acfd-4f9b-a204-7b9e8ac4442d",
+        "apim-request-id": "9dccc005-57b6-48df-b6e4-9ebbcb97ee06",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:03 GMT",
+        "Date": "Mon, 01 Feb 2021 15:40:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "380",
-        "X-Request-ID": "fd7a3c87-acfd-4f9b-a204-7b9e8ac4442d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "287",
+        "x-request-id": "9dccc005-57b6-48df-b6e4-9ebbcb97ee06"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:03.4021225-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:40:59.2501381-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9cb68e5d2c1e5140bfc9455e28a57262-92801c9a7e0a6e4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4ff4e1d39f599c458830bb93a76d17fe-58981a6d5d67074f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f9bdc89e03fc41c8e66c1c7e3737afee",
+        "x-ms-client-request-id": "7e1c6ce63737eeaf575fcef6e9d4d0b4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,47 +35,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e764178a-2433-442c-8f1c-c9e3dd287728",
+        "apim-request-id": "a0ce15fc-20f7-4c24-8acf-b066ad5fd384",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+        "Date": "Mon, 01 Feb 2021 13:42:01 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "433",
-        "x-request-id": "e764178a-2433-442c-8f1c-c9e3dd287728"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1106",
+        "X-Request-ID": "a0ce15fc-20f7-4c24-8acf-b066ad5fd384"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee249538e905b94baea2ddbfdf389557-7d317609acd24b4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0ad5c75ed5502d49a18ed5ed42612a99-fd883ac2feb43244-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f6ce5f57d4e9b4d0245ad529c5d00b4e",
+        "x-ms-client-request-id": "29d55a24d0c54e0b7b2730d1e42e11c8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "479d60f5-654a-4c95-82fe-f6530b21d21b",
+        "apim-request-id": "83de0575-c21a-43ae-ac23-90ebab311e65",
         "Content-Length": "980",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "479d60f5-654a-4c95-82fe-f6530b21d21b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "X-Request-ID": "83de0575-c21a-43ae-ac23-90ebab311e65"
       },
       "ResponseBody": {
-        "dataFeedId": "55da68de-dd13-49b0-866c-88467b4760b4",
+        "dataFeedId": "936f22c2-4046-490d-b597-035dea2a3a84",
         "dataFeedName": "dataFeedUKzatqz4",
         "metrics": [
           {
-            "metricId": "8a3f62a6-35a7-48bd-afd8-fd0e6c0c8cb0",
+            "metricId": "3d9fa26e-aba2-4eb1-8618-6d3b94378e1b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +109,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:50Z",
+        "createdTime": "2021-02-01T13:42:01Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,17 +120,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "694",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6050e6212ebe46459970cc8ac2387f31-c0e2c35184f7dc49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6341c5cfd720ef4aba5cd0e689f5aa3c-4f14c89efa1ead4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d130277b2ee4c811f697245997503e69",
+        "x-ms-client-request-id": "592497f65097693efe6c75b37b8de1c9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -134,10 +143,10 @@
           "blobTemplate": "template"
         },
         "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedUKzatqz4",
+        "dataFeedName": "dataFeedbDwhM6EP",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -158,53 +167,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8aa3ed9b-090d-4fb6-93f1-d939c2673a36",
+        "apim-request-id": "4b1efa31-087d-4bfd-b5bf-fb3552dfc7c7",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "505",
-        "x-request-id": "8aa3ed9b-090d-4fb6-93f1-d939c2673a36"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "987",
+        "X-Request-ID": "4b1efa31-087d-4bfd-b5bf-fb3552dfc7c7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8cafccb5e631bd439cb53c61941e854c-679e41b4ed518848-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3643c0bac1c1a948b405acd974aa80f7-c3f125e46002a945-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b3756cfe8d7bc9e1f709d4a12d9e7b16",
+        "x-ms-client-request-id": "a1d409f79e2d167b60cd020f07dd0928",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "84a3b9ab-4443-4f2f-99f4-d4d48fbc2446",
+        "apim-request-id": "ad87bcf4-c55f-471d-9c32-b2b7ab919a69",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:50 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "84a3b9ab-4443-4f2f-99f4-d4d48fbc2446"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "190",
+        "X-Request-ID": "ad87bcf4-c55f-471d-9c32-b2b7ab919a69"
       },
       "ResponseBody": {
-        "dataFeedId": "55da68de-dd13-49b0-866c-88467b4760b4",
-        "dataFeedName": "dataFeedUKzatqz4",
+        "dataFeedId": "936f22c2-4046-490d-b597-035dea2a3a84",
+        "dataFeedName": "dataFeedbDwhM6EP",
         "metrics": [
           {
-            "metricId": "8a3f62a6-35a7-48bd-afd8-fd0e6c0c8cb0",
+            "metricId": "3d9fa26e-aba2-4eb1-8618-6d3b94378e1b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -230,7 +242,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:50Z",
+        "createdTime": "2021-02-01T13:42:01Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,33 +253,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/55da68de-dd13-49b0-866c-88467b4760b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/936f22c2-4046-490d-b597-035dea2a3a84",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aa4b882ab3125b4c820aeaf3571562ff-7b871740bebfa947-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ec9ba0deea72b5499845d79c5cdba4a1-c655252a016ef74d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0f02cd60dd0728094d050052b0771dd3",
+        "x-ms-client-request-id": "5200054d77b0d31d1b6c2a595b58d3ee",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ff5c855e-b730-4805-b71a-b3b5c85dc32b",
+        "apim-request-id": "fd7a3c87-acfd-4f9b-a204-7b9e8ac4442d",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:51 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "304",
-        "x-request-id": "ff5c855e-b730-4805-b71a-b3b5c85dc32b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "380",
+        "X-Request-ID": "fd7a3c87-acfd-4f9b-a204-7b9e8ac4442d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:51.2031444-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:03.4021225-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-db3b7caa3fb2df4887e3c01b649eb775-84d5a1b30ae30c4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0ed507c45eb309478756032c60a2c5e1-16c4921ca9805147-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c45aab0de04a9efd5ac9427098b58dd7",
+        "x-ms-client-request-id": "7042c95ab598d78d1496af0917f013f8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,29 +32,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "082d1fe0-3cc1-402b-8fc6-c58b08e41fa0",
+        "apim-request-id": "8ebcfa39-b22b-4380-89f0-75cf180b41f0",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:11 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+        "Date": "Mon, 01 Feb 2021 13:12:22 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "347",
-        "x-request-id": "082d1fe0-3cc1-402b-8fc6-c58b08e41fa0"
+        "x-envoy-upstream-service-time": "561",
+        "x-request-id": "8ebcfa39-b22b-4380-89f0-75cf180b41f0"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "582",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ea11a6f1a7c1c240968ffc0b8ef2f7e0-46254f3036329749-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4c9f3d18b10b52478f9a37d6b1505310-2a7835c0f2f51248-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "09af9614f017f813256973132d590ef0",
+        "x-ms-client-request-id": "13736925592df00e029f23f4cf525f05",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,10 +64,10 @@
           "blobTemplate": "template"
         },
         "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedhmzpGlfW",
+        "dataFeedName": "dataFeedR4P5X8AS",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -81,53 +81,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "38245667-0bd0-4a70-8e8c-3b8423c3706e",
+        "apim-request-id": "0e09c2a9-f37b-4dc0-9e69-92754f239202",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:12 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "449",
-        "x-request-id": "38245667-0bd0-4a70-8e8c-3b8423c3706e"
+        "x-envoy-upstream-service-time": "670",
+        "x-request-id": "0e09c2a9-f37b-4dc0-9e69-92754f239202"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5c90877a6f89d24f991d7515cf9214c3-ee9a8495afde204c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-82589a0f8d60f54d9fac0d5edb27d737-08d1d95c667b174f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f4239f0252cf055f46bab92c35ff5e42",
+        "x-ms-client-request-id": "2cb9ba46ff35425e0a327d0fd19c331c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "24a8ce93-919d-4f80-8135-747b619cea6d",
+        "apim-request-id": "ca91ac91-40e8-4a0a-a1e4-bd38465a9555",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:12 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "x-request-id": "24a8ce93-919d-4f80-8135-747b619cea6d"
+        "x-envoy-upstream-service-time": "156",
+        "x-request-id": "ca91ac91-40e8-4a0a-a1e4-bd38465a9555"
       },
       "ResponseBody": {
-        "dataFeedId": "4d04fb17-32ff-4ea0-a709-6e0953fda96b",
-        "dataFeedName": "dataFeedhmzpGlfW",
+        "dataFeedId": "28d995aa-75f5-4b1a-9972-33c5bcf9031e",
+        "dataFeedName": "dataFeedR4P5X8AS",
         "metrics": [
           {
-            "metricId": "0ab4098e-64fa-4af4-b284-5820651f9ee4",
+            "metricId": "bc83b6b1-e458-4e0d-99d4-0991432b7d3f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -153,7 +153,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:12Z",
+        "createdTime": "2021-02-01T13:12:22Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,33 +164,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d04fb17-32ff-4ea0-a709-6e0953fda96b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6649cab08d2a914b8d85398a5894925c-8342bc4851d71246-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d703fbf3461e50498329b75c45b7e8fd-54cc97e4ae454f43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0f7d320a9cd11c3397619fe06de97100",
+        "x-ms-client-request-id": "e09f6197e96d0071bb516ef9929908c1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f36081e4-0119-453b-a16f-228815e6d56d",
+        "apim-request-id": "a2ac1733-6286-42d2-baff-6180dbc556a4",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:12 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "332",
-        "x-request-id": "f36081e4-0119-453b-a16f-228815e6d56d"
+        "x-envoy-upstream-service-time": "371",
+        "x-request-id": "a2ac1733-6286-42d2-baff-6180dbc556a4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:13.3579759-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:23.7149713-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0ed507c45eb309478756032c60a2c5e1-16c4921ca9805147-00",
+        "traceparent": "00-400b4298e29d4448ad739504c39715b2-02882a718a1e554c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7042c95ab598d78d1496af0917f013f8",
+        "x-ms-client-request-id": "b9fd87026a3f76342d65ed79d35c257a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,7 +21,7 @@
           "blobTemplate": "template"
         },
         "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedhmzpGlfW",
+        "dataFeedName": "dataFeeddKgbTiwq",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -32,39 +32,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8ebcfa39-b22b-4380-89f0-75cf180b41f0",
+        "apim-request-id": "6eec0d8b-d593-496e-acc2-17c484474e85",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
+        "Date": "Mon, 01 Feb 2021 15:45:22 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "561",
-        "x-request-id": "8ebcfa39-b22b-4380-89f0-75cf180b41f0"
+        "x-envoy-upstream-service-time": "542",
+        "x-request-id": "6eec0d8b-d593-496e-acc2-17c484474e85"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "582",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c9f3d18b10b52478f9a37d6b1505310-2a7835c0f2f51248-00",
+        "traceparent": "00-51706a2aadd88e4481d946b228c6a47e-29228ff82be0894d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "13736925592df00e029f23f4cf525f05",
+        "x-ms-client-request-id": "e2f930950ba9bae3b5387a064bd34c40",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "container": "container",
-          "blobTemplate": "template"
-        },
-        "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedR4P5X8AS",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedUnSyfwLE",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -81,46 +76,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0e09c2a9-f37b-4dc0-9e69-92754f239202",
+        "apim-request-id": "b6be6966-eea7-44f5-b635-6ca619e91903",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "670",
-        "x-request-id": "0e09c2a9-f37b-4dc0-9e69-92754f239202"
+        "x-envoy-upstream-service-time": "177",
+        "x-request-id": "b6be6966-eea7-44f5-b635-6ca619e91903"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-82589a0f8d60f54d9fac0d5edb27d737-08d1d95c667b174f-00",
+        "traceparent": "00-1bd5b8ebea072e4f924d048f0da4f360-f29c7dce3af26746-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2cb9ba46ff35425e0a327d0fd19c331c",
+        "x-ms-client-request-id": "1abc746df90b68cc88f3c311b13b34f6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ca91ac91-40e8-4a0a-a1e4-bd38465a9555",
+        "apim-request-id": "2a5e53cb-6a98-4804-9a3c-a76b0dc720db",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "156",
-        "x-request-id": "ca91ac91-40e8-4a0a-a1e4-bd38465a9555"
+        "x-envoy-upstream-service-time": "145",
+        "x-request-id": "2a5e53cb-6a98-4804-9a3c-a76b0dc720db"
       },
       "ResponseBody": {
-        "dataFeedId": "28d995aa-75f5-4b1a-9972-33c5bcf9031e",
-        "dataFeedName": "dataFeedR4P5X8AS",
+        "dataFeedId": "7239ec24-9b8b-4b80-a00c-bd91882d4128",
+        "dataFeedName": "dataFeedUnSyfwLE",
         "metrics": [
           {
-            "metricId": "bc83b6b1-e458-4e0d-99d4-0991432b7d3f",
+            "metricId": "04d1c5d3-4b7c-4749-924a-10d77af0aff7",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -153,7 +148,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:22Z",
+        "createdTime": "2021-02-01T15:45:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,37 +159,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/28d995aa-75f5-4b1a-9972-33c5bcf9031e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d703fbf3461e50498329b75c45b7e8fd-54cc97e4ae454f43-00",
+        "traceparent": "00-96c22001bc45e24b819ca6dd0132c003-d8cecb13b530564a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e09f6197e96d0071bb516ef9929908c1",
+        "x-ms-client-request-id": "2395b904d92ef6d0a4430406ef2e2b59",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a2ac1733-6286-42d2-baff-6180dbc556a4",
+        "apim-request-id": "e97d7a2b-5eb0-4759-9a12-82e155cbfe7c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "371",
-        "x-request-id": "a2ac1733-6286-42d2-baff-6180dbc556a4"
+        "x-envoy-upstream-service-time": "342",
+        "x-request-id": "e97d7a2b-5eb0-4759-9a12-82e155cbfe7c"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:23.7149713-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:23.9382408-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "2065298391"
+    "RandomSeed": "113100166"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-400b4298e29d4448ad739504c39715b2-02882a718a1e554c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d13a3ccdd753904b84316d91c44569e1-79908f8b407b154b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b9fd87026a3f76342d65ed79d35c257a",
         "x-ms-return-client-request-id": "true"
@@ -32,33 +35,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6eec0d8b-d593-496e-acc2-17c484474e85",
+        "apim-request-id": "0f3f3ce4-5668-4fa9-a2f7-57577d4051c4",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
+        "Date": "Mon, 01 Feb 2021 15:52:22 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aa01b4fb-baf6-461d-9374-d332db42490d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "542",
-        "x-request-id": "6eec0d8b-d593-496e-acc2-17c484474e85"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "530",
+        "X-Request-ID": "0f3f3ce4-5668-4fa9-a2f7-57577d4051c4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aa01b4fb-baf6-461d-9374-d332db42490d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-51706a2aadd88e4481d946b228c6a47e-29228ff82be0894d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3cdad03672297848afc7a1c82f960c00-2e703c7ac3b6e245-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e2f930950ba9bae3b5387a064bd34c40",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedUnSyfwLE",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -76,24 +82,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b6be6966-eea7-44f5-b635-6ca619e91903",
+        "apim-request-id": "0cd29340-5c53-4376-bf84-30a57eaa7e2c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "b6be6966-eea7-44f5-b635-6ca619e91903"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "174",
+        "X-Request-ID": "0cd29340-5c53-4376-bf84-30a57eaa7e2c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aa01b4fb-baf6-461d-9374-d332db42490d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1bd5b8ebea072e4f924d048f0da4f360-f29c7dce3af26746-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1c3cae5eeaec9047a62e2f48dc0e86d9-9723fb94bad48942-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1abc746df90b68cc88f3c311b13b34f6",
         "x-ms-return-client-request-id": "true"
@@ -101,21 +110,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2a5e53cb-6a98-4804-9a3c-a76b0dc720db",
+        "apim-request-id": "5adc6f5a-8463-48e9-b3a1-a22330db09ca",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "145",
-        "x-request-id": "2a5e53cb-6a98-4804-9a3c-a76b0dc720db"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "159",
+        "X-Request-ID": "5adc6f5a-8463-48e9-b3a1-a22330db09ca"
       },
       "ResponseBody": {
-        "dataFeedId": "7239ec24-9b8b-4b80-a00c-bd91882d4128",
+        "dataFeedId": "aa01b4fb-baf6-461d-9374-d332db42490d",
         "dataFeedName": "dataFeedUnSyfwLE",
         "metrics": [
           {
-            "metricId": "04d1c5d3-4b7c-4749-924a-10d77af0aff7",
+            "metricId": "412648cf-144a-43a5-abd3-5c3cc04eabe9",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -148,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:23Z",
+        "createdTime": "2021-02-01T15:52:22Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -159,13 +168,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7239ec24-9b8b-4b80-a00c-bd91882d4128",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aa01b4fb-baf6-461d-9374-d332db42490d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-96c22001bc45e24b819ca6dd0132c003-d8cecb13b530564a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fdd6ac2578ed00408f5931672d692cea-d987bc5eb351664a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2395b904d92ef6d0a4430406ef2e2b59",
         "x-ms-return-client-request-id": "true"
@@ -173,19 +185,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e97d7a2b-5eb0-4759-9a12-82e155cbfe7c",
+        "apim-request-id": "a4cebe6f-4890-4bb3-ba1b-6ae22add045d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "342",
-        "x-request-id": "e97d7a2b-5eb0-4759-9a12-82e155cbfe7c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "312",
+        "X-Request-ID": "a4cebe6f-4890-4bb3-ba1b-6ae22add045d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:23.9382408-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:23.0388029-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c371515a9d0cea4f8ddb4ebc9e2f21dd-33a92a982fe8524a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-347182a6ad911540a47cec3b90306f5a-2ecfc309a811c34a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "edbe7778cea33f93c9e673868c67afaf",
+        "x-ms-client-request-id": "8673e6c9678cafaf76af111c8f3ecae5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,29 +35,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "01fd1782-5774-40fc-b480-364f913806df",
+        "apim-request-id": "14fc694f-17b1-47f5-a14f-2980b9c56a7e",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:51 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+        "Date": "Mon, 01 Feb 2021 13:42:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "373",
-        "x-request-id": "01fd1782-5774-40fc-b480-364f913806df"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "632",
+        "X-Request-ID": "14fc694f-17b1-47f5-a14f-2980b9c56a7e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "582",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c3fa1c69e235f4799f940b4f2744721-e9d6d8b4a7f58a49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fe4ad17b6c48e74993857d20db43058a-052e5241b77d9847-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1c11af763e8fe5cac941b0ed63aa68ff",
+        "x-ms-client-request-id": "edb041c9aa63ff6860449f8898531553",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,10 +70,10 @@
           "blobTemplate": "template"
         },
         "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedjowDOhD4",
+        "dataFeedName": "dataFeedIt3EX1V7",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -81,53 +87,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b31fab53-8de8-4512-a6c9-df3b9742a9f1",
+        "apim-request-id": "4ced01a3-b4ee-4a17-9e79-ff7c0e73bca5",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:52 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "450",
-        "x-request-id": "b31fab53-8de8-4512-a6c9-df3b9742a9f1"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "979",
+        "X-Request-ID": "4ced01a3-b4ee-4a17-9e79-ff7c0e73bca5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d07afbcb2a94ba459c4eda900912e6b2-e4d30c41bdd50148-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c8f9d0ed4b9c1a49a7b34b8222e90567-723bc5ddfb1be044-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "889f4460539853159c926fe95d7cc6c7",
+        "x-ms-client-request-id": "e96f929c7c5dc7c6c3f8d915caa28d39",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "963d4607-bf17-4b58-b85f-b456d1833744",
+        "apim-request-id": "b53f7b24-846a-4cd1-9f1b-a7162c963eb9",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:52 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "963d4607-bf17-4b58-b85f-b456d1833744"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "X-Request-ID": "b53f7b24-846a-4cd1-9f1b-a7162c963eb9"
       },
       "ResponseBody": {
-        "dataFeedId": "e95a1309-2acb-497e-b88e-16ff9c9287cd",
-        "dataFeedName": "dataFeedjowDOhD4",
+        "dataFeedId": "90c872fb-b65f-4d83-9301-aff16633ac9b",
+        "dataFeedName": "dataFeedIt3EX1V7",
         "metrics": [
           {
-            "metricId": "ec7c0584-77d7-4dce-8a5b-d68d0a2bcdb2",
+            "metricId": "cba70260-b5e6-4dfa-b06c-65db77999f35",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureBlob",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -153,7 +162,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:51Z",
+        "createdTime": "2021-02-01T13:42:04Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,33 +173,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e95a1309-2acb-497e-b88e-16ff9c9287cd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d412a4758ce7343a7904e15f1a58b55-178902b8146df34c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ae3b1e07c44f604ba8720690003ec865-5e056907d0338047-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "15d9f8c3a2ca398dadd923621ea5dc1f",
+        "x-ms-client-request-id": "6223d9ada51e1fdc7e732548c8261722",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e547520d-146b-4310-b14e-7e958ebfeb58",
+        "apim-request-id": "a88368d4-7743-449b-95eb-21d6c49ebf54",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:52 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "309",
-        "x-request-id": "e547520d-146b-4310-b14e-7e958ebfeb58"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "411",
+        "X-Request-ID": "a88368d4-7743-449b-95eb-21d6c49ebf54"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:52.8032228-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:05.6656827-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-347182a6ad911540a47cec3b90306f5a-2ecfc309a811c34a-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-d9b03415400ef64fbef619eb0fa907a5-0eaf644f0029a747-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8673e6c9678cafaf76af111c8f3ecae5",
         "x-ms-return-client-request-id": "true"
@@ -35,41 +32,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "14fc694f-17b1-47f5-a14f-2980b9c56a7e",
+        "apim-request-id": "812db1c6-9816-4bab-978f-4e005cb51994",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:04 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
+        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "632",
-        "X-Request-ID": "14fc694f-17b1-47f5-a14f-2980b9c56a7e"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "568",
+        "x-request-id": "812db1c6-9816-4bab-978f-4e005cb51994"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "582",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fe4ad17b6c48e74993857d20db43058a-052e5241b77d9847-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ed52ece83ba02549b571703f3381eab9-68ba8cbdf044fa4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "edb041c9aa63ff6860449f8898531553",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "container": "container",
-          "blobTemplate": "template"
-        },
-        "dataSourceType": "AzureBlob",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedIt3EX1V7",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -87,27 +76,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4ced01a3-b4ee-4a17-9e79-ff7c0e73bca5",
+        "apim-request-id": "69c56da5-93d6-454f-b9b3-2852bc6001d1",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:05 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "979",
-        "X-Request-ID": "4ced01a3-b4ee-4a17-9e79-ff7c0e73bca5"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "177",
+        "x-request-id": "69c56da5-93d6-454f-b9b3-2852bc6001d1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c8f9d0ed4b9c1a49a7b34b8222e90567-723bc5ddfb1be044-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-de7d5014b49fef40b5148847951b9ec3-cf42f5092fd80449-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e96f929c7c5dc7c6c3f8d915caa28d39",
         "x-ms-return-client-request-id": "true"
@@ -115,21 +101,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b53f7b24-846a-4cd1-9f1b-a7162c963eb9",
+        "apim-request-id": "20722d0a-5971-4601-9a46-a7710cae59f3",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:05 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "183",
-        "X-Request-ID": "b53f7b24-846a-4cd1-9f1b-a7162c963eb9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "20722d0a-5971-4601-9a46-a7710cae59f3"
       },
       "ResponseBody": {
-        "dataFeedId": "90c872fb-b65f-4d83-9301-aff16633ac9b",
+        "dataFeedId": "99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
         "dataFeedName": "dataFeedIt3EX1V7",
         "metrics": [
           {
-            "metricId": "cba70260-b5e6-4dfa-b06c-65db77999f35",
+            "metricId": "8adb9e3e-836c-459f-a380-5b10a97ab385",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -162,7 +148,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:04Z",
+        "createdTime": "2021-02-01T15:41:00Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -173,16 +159,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/90c872fb-b65f-4d83-9301-aff16633ac9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ae3b1e07c44f604ba8720690003ec865-5e056907d0338047-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-31a906121939ac48b1c6a71e6ea33609-39ad237adfd40746-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6223d9ada51e1fdc7e732548c8261722",
         "x-ms-return-client-request-id": "true"
@@ -190,19 +173,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a88368d4-7743-449b-95eb-21d6c49ebf54",
+        "apim-request-id": "a8228418-cd74-432e-9f3e-5c0b3a298349",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:05 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "411",
-        "X-Request-ID": "a88368d4-7743-449b-95eb-21d6c49ebf54"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "309",
+        "x-request-id": "a8228418-cd74-432e-9f3e-5c0b3a298349"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:05.6656827-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:00.6435555-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d9b03415400ef64fbef619eb0fa907a5-0eaf644f0029a747-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cbe8253b5fd8674a834e4da657d215a2-759db756b1c27247-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8673e6c9678cafaf76af111c8f3ecae5",
         "x-ms-return-client-request-id": "true"
@@ -32,33 +35,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "812db1c6-9816-4bab-978f-4e005cb51994",
+        "apim-request-id": "96fde04c-d897-480b-a05e-8aede7716288",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
+        "Date": "Mon, 01 Feb 2021 15:52:54 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0ac81ae-aaad-44c5-ba37-b06ed4b1d3a9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "568",
-        "x-request-id": "812db1c6-9816-4bab-978f-4e005cb51994"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "426",
+        "X-Request-ID": "96fde04c-d897-480b-a05e-8aede7716288"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0ac81ae-aaad-44c5-ba37-b06ed4b1d3a9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ed52ece83ba02549b571703f3381eab9-68ba8cbdf044fa4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-70f749c3d42a1f4ba4a94e53c3f04756-c30a2705ef2c6548-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "edb041c9aa63ff6860449f8898531553",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedIt3EX1V7",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -76,24 +82,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "69c56da5-93d6-454f-b9b3-2852bc6001d1",
+        "apim-request-id": "6fcdffce-abbe-433e-a5d1-e7c6e0eef8b5",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "69c56da5-93d6-454f-b9b3-2852bc6001d1"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "176",
+        "X-Request-ID": "6fcdffce-abbe-433e-a5d1-e7c6e0eef8b5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0ac81ae-aaad-44c5-ba37-b06ed4b1d3a9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-de7d5014b49fef40b5148847951b9ec3-cf42f5092fd80449-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-eb8e1c5f2a27964d99f035f42a004a95-82bda6d781cf9845-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e96f929c7c5dc7c6c3f8d915caa28d39",
         "x-ms-return-client-request-id": "true"
@@ -101,21 +110,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "20722d0a-5971-4601-9a46-a7710cae59f3",
+        "apim-request-id": "95735334-0f56-4af3-92a5-f5e3fe09ae86",
         "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158",
-        "x-request-id": "20722d0a-5971-4601-9a46-a7710cae59f3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "145",
+        "X-Request-ID": "95735334-0f56-4af3-92a5-f5e3fe09ae86"
       },
       "ResponseBody": {
-        "dataFeedId": "99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
+        "dataFeedId": "d0ac81ae-aaad-44c5-ba37-b06ed4b1d3a9",
         "dataFeedName": "dataFeedIt3EX1V7",
         "metrics": [
           {
-            "metricId": "8adb9e3e-836c-459f-a380-5b10a97ab385",
+            "metricId": "622a115a-3239-4287-b2df-19a24b567227",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -148,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:00Z",
+        "createdTime": "2021-02-01T15:52:54Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -159,13 +168,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/99ea5ecf-bfc6-498e-9174-ccd2c9c49668",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0ac81ae-aaad-44c5-ba37-b06ed4b1d3a9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-31a906121939ac48b1c6a71e6ea33609-39ad237adfd40746-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ff1394d652a4014fa16556e545be26ca-9e29fa9fe4413042-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6223d9ada51e1fdc7e732548c8261722",
         "x-ms-return-client-request-id": "true"
@@ -173,19 +185,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a8228418-cd74-432e-9f3e-5c0b3a298349",
+        "apim-request-id": "ed8f000a-4c95-4877-b6d8-90996d558e04",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:00 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "309",
-        "x-request-id": "a8228418-cd74-432e-9f3e-5c0b3a298349"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "360",
+        "X-Request-ID": "ed8f000a-4c95-4877-b6d8-90996d558e04"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:00.6435555-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:55.0173758-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a7eef185b8990e42a495e8547a07d6c0-1b4d28885eae6646-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-dcf00fe876f8f04b80e0db2c5806e155-b3e66a768022fa47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e51529713cc7169a3962ae9df9ed2c3f",
         "x-ms-return-client-request-id": "true"
@@ -32,62 +32,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "265b1994-a02c-43ed-889b-b80143799cf2",
+        "apim-request-id": "75dded76-d75e-49e4-aafc-e5551d2c09d6",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:11 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f89e8bc2-060e-4493-a297-8f43e122e099",
+        "Date": "Mon, 01 Feb 2021 12:46:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "584",
-        "x-request-id": "265b1994-a02c-43ed-889b-b80143799cf2"
+        "x-envoy-upstream-service-time": "1069",
+        "x-request-id": "75dded76-d75e-49e4-aafc-e5551d2c09d6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f89e8bc2-060e-4493-a297-8f43e122e099",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "284",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-40fd184238599c4a93e14cceda760e52-1da86a45cc78a645-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-77778f431948ed448c2f90c7c50c5af9-7aaa49a6726d5c4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "999e8c680b9e655411ef694a058352eb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "container": "container",
-          "blobTemplate": "template"
-        },
-        "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedBAJQJLAO",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a83d3acc-63df-47ae-9b39-3a762e39bbb6",
+        "apim-request-id": "ad4ecf46-1724-42fa-bdfa-37f6025800f0",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:12 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "475",
-        "x-request-id": "a83d3acc-63df-47ae-9b39-3a762e39bbb6"
+        "x-envoy-upstream-service-time": "348",
+        "x-request-id": "ad4ecf46-1724-42fa-bdfa-37f6025800f0"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f89e8bc2-060e-4493-a297-8f43e122e099",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7f2920a356e9e94ca403edca1894e172-138bc198708e1b41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5fd29c2be084fe42b2c3777826f02f59-73dd65c96d0d1e41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "94eeaaf17957f344ad67a453b89f4db7",
         "x-ms-return-client-request-id": "true"
@@ -95,21 +88,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e625946f-ac24-4b8d-ac6e-a4f97b19e586",
+        "apim-request-id": "374fcf66-0038-4253-86b5-99bf9d3e6f8a",
         "Content-Length": "1031",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:12 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "140",
-        "x-request-id": "e625946f-ac24-4b8d-ac6e-a4f97b19e586"
+        "x-envoy-upstream-service-time": "386",
+        "x-request-id": "374fcf66-0038-4253-86b5-99bf9d3e6f8a"
       },
       "ResponseBody": {
-        "dataFeedId": "f89e8bc2-060e-4493-a297-8f43e122e099",
+        "dataFeedId": "be7bf194-6918-41d7-b418-0119b4532d4a",
         "dataFeedName": "dataFeedBAJQJLAO",
         "metrics": [
           {
-            "metricId": "3e9c6b9d-6e23-412d-8e16-d0c86e468adf",
+            "metricId": "8ad8171f-8677-4672-8c4f-8b3f13065c44",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -140,7 +133,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:11Z",
+        "createdTime": "2021-02-01T12:46:27Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,13 +144,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f89e8bc2-060e-4493-a297-8f43e122e099",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d7dc4079ee11741a50aa6592d51b4ff-902dd7b1146f4d42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8bc19d7f65f31a4797d6eec031995d79-bdcfb30a750dd449-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e750fe2d4b7d6589d4afd3d8d25011b5",
         "x-ms-return-client-request-id": "true"
@@ -165,19 +158,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "00712763-10c5-4672-9611-4f085cc14f83",
+        "apim-request-id": "27e3667b-e0b5-44ec-af8d-c9ccfffb6894",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:12 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "291",
-        "x-request-id": "00712763-10c5-4672-9611-4f085cc14f83"
+        "x-envoy-upstream-service-time": "535",
+        "x-request-id": "27e3667b-e0b5-44ec-af8d-c9ccfffb6894"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:12.6790369-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:28.2573533-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dcf00fe876f8f04b80e0db2c5806e155-b3e66a768022fa47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-dbcc0e9ec760144c90775b371e89d07e-28c8946d52b00843-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e51529713cc7169a3962ae9df9ed2c3f",
         "x-ms-return-client-request-id": "true"
@@ -32,55 +35,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "75dded76-d75e-49e4-aafc-e5551d2c09d6",
+        "apim-request-id": "945d350c-33bf-4c29-91f5-5bab50bcfcea",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
+        "Date": "Mon, 01 Feb 2021 15:52:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a3bbe529-d325-483a-97af-29423d3e2e8e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1069",
-        "x-request-id": "75dded76-d75e-49e4-aafc-e5551d2c09d6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "433",
+        "X-Request-ID": "945d350c-33bf-4c29-91f5-5bab50bcfcea"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a3bbe529-d325-483a-97af-29423d3e2e8e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-77778f431948ed448c2f90c7c50c5af9-7aaa49a6726d5c4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8e3d058033c8574fa7f6a67a68e81a93-6c19f4d95473164b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "999e8c680b9e655411ef694a058352eb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ad4ecf46-1724-42fa-bdfa-37f6025800f0",
+        "apim-request-id": "939292c0-fc41-4705-99b4-5dc78f40ec7f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:27 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "348",
-        "x-request-id": "ad4ecf46-1724-42fa-bdfa-37f6025800f0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "208",
+        "X-Request-ID": "939292c0-fc41-4705-99b4-5dc78f40ec7f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a3bbe529-d325-483a-97af-29423d3e2e8e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5fd29c2be084fe42b2c3777826f02f59-73dd65c96d0d1e41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0fad8a0bef473f44b30105088cebf401-ad67958aba5ef94e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "94eeaaf17957f344ad67a453b89f4db7",
         "x-ms-return-client-request-id": "true"
@@ -88,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "374fcf66-0038-4253-86b5-99bf9d3e6f8a",
+        "apim-request-id": "91e666f6-7bab-42cb-a9fc-9534686bb352",
         "Content-Length": "1031",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:28 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "386",
-        "x-request-id": "374fcf66-0038-4253-86b5-99bf9d3e6f8a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "159",
+        "X-Request-ID": "91e666f6-7bab-42cb-a9fc-9534686bb352"
       },
       "ResponseBody": {
-        "dataFeedId": "be7bf194-6918-41d7-b418-0119b4532d4a",
+        "dataFeedId": "a3bbe529-d325-483a-97af-29423d3e2e8e",
         "dataFeedName": "dataFeedBAJQJLAO",
         "metrics": [
           {
-            "metricId": "8ad8171f-8677-4672-8c4f-8b3f13065c44",
+            "metricId": "e8a10814-289e-4e56-825b-cf04c94a10ae",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -133,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:27Z",
+        "createdTime": "2021-02-01T15:52:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -144,13 +153,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be7bf194-6918-41d7-b418-0119b4532d4a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a3bbe529-d325-483a-97af-29423d3e2e8e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8bc19d7f65f31a4797d6eec031995d79-bdcfb30a750dd449-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a32aeb48ae2a90469a2d261c279a1d02-9ed1c1fc7ef82543-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e750fe2d4b7d6589d4afd3d8d25011b5",
         "x-ms-return-client-request-id": "true"
@@ -158,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "27e3667b-e0b5-44ec-af8d-c9ccfffb6894",
+        "apim-request-id": "8dd57d09-1676-4b24-9fd3-00069d46c1bc",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:28 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "535",
-        "x-request-id": "27e3667b-e0b5-44ec-af8d-c9ccfffb6894"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "310",
+        "X-Request-ID": "8dd57d09-1676-4b24-9fd3-00069d46c1bc"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:28.2573533-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:24.2323745-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-449da1d871905d458684cef4c05ea65c-69a14ca26c2fa345-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ae1ddeba2e14664f8a15b94810c623d3-8132a9b8cf029a43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b09b0bcba03fddd1799fc50c8710db64",
         "x-ms-return-client-request-id": "true"
@@ -32,62 +35,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a99c60db-683a-4356-9e85-b8ee96eb72fc",
+        "apim-request-id": "c1a6b93d-b915-447a-99e5-bb2fd23f9f89",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cc2798ca-fac0-4c00-a96f-1b2bf0ef3784",
+        "Date": "Mon, 01 Feb 2021 13:42:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "572",
-        "x-request-id": "a99c60db-683a-4356-9e85-b8ee96eb72fc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "489",
+        "X-Request-ID": "c1a6b93d-b915-447a-99e5-bb2fd23f9f89"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cc2798ca-fac0-4c00-a96f-1b2bf0ef3784",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "284",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5aba334fe336d840b723ab508d5b13ab-9a96a31d241ff84b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7c0c4209431e004ab785dd7e68901166-aeb2510a64815540-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "83be54ca081c1b99d0ac0763fbb68630",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "container": "container",
-          "blobTemplate": "template"
-        },
-        "dataSourceType": "AzureBlob",
-        "dataFeedName": "dataFeedjhuxiH8g",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "06a29604-f209-4a45-bb50-d85f6de63340",
+        "apim-request-id": "4b0bbfa3-ece7-422c-a993-d539b2878599",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "635",
-        "x-request-id": "06a29604-f209-4a45-bb50-d85f6de63340"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "204",
+        "X-Request-ID": "4b0bbfa3-ece7-422c-a993-d539b2878599"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cc2798ca-fac0-4c00-a96f-1b2bf0ef3784",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5f869ddce36c1e48b5a7fb25b082ba36-d25f04f79b85474c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-42c9cc9dad504e4bbe98c0215aa8b4d7-17567b553f623244-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d12149155385587c2bcba6227038ed43",
         "x-ms-return-client-request-id": "true"
@@ -95,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8f107768-faaa-4642-9502-9487076bd633",
+        "apim-request-id": "4a74221b-80f8-4a3e-9381-eb56dee9cf51",
         "Content-Length": "1031",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "138",
-        "x-request-id": "8f107768-faaa-4642-9502-9487076bd633"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "191",
+        "X-Request-ID": "4a74221b-80f8-4a3e-9381-eb56dee9cf51"
       },
       "ResponseBody": {
-        "dataFeedId": "cc2798ca-fac0-4c00-a96f-1b2bf0ef3784",
+        "dataFeedId": "c10f3db3-1367-43e6-a406-89008f748332",
         "dataFeedName": "dataFeedjhuxiH8g",
         "metrics": [
           {
-            "metricId": "14419e95-550d-49c3-86d5-f9db568723b0",
+            "metricId": "783b370c-55ed-4f24-98cb-b2c91cefe951",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -140,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:18Z",
+        "createdTime": "2021-02-01T13:42:06Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,13 +153,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cc2798ca-fac0-4c00-a96f-1b2bf0ef3784",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-70a841822698d8488c48d79eec762cef-3bf12b88a2386a4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7c570cc297a77f40b774d5f637974329-4626382a2055de4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e429b6a5dce1c226717fdf92996ee1c3",
         "x-ms-return-client-request-id": "true"
@@ -165,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "434310b0-fb9f-45ec-bc7e-b6864cfc3905",
+        "apim-request-id": "974b0e05-3312-48cd-a511-0befd06121de",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:20 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "290",
-        "x-request-id": "434310b0-fb9f-45ec-bc7e-b6864cfc3905"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "372",
+        "X-Request-ID": "974b0e05-3312-48cd-a511-0befd06121de"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:19.8505797-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:07.0838299-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureBlobDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ae1ddeba2e14664f8a15b94810c623d3-8132a9b8cf029a43-00",
+        "traceparent": "00-c4eb11cffba49c46b14927d5e70ed24a-f1dd851393a22e44-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -35,26 +35,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c1a6b93d-b915-447a-99e5-bb2fd23f9f89",
+        "apim-request-id": "f145a7c5-172f-4b67-a219-d8fc8290f197",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:06 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
+        "Date": "Mon, 01 Feb 2021 15:52:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb3f48d0-4f8b-47f5-89b5-a96dd21a2993",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "489",
-        "X-Request-ID": "c1a6b93d-b915-447a-99e5-bb2fd23f9f89"
+        "x-envoy-upstream-service-time": "448",
+        "X-Request-ID": "f145a7c5-172f-4b67-a219-d8fc8290f197"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb3f48d0-4f8b-47f5-89b5-a96dd21a2993",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c0c4209431e004ab785dd7e68901166-aeb2510a64815540-00",
+        "traceparent": "00-43be1d876009ca48a4b7dbe5e0a3f066-1eb97b4a837ac941-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -64,28 +64,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4b0bbfa3-ece7-422c-a993-d539b2878599",
+        "apim-request-id": "c61c2504-fea4-49bd-8652-b91296f26230",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:06 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "204",
-        "X-Request-ID": "4b0bbfa3-ece7-422c-a993-d539b2878599"
+        "x-envoy-upstream-service-time": "190",
+        "X-Request-ID": "c61c2504-fea4-49bd-8652-b91296f26230"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb3f48d0-4f8b-47f5-89b5-a96dd21a2993",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-42c9cc9dad504e4bbe98c0215aa8b4d7-17567b553f623244-00",
+        "traceparent": "00-e890c52ef0a8bd4bb55cf7cad8b9127d-65ca6100535a6341-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -97,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4a74221b-80f8-4a3e-9381-eb56dee9cf51",
+        "apim-request-id": "b812142e-1abe-4acd-87c4-f1be7589ecd5",
         "Content-Length": "1031",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:06 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "X-Request-ID": "4a74221b-80f8-4a3e-9381-eb56dee9cf51"
+        "x-envoy-upstream-service-time": "178",
+        "X-Request-ID": "b812142e-1abe-4acd-87c4-f1be7589ecd5"
       },
       "ResponseBody": {
-        "dataFeedId": "c10f3db3-1367-43e6-a406-89008f748332",
+        "dataFeedId": "eb3f48d0-4f8b-47f5-89b5-a96dd21a2993",
         "dataFeedName": "dataFeedjhuxiH8g",
         "metrics": [
           {
-            "metricId": "783b370c-55ed-4f24-98cb-b2c91cefe951",
+            "metricId": "fd6b2390-3d32-431a-86cc-5f9467681e0a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:06Z",
+        "createdTime": "2021-02-01T15:52:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -153,12 +153,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c10f3db3-1367-43e6-a406-89008f748332",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb3f48d0-4f8b-47f5-89b5-a96dd21a2993",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c570cc297a77f40b774d5f637974329-4626382a2055de4e-00",
+        "traceparent": "00-89ed9bee5b55cc43865d842d72e342b7-3292f48682f31142-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -170,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "974b0e05-3312-48cd-a511-0befd06121de",
+        "apim-request-id": "4129aa10-95cf-4870-923d-beee18390971",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "372",
-        "X-Request-ID": "974b0e05-3312-48cd-a511-0befd06121de"
+        "x-envoy-upstream-service-time": "365",
+        "X-Request-ID": "4129aa10-95cf-4870-923d-beee18390971"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:07.0838299-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:56.3454622-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f7e4819d4b631848a749723687c137f4-54b7c56e18f22342-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b52943a9be9299429339dfef79c3f85e-ebbed86d0a794743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7e6026f0578f9751dbf10484adb7077d",
+        "x-ms-client-request-id": "8404f1dbb7ad7d073e3277e44f824d55",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +33,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "237f1166-3eda-413a-baa6-d33293017b80",
+        "apim-request-id": "cee39d69-a7e3-4043-b43c-1b202acc91c0",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/20d23d52-9d08-4524-aaa4-def16d60813e",
+        "Date": "Mon, 01 Feb 2021 13:12:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "621",
-        "x-request-id": "237f1166-3eda-413a-baa6-d33293017b80"
+        "x-envoy-upstream-service-time": "564",
+        "x-request-id": "cee39d69-a7e3-4043-b43c-1b202acc91c0"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/20d23d52-9d08-4524-aaa4-def16d60813e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-170caeb3f77fae41873daa064b2a2bbf-ef7c9724c12efa49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0c36b63199917045926e9946a652828a-0e6b43576ffae648-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e477323e824f554ddc8e8ea63c56e739",
+        "x-ms-client-request-id": "a68e8edc563c39e75ed54f6d4f2656db",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f5fc753f-4473-4e5e-ab69-4ff15a4e1b18",
+        "apim-request-id": "1631ec94-00d9-4e5c-b4db-2046efdef7cf",
         "Content-Length": "1002",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:45 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "206",
-        "x-request-id": "f5fc753f-4473-4e5e-ab69-4ff15a4e1b18"
+        "x-envoy-upstream-service-time": "154",
+        "x-request-id": "1631ec94-00d9-4e5c-b4db-2046efdef7cf"
       },
       "ResponseBody": {
-        "dataFeedId": "20d23d52-9d08-4524-aaa4-def16d60813e",
+        "dataFeedId": "e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
         "dataFeedName": "dataFeeduxkt4O0L",
         "metrics": [
           {
-            "metricId": "15405c6f-86d7-4bca-bb23-86d82796d896",
+            "metricId": "3326c382-b082-4e76-9c65-f9e30c8026f8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:44Z",
+        "createdTime": "2021-02-01T13:12:24Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +116,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/20d23d52-9d08-4524-aaa4-def16d60813e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "716",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ed9243a961ea6469a67715b64eda3be-04e8b12393aef548-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-07e372a5dce1fa4ab6dc3346394ea002-b94c3af82d1bf44f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6d4fd55e264fdb56fd0412f96b91afac",
+        "x-ms-client-request-id": "f91204fd916bacaf108bfa28d58ab66d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +137,10 @@
           "collectionId": "collectId"
         },
         "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeeduxkt4O0L",
+        "dataFeedName": "dataFeedvmT7DNpI",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +161,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "957c362d-b655-4e97-ad19-90b39ebaa931",
+        "apim-request-id": "d4d5a897-6c5f-48c4-a095-81bfcd696fee",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:45 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "687",
-        "x-request-id": "957c362d-b655-4e97-ad19-90b39ebaa931"
+        "x-envoy-upstream-service-time": "675",
+        "x-request-id": "d4d5a897-6c5f-48c4-a095-81bfcd696fee"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/20d23d52-9d08-4524-aaa4-def16d60813e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6c4600ec48745140ab7d49b3a9620144-52b3f42dcbc45443-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-540efddfe1253e4581fd0bb96f09290f-324d9af91e3ebe4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "28fa8b108ad56db6d90aa200c8ab5b85",
+        "x-ms-client-request-id": "00a20ad9abc8855b09cb26d8689a2d17",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ea5cdd98-e22c-41e3-a402-8bb1cc92684a",
+        "apim-request-id": "c5750543-bf18-46ed-8b55-a44e4b1a03c7",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:46 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "198",
-        "x-request-id": "ea5cdd98-e22c-41e3-a402-8bb1cc92684a"
+        "x-envoy-upstream-service-time": "169",
+        "x-request-id": "c5750543-bf18-46ed-8b55-a44e4b1a03c7"
       },
       "ResponseBody": {
-        "dataFeedId": "20d23d52-9d08-4524-aaa4-def16d60813e",
-        "dataFeedName": "dataFeeduxkt4O0L",
+        "dataFeedId": "e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+        "dataFeedName": "dataFeedvmT7DNpI",
         "metrics": [
           {
-            "metricId": "15405c6f-86d7-4bca-bb23-86d82796d896",
+            "metricId": "3326c382-b082-4e76-9c65-f9e30c8026f8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureCosmosDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +233,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:44Z",
+        "createdTime": "2021-02-01T13:12:24Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +245,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/20d23d52-9d08-4524-aaa4-def16d60813e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-474bd08aa5ee87408d7fd301b51b9f0b-c5cfa112d9c40546-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ce5878e6e9ce434a9fdada983bea5b62-3882b76c4594724d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d826cb099a68172ddb9ce64a7053e94b",
+        "x-ms-client-request-id": "4ae69cdb53704be9dfe295b05bbe64d3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "cab937ee-22fc-4c70-ba08-65ec98e07437",
+        "apim-request-id": "2076cf93-ce74-4721-a14b-dc993e8bacd1",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:46 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "338",
-        "x-request-id": "cab937ee-22fc-4c70-ba08-65ec98e07437"
+        "x-envoy-upstream-service-time": "369",
+        "x-request-id": "2076cf93-ce74-4721-a14b-dc993e8bacd1"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:46.2082456-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:25.8043731-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b52943a9be9299429339dfef79c3f85e-ebbed86d0a794743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-730c9a70c116474493722ce1dace538a-741979f2d034fb4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8404f1dbb7ad7d073e3277e44f824d55",
         "x-ms-return-client-request-id": "true"
@@ -33,25 +36,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "cee39d69-a7e3-4043-b43c-1b202acc91c0",
+        "apim-request-id": "dadb737f-4df0-4cea-a482-df64b98e5f57",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:24 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+        "Date": "Mon, 01 Feb 2021 14:24:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/60787e73-f6a2-411f-a4c2-a1dacc157eda",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "564",
-        "x-request-id": "cee39d69-a7e3-4043-b43c-1b202acc91c0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "687",
+        "X-Request-ID": "dadb737f-4df0-4cea-a482-df64b98e5f57"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/60787e73-f6a2-411f-a4c2-a1dacc157eda",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0c36b63199917045926e9946a652828a-0e6b43576ffae648-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1a67e05d8ee8aa46b9194b8fec8b855b-69eaac69cfcf914c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a68e8edc563c39e75ed54f6d4f2656db",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1631ec94-00d9-4e5c-b4db-2046efdef7cf",
+        "apim-request-id": "4779d63e-d2d9-4e77-93d4-770c5a180821",
         "Content-Length": "1002",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:24 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "154",
-        "x-request-id": "1631ec94-00d9-4e5c-b4db-2046efdef7cf"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "139",
+        "X-Request-ID": "4779d63e-d2d9-4e77-93d4-770c5a180821"
       },
       "ResponseBody": {
-        "dataFeedId": "e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+        "dataFeedId": "60787e73-f6a2-411f-a4c2-a1dacc157eda",
         "dataFeedName": "dataFeeduxkt4O0L",
         "metrics": [
           {
-            "metricId": "3326c382-b082-4e76-9c65-f9e30c8026f8",
+            "metricId": "8f85097a-c3cf-421c-8ef1-0d1f15646ee6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:24Z",
+        "createdTime": "2021-02-01T14:24:39Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,15 +122,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/60787e73-f6a2-411f-a4c2-a1dacc157eda",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "716",
+        "Content-Length": "733",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-07e372a5dce1fa4ab6dc3346394ea002-b94c3af82d1bf44f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3463b06235aea64b997a39d5f09c8a26-e752857e91779b4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f91204fd916bacaf108bfa28d58ab66d",
         "x-ms-return-client-request-id": "true"
@@ -151,7 +160,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -161,24 +171,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d4d5a897-6c5f-48c4-a095-81bfcd696fee",
+        "apim-request-id": "426f5d13-05bc-45c3-ab2c-628bf5bf8616",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:24 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "675",
-        "x-request-id": "d4d5a897-6c5f-48c4-a095-81bfcd696fee"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "807",
+        "X-Request-ID": "426f5d13-05bc-45c3-ab2c-628bf5bf8616"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/60787e73-f6a2-411f-a4c2-a1dacc157eda",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-540efddfe1253e4581fd0bb96f09290f-324d9af91e3ebe4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1191cc7507e68644b4ae86a82269e486-6c4b9f957b7eab4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "00a20ad9abc8855b09cb26d8689a2d17",
         "x-ms-return-client-request-id": "true"
@@ -186,21 +199,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c5750543-bf18-46ed-8b55-a44e4b1a03c7",
-        "Content-Length": "1128",
+        "apim-request-id": "e7dda6ae-bf41-4ab1-8180-76377227f6d9",
+        "Content-Length": "1145",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:25 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "169",
-        "x-request-id": "c5750543-bf18-46ed-8b55-a44e4b1a03c7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "144",
+        "X-Request-ID": "e7dda6ae-bf41-4ab1-8180-76377227f6d9"
       },
       "ResponseBody": {
-        "dataFeedId": "e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+        "dataFeedId": "60787e73-f6a2-411f-a4c2-a1dacc157eda",
         "dataFeedName": "dataFeedvmT7DNpI",
         "metrics": [
           {
-            "metricId": "3326c382-b082-4e76-9c65-f9e30c8026f8",
+            "metricId": "8f85097a-c3cf-421c-8ef1-0d1f15646ee6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -226,6 +239,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -233,7 +247,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:24Z",
+        "createdTime": "2021-02-01T14:24:39Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,13 +259,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0d4b0d7-7ac5-4dd1-b34b-c7be3372e31a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/60787e73-f6a2-411f-a4c2-a1dacc157eda",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ce5878e6e9ce434a9fdada983bea5b62-3882b76c4594724d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-375db57ad627584893a528ba62073f58-9b198d80faa7d845-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4ae69cdb53704be9dfe295b05bbe64d3",
         "x-ms-return-client-request-id": "true"
@@ -259,19 +276,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2076cf93-ce74-4721-a14b-dc993e8bacd1",
+        "apim-request-id": "677dfe63-cd46-4175-8cbf-777780d40074",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:25 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "369",
-        "x-request-id": "2076cf93-ce74-4721-a14b-dc993e8bacd1"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "304",
+        "X-Request-ID": "677dfe63-cd46-4175-8cbf-777780d40074"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:25.8043731-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:24:40.8426828-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6a00f1ded6509444a25fc4febe72f0f6-b02b76e2d60c364f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-7aa06a068bac4d429e6ef37a0988881b-7c9f8bd095d12849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "053953a3bc1324c35d91f45da1bd8f39",
         "x-ms-return-client-request-id": "true"
@@ -36,28 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "23c9805d-61d5-4f06-b977-c2c089ffe096",
+        "apim-request-id": "862a990b-777e-43a6-a7a4-40dd5b38f8be",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:07 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
+        "Date": "Mon, 01 Feb 2021 15:41:01 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8c23dc9-311e-4fc4-ac33-868b5ed5c15b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "660",
-        "X-Request-ID": "23c9805d-61d5-4f06-b977-c2c089ffe096"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "460",
+        "x-request-id": "862a990b-777e-43a6-a7a4-40dd5b38f8be"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8c23dc9-311e-4fc4-ac33-868b5ed5c15b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1a5058aafa46c549b2602e5e27e66548-e5e2197b9ca71347-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-6d7a1ad498ad0e449e8effeb91a31192-74e2761d94013444-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c1c79b88777908719e799834b6b86cd0",
         "x-ms-return-client-request-id": "true"
@@ -65,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a92b8121-5629-4f1f-a39a-32075d6f89fd",
+        "apim-request-id": "f6f2aff6-ee54-4784-a22b-d4776f14d253",
         "Content-Length": "1002",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "183",
-        "X-Request-ID": "a92b8121-5629-4f1f-a39a-32075d6f89fd"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "f6f2aff6-ee54-4784-a22b-d4776f14d253"
       },
       "ResponseBody": {
-        "dataFeedId": "b9c6e425-49ed-4bba-b19a-9910975a0960",
+        "dataFeedId": "d8c23dc9-311e-4fc4-ac33-868b5ed5c15b",
         "dataFeedName": "dataFeedov6CZcD6",
         "metrics": [
           {
-            "metricId": "4b591efb-9d10-4846-a9c4-4e5ebe929d61",
+            "metricId": "4ce8a664-b037-428a-86a0-6b7beace3e71",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -110,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:07Z",
+        "createdTime": "2021-02-01T15:41:01Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -122,18 +116,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8c23dc9-311e-4fc4-ac33-868b5ed5c15b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "716",
+        "Content-Length": "733",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4aba67d629cb824c80e10448f076d8df-7d937a861dcf4347-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-f236c1824ac95c4f83e945b86491ac14-038d2815d6466d4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8788e4b463821a68f8b80c4a715406e9",
         "x-ms-return-client-request-id": "true"
@@ -160,7 +151,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -170,27 +162,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7e02dca0-713c-4e40-a11d-2b0eecb4c7f5",
+        "apim-request-id": "c5a58423-633e-4308-96d5-1e4fb2aa89d3",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:09 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "803",
-        "X-Request-ID": "7e02dca0-713c-4e40-a11d-2b0eecb4c7f5"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "724",
+        "x-request-id": "c5a58423-633e-4308-96d5-1e4fb2aa89d3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8c23dc9-311e-4fc4-ac33-868b5ed5c15b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6eb3481954f0d74ca32bea9f1d9bcb03-6f6cfd36ca49304d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-88b041ba74e01d43b6f8123f5db4ee11-806c5efb521da740-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ac36a3912e182b93e131679a248e6da4",
         "x-ms-return-client-request-id": "true"
@@ -198,21 +187,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f11580a3-ec25-467c-8f30-f06d059fb91a",
-        "Content-Length": "1128",
+        "apim-request-id": "11de7f34-667f-439b-ac7a-a2d1198bb476",
+        "Content-Length": "1145",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:09 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "174",
-        "X-Request-ID": "f11580a3-ec25-467c-8f30-f06d059fb91a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "x-request-id": "11de7f34-667f-439b-ac7a-a2d1198bb476"
       },
       "ResponseBody": {
-        "dataFeedId": "b9c6e425-49ed-4bba-b19a-9910975a0960",
+        "dataFeedId": "d8c23dc9-311e-4fc4-ac33-868b5ed5c15b",
         "dataFeedName": "dataFeedXMi101m0",
         "metrics": [
           {
-            "metricId": "4b591efb-9d10-4846-a9c4-4e5ebe929d61",
+            "metricId": "4ce8a664-b037-428a-86a0-6b7beace3e71",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -238,6 +227,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -245,7 +235,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:07Z",
+        "createdTime": "2021-02-01T15:41:01Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -257,16 +247,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d8c23dc9-311e-4fc4-ac33-868b5ed5c15b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-97a96914338e19428f11936384c6eb79-629bf6f45763904d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a11b2cdbef93974aa5cb7cdae3a9c46a-7076633aea1a004a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bda82325083524b733acc9c06b26964a",
         "x-ms-return-client-request-id": "true"
@@ -274,19 +261,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e53607da-d9fc-4e7e-be06-cbaacbeffeb9",
+        "apim-request-id": "4cc09497-ea2d-478b-a2d1-4f32ac38f800",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:09 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "350",
-        "X-Request-ID": "e53607da-d9fc-4e7e-be06-cbaacbeffeb9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "318",
+        "x-request-id": "4cc09497-ea2d-478b-a2d1-4f32ac38f800"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:09.4030212-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:02.6655988-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6562caff7bcba941905a105eac9d910b-1fa956517a40ef41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6a00f1ded6509444a25fc4febe72f0f6-b02b76e2d60c364f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "bedc21a7df480cf0a353390513bcc324",
+        "x-ms-client-request-id": "053953a3bc1324c35d91f45da1bd8f39",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +36,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5c33350b-fb40-4111-87bc-70c1bb952be7",
+        "apim-request-id": "23c9805d-61d5-4f06-b977-c2c089ffe096",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:09 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8df5bec7-9dcc-4b93-938e-7e0ca3e7c74e",
+        "Date": "Mon, 01 Feb 2021 13:42:07 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "577",
-        "x-request-id": "5c33350b-fb40-4111-87bc-70c1bb952be7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "660",
+        "X-Request-ID": "23c9805d-61d5-4f06-b977-c2c089ffe096"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8df5bec7-9dcc-4b93-938e-7e0ca3e7c74e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3627bd25f5cf844792dad8f87121c6c0-7770e2e4ca09fa40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1a5058aafa46c549b2602e5e27e66548-e5e2197b9ca71347-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5df4915dbda1398f889bc7c179777108",
+        "x-ms-client-request-id": "c1c79b88777908719e799834b6b86cd0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "054aebd1-7941-4476-98e0-79f464ae2998",
+        "apim-request-id": "a92b8121-5629-4f1f-a39a-32075d6f89fd",
         "Content-Length": "1002",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:09 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "054aebd1-7941-4476-98e0-79f464ae2998"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "X-Request-ID": "a92b8121-5629-4f1f-a39a-32075d6f89fd"
       },
       "ResponseBody": {
-        "dataFeedId": "8df5bec7-9dcc-4b93-938e-7e0ca3e7c74e",
+        "dataFeedId": "b9c6e425-49ed-4bba-b19a-9910975a0960",
         "dataFeedName": "dataFeedov6CZcD6",
         "metrics": [
           {
-            "metricId": "bc0c9ddc-ef23-4b9f-b378-e95593c38605",
+            "metricId": "4b591efb-9d10-4846-a9c4-4e5ebe929d61",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:09Z",
+        "createdTime": "2021-02-01T13:42:07Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +122,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8df5bec7-9dcc-4b93-938e-7e0ca3e7c74e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "716",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a1bb847db19dc14396e75c8a5ae42292-0fd8fd8e53a45a4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4aba67d629cb824c80e10448f076d8df-7d937a861dcf4347-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3498799eb8b6d06cb4e488878263681a",
+        "x-ms-client-request-id": "8788e4b463821a68f8b80c4a715406e9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +146,10 @@
           "collectionId": "collectId"
         },
         "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeedov6CZcD6",
+        "dataFeedName": "dataFeedXMi101m0",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +170,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fbdf5c74-3588-4a77-96d9-9db30ec78ea8",
+        "apim-request-id": "7e02dca0-713c-4e40-a11d-2b0eecb4c7f5",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:10 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "706",
-        "x-request-id": "fbdf5c74-3588-4a77-96d9-9db30ec78ea8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "803",
+        "X-Request-ID": "7e02dca0-713c-4e40-a11d-2b0eecb4c7f5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8df5bec7-9dcc-4b93-938e-7e0ca3e7c74e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-718f2f8b2e4ef54ebb0fac157436614a-bf02d80bac917245-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6eb3481954f0d74ca32bea9f1d9bcb03-6f6cfd36ca49304d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "4a0cb8f85471e90691a336ac182e932b",
+        "x-ms-client-request-id": "ac36a3912e182b93e131679a248e6da4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1ad1a6c7-934a-431a-b7b3-82b15b85c3c9",
+        "apim-request-id": "f11580a3-ec25-467c-8f30-f06d059fb91a",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:10 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "1ad1a6c7-934a-431a-b7b3-82b15b85c3c9"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "174",
+        "X-Request-ID": "f11580a3-ec25-467c-8f30-f06d059fb91a"
       },
       "ResponseBody": {
-        "dataFeedId": "8df5bec7-9dcc-4b93-938e-7e0ca3e7c74e",
-        "dataFeedName": "dataFeedov6CZcD6",
+        "dataFeedId": "b9c6e425-49ed-4bba-b19a-9910975a0960",
+        "dataFeedName": "dataFeedXMi101m0",
         "metrics": [
           {
-            "metricId": "bc0c9ddc-ef23-4b9f-b378-e95593c38605",
+            "metricId": "4b591efb-9d10-4846-a9c4-4e5ebe929d61",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureCosmosDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +245,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:09Z",
+        "createdTime": "2021-02-01T13:42:07Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +257,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8df5bec7-9dcc-4b93-938e-7e0ca3e7c74e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9c6e425-49ed-4bba-b19a-9910975a0960",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dc22a3c2deb05c44a2c1ac0803f5f4e8-a459ec92ec26f34c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-97a96914338e19428f11936384c6eb79-629bf6f45763904d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9a6731e18e24a46d2523a8bd3508b724",
+        "x-ms-client-request-id": "bda82325083524b733acc9c06b26964a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2a71cc25-d242-422d-89c3-fabe697f7c78",
+        "apim-request-id": "e53607da-d9fc-4e7e-be06-cbaacbeffeb9",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:11 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "429",
-        "x-request-id": "2a71cc25-d242-422d-89c3-fabe697f7c78"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "350",
+        "X-Request-ID": "e53607da-d9fc-4e7e-be06-cbaacbeffeb9"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:10.9030220-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:09.4030212-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-927dd059969cf3408585bf843873119a-a795c06627ae354a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c8cf8f32a06d7042b6f81f50c0384de2-69e4ed12b6851a47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ceb18aa11a26c92398e548a99c1b88b4",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d3c7038a-34ad-41d5-b465-833b9ca37445",
+        "apim-request-id": "28cfdea5-0ece-4393-9f7b-e45cd3385782",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
+        "Date": "Mon, 01 Feb 2021 15:52:25 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/69e78e63-c05a-4e8d-8efa-7d6a5a0e57cd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "412",
-        "x-request-id": "d3c7038a-34ad-41d5-b465-833b9ca37445"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "614",
+        "X-Request-ID": "28cfdea5-0ece-4393-9f7b-e45cd3385782"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/69e78e63-c05a-4e8d-8efa-7d6a5a0e57cd",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b816b6e6435b8d4b9a4da0bfca30ffbc-7bbc67c6d96f3349-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2025486c43359a4cbf6c326e4070eef2-fd66b479c159434e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1fb279e7ce539956b9ed7e2e2dba87ec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedxyXJvUQO",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1ae85776-dc9d-48c6-837c-a3fc154d0d3e",
+        "apim-request-id": "47ae8f14-4d2a-4849-917b-b60f05f2e72e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "1ae85776-dc9d-48c6-837c-a3fc154d0d3e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "205",
+        "X-Request-ID": "47ae8f14-4d2a-4849-917b-b60f05f2e72e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/69e78e63-c05a-4e8d-8efa-7d6a5a0e57cd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-52d81a55ca754d4687cb4be936cdd448-27e80f5a6e3b5d4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2a8ef9ffcbe6c14aa2ee92c3f730a391-02ca3c2138aabf41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3d849c23eff020859b76fa8934b88539",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "33ac18c2-e97f-411e-8d9c-49f3d4846cad",
+        "apim-request-id": "beb7fcc0-8e61-4c5e-ab03-5549a5b4ea30",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "168",
-        "x-request-id": "33ac18c2-e97f-411e-8d9c-49f3d4846cad"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "182",
+        "X-Request-ID": "beb7fcc0-8e61-4c5e-ab03-5549a5b4ea30"
       },
       "ResponseBody": {
-        "dataFeedId": "eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
+        "dataFeedId": "69e78e63-c05a-4e8d-8efa-7d6a5a0e57cd",
         "dataFeedName": "dataFeedxyXJvUQO",
         "metrics": [
           {
-            "metricId": "a685007f-a7da-498b-a446-0b38bd063d7c",
+            "metricId": "9bc530a0-307c-4e0b-b6b4-75b56d6e823e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:24Z",
+        "createdTime": "2021-02-01T15:52:25Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/69e78e63-c05a-4e8d-8efa-7d6a5a0e57cd",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b9f6d7467ae252409099056214ee8b28-3e855fba3c1ca141-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-893a5e882793274e9e2c740afb901fb9-fb5cad8b67fd6f4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "63ce0bdead3cd2a0341715399bf49cde",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c2d34e15-7280-4fcf-81ce-b344beb1e7c2",
+        "apim-request-id": "057fb711-84a9-4f64-9f86-4fc750077682",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "354",
-        "x-request-id": "c2d34e15-7280-4fcf-81ce-b344beb1e7c2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "470",
+        "X-Request-ID": "057fb711-84a9-4f64-9f86-4fc750077682"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:25.1773409-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:25.6728385-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e607c57a8f3e984a80ee9c3e04e87f47-d2f6dd4e23622346-00",
+        "traceparent": "00-927dd059969cf3408585bf843873119a-a795c06627ae354a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "08ce497013d8a6c7e992dc658b978b1c",
+        "x-ms-client-request-id": "ceb18aa11a26c92398e548a99c1b88b4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,7 +22,7 @@
           "collectionId": "collectId"
         },
         "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeed6vhmLu9a",
+        "dataFeedName": "dataFeedBRes2Pal",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -33,40 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f735c20b-bf1d-4265-83a9-6dcf05505bef",
+        "apim-request-id": "d3c7038a-34ad-41d5-b465-833b9ca37445",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
+        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "564",
-        "x-request-id": "f735c20b-bf1d-4265-83a9-6dcf05505bef"
+        "x-envoy-upstream-service-time": "412",
+        "x-request-id": "d3c7038a-34ad-41d5-b465-833b9ca37445"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "604",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-30ef01c0fec3a046b2152b7c3055912b-1c48a1601b076141-00",
+        "traceparent": "00-b816b6e6435b8d4b9a4da0bfca30ffbc-7bbc67c6d96f3349-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1137606e97cb9bb91fb6d4625a2784f3",
+        "x-ms-client-request-id": "1fb279e7ce539956b9ed7e2e2dba87ec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "sqlQuery": "query",
-          "database": "database",
-          "collectionId": "collectId"
-        },
-        "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeedBWFFMNb8",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedxyXJvUQO",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -83,46 +77,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "39119ba4-f36a-4d3e-ac15-12c35776ef8b",
+        "apim-request-id": "1ae85776-dc9d-48c6-837c-a3fc154d0d3e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:26 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "662",
-        "x-request-id": "39119ba4-f36a-4d3e-ac15-12c35776ef8b"
+        "x-envoy-upstream-service-time": "155",
+        "x-request-id": "1ae85776-dc9d-48c6-837c-a3fc154d0d3e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-568050cdebe88047aa4abf7588a6bd47-f8de72dbad4b5548-00",
+        "traceparent": "00-52d81a55ca754d4687cb4be936cdd448-27e80f5a6e3b5d4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "98ec821d631ab393f9126cdd7136ce70",
+        "x-ms-client-request-id": "3d849c23eff020859b76fa8934b88539",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3c065f90-e120-436a-b35e-269efa1bab54",
+        "apim-request-id": "33ac18c2-e97f-411e-8d9c-49f3d4846cad",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:26 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "161",
-        "x-request-id": "3c065f90-e120-436a-b35e-269efa1bab54"
+        "x-envoy-upstream-service-time": "168",
+        "x-request-id": "33ac18c2-e97f-411e-8d9c-49f3d4846cad"
       },
       "ResponseBody": {
-        "dataFeedId": "8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
-        "dataFeedName": "dataFeedBWFFMNb8",
+        "dataFeedId": "eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
+        "dataFeedName": "dataFeedxyXJvUQO",
         "metrics": [
           {
-            "metricId": "66430ce4-27b1-482a-8211-9964039f7bcb",
+            "metricId": "a685007f-a7da-498b-a446-0b38bd063d7c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -155,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:26Z",
+        "createdTime": "2021-02-01T15:45:24Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,37 +161,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/eb149354-9eaf-4498-b85f-ccb95c7a1d3e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b0a0bcc7fe1a9f4a86fffd8456f22f55-7d6c5da6948bb049-00",
+        "traceparent": "00-b9f6d7467ae252409099056214ee8b28-3e855fba3c1ca141-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "74149cf87642d8be8f32e9223e644bc2",
+        "x-ms-client-request-id": "63ce0bdead3cd2a0341715399bf49cde",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b13b12fe-ebb9-4d9b-938d-5f4847a6c766",
+        "apim-request-id": "c2d34e15-7280-4fcf-81ce-b344beb1e7c2",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:27 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "306",
-        "x-request-id": "b13b12fe-ebb9-4d9b-938d-5f4847a6c766"
+        "x-envoy-upstream-service-time": "354",
+        "x-request-id": "c2d34e15-7280-4fcf-81ce-b344beb1e7c2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:27.6996638-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:25.1773409-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "591034984"
+    "RandomSeed": "1183464636"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-58d66c7b3b317745b258e2ceec81da0d-6d83b8ad823fc64f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e607c57a8f3e984a80ee9c3e04e87f47-d2f6dd4e23622346-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "83b984087ad589887049ce08d813c7a6",
+        "x-ms-client-request-id": "08ce497013d8a6c7e992dc658b978b1c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +33,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "52e7567e-0976-4660-9ad9-a7f813a56fd6",
+        "apim-request-id": "f735c20b-bf1d-4265-83a9-6dcf05505bef",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:47 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4a4ec57b-32c1-4574-ac01-6266e91abffe",
+        "Date": "Mon, 01 Feb 2021 13:12:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "375",
-        "x-request-id": "52e7567e-0976-4660-9ad9-a7f813a56fd6"
+        "x-envoy-upstream-service-time": "564",
+        "x-request-id": "f735c20b-bf1d-4265-83a9-6dcf05505bef"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4a4ec57b-32c1-4574-ac01-6266e91abffe",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "604",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-84b474a0177dbc49a09416d855a79176-48800366b282f843-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-30ef01c0fec3a046b2152b7c3055912b-1c48a1601b076141-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "65dc92e9978b1c8b6e603711cb97b99b",
+        "x-ms-client-request-id": "1137606e97cb9bb91fb6d4625a2784f3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +66,10 @@
           "collectionId": "collectId"
         },
         "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeed6vhmLu9a",
+        "dataFeedName": "dataFeedBWFFMNb8",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +83,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1d9e03bd-3c6b-434e-b165-66e6a3884278",
+        "apim-request-id": "39119ba4-f36a-4d3e-ac15-12c35776ef8b",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:47 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "552",
-        "x-request-id": "1d9e03bd-3c6b-434e-b165-66e6a3884278"
+        "x-envoy-upstream-service-time": "662",
+        "x-request-id": "39119ba4-f36a-4d3e-ac15-12c35776ef8b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4a4ec57b-32c1-4574-ac01-6266e91abffe",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c490fca895468d4283dfe71b0228e26c-71ba53df2f6b9d4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-568050cdebe88047aa4abf7588a6bd47-f8de72dbad4b5548-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "62d4b61f275af3841d82ec981a6393b3",
+        "x-ms-client-request-id": "98ec821d631ab393f9126cdd7136ce70",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bb3068bd-c529-4a6f-b825-ee13447803ab",
+        "apim-request-id": "3c065f90-e120-436a-b35e-269efa1bab54",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:48 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "178",
-        "x-request-id": "bb3068bd-c529-4a6f-b825-ee13447803ab"
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "3c065f90-e120-436a-b35e-269efa1bab54"
       },
       "ResponseBody": {
-        "dataFeedId": "4a4ec57b-32c1-4574-ac01-6266e91abffe",
-        "dataFeedName": "dataFeed6vhmLu9a",
+        "dataFeedId": "8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
+        "dataFeedName": "dataFeedBWFFMNb8",
         "metrics": [
           {
-            "metricId": "1079dea8-5e5f-4c6d-a473-33872c46fa45",
+            "metricId": "66430ce4-27b1-482a-8211-9964039f7bcb",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureCosmosDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +155,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:47Z",
+        "createdTime": "2021-02-01T13:12:26Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +167,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4a4ec57b-32c1-4574-ac01-6266e91abffe",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8d3cd9ab-d37f-4fd6-9058-00cfb52929e0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-caf4862c2090a54eb7234153a0cacc29-4fcde6777b34bd49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b0a0bcc7fe1a9f4a86fffd8456f22f55-7d6c5da6948bb049-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "dd6c12f9367170cef89c14744276bed8",
+        "x-ms-client-request-id": "74149cf87642d8be8f32e9223e644bc2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5107d983-c2b0-4a6f-a686-648691519c76",
+        "apim-request-id": "b13b12fe-ebb9-4d9b-938d-5f4847a6c766",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:48 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "357",
-        "x-request-id": "5107d983-c2b0-4a6f-a686-648691519c76"
+        "x-envoy-upstream-service-time": "306",
+        "x-request-id": "b13b12fe-ebb9-4d9b-938d-5f4847a6c766"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:48.3066873-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:27.6996638-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b05ada8503778746be6a2c765d1b7d57-734e2ee66ca11a44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0cfc69d52fbb0c4ab51a4d2939195645-e81dbd5d57eb9f46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f3b984a851df6bbad17503620662c19d",
+        "x-ms-client-request-id": "620375d162069dc1f185eefa169aa43f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +36,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "970d7f53-ac47-4f27-a5b8-7677589e5b0d",
+        "apim-request-id": "f9a7eb39-5bbc-4c9d-8681-e2c1ddbc3390",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:11 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/91dcd7d1-6516-4459-84e9-b7534781ea44",
+        "Date": "Mon, 01 Feb 2021 13:42:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "559",
-        "x-request-id": "970d7f53-ac47-4f27-a5b8-7677589e5b0d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "653",
+        "X-Request-ID": "f9a7eb39-5bbc-4c9d-8681-e2c1ddbc3390"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/91dcd7d1-6516-4459-84e9-b7534781ea44",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "604",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cfe9637146ea744797677fbadf1eb659-fe5d68ccd03d9346-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6d0804a099da9848b2253ee670bbade1-a512c53a53c5394c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "faee85f19a163fa4d6c29ad691c33f3c",
+        "x-ms-client-request-id": "d69ac2d6c3913c3f2452dae28ea2f051",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +72,10 @@
           "collectionId": "collectId"
         },
         "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeedCG23sntr",
+        "dataFeedName": "dataFeedU36paY9y",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +89,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6121e762-bba8-48a3-94f6-b22955f54cd2",
+        "apim-request-id": "0edf81f2-592c-4323-b929-a61f024d67cf",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:12 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "718",
-        "x-request-id": "6121e762-bba8-48a3-94f6-b22955f54cd2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "746",
+        "X-Request-ID": "0edf81f2-592c-4323-b929-a61f024d67cf"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/91dcd7d1-6516-4459-84e9-b7534781ea44",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f2300b9681709244a2c52d96eaf9141b-bf7642a7cfaf914b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cc501c0b2bd5e24a883f29888cb6346c-104b9b97a7f5034e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e2da5224a28e51f0a226f359e7d6bbd3",
+        "x-ms-client-request-id": "59f326a2d6e7d3bb3a46fca49754c50d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bff99e0d-140d-4f9e-a1da-8eab81002011",
+        "apim-request-id": "fe1c63f5-b100-43dd-a185-76a6c1e1c3fd",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:12 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "bff99e0d-140d-4f9e-a1da-8eab81002011"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "X-Request-ID": "fe1c63f5-b100-43dd-a185-76a6c1e1c3fd"
       },
       "ResponseBody": {
-        "dataFeedId": "91dcd7d1-6516-4459-84e9-b7534781ea44",
-        "dataFeedName": "dataFeedCG23sntr",
+        "dataFeedId": "5a710092-6a79-4809-a83c-14e9ca5a4d5a",
+        "dataFeedName": "dataFeedU36paY9y",
         "metrics": [
           {
-            "metricId": "b3fd9429-3ef7-4d30-805f-460a64df4476",
+            "metricId": "ecf40fac-baad-43aa-bcaa-b37549eff408",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureCosmosDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +164,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:11Z",
+        "createdTime": "2021-02-01T13:42:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +176,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/91dcd7d1-6516-4459-84e9-b7534781ea44",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e59d2a76c6992d449128edf13644f00a-f937042514a8a048-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5f17859900b9ac4cbf618a6d0eaf67e6-477c03659962cb4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a4fc463a54970dc5df7a1c1cb7e4da0e",
+        "x-ms-client-request-id": "1c1c7adfe4b70eda35c63db487df0f4f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d3e6db6b-a5f3-40da-8dac-900e34046814",
+        "apim-request-id": "8681f507-cb2e-494c-9506-e30c6bcbd9e6",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:13 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "405",
-        "x-request-id": "d3e6db6b-a5f3-40da-8dac-900e34046814"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "339",
+        "X-Request-ID": "8681f507-cb2e-494c-9506-e30c6bcbd9e6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:13.0615071-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:11.4414180-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c42a1038181a674fbc96c532f2fee1d4-c0d7b39f51d0ff4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-35870d0c65c67942944330fecf01a939-a392bf9861931a43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "620375d162069dc1f185eefa169aa43f",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "76cb0c00-4a40-49ca-b605-702633830f48",
+        "apim-request-id": "b64bbfdc-4939-4623-84af-ae8628dbeb5a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
+        "Date": "Mon, 01 Feb 2021 15:52:56 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fa3e1ee9-4ae3-4cf9-b4a9-f8e1becfaaf2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "441",
-        "x-request-id": "76cb0c00-4a40-49ca-b605-702633830f48"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "408",
+        "X-Request-ID": "b64bbfdc-4939-4623-84af-ae8628dbeb5a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fa3e1ee9-4ae3-4cf9-b4a9-f8e1becfaaf2",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0ac62ea1ff09e042a5a2eb87d8e03928-7951982fa16f3741-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9993ee1cdd05004db1ba704f9d4cacfd-961337b810dc7f43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d69ac2d6c3913c3f2452dae28ea2f051",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedU36paY9y",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "dc4fb987-c0bd-4fee-8883-afe2df606073",
+        "apim-request-id": "d43b4a7e-a6e3-417b-86b0-358fe437eaeb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "184",
-        "x-request-id": "dc4fb987-c0bd-4fee-8883-afe2df606073"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "191",
+        "X-Request-ID": "d43b4a7e-a6e3-417b-86b0-358fe437eaeb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fa3e1ee9-4ae3-4cf9-b4a9-f8e1becfaaf2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b3d009986a4b4c4f83b3ae0212dc2f4b-8b8953d2256fd743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-53e9b2f5341e3e4c9bc98113d810e199-ac1f2e6d4f17c44e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "59f326a2d6e7d3bb3a46fca49754c50d",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "154cd247-ea7b-4ace-bdf7-8efe1d1707ce",
+        "apim-request-id": "e5ff911f-8ea3-447f-914b-a912d31a000d",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "173",
-        "x-request-id": "154cd247-ea7b-4ace-bdf7-8efe1d1707ce"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "172",
+        "X-Request-ID": "e5ff911f-8ea3-447f-914b-a912d31a000d"
       },
       "ResponseBody": {
-        "dataFeedId": "b1e18f02-4929-41af-9c0f-d1c7c1009082",
+        "dataFeedId": "fa3e1ee9-4ae3-4cf9-b4a9-f8e1becfaaf2",
         "dataFeedName": "dataFeedU36paY9y",
         "metrics": [
           {
-            "metricId": "b0b0409f-a9a2-4eb7-88d4-123dec328342",
+            "metricId": "022ddbe0-2a4c-4d20-9ed8-3794f09ed24b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:03Z",
+        "createdTime": "2021-02-01T15:52:57Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fa3e1ee9-4ae3-4cf9-b4a9-f8e1becfaaf2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-70cc0fbf9938af4ab33ae5af8679aaa6-44d3b56232ff9b49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6cb24ca19320314689534908163932e1-d93b312c29ac9349-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1c1c7adfe4b70eda35c63db487df0f4f",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "239b2af4-f171-4671-a294-91228fd96bb6",
+        "apim-request-id": "59010bb1-b789-44e4-92a8-ae3b1f88b4d8",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "341",
-        "x-request-id": "239b2af4-f171-4671-a294-91228fd96bb6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "363",
+        "X-Request-ID": "59010bb1-b789-44e4-92a8-ae3b1f88b4d8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:03.8904615-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:57.5685783-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0cfc69d52fbb0c4ab51a4d2939195645-e81dbd5d57eb9f46-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c42a1038181a674fbc96c532f2fee1d4-c0d7b39f51d0ff4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "620375d162069dc1f185eefa169aa43f",
         "x-ms-return-client-request-id": "true"
@@ -36,42 +33,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f9a7eb39-5bbc-4c9d-8681-e2c1ddbc3390",
+        "apim-request-id": "76cb0c00-4a40-49ca-b605-702633830f48",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:10 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
+        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "653",
-        "X-Request-ID": "f9a7eb39-5bbc-4c9d-8681-e2c1ddbc3390"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "441",
+        "x-request-id": "76cb0c00-4a40-49ca-b605-702633830f48"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "604",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6d0804a099da9848b2253ee670bbade1-a512c53a53c5394c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-0ac62ea1ff09e042a5a2eb87d8e03928-7951982fa16f3741-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d69ac2d6c3913c3f2452dae28ea2f051",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "sqlQuery": "query",
-          "database": "database",
-          "collectionId": "collectId"
-        },
-        "dataSourceType": "AzureCosmosDB",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedU36paY9y",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -89,27 +77,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0edf81f2-592c-4323-b929-a61f024d67cf",
+        "apim-request-id": "dc4fb987-c0bd-4fee-8883-afe2df606073",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:10 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "746",
-        "X-Request-ID": "0edf81f2-592c-4323-b929-a61f024d67cf"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "dc4fb987-c0bd-4fee-8883-afe2df606073"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cc501c0b2bd5e24a883f29888cb6346c-104b9b97a7f5034e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-b3d009986a4b4c4f83b3ae0212dc2f4b-8b8953d2256fd743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "59f326a2d6e7d3bb3a46fca49754c50d",
         "x-ms-return-client-request-id": "true"
@@ -117,21 +102,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fe1c63f5-b100-43dd-a185-76a6c1e1c3fd",
+        "apim-request-id": "154cd247-ea7b-4ace-bdf7-8efe1d1707ce",
         "Content-Length": "1128",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:11 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "166",
-        "X-Request-ID": "fe1c63f5-b100-43dd-a185-76a6c1e1c3fd"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "173",
+        "x-request-id": "154cd247-ea7b-4ace-bdf7-8efe1d1707ce"
       },
       "ResponseBody": {
-        "dataFeedId": "5a710092-6a79-4809-a83c-14e9ca5a4d5a",
+        "dataFeedId": "b1e18f02-4929-41af-9c0f-d1c7c1009082",
         "dataFeedName": "dataFeedU36paY9y",
         "metrics": [
           {
-            "metricId": "ecf40fac-baad-43aa-bcaa-b37549eff408",
+            "metricId": "b0b0409f-a9a2-4eb7-88d4-123dec328342",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -164,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:10Z",
+        "createdTime": "2021-02-01T15:41:03Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -176,16 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5a710092-6a79-4809-a83c-14e9ca5a4d5a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1e18f02-4929-41af-9c0f-d1c7c1009082",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5f17859900b9ac4cbf618a6d0eaf67e6-477c03659962cb4e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-70cc0fbf9938af4ab33ae5af8679aaa6-44d3b56232ff9b49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1c1c7adfe4b70eda35c63db487df0f4f",
         "x-ms-return-client-request-id": "true"
@@ -193,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8681f507-cb2e-494c-9506-e30c6bcbd9e6",
+        "apim-request-id": "239b2af4-f171-4671-a294-91228fd96bb6",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:11 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "339",
-        "X-Request-ID": "8681f507-cb2e-494c-9506-e30c6bcbd9e6"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "341",
+        "x-request-id": "239b2af4-f171-4671-a294-91228fd96bb6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:11.4414180-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:03.8904615-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8d7291dfa688104185336a6a00f6d726-5c8a0540b2899d4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0479a8bae36d5d4781add5f7f9cef2e0-2a504dce3488284c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "40a34cd5295bc71eaf581e8c96161ba3",
         "x-ms-return-client-request-id": "true"
@@ -33,55 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a147ab91-f8d6-4b8f-a4ca-f233e5a5a670",
+        "apim-request-id": "d96d0b59-6aaf-4958-9a2d-644936ec8beb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
+        "Date": "Mon, 01 Feb 2021 15:52:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1a8cc048-71f8-43b0-9635-62bb1cd9f97f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "399",
-        "x-request-id": "a147ab91-f8d6-4b8f-a4ca-f233e5a5a670"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "427",
+        "X-Request-ID": "d96d0b59-6aaf-4958-9a2d-644936ec8beb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1a8cc048-71f8-43b0-9635-62bb1cd9f97f",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b1863951e82c64cba48d283ead9401d-e84259ae4d4f374d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c652e64f3999064a9ed84dade69f9903-28027d3c64363045-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "54854b21bb0bb791d3c292255c426a58",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5199be53-764f-4de6-b430-309ce0acd663",
+        "apim-request-id": "d29c34c0-1678-4d5e-af8e-ea204af852c3",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165",
-        "x-request-id": "5199be53-764f-4de6-b430-309ce0acd663"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "181",
+        "X-Request-ID": "d29c34c0-1678-4d5e-af8e-ea204af852c3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1a8cc048-71f8-43b0-9635-62bb1cd9f97f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-62f7400bf563e44587fe3ad0ebf7165f-1e0467fe52cea140-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cf8fdf1b08be9b40a910d8b7567e4ac4-7d1cf6963c92da42-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2ee96d6ff42eb249eefd4e8e67052a01",
         "x-ms-return-client-request-id": "true"
@@ -89,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b365d67d-9213-4c68-8277-f6bae5340220",
+        "apim-request-id": "9abb67f2-70dd-4c94-817d-69fbe8b562cb",
         "Content-Length": "1053",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "147",
-        "x-request-id": "b365d67d-9213-4c68-8277-f6bae5340220"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "158",
+        "X-Request-ID": "9abb67f2-70dd-4c94-817d-69fbe8b562cb"
       },
       "ResponseBody": {
-        "dataFeedId": "9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
+        "dataFeedId": "1a8cc048-71f8-43b0-9635-62bb1cd9f97f",
         "dataFeedName": "dataFeedg8aWDqZ6",
         "metrics": [
           {
-            "metricId": "82468e99-af6a-4aec-a033-1b2726a7ba92",
+            "metricId": "c9e3829a-f17d-4794-a440-87df8126cd99",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -134,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:29Z",
+        "createdTime": "2021-02-01T15:52:26Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -146,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1a8cc048-71f8-43b0-9635-62bb1cd9f97f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1b12c920eb05074fb6780e1426257746-f703b9a3e01d244d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6aed26c8e354e144af54a4c934c32ea6-8c32f100d2e2dd40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9be8262bfe481988bbec6c9897f86a6d",
         "x-ms-return-client-request-id": "true"
@@ -160,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "76ecd313-04a1-4d33-88d2-e9e79c018016",
+        "apim-request-id": "e7d70979-b2ee-4d8b-9913-6585a2e8cd47",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "318",
-        "x-request-id": "76ecd313-04a1-4d33-88d2-e9e79c018016"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "326",
+        "X-Request-ID": "e7d70979-b2ee-4d8b-9913-6585a2e8cd47"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:29.9308218-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:27.0009296-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9b298687392e8545bbc6d45fae4d5410-ef40b4d5b67eae45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8d7291dfa688104185336a6a00f6d726-5c8a0540b2899d4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "40a34cd5295bc71eaf581e8c96161ba3",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +33,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f65c2213-57df-4422-983c-c93cbe433b76",
+        "apim-request-id": "a147ab91-f8d6-4b8f-a4ca-f233e5a5a670",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:50 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3eb77ec-a680-4ebd-82af-02aa41ffe03a",
+        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "456",
-        "x-request-id": "f65c2213-57df-4422-983c-c93cbe433b76"
+        "x-envoy-upstream-service-time": "399",
+        "x-request-id": "a147ab91-f8d6-4b8f-a4ca-f233e5a5a670"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3eb77ec-a680-4ebd-82af-02aa41ffe03a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "306",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c4df02b3c139fe448c7536caafe885a9-ee0b9d08ac542a48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7b1863951e82c64cba48d283ead9401d-e84259ae4d4f374d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "54854b21bb0bb791d3c292255c426a58",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "sqlQuery": "query",
-          "database": "database",
-          "collectionId": "collectId"
-        },
-        "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeedg8aWDqZ6",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1a3cada8-ea4f-4732-bd38-2cdf5f7d6d3d",
+        "apim-request-id": "5199be53-764f-4de6-b430-309ce0acd663",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:51 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "498",
-        "x-request-id": "1a3cada8-ea4f-4732-bd38-2cdf5f7d6d3d"
+        "x-envoy-upstream-service-time": "165",
+        "x-request-id": "5199be53-764f-4de6-b430-309ce0acd663"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3eb77ec-a680-4ebd-82af-02aa41ffe03a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-339fc097da389a4cace1d8ceb2e6eca4-2d2af4ec03094b42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-62f7400bf563e44587fe3ad0ebf7165f-1e0467fe52cea140-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2ee96d6ff42eb249eefd4e8e67052a01",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +89,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b18be12e-6243-4b0c-82f4-c794926f22ff",
+        "apim-request-id": "b365d67d-9213-4c68-8277-f6bae5340220",
         "Content-Length": "1053",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:51 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165",
-        "x-request-id": "b18be12e-6243-4b0c-82f4-c794926f22ff"
+        "x-envoy-upstream-service-time": "147",
+        "x-request-id": "b365d67d-9213-4c68-8277-f6bae5340220"
       },
       "ResponseBody": {
-        "dataFeedId": "f3eb77ec-a680-4ebd-82af-02aa41ffe03a",
+        "dataFeedId": "9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
         "dataFeedName": "dataFeedg8aWDqZ6",
         "metrics": [
           {
-            "metricId": "87f4b983-dde2-48d8-99d8-f7b965bbbe05",
+            "metricId": "82468e99-af6a-4aec-a033-1b2726a7ba92",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +134,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:50Z",
+        "createdTime": "2021-02-01T12:46:29Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +146,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3eb77ec-a680-4ebd-82af-02aa41ffe03a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9ee8f4f4-012b-47e8-a30b-95b6dfd8f130",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-209efec4bdd2e744b526b46778ef53bf-536237aa40386b49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1b12c920eb05074fb6780e1426257746-f703b9a3e01d244d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9be8262bfe481988bbec6c9897f86a6d",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +160,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "79cb9961-31ea-4fb4-921f-db54dcfa0bb3",
+        "apim-request-id": "76ecd313-04a1-4d33-88d2-e9e79c018016",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:51 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "383",
-        "x-request-id": "79cb9961-31ea-4fb4-921f-db54dcfa0bb3"
+        "x-envoy-upstream-service-time": "318",
+        "x-request-id": "76ecd313-04a1-4d33-88d2-e9e79c018016"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:51.7641576-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:29.9308218-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0e971c90f8196d4d91bfac4887ee1d90-718a2aa19f5bca45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9567f2095815b14eb49944d4eceba049-25658a67fa2eda46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e0224d1038a082c5d91f607f5228b80c",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "684078d5-60df-442a-9eff-0cd7d3c4fc19",
+        "apim-request-id": "233246ba-550f-4ff5-868b-9dd67881938e",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/764e41fd-9abf-4ba8-8d59-985bb7154276",
+        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "690",
-        "x-request-id": "684078d5-60df-442a-9eff-0cd7d3c4fc19"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "623",
+        "X-Request-ID": "233246ba-550f-4ff5-868b-9dd67881938e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/764e41fd-9abf-4ba8-8d59-985bb7154276",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "306",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ab72c3d1e00f041b0b474f4d3f97472-94b0b50223da4c48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-989619b977324f4ea7e99663d091ac26-fac458f3a0aab046-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9a6a0e55db68df488bc6bc513ce48cdd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "sqlQuery": "query",
-          "database": "database",
-          "collectionId": "collectId"
-        },
-        "dataSourceType": "AzureCosmosDB",
-        "dataFeedName": "dataFeedcJuuEvid",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "17d835cf-fdcb-4a55-9cb6-4f4240cc71a4",
+        "apim-request-id": "036118b7-effb-4b79-9513-09f121dfea6f",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:17 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "794",
-        "x-request-id": "17d835cf-fdcb-4a55-9cb6-4f4240cc71a4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "200",
+        "X-Request-ID": "036118b7-effb-4b79-9513-09f121dfea6f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/764e41fd-9abf-4ba8-8d59-985bb7154276",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7a7c16fce941714b8a3101fbe8de4625-53f1a8c6ee8b9a40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a32d280ee19a0e4790a86ed4c1174b0a-47b3b799c82de943-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5adc7a088a74771331216309a8620fbe",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3b495381-b4e2-4a6c-8480-dd9b2d075ddc",
+        "apim-request-id": "48851f50-8ef1-419b-8db3-187c07e30142",
         "Content-Length": "1053",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:17 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "219",
-        "x-request-id": "3b495381-b4e2-4a6c-8480-dd9b2d075ddc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "174",
+        "X-Request-ID": "48851f50-8ef1-419b-8db3-187c07e30142"
       },
       "ResponseBody": {
-        "dataFeedId": "764e41fd-9abf-4ba8-8d59-985bb7154276",
+        "dataFeedId": "ce77f123-86e9-4969-820f-5211171fec41",
         "dataFeedName": "dataFeedcJuuEvid",
         "metrics": [
           {
-            "metricId": "d51ef4bd-c866-4f8b-8da3-47236aa594e5",
+            "metricId": "8169e4a6-b33e-4f81-b348-ad2f35c7d4b1",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:16Z",
+        "createdTime": "2021-02-01T13:42:12Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/764e41fd-9abf-4ba8-8d59-985bb7154276",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-880ab2bf5d9da7418949a9e64e789444-5a9d664c038e5240-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2d339a5786f08343bf0a81e7eb8121d1-4c10f0eda0455e47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b80c8912593c352c054355d97c7445f4",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "37e23276-809c-40a4-9d1c-050771c68830",
+        "apim-request-id": "41c09358-6454-4300-8373-854539bff420",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:18 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "357",
-        "x-request-id": "37e23276-809c-40a4-9d1c-050771c68830"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "355",
+        "X-Request-ID": "41c09358-6454-4300-8373-854539bff420"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:17.8866594-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:12.9152292-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureCosmosDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "290",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9567f2095815b14eb49944d4eceba049-25658a67fa2eda46-00",
+        "traceparent": "00-f39f106786bd534f98abeb29df9bcd36-48f60d41cce66843-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -36,26 +36,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "233246ba-550f-4ff5-868b-9dd67881938e",
+        "apim-request-id": "3d89810a-5d78-46d5-a683-2c858f005b25",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
+        "Date": "Mon, 01 Feb 2021 15:52:57 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c21d9de-81c6-4610-8e14-066b9fedf40b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "623",
-        "X-Request-ID": "233246ba-550f-4ff5-868b-9dd67881938e"
+        "x-envoy-upstream-service-time": "498",
+        "X-Request-ID": "3d89810a-5d78-46d5-a683-2c858f005b25"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c21d9de-81c6-4610-8e14-066b9fedf40b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-989619b977324f4ea7e99663d091ac26-fac458f3a0aab046-00",
+        "traceparent": "00-774b0a424912e249bb9ca9caa671725f-1ab43b74d6db7c4d-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -65,28 +65,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "036118b7-effb-4b79-9513-09f121dfea6f",
+        "apim-request-id": "5ef4da75-1c62-4314-b8ba-0dc349c10f53",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "200",
-        "X-Request-ID": "036118b7-effb-4b79-9513-09f121dfea6f"
+        "x-envoy-upstream-service-time": "152",
+        "X-Request-ID": "5ef4da75-1c62-4314-b8ba-0dc349c10f53"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c21d9de-81c6-4610-8e14-066b9fedf40b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a32d280ee19a0e4790a86ed4c1174b0a-47b3b799c82de943-00",
+        "traceparent": "00-b035043335bbac44b4e9aa8a29fbb24f-4022f657a993884f-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -98,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "48851f50-8ef1-419b-8db3-187c07e30142",
+        "apim-request-id": "fe9c210f-4e5b-4bcb-8eba-791ad43fbcf6",
         "Content-Length": "1053",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "174",
-        "X-Request-ID": "48851f50-8ef1-419b-8db3-187c07e30142"
+        "x-envoy-upstream-service-time": "152",
+        "X-Request-ID": "fe9c210f-4e5b-4bcb-8eba-791ad43fbcf6"
       },
       "ResponseBody": {
-        "dataFeedId": "ce77f123-86e9-4969-820f-5211171fec41",
+        "dataFeedId": "3c21d9de-81c6-4610-8e14-066b9fedf40b",
         "dataFeedName": "dataFeedcJuuEvid",
         "metrics": [
           {
-            "metricId": "8169e4a6-b33e-4f81-b348-ad2f35c7d4b1",
+            "metricId": "5f09f84c-0ece-4e3c-9abd-6d881de693aa",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -143,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:12Z",
+        "createdTime": "2021-02-01T15:52:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -155,12 +155,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ce77f123-86e9-4969-820f-5211171fec41",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c21d9de-81c6-4610-8e14-066b9fedf40b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2d339a5786f08343bf0a81e7eb8121d1-4c10f0eda0455e47-00",
+        "traceparent": "00-2ba81988b7ca244eb9564a17bfb76239-603c556b4bbc7b45-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -172,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "41c09358-6454-4300-8373-854539bff420",
+        "apim-request-id": "919b6d88-9757-49d6-85a3-cc74f34e15ba",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "355",
-        "X-Request-ID": "41c09358-6454-4300-8373-854539bff420"
+        "x-envoy-upstream-service-time": "309",
+        "X-Request-ID": "919b6d88-9757-49d6-85a3-cc74f34e15ba"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:12.9152292-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:58.9062701-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2d844f1938d70c40a229a83c8e732de9-6010b7bb897d3341-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7c30ee40c9a2fb49b49aa964ec6dcc16-074149a6d728f042-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7a7d4d42aa095d73ffa642bbc1614cd0",
+        "x-ms-client-request-id": "bb42a6ff61c1d04c47b502a9f9908d07",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +31,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e77ece7b-e303-4210-8fc5-27c8137cedcf",
+        "apim-request-id": "3621872f-f05b-48ac-9722-8f89fa124c1c",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:52 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3efacf6d-6c81-494d-b757-8d0a2f149220",
+        "Date": "Mon, 01 Feb 2021 13:12:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "367",
-        "x-request-id": "e77ece7b-e303-4210-8fc5-27c8137cedcf"
+        "x-envoy-upstream-service-time": "571",
+        "x-request-id": "3621872f-f05b-48ac-9722-8f89fa124c1c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3efacf6d-6c81-494d-b757-8d0a2f149220",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8c8110b8d8ae6644aa21b093446e493d-41b26410b8faf046-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-83d197f1a18b7343b9483ac9ab3ee8ef-72450b9ebfcb5c4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a902b54790f9078d9828c7b7f556593e",
+        "x-ms-client-request-id": "b7c7289856f53e5974f48c02cfe5d9e9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2700eced-890d-427b-9a91-ffaaa2e6b3dd",
+        "apim-request-id": "1a232a1d-17ca-44da-9094-9726a045ea80",
         "Content-Length": "954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:52 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "156",
-        "x-request-id": "2700eced-890d-427b-9a91-ffaaa2e6b3dd"
+        "x-envoy-upstream-service-time": "160",
+        "x-request-id": "1a232a1d-17ca-44da-9094-9726a045ea80"
       },
       "ResponseBody": {
-        "dataFeedId": "3efacf6d-6c81-494d-b757-8d0a2f149220",
+        "dataFeedId": "a680de33-10a3-4d7e-b0fc-fb30a16146c3",
         "dataFeedName": "dataFeedlyX8Vr5E",
         "metrics": [
           {
-            "metricId": "ae7014f4-998c-4481-ac14-9762b4e5b5d3",
+            "metricId": "b482e537-189c-427c-8e7d-c2df0abb3601",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:52Z",
+        "createdTime": "2021-02-01T13:12:28Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +112,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3efacf6d-6c81-494d-b757-8d0a2f149220",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "668",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-47eab6bea8c45441aff1aec83f082e90-4b4ba8c0d679684c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-db5701f50c03894ca9844fd7e1824a2b-a390717f9b159a4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "028cf474e5cfe9d9801f545bc8115f01",
+        "x-ms-client-request-id": "5b541f8011c8015fb179311ce068f4b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +131,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeedlyX8Vr5E",
+        "dataFeedName": "dataFeedOwA4fUul",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +155,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0bac4d75-8a04-4388-8880-027c45f2f70b",
+        "apim-request-id": "3718dc40-83c5-49d2-9b17-7d9f8280867f",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:53 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "540",
-        "x-request-id": "0bac4d75-8a04-4388-8880-027c45f2f70b"
+        "x-envoy-upstream-service-time": "691",
+        "x-request-id": "3718dc40-83c5-49d2-9b17-7d9f8280867f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3efacf6d-6c81-494d-b757-8d0a2f149220",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2e656ec2bdbd5342a8dee21d6035cd2f-4be43f9c25d7cf49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4f6f1e7d384fcb4193e849d3ed7657e4-108dcfc481d00c4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1c3179b168e0b2f4c075e1e1e3bc68a8",
+        "x-ms-client-request-id": "e1e175c0bce3a8684c0346cdd5490162",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0b5933ce-1c2a-4532-9117-7eccb559cb51",
+        "apim-request-id": "f2230e55-490d-474a-a4c1-6fad88049189",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:54 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1008",
-        "x-request-id": "0b5933ce-1c2a-4532-9117-7eccb559cb51"
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "f2230e55-490d-474a-a4c1-6fad88049189"
       },
       "ResponseBody": {
-        "dataFeedId": "3efacf6d-6c81-494d-b757-8d0a2f149220",
-        "dataFeedName": "dataFeedlyX8Vr5E",
+        "dataFeedId": "a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+        "dataFeedName": "dataFeedOwA4fUul",
         "metrics": [
           {
-            "metricId": "ae7014f4-998c-4481-ac14-9762b4e5b5d3",
+            "metricId": "b482e537-189c-427c-8e7d-c2df0abb3601",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataExplorer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +227,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:52Z",
+        "createdTime": "2021-02-01T13:12:28Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +237,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3efacf6d-6c81-494d-b757-8d0a2f149220",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-60656f5da9c7f84fbc195ad8b5ec9cd6-a2b33d25e7f14649-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ae8e3fb74c95ca459bf9cc4b9fa65e77-a1ed8e7cd2ff944a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "cd46034c49d56201dc1928da3b313f87",
+        "x-ms-client-request-id": "da2819dc313b873fc9c5067b253d5e0c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "bacebcb1-0499-4262-959f-c43319ab9d04",
+        "apim-request-id": "10999d1f-78e6-46c9-a7c4-971f1ca925d3",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:54 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "417",
-        "x-request-id": "bacebcb1-0499-4262-959f-c43319ab9d04"
+        "x-envoy-upstream-service-time": "387",
+        "x-request-id": "10999d1f-78e6-46c9-a7c4-971f1ca925d3"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:54.4432560-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:29.7555857-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c30ee40c9a2fb49b49aa964ec6dcc16-074149a6d728f042-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7bf0fed180be4b4988bb2155372a72e1-d9d53ff100a42747-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bb42a6ff61c1d04c47b502a9f9908d07",
         "x-ms-return-client-request-id": "true"
@@ -31,25 +34,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3621872f-f05b-48ac-9722-8f89fa124c1c",
+        "apim-request-id": "2266f927-d65a-4a8a-8226-ba87cd429ad1",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+        "Date": "Mon, 01 Feb 2021 14:24:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14374405-3b91-4714-bb0b-b4bbbf07ce05",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "571",
-        "x-request-id": "3621872f-f05b-48ac-9722-8f89fa124c1c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "554",
+        "X-Request-ID": "2266f927-d65a-4a8a-8226-ba87cd429ad1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14374405-3b91-4714-bb0b-b4bbbf07ce05",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-83d197f1a18b7343b9483ac9ab3ee8ef-72450b9ebfcb5c4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-37cd737eb6f6814ca3f0e6cfa15d0463-3fb399bdbba3744e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b7c7289856f53e5974f48c02cfe5d9e9",
         "x-ms-return-client-request-id": "true"
@@ -57,21 +63,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1a232a1d-17ca-44da-9094-9726a045ea80",
+        "apim-request-id": "a0f1ae67-d3b0-4847-9f89-a3b72c1d87e0",
         "Content-Length": "954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:27 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "1a232a1d-17ca-44da-9094-9726a045ea80"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "145",
+        "X-Request-ID": "a0f1ae67-d3b0-4847-9f89-a3b72c1d87e0"
       },
       "ResponseBody": {
-        "dataFeedId": "a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+        "dataFeedId": "14374405-3b91-4714-bb0b-b4bbbf07ce05",
         "dataFeedName": "dataFeedlyX8Vr5E",
         "metrics": [
           {
-            "metricId": "b482e537-189c-427c-8e7d-c2df0abb3601",
+            "metricId": "922a5430-d377-4f84-af2e-709713dc1ef1",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:28Z",
+        "createdTime": "2021-02-01T14:24:43Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,15 +118,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14374405-3b91-4714-bb0b-b4bbbf07ce05",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "668",
+        "Content-Length": "685",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-db5701f50c03894ca9844fd7e1824a2b-a390717f9b159a4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3e4cf6275094a244947a1a5b4eb9bcba-6ad85aef1317de46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5b541f8011c8015fb179311ce068f4b2",
         "x-ms-return-client-request-id": "true"
@@ -145,7 +154,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -155,24 +165,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3718dc40-83c5-49d2-9b17-7d9f8280867f",
+        "apim-request-id": "579eaf0e-1fd3-486f-af51-3ec6927c0c51",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:28 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "691",
-        "x-request-id": "3718dc40-83c5-49d2-9b17-7d9f8280867f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "798",
+        "X-Request-ID": "579eaf0e-1fd3-486f-af51-3ec6927c0c51"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14374405-3b91-4714-bb0b-b4bbbf07ce05",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4f6f1e7d384fcb4193e849d3ed7657e4-108dcfc481d00c4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0b7efed644d7174a9101d05a5634f5d0-562ad11b940de34c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e1e175c0bce3a8684c0346cdd5490162",
         "x-ms-return-client-request-id": "true"
@@ -180,21 +193,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f2230e55-490d-474a-a4c1-6fad88049189",
-        "Content-Length": "1080",
+        "apim-request-id": "3e6bc8b3-2bf9-4727-b8df-ef32668e16f3",
+        "Content-Length": "1097",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:28 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "f2230e55-490d-474a-a4c1-6fad88049189"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "143",
+        "X-Request-ID": "3e6bc8b3-2bf9-4727-b8df-ef32668e16f3"
       },
       "ResponseBody": {
-        "dataFeedId": "a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+        "dataFeedId": "14374405-3b91-4714-bb0b-b4bbbf07ce05",
         "dataFeedName": "dataFeedOwA4fUul",
         "metrics": [
           {
-            "metricId": "b482e537-189c-427c-8e7d-c2df0abb3601",
+            "metricId": "922a5430-d377-4f84-af2e-709713dc1ef1",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -220,6 +233,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -227,7 +241,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:28Z",
+        "createdTime": "2021-02-01T14:24:43Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,13 +251,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a680de33-10a3-4d7e-b0fc-fb30a16146c3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14374405-3b91-4714-bb0b-b4bbbf07ce05",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ae8e3fb74c95ca459bf9cc4b9fa65e77-a1ed8e7cd2ff944a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-34b9adc04836f646b8d60ddee613adbd-4b36bca2ae397341-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "da2819dc313b873fc9c5067b253d5e0c",
         "x-ms-return-client-request-id": "true"
@@ -251,19 +268,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "10999d1f-78e6-46c9-a7c4-971f1ca925d3",
+        "apim-request-id": "b49d4e52-0fd6-48d0-8ffd-4289deee042e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:30 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "387",
-        "x-request-id": "10999d1f-78e6-46c9-a7c4-971f1ca925d3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "309",
+        "X-Request-ID": "b49d4e52-0fd6-48d0-8ffd-4289deee042e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:29.7555857-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:24:44.9529225-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0bb0ddd6ab1b1241987a690a0b605fd1-baf3bfa239911543-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-5afb4a262e592047b6483d1cb5d1b256-ae80dedf1d723c42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d0fa0538560779237dfa6eee3f178f42",
         "x-ms-return-client-request-id": "true"
@@ -34,28 +31,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6284dbcd-26f9-43d2-ad67-4d037651beb5",
+        "apim-request-id": "27b54a31-54ce-4c33-9d3e-415119674eab",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:13 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
+        "Date": "Mon, 01 Feb 2021 15:41:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad8901a0-1d37-4f8f-8a3c-2578b93b2af5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "558",
-        "X-Request-ID": "6284dbcd-26f9-43d2-ad67-4d037651beb5"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "609",
+        "x-request-id": "27b54a31-54ce-4c33-9d3e-415119674eab"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad8901a0-1d37-4f8f-8a3c-2578b93b2af5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d36733f20103474fa575fe9104be2f12-450d9fc299f91647-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-be60da7950da6e42b56fa3ceb421a4f4-0285288ce1055e46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "82b85caba0fd6bd9f89afdf736cd17d4",
         "x-ms-return-client-request-id": "true"
@@ -63,21 +57,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a32752c6-25e0-4fa2-aa1e-7a4f440962b7",
+        "apim-request-id": "fa933d3b-1173-4090-876f-a4a4199e56cf",
         "Content-Length": "954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:13 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "316",
-        "X-Request-ID": "a32752c6-25e0-4fa2-aa1e-7a4f440962b7"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "fa933d3b-1173-4090-876f-a4a4199e56cf"
       },
       "ResponseBody": {
-        "dataFeedId": "0ee4412d-a42d-4548-8ba3-214880e7c864",
+        "dataFeedId": "ad8901a0-1d37-4f8f-8a3c-2578b93b2af5",
         "dataFeedName": "dataFeedqtqXRYM8",
         "metrics": [
           {
-            "metricId": "46fe6184-5a43-4e7c-8b3f-820efad7f61e",
+            "metricId": "ac22bea9-1cd4-42f8-ace4-27b5109a555a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -108,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:13Z",
+        "createdTime": "2021-02-01T15:41:04Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,18 +112,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad8901a0-1d37-4f8f-8a3c-2578b93b2af5",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "668",
+        "Content-Length": "685",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c89dc21d8d9e1f48ad7c8572fee0507a-40dbb4d103a4b84a-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-8c803e99ba6af144a4ce3ce35af475f1-198e681b14f2b046-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1396621345368f35cf02576a6654f41d",
         "x-ms-return-client-request-id": "true"
@@ -154,7 +145,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -164,27 +156,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "bf5598d8-17c1-4c8d-a1c2-fcdf4eb71616",
+        "apim-request-id": "21f8b368-0cbe-4f05-af35-d18c1e4cd627",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:14 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "731",
-        "X-Request-ID": "bf5598d8-17c1-4c8d-a1c2-fcdf4eb71616"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "625",
+        "x-request-id": "21f8b368-0cbe-4f05-af35-d18c1e4cd627"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad8901a0-1d37-4f8f-8a3c-2578b93b2af5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cee8e44e861206478c4a1bab3e0559e7-a088edc9fef82f4e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a023d55c9542b343a623c82d31422e79-6c5a9034ac095d43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2da42c57792f97982b8fd86d592b43b0",
         "x-ms-return-client-request-id": "true"
@@ -192,21 +181,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3e849327-e195-462d-b03f-6f5c75527b49",
-        "Content-Length": "1080",
+        "apim-request-id": "36aae744-b87d-4b87-b9ac-94cc7ca62c06",
+        "Content-Length": "1097",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:14 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "X-Request-ID": "3e849327-e195-462d-b03f-6f5c75527b49"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "197",
+        "x-request-id": "36aae744-b87d-4b87-b9ac-94cc7ca62c06"
       },
       "ResponseBody": {
-        "dataFeedId": "0ee4412d-a42d-4548-8ba3-214880e7c864",
+        "dataFeedId": "ad8901a0-1d37-4f8f-8a3c-2578b93b2af5",
         "dataFeedName": "dataFeedCBL3dSPT",
         "metrics": [
           {
-            "metricId": "46fe6184-5a43-4e7c-8b3f-820efad7f61e",
+            "metricId": "ac22bea9-1cd4-42f8-ace4-27b5109a555a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -232,6 +221,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -239,7 +229,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:13Z",
+        "createdTime": "2021-02-01T15:41:04Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,16 +239,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ad8901a0-1d37-4f8f-8a3c-2578b93b2af5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b899f1f86dee54da068812a57ca5163-7c292f875ca8364c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-29ffa2ca1d2f324d974d51cfda9e2029-01a14a6de954d543-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dcda9ae27c80650b2728b3fa486f04a4",
         "x-ms-return-client-request-id": "true"
@@ -266,19 +253,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b653fb76-b4f3-45ef-b683-44ebd6fb2d70",
+        "apim-request-id": "812f503f-1d49-47fd-a0cc-1b0eba38d69d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:14 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "408",
-        "X-Request-ID": "b653fb76-b4f3-45ef-b683-44ebd6fb2d70"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "335",
+        "x-request-id": "812f503f-1d49-47fd-a0cc-1b0eba38d69d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:15.2023875-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:06.1426760-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-55986f10eb5cfd4b816d91fdc650dba2-cba45207ee103648-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0bb0ddd6ab1b1241987a690a0b605fd1-baf3bfa239911543-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "4f6fe735e88a95fc3805fad007562379",
+        "x-ms-client-request-id": "d0fa0538560779237dfa6eee3f178f42",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +34,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e391a363-31fc-4cbf-92a7-6588626a031c",
+        "apim-request-id": "6284dbcd-26f9-43d2-ad67-4d037651beb5",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64627589-caa2-493a-9203-456689a5cecd",
+        "Date": "Mon, 01 Feb 2021 13:42:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "564",
-        "x-request-id": "e391a363-31fc-4cbf-92a7-6588626a031c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "558",
+        "X-Request-ID": "6284dbcd-26f9-43d2-ad67-4d037651beb5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64627589-caa2-493a-9203-456689a5cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-69b262d5d2234346a31870b63f1e55cc-b3653bd2d15afa41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d36733f20103474fa575fe9104be2f12-450d9fc299f91647-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ee6efa7d173f428fab5cb882fda0d96b",
+        "x-ms-client-request-id": "82b85caba0fd6bd9f89afdf736cd17d4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "293a6794-9eb1-4459-8c69-f4232c9e5d99",
+        "apim-request-id": "a32752c6-25e0-4fa2-aa1e-7a4f440962b7",
         "Content-Length": "954",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "293a6794-9eb1-4459-8c69-f4232c9e5d99"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "316",
+        "X-Request-ID": "a32752c6-25e0-4fa2-aa1e-7a4f440962b7"
       },
       "ResponseBody": {
-        "dataFeedId": "64627589-caa2-493a-9203-456689a5cecd",
+        "dataFeedId": "0ee4412d-a42d-4548-8ba3-214880e7c864",
         "dataFeedName": "dataFeedqtqXRYM8",
         "metrics": [
           {
-            "metricId": "20edc4f7-fe9b-4cc3-ae94-7035b5869adc",
+            "metricId": "46fe6184-5a43-4e7c-8b3f-820efad7f61e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:18Z",
+        "createdTime": "2021-02-01T13:42:13Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +118,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64627589-caa2-493a-9203-456689a5cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "668",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4b0b804cdbd28242a202d5fb60699b9d-581f45a360a00148-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c89dc21d8d9e1f48ad7c8572fee0507a-40dbb4d103a4b84a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f7fd9af8cd36d417136296133645358f",
+        "x-ms-client-request-id": "1396621345368f35cf02576a6654f41d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +140,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeedqtqXRYM8",
+        "dataFeedName": "dataFeedCBL3dSPT",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +164,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c9f80c23-0998-4877-af71-ca2e410e371f",
+        "apim-request-id": "bf5598d8-17c1-4c8d-a1c2-fcdf4eb71616",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "649",
-        "x-request-id": "c9f80c23-0998-4877-af71-ca2e410e371f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "731",
+        "X-Request-ID": "bf5598d8-17c1-4c8d-a1c2-fcdf4eb71616"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64627589-caa2-493a-9203-456689a5cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8305035295e2cd4d9ecaa90cb2fb75a2-084a1c744c9d5841-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cee8e44e861206478c4a1bab3e0559e7-a088edc9fef82f4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6a5702cf54661df4572ca42d2f799897",
+        "x-ms-client-request-id": "2da42c57792f97982b8fd86d592b43b0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c76750d2-92e9-4831-a788-32bce029e936",
+        "apim-request-id": "3e849327-e195-462d-b03f-6f5c75527b49",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "c76750d2-92e9-4831-a788-32bce029e936"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "X-Request-ID": "3e849327-e195-462d-b03f-6f5c75527b49"
       },
       "ResponseBody": {
-        "dataFeedId": "64627589-caa2-493a-9203-456689a5cecd",
-        "dataFeedName": "dataFeedqtqXRYM8",
+        "dataFeedId": "0ee4412d-a42d-4548-8ba3-214880e7c864",
+        "dataFeedName": "dataFeedCBL3dSPT",
         "metrics": [
           {
-            "metricId": "20edc4f7-fe9b-4cc3-ae94-7035b5869adc",
+            "metricId": "46fe6184-5a43-4e7c-8b3f-820efad7f61e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataExplorer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +239,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:18Z",
+        "createdTime": "2021-02-01T13:42:13Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +249,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/64627589-caa2-493a-9203-456689a5cecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0ee4412d-a42d-4548-8ba3-214880e7c864",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-40e3f23a2fde7f44933729652b021ac1-029db0233fa60d4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7b899f1f86dee54da068812a57ca5163-7c292f875ca8364c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6dd88f2b2b59b043e29adadc807c0b65",
+        "x-ms-client-request-id": "dcda9ae27c80650b2728b3fa486f04a4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1aee86d2-26a3-438e-a7b5-7ad32f4c0595",
+        "apim-request-id": "b653fb76-b4f3-45ef-b683-44ebd6fb2d70",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:20 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "364",
-        "x-request-id": "1aee86d2-26a3-438e-a7b5-7ad32f4c0595"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "408",
+        "X-Request-ID": "b653fb76-b4f3-45ef-b683-44ebd6fb2d70"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:20.1583012-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:15.2023875-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-64d2f639099d7d42a8a5526152139e54-ff05724f8e16da43-00",
+        "traceparent": "00-6cb67c27450f9f41b1bf26e03e7be102-e1133548ff6dba49-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ef7812036ff795d8f8f5476d45070418",
+        "x-ms-client-request-id": "463260d5e5e398420c7f0207ad41ef0d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,7 +20,7 @@
           "query": "query"
         },
         "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeed5HTZRgjG",
+        "dataFeedName": "dataFeedYtc7NEWp",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -31,38 +31,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2de310ef-4c29-49ca-ba2e-61b9b2e49a85",
+        "apim-request-id": "fe51a7bf-cc37-48b8-90bc-b1a74a621769",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
+        "Date": "Mon, 01 Feb 2021 15:45:25 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "547",
-        "x-request-id": "2de310ef-4c29-49ca-ba2e-61b9b2e49a85"
+        "x-envoy-upstream-service-time": "421",
+        "x-request-id": "fe51a7bf-cc37-48b8-90bc-b1a74a621769"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "556",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bf8a5b9afbf6be47b9d0a0aff26a47db-2b12247378e97c40-00",
+        "traceparent": "00-5f9c41507a5ca24ab029ef41fbe8dc58-c01488bf83aa4d49-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "51e5d6d82c66d4caf5b93fd0174f7490",
+        "x-ms-client-request-id": "29c5295bcb04a95ba10cb55bfb6c311a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeedgtv8EGKf",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedOrzgLdZs",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -79,46 +75,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "941ed216-f30b-40cd-989b-145522c76f08",
+        "apim-request-id": "b1c0121a-450a-45c8-b3c6-47ab36a25975",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:31 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "656",
-        "x-request-id": "941ed216-f30b-40cd-989b-145522c76f08"
+        "x-envoy-upstream-service-time": "207",
+        "x-request-id": "b1c0121a-450a-45c8-b3c6-47ab36a25975"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-78143c92e9cb614aae3235da033821ad-5a848be6be448d43-00",
+        "traceparent": "00-6878ad5c84f1074cb30858f43e9a08b1-c3e6ab71ab58b74b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "43a12274ec987754482e8177195ea6a5",
+        "x-ms-client-request-id": "9de4edc5896f7be76ea41622df8895a9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c8f993fa-6919-4493-adda-76f128d62611",
+        "apim-request-id": "b3acb826-5793-41c2-af7e-e72825251525",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:31 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "153",
-        "x-request-id": "c8f993fa-6919-4493-adda-76f128d62611"
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "b3acb826-5793-41c2-af7e-e72825251525"
       },
       "ResponseBody": {
-        "dataFeedId": "58db79cc-6679-4400-9097-a22389031e31",
-        "dataFeedName": "dataFeedgtv8EGKf",
+        "dataFeedId": "5475a04e-5e17-419e-83f5-d2141b2a34fc",
+        "dataFeedName": "dataFeedOrzgLdZs",
         "metrics": [
           {
-            "metricId": "4b6d2f6e-b5f8-4033-914a-3b250fb4c4ef",
+            "metricId": "cd26751b-9502-4f65-a99a-ba179beab177",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -151,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:30Z",
+        "createdTime": "2021-02-01T15:45:25Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,37 +157,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-83476d730f26874796e4bcd20c581752-9fac7b6db2dc1c4d-00",
+        "traceparent": "00-543340dfe6ba3047b0351c87bad6b2b3-82d982f96e009b44-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fd615b31f5a3d65b48a4f93d2f087da8",
+        "x-ms-client-request-id": "5e2d151e3ea409000488a4d62fe79c9f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5689377c-9722-47c1-8f60-368b8e936127",
+        "apim-request-id": "477cb8bd-bf9e-4bef-a476-6d44383d8180",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:31 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "287",
-        "x-request-id": "5689377c-9722-47c1-8f60-368b8e936127"
+        "x-envoy-upstream-service-time": "364",
+        "x-request-id": "477cb8bd-bf9e-4bef-a476-6d44383d8180"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:31.6085121-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:26.4576386-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "422751410"
+    "RandomSeed": "480888967"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f24e6690c1d6d24f8b070a693974b83c-14aa9d1787443746-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-64d2f639099d7d42a8a5526152139e54-ff05724f8e16da43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "397435ad88d4c147031278eff76fd895",
+        "x-ms-client-request-id": "ef7812036ff795d8f8f5476d45070418",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +31,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "929e9b26-e257-487d-ada5-38ca97e4f33b",
+        "apim-request-id": "2de310ef-4c29-49ca-ba2e-61b9b2e49a85",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:54 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b92900b6-7d63-4fcb-b82f-f3eb5da768b4",
+        "Date": "Mon, 01 Feb 2021 13:12:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "415",
-        "x-request-id": "929e9b26-e257-487d-ada5-38ca97e4f33b"
+        "x-envoy-upstream-service-time": "547",
+        "x-request-id": "2de310ef-4c29-49ca-ba2e-61b9b2e49a85"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b92900b6-7d63-4fcb-b82f-f3eb5da768b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "556",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a3a0b88f64ce8744964544859827ba4f-ef5f58cc3279514d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bf8a5b9afbf6be47b9d0a0aff26a47db-2b12247378e97c40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6d47f5f807451804d8d6e551662ccad4",
+        "x-ms-client-request-id": "51e5d6d82c66d4caf5b93fd0174f7490",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +62,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeed5HTZRgjG",
+        "dataFeedName": "dataFeedgtv8EGKf",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +79,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "481931a0-9639-41a6-ab0d-9ae06a6b3576",
+        "apim-request-id": "941ed216-f30b-40cd-989b-145522c76f08",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:55 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "586",
-        "x-request-id": "481931a0-9639-41a6-ab0d-9ae06a6b3576"
+        "x-envoy-upstream-service-time": "656",
+        "x-request-id": "941ed216-f30b-40cd-989b-145522c76f08"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b92900b6-7d63-4fcb-b82f-f3eb5da768b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3551cd0034a2b74fab16d6d35238b339-0392000b4e7fcc48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-78143c92e9cb614aae3235da033821ad-5a848be6be448d43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d03fb9f54f1790747422a14398ec5477",
+        "x-ms-client-request-id": "43a12274ec987754482e8177195ea6a5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d9fc408f-298a-41bf-8fd2-2fca554b617d",
+        "apim-request-id": "c8f993fa-6919-4493-adda-76f128d62611",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:55 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "210",
-        "x-request-id": "d9fc408f-298a-41bf-8fd2-2fca554b617d"
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "c8f993fa-6919-4493-adda-76f128d62611"
       },
       "ResponseBody": {
-        "dataFeedId": "b92900b6-7d63-4fcb-b82f-f3eb5da768b4",
-        "dataFeedName": "dataFeed5HTZRgjG",
+        "dataFeedId": "58db79cc-6679-4400-9097-a22389031e31",
+        "dataFeedName": "dataFeedgtv8EGKf",
         "metrics": [
           {
-            "metricId": "b5fcb65f-4500-4f4d-9548-da3bde3e76f7",
+            "metricId": "4b6d2f6e-b5f8-4033-914a-3b250fb4c4ef",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataExplorer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:55Z",
+        "createdTime": "2021-02-01T13:12:30Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +161,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b92900b6-7d63-4fcb-b82f-f3eb5da768b4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58db79cc-6679-4400-9097-a22389031e31",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a282771d2bb5784d92fbbe9dda675043-da8a960c3c7c3546-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-83476d730f26874796e4bcd20c581752-9fac7b6db2dc1c4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "77812e485e19a5a6315b61fda3f55bd6",
+        "x-ms-client-request-id": "fd615b31f5a3d65b48a4f93d2f087da8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e69ae4f7-c1ac-4496-86ab-7f6a56ed7cd1",
+        "apim-request-id": "5689377c-9722-47c1-8f60-368b8e936127",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:56 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "363",
-        "x-request-id": "e69ae4f7-c1ac-4496-86ab-7f6a56ed7cd1"
+        "x-envoy-upstream-service-time": "287",
+        "x-request-id": "5689377c-9722-47c1-8f60-368b8e936127"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:08:56.1967610-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:31.6085121-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6cb67c27450f9f41b1bf26e03e7be102-e1133548ff6dba49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-692bdd5adf246449974b47052cdb7daf-5b400898bbb0bf4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "463260d5e5e398420c7f0207ad41ef0d",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "fe51a7bf-cc37-48b8-90bc-b1a74a621769",
+        "apim-request-id": "da8f57a2-bc33-4089-a6d4-32c87cbe90aa",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:25 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
+        "Date": "Mon, 01 Feb 2021 15:52:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/31542cba-2bad-4338-83fc-b0d44dae9e92",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "421",
-        "x-request-id": "fe51a7bf-cc37-48b8-90bc-b1a74a621769"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "435",
+        "X-Request-ID": "da8f57a2-bc33-4089-a6d4-32c87cbe90aa"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/31542cba-2bad-4338-83fc-b0d44dae9e92",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5f9c41507a5ca24ab029ef41fbe8dc58-c01488bf83aa4d49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-28b7b49ab2f25e40ad9a608345d063ad-14a9a1beddb7294c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "29c5295bcb04a95ba10cb55bfb6c311a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedOrzgLdZs",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b1c0121a-450a-45c8-b3c6-47ab36a25975",
+        "apim-request-id": "8cb51a7e-7eb9-44c1-8577-251a40a14217",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:25 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "207",
-        "x-request-id": "b1c0121a-450a-45c8-b3c6-47ab36a25975"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "177",
+        "X-Request-ID": "8cb51a7e-7eb9-44c1-8577-251a40a14217"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/31542cba-2bad-4338-83fc-b0d44dae9e92",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6878ad5c84f1074cb30858f43e9a08b1-c3e6ab71ab58b74b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9d791efbc5f3fe4398b24ff39b153cad-d0e3007b8c6f904e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9de4edc5896f7be76ea41622df8895a9",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b3acb826-5793-41c2-af7e-e72825251525",
+        "apim-request-id": "5c43a331-00ca-403e-b1a8-c60822d25679",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:25 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "b3acb826-5793-41c2-af7e-e72825251525"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "155",
+        "X-Request-ID": "5c43a331-00ca-403e-b1a8-c60822d25679"
       },
       "ResponseBody": {
-        "dataFeedId": "5475a04e-5e17-419e-83f5-d2141b2a34fc",
+        "dataFeedId": "31542cba-2bad-4338-83fc-b0d44dae9e92",
         "dataFeedName": "dataFeedOrzgLdZs",
         "metrics": [
           {
-            "metricId": "cd26751b-9502-4f65-a99a-ba179beab177",
+            "metricId": "ecfa6a4f-62cb-4da1-9953-43c980a0fe3c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:25Z",
+        "createdTime": "2021-02-01T15:52:27Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5475a04e-5e17-419e-83f5-d2141b2a34fc",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/31542cba-2bad-4338-83fc-b0d44dae9e92",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-543340dfe6ba3047b0351c87bad6b2b3-82d982f96e009b44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-02e1e01ce0e1a84cb5bd7e7bad918b4d-10f07c3095b06149-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5e2d151e3ea409000488a4d62fe79c9f",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "477cb8bd-bf9e-4bef-a476-6d44383d8180",
+        "apim-request-id": "82789566-d84a-46f4-b340-ed16c18a0180",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:26 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "364",
-        "x-request-id": "477cb8bd-bf9e-4bef-a476-6d44383d8180"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "311",
+        "X-Request-ID": "82789566-d84a-46f4-b340-ed16c18a0180"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:26.4576386-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:28.2165907-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e32f54a35f2a154eb57e940eabdee8ed-fbaece1df1d2b946-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ba100846185d96408ae7135d6a677606-b8fd81ba4df3a647-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "738c66cf533d3120a843a8853c51c4dd",
         "x-ms-return-client-request-id": "true"
@@ -34,40 +31,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "be3713bd-b8b0-43ce-bac6-910a23dbab13",
+        "apim-request-id": "a319be25-7fe6-483d-8a40-94f919b3eb5e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
+        "Date": "Mon, 01 Feb 2021 15:41:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "739",
-        "X-Request-ID": "be3713bd-b8b0-43ce-bac6-910a23dbab13"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "596",
+        "x-request-id": "a319be25-7fe6-483d-8a40-94f919b3eb5e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "556",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2da578c1f5560c40a9c34b671553f4fc-a3db2ccca7788a44-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-9eb41fada973914bb140208533e0871c-4c863bf10d273b45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4261b61e496a8967fa06cdbc142631c2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "AzureDataExplorer",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedslpZOlRZ",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -85,27 +75,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "45b2a4fc-0611-4798-971c-01e62f8ac27e",
+        "apim-request-id": "ae31a400-72e9-4f0e-aa96-893e874e03f3",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:16 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "544",
-        "X-Request-ID": "45b2a4fc-0611-4798-971c-01e62f8ac27e"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "177",
+        "x-request-id": "ae31a400-72e9-4f0e-aa96-893e874e03f3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-838554eb0d768443a6cc9ff9d70bdcb4-117d6f6f5e089c4d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a5e27c8acebe7c44951274e134dc0ca0-eeb5e8ae228a2b4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2833097a97b8fd7e039e7e92bc07fba3",
         "x-ms-return-client-request-id": "true"
@@ -113,21 +100,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f055e4db-d1a2-4d50-9dc7-316b1a32363a",
+        "apim-request-id": "cebc3e3a-d6eb-41e5-9061-785e360200f7",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "168",
-        "X-Request-ID": "f055e4db-d1a2-4d50-9dc7-316b1a32363a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "cebc3e3a-d6eb-41e5-9061-785e360200f7"
       },
       "ResponseBody": {
-        "dataFeedId": "1888e59f-a956-43e6-9105-7384a46279c9",
+        "dataFeedId": "d2058a3f-30e1-4082-ab28-94812275d5c2",
         "dataFeedName": "dataFeedslpZOlRZ",
         "metrics": [
           {
-            "metricId": "d493514b-3656-48bc-bc70-45bb4d05d05e",
+            "metricId": "d799e643-4d5c-48f9-8081-4a5e58f095e9",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -160,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:16Z",
+        "createdTime": "2021-02-01T15:41:07Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,16 +157,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-71f7ab41b1c0e640a4317e8cfc6bb212-87a22d0606645245-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-353f40b1568e244e8c442a63927af9b9-94514c12f287d647-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ea270a96abc18531ff03793685631d82",
         "x-ms-return-client-request-id": "true"
@@ -187,19 +171,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4f5bc6bb-a6dd-408d-960b-fcdd9f38756f",
+        "apim-request-id": "70333efe-d450-4c07-bee4-8f19569c42cd",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "358",
-        "X-Request-ID": "4f5bc6bb-a6dd-408d-960b-fcdd9f38756f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "337",
+        "x-request-id": "70333efe-d450-4c07-bee4-8f19569c42cd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:17.1771980-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:07.6524348-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4edf044a54426e4e9228ca99234c600f-2a61227c38751344-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e32f54a35f2a154eb57e940eabdee8ed-fbaece1df1d2b946-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "45e75af523a19ceecf668c733d532031",
+        "x-ms-client-request-id": "738c66cf533d3120a843a8853c51c4dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +34,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5248fa6d-482b-4820-9974-cb770f0b28c0",
+        "apim-request-id": "be3713bd-b8b0-43ce-bac6-910a23dbab13",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/900a46c7-526e-499c-8346-6115a977bca5",
+        "Date": "Mon, 01 Feb 2021 13:42:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "618",
-        "x-request-id": "5248fa6d-482b-4820-9974-cb770f0b28c0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "739",
+        "X-Request-ID": "be3713bd-b8b0-43ce-bac6-910a23dbab13"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/900a46c7-526e-499c-8346-6115a977bca5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "556",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a82f28a16405df489fccb342a0d949e6-090ac2df5956974f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2da578c1f5560c40a9c34b671553f4fc-a3db2ccca7788a44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "85a843a8513cddc41eb661426a496789",
+        "x-ms-client-request-id": "4261b61e496a8967fa06cdbc142631c2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +68,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeed44nhOsM3",
+        "dataFeedName": "dataFeedslpZOlRZ",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +85,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b34407f9-81e7-4c67-b54f-8880d994ee17",
+        "apim-request-id": "45b2a4fc-0611-4798-971c-01e62f8ac27e",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:21 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "621",
-        "x-request-id": "b34407f9-81e7-4c67-b54f-8880d994ee17"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "544",
+        "X-Request-ID": "45b2a4fc-0611-4798-971c-01e62f8ac27e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/900a46c7-526e-499c-8346-6115a977bca5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c421f6ec0336824783712facc1b15326-35ded109e2a00c49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-838554eb0d768443a6cc9ff9d70bdcb4-117d6f6f5e089c4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "bccd06fa2614c2317a093328b8977efd",
+        "x-ms-client-request-id": "2833097a97b8fd7e039e7e92bc07fba3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d3ccffad-e19e-41c7-85fc-4aa7a34dc8e3",
+        "apim-request-id": "f055e4db-d1a2-4d50-9dc7-316b1a32363a",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:21 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "d3ccffad-e19e-41c7-85fc-4aa7a34dc8e3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "168",
+        "X-Request-ID": "f055e4db-d1a2-4d50-9dc7-316b1a32363a"
       },
       "ResponseBody": {
-        "dataFeedId": "900a46c7-526e-499c-8346-6115a977bca5",
-        "dataFeedName": "dataFeed44nhOsM3",
+        "dataFeedId": "1888e59f-a956-43e6-9105-7384a46279c9",
+        "dataFeedName": "dataFeedslpZOlRZ",
         "metrics": [
           {
-            "metricId": "8982b9e4-68bd-4627-b01c-8e056d77cdf7",
+            "metricId": "d493514b-3656-48bc-bc70-45bb4d05d05e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataExplorer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +160,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:21Z",
+        "createdTime": "2021-02-01T13:42:16Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +170,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/900a46c7-526e-499c-8346-6115a977bca5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1888e59f-a956-43e6-9105-7384a46279c9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-26794d28e3c5d746a9c656e1a0dec5aa-8338436d288ac54f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-71f7ab41b1c0e640a4317e8cfc6bb212-87a22d0606645245-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "927e9e0307bca3fb960a27eac1ab3185",
+        "x-ms-client-request-id": "ea270a96abc18531ff03793685631d82",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7ae6903d-4d51-4907-a8b2-aa9e988242e7",
+        "apim-request-id": "4f5bc6bb-a6dd-408d-960b-fcdd9f38756f",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:22 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "351",
-        "x-request-id": "7ae6903d-4d51-4907-a8b2-aa9e988242e7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "358",
+        "X-Request-ID": "4f5bc6bb-a6dd-408d-960b-fcdd9f38756f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:22.1215919-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:17.1771980-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ba100846185d96408ae7135d6a677606-b8fd81ba4df3a647-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-48160ab4a66a3b419884c56ac4324e60-0814f4d7b3a18148-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "738c66cf533d3120a843a8853c51c4dd",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a319be25-7fe6-483d-8a40-94f919b3eb5e",
+        "apim-request-id": "b80dd442-4a0c-49b6-9cab-100b90452cff",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:06 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
+        "Date": "Mon, 01 Feb 2021 15:52:58 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/81624928-bb8b-4c95-a75d-6de4c31b6bda",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "596",
-        "x-request-id": "a319be25-7fe6-483d-8a40-94f919b3eb5e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "390",
+        "X-Request-ID": "b80dd442-4a0c-49b6-9cab-100b90452cff"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/81624928-bb8b-4c95-a75d-6de4c31b6bda",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9eb41fada973914bb140208533e0871c-4c863bf10d273b45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-14e466042c05da4db0f8d150237c8b78-3145c958ac7e964a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4261b61e496a8967fa06cdbc142631c2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedslpZOlRZ",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ae31a400-72e9-4f0e-aa96-893e874e03f3",
+        "apim-request-id": "30121d5b-7b3a-42d6-8a7c-4ccfc418c38a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "ae31a400-72e9-4f0e-aa96-893e874e03f3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "174",
+        "X-Request-ID": "30121d5b-7b3a-42d6-8a7c-4ccfc418c38a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/81624928-bb8b-4c95-a75d-6de4c31b6bda",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a5e27c8acebe7c44951274e134dc0ca0-eeb5e8ae228a2b4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5718c221fe07644d8878e6de0f752026-383c97778933064e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2833097a97b8fd7e039e7e92bc07fba3",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cebc3e3a-d6eb-41e5-9061-785e360200f7",
+        "apim-request-id": "0d637c19-bbf8-4975-b5e1-52480ee4ce3d",
         "Content-Length": "1080",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "cebc3e3a-d6eb-41e5-9061-785e360200f7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "141",
+        "X-Request-ID": "0d637c19-bbf8-4975-b5e1-52480ee4ce3d"
       },
       "ResponseBody": {
-        "dataFeedId": "d2058a3f-30e1-4082-ab28-94812275d5c2",
+        "dataFeedId": "81624928-bb8b-4c95-a75d-6de4c31b6bda",
         "dataFeedName": "dataFeedslpZOlRZ",
         "metrics": [
           {
-            "metricId": "d799e643-4d5c-48f9-8081-4a5e58f095e9",
+            "metricId": "b73d04d1-5f96-41d7-b528-8fb2820b4643",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:07Z",
+        "createdTime": "2021-02-01T15:52:59Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d2058a3f-30e1-4082-ab28-94812275d5c2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/81624928-bb8b-4c95-a75d-6de4c31b6bda",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-353f40b1568e244e8c442a63927af9b9-94514c12f287d647-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-abc23770dbdee645bfb6936868a58507-66cd6b52d298a547-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ea270a96abc18531ff03793685631d82",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "70333efe-d450-4c07-bee4-8f19569c42cd",
+        "apim-request-id": "6643797d-4800-4784-8395-ab4d2b7ed527",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "337",
-        "x-request-id": "70333efe-d450-4c07-bee4-8f19569c42cd"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "307",
+        "X-Request-ID": "6643797d-4800-4784-8395-ab4d2b7ed527"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:07.6524348-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:59.9996443-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9cc4abbd996c334b82b1ccdc4527602d-d86cd9f048328542-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4d5b13721643de4ebe6b275b117b4803-475f7bdf2da0ae43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "344c16d4fd524e8e0dfbc669924e3157",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +31,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "390ad2ca-ce9d-462e-916c-341bf4b3bce9",
+        "apim-request-id": "b0751ff8-b04f-45df-aeb6-01f4ac951052",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:58 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e2a9081-1b44-4f79-873d-91cce846cc45",
+        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "566",
-        "x-request-id": "390ad2ca-ce9d-462e-916c-341bf4b3bce9"
+        "x-envoy-upstream-service-time": "378",
+        "x-request-id": "b0751ff8-b04f-45df-aeb6-01f4ac951052"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e2a9081-1b44-4f79-873d-91cce846cc45",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "258",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-042bb46e51a3624ba0df5ae0ed266720-2a3e832028b20640-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f8b0149b6f898d47989dfe1f29b43f67-3b8c97eba0fc4343-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "efae618c01e4b5af49a899bfd0ac8a3f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeedqyNTDz1h",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1917bc5e-514d-4863-935e-90e4da265981",
+        "apim-request-id": "56e4b92a-dde7-49e0-9746-af943de442a1",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:59 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "667",
-        "x-request-id": "1917bc5e-514d-4863-935e-90e4da265981"
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "56e4b92a-dde7-49e0-9746-af943de442a1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e2a9081-1b44-4f79-873d-91cce846cc45",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-67bd22d954771c4da44a35120e546dda-b418f4cb0108b549-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8df9738be372f44aa0aca12804e0a679-ec848f3ec82d2e4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8b648dd678ba90a60c8b92700cb23300",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +87,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "60bc5fa5-d7a4-49a1-843e-34058aad26f9",
+        "apim-request-id": "cf7b860b-da80-44a3-8ee7-08ac6830e567",
         "Content-Length": "1005",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:08:59 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "x-request-id": "60bc5fa5-d7a4-49a1-843e-34058aad26f9"
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "cf7b860b-da80-44a3-8ee7-08ac6830e567"
       },
       "ResponseBody": {
-        "dataFeedId": "5e2a9081-1b44-4f79-873d-91cce846cc45",
+        "dataFeedId": "4c83502e-e850-4865-a174-8c0ec20fe318",
         "dataFeedName": "dataFeedqyNTDz1h",
         "metrics": [
           {
-            "metricId": "b85b101c-47aa-456e-b5fc-b755b41521d2",
+            "metricId": "8250e26e-c322-4973-8f8e-8c93f380b3dc",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +132,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:08:59Z",
+        "createdTime": "2021-02-01T12:46:30Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +142,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e2a9081-1b44-4f79-873d-91cce846cc45",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4792517a20cd8c4caf01d6af61c2c003-d2995214bf38a44d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ee3d2e7382fa3c4ca747db4561b7b46a-85b010f82e67e14d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a1042818d4c2d3bf6697eaa963ce7d61",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +156,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "46a2da05-21b2-42cf-9451-f09e02cb48c6",
+        "apim-request-id": "29bdc92a-08bd-4e4b-a11a-72ac5208b593",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:08:59 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "327",
-        "x-request-id": "46a2da05-21b2-42cf-9451-f09e02cb48c6"
+        "x-envoy-upstream-service-time": "318",
+        "x-request-id": "29bdc92a-08bd-4e4b-a11a-72ac5208b593"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:00.1722396-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:31.2103693-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4d5b13721643de4ebe6b275b117b4803-475f7bdf2da0ae43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-eca25b69327d7a4994aebe853c0e5778-97bbf4ed521fd44e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "344c16d4fd524e8e0dfbc669924e3157",
         "x-ms-return-client-request-id": "true"
@@ -31,55 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b0751ff8-b04f-45df-aeb6-01f4ac951052",
+        "apim-request-id": "b5b1e77f-542d-430b-b6a3-7cc1e272d807",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
+        "Date": "Mon, 01 Feb 2021 15:52:28 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0da2ef8-1c5f-44ef-b7b0-ba7d6c4ee05d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "378",
-        "x-request-id": "b0751ff8-b04f-45df-aeb6-01f4ac951052"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "419",
+        "X-Request-ID": "b5b1e77f-542d-430b-b6a3-7cc1e272d807"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0da2ef8-1c5f-44ef-b7b0-ba7d6c4ee05d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f8b0149b6f898d47989dfe1f29b43f67-3b8c97eba0fc4343-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-36368daa21aff04281818ae9bdfc6d93-2046be1d4545ba48-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "efae618c01e4b5af49a899bfd0ac8a3f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "56e4b92a-dde7-49e0-9746-af943de442a1",
+        "apim-request-id": "57417cdd-b020-4b68-8a18-652d4c5e3e20",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "56e4b92a-dde7-49e0-9746-af943de442a1"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "168",
+        "X-Request-ID": "57417cdd-b020-4b68-8a18-652d4c5e3e20"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0da2ef8-1c5f-44ef-b7b0-ba7d6c4ee05d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8df9738be372f44aa0aca12804e0a679-ec848f3ec82d2e4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5154f41165e8fc4aa4db23b660c207d3-114ecc24a2403d40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8b648dd678ba90a60c8b92700cb23300",
         "x-ms-return-client-request-id": "true"
@@ -87,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cf7b860b-da80-44a3-8ee7-08ac6830e567",
+        "apim-request-id": "e51f4d66-b18b-4c93-83cc-0d5c07ba0bd6",
         "Content-Length": "1005",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158",
-        "x-request-id": "cf7b860b-da80-44a3-8ee7-08ac6830e567"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "143",
+        "X-Request-ID": "e51f4d66-b18b-4c93-83cc-0d5c07ba0bd6"
       },
       "ResponseBody": {
-        "dataFeedId": "4c83502e-e850-4865-a174-8c0ec20fe318",
+        "dataFeedId": "e0da2ef8-1c5f-44ef-b7b0-ba7d6c4ee05d",
         "dataFeedName": "dataFeedqyNTDz1h",
         "metrics": [
           {
-            "metricId": "8250e26e-c322-4973-8f8e-8c93f380b3dc",
+            "metricId": "44f7f039-80bb-4a3c-8b0a-68c3aa3a0993",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -132,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:30Z",
+        "createdTime": "2021-02-01T15:52:28Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -142,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4c83502e-e850-4865-a174-8c0ec20fe318",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0da2ef8-1c5f-44ef-b7b0-ba7d6c4ee05d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee3d2e7382fa3c4ca747db4561b7b46a-85b010f82e67e14d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-63cb415f786b8f4586c79de2c3ef2440-82fa02fe67017d4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a1042818d4c2d3bf6697eaa963ce7d61",
         "x-ms-return-client-request-id": "true"
@@ -156,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "29bdc92a-08bd-4e4b-a11a-72ac5208b593",
+        "apim-request-id": "6d796dea-fec3-4edc-b963-b891c68811b7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:30 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "318",
-        "x-request-id": "29bdc92a-08bd-4e4b-a11a-72ac5208b593"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "311",
+        "X-Request-ID": "6d796dea-fec3-4edc-b963-b891c68811b7"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:31.2103693-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:29.3622461-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c0b9f3acacba24086774f14fbf4d2c0-cc70142de4101542-00",
+        "traceparent": "00-9c6c646c25c1914b9a2a681913ea4558-3ade0b1703fa8a4a-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -34,26 +34,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "1a8f2636-9a71-42b7-b536-11fb9b05233c",
+        "apim-request-id": "22258953-27dd-400a-ae1e-0ce54b6a0069",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
+        "Date": "Mon, 01 Feb 2021 15:52:59 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d33221d9-e4de-4bd4-8123-2aaacad9d6c5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "590",
-        "X-Request-ID": "1a8f2636-9a71-42b7-b536-11fb9b05233c"
+        "x-envoy-upstream-service-time": "475",
+        "X-Request-ID": "22258953-27dd-400a-ae1e-0ce54b6a0069"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d33221d9-e4de-4bd4-8123-2aaacad9d6c5",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-498e25db02984a43bf82795310a667fa-0217ab9860e1ea4a-00",
+        "traceparent": "00-6c7cb376960e814cb6665ae511481782-bb48dfa33a867a4a-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -63,28 +63,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "da93088d-48e0-4d5b-9ca7-de8434a4f28f",
+        "apim-request-id": "1f8aed97-c77d-41e4-944f-d744a5e7afb7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:18 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "181",
-        "X-Request-ID": "da93088d-48e0-4d5b-9ca7-de8434a4f28f"
+        "x-envoy-upstream-service-time": "168",
+        "X-Request-ID": "1f8aed97-c77d-41e4-944f-d744a5e7afb7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d33221d9-e4de-4bd4-8123-2aaacad9d6c5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d0d7070005d0a4399593c97fbdceec6-a09b51dd9259044b-00",
+        "traceparent": "00-16d9e340a338c843ab38e90472f64fed-f42e5f579a47d044-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -96,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "444ea448-0cc4-4190-825e-7e3af6516b59",
+        "apim-request-id": "9e0e3247-cebc-4038-849f-f21d34f0f5be",
         "Content-Length": "1005",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:18 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "193",
-        "X-Request-ID": "444ea448-0cc4-4190-825e-7e3af6516b59"
+        "x-envoy-upstream-service-time": "152",
+        "X-Request-ID": "9e0e3247-cebc-4038-849f-f21d34f0f5be"
       },
       "ResponseBody": {
-        "dataFeedId": "afdf8ca6-c648-441c-894c-0a531f66efd7",
+        "dataFeedId": "d33221d9-e4de-4bd4-8123-2aaacad9d6c5",
         "dataFeedName": "dataFeedONgk1nBH",
         "metrics": [
           {
-            "metricId": "c45169c6-1d63-4821-abb0-0869c752a51c",
+            "metricId": "9bd42848-a398-47bd-af92-7cb01831608b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -141,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:18Z",
+        "createdTime": "2021-02-01T15:53:00Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,12 +151,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d33221d9-e4de-4bd4-8123-2aaacad9d6c5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f15d3a0a82e4c84c9163b5929c0bc64d-361b654698580743-00",
+        "traceparent": "00-cdd1a4888320b34bb9517baaba6b35b7-178853e1de009e49-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -168,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "16a6a5af-5eb3-4565-81a7-4031cdb9bc8e",
+        "apim-request-id": "cf298e26-72a6-4130-ac3e-e2c800c1b62d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:19 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "891",
-        "X-Request-ID": "16a6a5af-5eb3-4565-81a7-4031cdb9bc8e"
+        "x-envoy-upstream-service-time": "298",
+        "X-Request-ID": "cf298e26-72a6-4130-ac3e-e2c800c1b62d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:18.6157119-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:01.3019767-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataExplorerDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "242",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cbde884fc3c4e74aa5cf925778079114-4c12a2ae04410244-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9c0b9f3acacba24086774f14fbf4d2c0-cc70142de4101542-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e2a5e217dc91615c4d8a4dd60839f556",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ff54aeae-611f-40fe-a32f-692f3c191868",
+        "apim-request-id": "1a8f2636-9a71-42b7-b536-11fb9b05233c",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:25 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3cf7be0-6ca7-4cf4-9f4c-f44ddd483d0d",
+        "Date": "Mon, 01 Feb 2021 13:42:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "638",
-        "x-request-id": "ff54aeae-611f-40fe-a32f-692f3c191868"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "590",
+        "X-Request-ID": "1a8f2636-9a71-42b7-b536-11fb9b05233c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3cf7be0-6ca7-4cf4-9f4c-f44ddd483d0d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "258",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-838eac1b61a32f41a7f9dbc877f1f0f8-88d6ea4d0a151240-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-498e25db02984a43bf82795310a667fa-0217ab9860e1ea4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b5017883541ace38b396625471509120",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "AzureDataExplorer",
-        "dataFeedName": "dataFeedONgk1nBH",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6474864f-29a3-4adb-86f0-e893f3323904",
+        "apim-request-id": "da93088d-48e0-4d5b-9ca7-de8434a4f28f",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:25 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "705",
-        "x-request-id": "6474864f-29a3-4adb-86f0-e893f3323904"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "181",
+        "X-Request-ID": "da93088d-48e0-4d5b-9ca7-de8434a4f28f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3cf7be0-6ca7-4cf4-9f4c-f44ddd483d0d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c86145344f0f564fa33e1e014e87fb80-4a1d7fe0a7c2cf48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7d0d7070005d0a4399593c97fbdceec6-a09b51dd9259044b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f63d8825e6737dadf6426efb3702ff44",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "24b19cc0-b9bb-4bbd-b151-9b68508f3db6",
+        "apim-request-id": "444ea448-0cc4-4190-825e-7e3af6516b59",
         "Content-Length": "1005",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 20 Jan 2021 19:09:26 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "24b19cc0-b9bb-4bbd-b151-9b68508f3db6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "193",
+        "X-Request-ID": "444ea448-0cc4-4190-825e-7e3af6516b59"
       },
       "ResponseBody": {
-        "dataFeedId": "c3cf7be0-6ca7-4cf4-9f4c-f44ddd483d0d",
+        "dataFeedId": "afdf8ca6-c648-441c-894c-0a531f66efd7",
         "dataFeedName": "dataFeedONgk1nBH",
         "metrics": [
           {
-            "metricId": "0493cebc-9fb2-4df8-b8b2-8af6166dfb5b",
+            "metricId": "c45169c6-1d63-4821-abb0-0869c752a51c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-20T19:09:25Z",
+        "createdTime": "2021-02-01T13:42:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c3cf7be0-6ca7-4cf4-9f4c-f44ddd483d0d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/afdf8ca6-c648-441c-894c-0a531f66efd7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3c2ca34fe652c6439cb30e06b5bf9a17-24e50f1e542d604c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210120.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f15d3a0a82e4c84c9163b5929c0bc64d-361b654698580743-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fd898b011136c278aad62ffa7a07f0fd",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "39ac03bc-3e2c-4d07-96ad-83c535a4578c",
+        "apim-request-id": "16a6a5af-5eb3-4565-81a7-4031cdb9bc8e",
         "Content-Length": "0",
-        "Date": "Wed, 20 Jan 2021 19:09:26 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "345",
-        "x-request-id": "39ac03bc-3e2c-4d07-96ad-83c535a4578c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "891",
+        "X-Request-ID": "16a6a5af-5eb3-4565-81a7-4031cdb9bc8e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-20T11:09:26.5820442-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:18.6157119-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c450448eed584748967d2137225aa396-fc50e2d3fc874d4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-042a1e18f4bbcd44bd286b17a20a7dcf-46fb6b9de6ae884a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e72f20c5a0ce98fbbae70d74c7e6051c",
         "x-ms-return-client-request-id": "true"
@@ -34,25 +37,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d9cce354-f409-4e64-840a-1c3e6f9ac1f6",
+        "apim-request-id": "03bb1c0a-4d0f-4eea-96a1-6b8ca1d34588",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:32 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
+        "Date": "Mon, 01 Feb 2021 14:24:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6c8216dd-d405-4c0b-bb0a-6b6732871f16",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "541",
-        "x-request-id": "d9cce354-f409-4e64-840a-1c3e6f9ac1f6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "605",
+        "X-Request-ID": "03bb1c0a-4d0f-4eea-96a1-6b8ca1d34588"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6c8216dd-d405-4c0b-bb0a-6b6732871f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ccc2a91cca047c4eb815bdba28f871ff-328dfdcb06df4e4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8ae4ceb6665dc34d86aa415eb3ad8042-a183e6a7d6894540-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f9a73fccd5a38eb920b21084429bc302",
         "x-ms-return-client-request-id": "true"
@@ -60,21 +66,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "67d54e81-0ab8-414c-867e-2bf11432f17e",
+        "apim-request-id": "db48a2fc-a2aa-48f9-b434-b0a6a17d391a",
         "Content-Length": "1041",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:32 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "147",
-        "x-request-id": "67d54e81-0ab8-414c-867e-2bf11432f17e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "154",
+        "X-Request-ID": "db48a2fc-a2aa-48f9-b434-b0a6a17d391a"
       },
       "ResponseBody": {
-        "dataFeedId": "a129efc7-83c1-436e-a542-29f75cf08d6e",
+        "dataFeedId": "6c8216dd-d405-4c0b-bb0a-6b6732871f16",
         "dataFeedName": "dataFeedoowhDb3K",
         "metrics": [
           {
-            "metricId": "079dc259-3e19-4f6e-bb34-59726db1ecfd",
+            "metricId": "c6360c9b-bf17-4d53-a6c1-9cad7d72c1da",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -105,7 +111,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:32Z",
+        "createdTime": "2021-02-01T14:24:47Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,15 +124,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6c8216dd-d405-4c0b-bb0a-6b6732871f16",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "755",
+        "Content-Length": "772",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8300acf93d088d4e839be71ff199077f-da0fa82c65018a40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4aa12cb8aaca9a488f84a19dd0fbca18-4b531cb3b8619c4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6f6f07206169a8f7db957b041b0e8e3c",
         "x-ms-return-client-request-id": "true"
@@ -154,7 +163,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -164,24 +174,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f25b90b1-b223-482d-86f3-f50ceaa0b927",
+        "apim-request-id": "a594ce56-7a34-42a9-b1c5-b100cc758388",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:33 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "703",
-        "x-request-id": "f25b90b1-b223-482d-86f3-f50ceaa0b927"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "696",
+        "X-Request-ID": "a594ce56-7a34-42a9-b1c5-b100cc758388"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6c8216dd-d405-4c0b-bb0a-6b6732871f16",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2f6e78cdff19a747bf99f03afd8bebb1-be6c53c8be67344f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ff21b02348b2de4e8c24d97929c4f870-f406baaec823584c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a12436d114d2efa566a0c61c9077551f",
         "x-ms-return-client-request-id": "true"
@@ -189,21 +202,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e2aa916d-a9c7-416b-8d7e-e69a5ffa4ff7",
-        "Content-Length": "1167",
+        "apim-request-id": "a61c203c-3004-418a-85d8-974e8ebd3fef",
+        "Content-Length": "1184",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:33 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "e2aa916d-a9c7-416b-8d7e-e69a5ffa4ff7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "138",
+        "X-Request-ID": "a61c203c-3004-418a-85d8-974e8ebd3fef"
       },
       "ResponseBody": {
-        "dataFeedId": "a129efc7-83c1-436e-a542-29f75cf08d6e",
+        "dataFeedId": "6c8216dd-d405-4c0b-bb0a-6b6732871f16",
         "dataFeedName": "dataFeedXGc3Uzmk",
         "metrics": [
           {
-            "metricId": "079dc259-3e19-4f6e-bb34-59726db1ecfd",
+            "metricId": "c6360c9b-bf17-4d53-a6c1-9cad7d72c1da",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -229,6 +242,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -236,7 +250,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:32Z",
+        "createdTime": "2021-02-01T14:24:47Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,13 +263,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6c8216dd-d405-4c0b-bb0a-6b6732871f16",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f1c03048555a8145b85137e580eb5729-f05639447f247b40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c8aed1e67a5dbf45a25e09e4a6da65d2-fe537000b4715949-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c0540b2495776ab348fe1d0d5ab57312",
         "x-ms-return-client-request-id": "true"
@@ -263,19 +280,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "68321bd4-61d2-4fea-a487-6cfd917d7d8b",
+        "apim-request-id": "2860b85e-b432-4894-b00c-083a252b13b4",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:34 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "356",
-        "x-request-id": "68321bd4-61d2-4fea-a487-6cfd917d7d8b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "281",
+        "X-Request-ID": "2860b85e-b432-4894-b00c-083a252b13b4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:33.6521085-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:24:48.7211155-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-97a5da7b0f0e90478f79e701af2bd1fb-28ba38e9523ed844-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c450448eed584748967d2137225aa396-fc50e2d3fc874d4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f053d72379e1480dc5202fe7cea0fb98",
+        "x-ms-client-request-id": "e72f20c5a0ce98fbbae70d74c7e6051c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,47 +34,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8810e891-1533-4872-8401-438dc5f0ed77",
+        "apim-request-id": "d9cce354-f409-4e64-840a-1c3e6f9ac1f6",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:13 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+        "Date": "Mon, 01 Feb 2021 13:12:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "368",
-        "x-request-id": "8810e891-1533-4872-8401-438dc5f0ed77"
+        "x-envoy-upstream-service-time": "541",
+        "x-request-id": "d9cce354-f409-4e64-840a-1c3e6f9ac1f6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c8b06dd7bc051488dbf16e3ef45c3fd-056cf5facc5c6241-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ccc2a91cca047c4eb815bdba28f871ff-328dfdcb06df4e4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "740de7bae6c71c05cc3fa7f9a3d5b98e",
+        "x-ms-client-request-id": "f9a73fccd5a38eb920b21084429bc302",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1a461423-23e9-464a-9c7a-8df922b64df3",
+        "apim-request-id": "67d54e81-0ab8-414c-867e-2bf11432f17e",
         "Content-Length": "1041",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:13 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "1a461423-23e9-464a-9c7a-8df922b64df3"
+        "x-envoy-upstream-service-time": "147",
+        "x-request-id": "67d54e81-0ab8-414c-867e-2bf11432f17e"
       },
       "ResponseBody": {
-        "dataFeedId": "2457caa0-03b0-4c07-9ff7-347b8995aecd",
+        "dataFeedId": "a129efc7-83c1-436e-a542-29f75cf08d6e",
         "dataFeedName": "dataFeedoowhDb3K",
         "metrics": [
           {
-            "metricId": "e8e9f5db-d063-42a0-a3a0-145378b7767d",
+            "metricId": "079dc259-3e19-4f6e-bb34-59726db1ecfd",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -105,7 +105,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:14Z",
+        "createdTime": "2021-02-01T13:12:32Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,17 +118,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "755",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-48d860ee23f947438970eb3c853e43e1-85d9f15c32dae143-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8300acf93d088d4e839be71ff199077f-da0fa82c65018a40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8410b2209b4202c320076f6f6961f7a8",
+        "x-ms-client-request-id": "6f6f07206169a8f7db957b041b0e8e3c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -140,10 +140,10 @@
           "fileTemplate": "file"
         },
         "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeedoowhDb3K",
+        "dataFeedName": "dataFeedXGc3Uzmk",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -164,53 +164,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "bef9e111-3b50-4a1f-b006-eec6cd9f7378",
+        "apim-request-id": "f25b90b1-b223-482d-86f3-f50ceaa0b927",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:13 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "470",
-        "x-request-id": "bef9e111-3b50-4a1f-b006-eec6cd9f7378"
+        "x-envoy-upstream-service-time": "703",
+        "x-request-id": "f25b90b1-b223-482d-86f3-f50ceaa0b927"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c643989cef5c4744ace3f67cd2dd8288-482e01cadc51614d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2f6e78cdff19a747bf99f03afd8bebb1-be6c53c8be67344f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "047b95db0e1b3c8ed13624a1d214a5ef",
+        "x-ms-client-request-id": "a12436d114d2efa566a0c61c9077551f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1685ae02-c8b7-49a2-9492-8ec2787cebd5",
+        "apim-request-id": "e2aa916d-a9c7-416b-8d7e-e69a5ffa4ff7",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:14 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "147",
-        "x-request-id": "1685ae02-c8b7-49a2-9492-8ec2787cebd5"
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "e2aa916d-a9c7-416b-8d7e-e69a5ffa4ff7"
       },
       "ResponseBody": {
-        "dataFeedId": "2457caa0-03b0-4c07-9ff7-347b8995aecd",
-        "dataFeedName": "dataFeedoowhDb3K",
+        "dataFeedId": "a129efc7-83c1-436e-a542-29f75cf08d6e",
+        "dataFeedName": "dataFeedXGc3Uzmk",
         "metrics": [
           {
-            "metricId": "e8e9f5db-d063-42a0-a3a0-145378b7767d",
+            "metricId": "079dc259-3e19-4f6e-bb34-59726db1ecfd",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataLakeStorageGen2",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -236,7 +236,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:14Z",
+        "createdTime": "2021-02-01T13:12:32Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,33 +249,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2457caa0-03b0-4c07-9ff7-347b8995aecd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a129efc7-83c1-436e-a542-29f75cf08d6e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d7c098caaeb78d4084a0a836fee13c1c-3db72a6add8de041-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f1c03048555a8145b85137e580eb5729-f05639447f247b40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1cc6a06677901f55240b54c07795b36a",
+        "x-ms-client-request-id": "c0540b2495776ab348fe1d0d5ab57312",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "23490b98-91ad-4e43-a011-4867ad6d1cb3",
+        "apim-request-id": "68321bd4-61d2-4fea-a487-6cfd917d7d8b",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:14 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "339",
-        "x-request-id": "23490b98-91ad-4e43-a011-4867ad6d1cb3"
+        "x-envoy-upstream-service-time": "356",
+        "x-request-id": "68321bd4-61d2-4fea-a487-6cfd917d7d8b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:15.0128906-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:33.6521085-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aabed615a3101c44a75dbd0403585c47-b11db76c2d5a8040-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2a09708baf140e419d7942dbc0a868bb-79c7c786f2935540-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e8338ea419d97e107e735ffbfa09de12",
+        "x-ms-client-request-id": "fb5f737e09fa12de336ebc6b076ee5ca",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,47 +37,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5d9e63dc-471e-4361-8aba-29361cc01d6c",
+        "apim-request-id": "e2edb371-98fb-4709-93dc-6485d3ee59b3",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:53 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+        "Date": "Mon, 01 Feb 2021 13:42:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "406",
-        "x-request-id": "5d9e63dc-471e-4361-8aba-29361cc01d6c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "495",
+        "X-Request-ID": "e2edb371-98fb-4709-93dc-6485d3ee59b3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4fd82a9690e4ff4d8adb6324377b1582-04707fe931687444-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d64cb2a4812f0c408e7db68719f98ac7-9d8cd6f4acf2614b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6bbc6e336e07cae5b3cfbb29451b18cd",
+        "x-ms-client-request-id": "29bbcfb31b45cd18e05ed06d3fb33207",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7c4593ff-ee90-4e55-946b-517209eabe56",
+        "apim-request-id": "972210a7-ccce-41ea-aac3-513eb3b64b67",
         "Content-Length": "1041",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:53 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "181",
-        "x-request-id": "7c4593ff-ee90-4e55-946b-517209eabe56"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "221",
+        "X-Request-ID": "972210a7-ccce-41ea-aac3-513eb3b64b67"
       },
       "ResponseBody": {
-        "dataFeedId": "b338e572-c6ff-4fa2-bb3f-901035743fe8",
+        "dataFeedId": "d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
         "dataFeedName": "dataFeeddTt9Ks3M",
         "metrics": [
           {
-            "metricId": "7a126619-f8f8-4132-9201-ceefc0a4b9be",
+            "metricId": "aa18c50a-eb36-4d55-9f87-9a3f1ce54d62",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -105,7 +111,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:53Z",
+        "createdTime": "2021-02-01T13:42:19Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,17 +124,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "755",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90192f94911a264f8e923b36eca100d1-97e34491493c9943-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fe94b17e3c2d584da7dcdbac47c04723-a997f3a8051e9745-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6dd05ee0b33f0732a71aadfadb66f67b",
+        "x-ms-client-request-id": "faad1aa766db7bf63c6e5964a7c04035",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -140,10 +149,10 @@
           "fileTemplate": "file"
         },
         "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeeddTt9Ks3M",
+        "dataFeedName": "dataFeedh9eW4KWH",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -164,53 +173,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b5cf2541-dc52-4239-bd86-7d5fb5c42d97",
+        "apim-request-id": "702768c9-5d04-469f-8c71-6c7b38bc7dae",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:54 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "527",
-        "x-request-id": "b5cf2541-dc52-4239-bd86-7d5fb5c42d97"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "749",
+        "X-Request-ID": "702768c9-5d04-469f-8c71-6c7b38bc7dae"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0439e1df3a97f04f9306878fbfaa43b5-8ac4cdb18a702b42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-92c57a93b3ab434895da5a55ac6b86b6-fa6efdeba850134d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "64596e3cc0a73540a969340a5de63862",
+        "x-ms-client-request-id": "0a3469a9e65d62385b921a9b3970d27f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b9be27a4-bad6-4183-927f-5c4de825e65c",
+        "apim-request-id": "24933e05-3f62-4684-adcc-fa5bfbeb71c1",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:54 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "178",
-        "x-request-id": "b9be27a4-bad6-4183-927f-5c4de825e65c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "470",
+        "X-Request-ID": "24933e05-3f62-4684-adcc-fa5bfbeb71c1"
       },
       "ResponseBody": {
-        "dataFeedId": "b338e572-c6ff-4fa2-bb3f-901035743fe8",
-        "dataFeedName": "dataFeeddTt9Ks3M",
+        "dataFeedId": "d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+        "dataFeedName": "dataFeedh9eW4KWH",
         "metrics": [
           {
-            "metricId": "7a126619-f8f8-4132-9201-ceefc0a4b9be",
+            "metricId": "aa18c50a-eb36-4d55-9f87-9a3f1ce54d62",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataLakeStorageGen2",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -236,7 +248,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:53Z",
+        "createdTime": "2021-02-01T13:42:19Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,33 +261,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b338e572-c6ff-4fa2-bb3f-901035743fe8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cb682ce5fbb13b408e2d0f25da90d242-a7629b4d42e60d4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-514d6004624c8348b2547cfd4d3c6dc2-b56d092e2b50cb41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9b1a925b70397fd23bb5c4edc1eaee4c",
+        "x-ms-client-request-id": "edc4b53beac14ceed83fedd7c2b32620",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d1ce70dd-e756-4145-a258-6c1b8eda7553",
+        "apim-request-id": "3c5ff5bc-391c-40bb-a369-3fb6927373a1",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:54 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "325",
-        "x-request-id": "d1ce70dd-e756-4145-a258-6c1b8eda7553"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "351",
+        "X-Request-ID": "3c5ff5bc-391c-40bb-a369-3fb6927373a1"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:54.6430576-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:21.6420556-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2a09708baf140e419d7942dbc0a868bb-79c7c786f2935540-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-f0d6f24ca84a704ab5646e477a72e7ad-8c67d9d777f0c84d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fb5f737e09fa12de336ebc6b076ee5ca",
         "x-ms-return-client-request-id": "true"
@@ -37,28 +34,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e2edb371-98fb-4709-93dc-6485d3ee59b3",
+        "apim-request-id": "9685cd9c-f77e-49ba-acae-541089f6f360",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+        "Date": "Mon, 01 Feb 2021 15:41:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b07766c8-218f-4973-9e93-bee85243ae90",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "495",
-        "X-Request-ID": "e2edb371-98fb-4709-93dc-6485d3ee59b3"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "639",
+        "x-request-id": "9685cd9c-f77e-49ba-acae-541089f6f360"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b07766c8-218f-4973-9e93-bee85243ae90",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d64cb2a4812f0c408e7db68719f98ac7-9d8cd6f4acf2614b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-f7390921fcf4194b8b188c78c906491c-aa196376bbac2a43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "29bbcfb31b45cd18e05ed06d3fb33207",
         "x-ms-return-client-request-id": "true"
@@ -66,21 +60,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "972210a7-ccce-41ea-aac3-513eb3b64b67",
+        "apim-request-id": "c910acd6-ad55-47f6-b8fe-38d236838e1c",
         "Content-Length": "1041",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "221",
-        "X-Request-ID": "972210a7-ccce-41ea-aac3-513eb3b64b67"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "145",
+        "x-request-id": "c910acd6-ad55-47f6-b8fe-38d236838e1c"
       },
       "ResponseBody": {
-        "dataFeedId": "d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+        "dataFeedId": "b07766c8-218f-4973-9e93-bee85243ae90",
         "dataFeedName": "dataFeeddTt9Ks3M",
         "metrics": [
           {
-            "metricId": "aa18c50a-eb36-4d55-9f87-9a3f1ce54d62",
+            "metricId": "868c3249-f150-45d0-8aad-0ac44d5f42a2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -111,7 +105,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:19Z",
+        "createdTime": "2021-02-01T15:41:08Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -124,18 +118,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b07766c8-218f-4973-9e93-bee85243ae90",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "755",
+        "Content-Length": "772",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fe94b17e3c2d584da7dcdbac47c04723-a997f3a8051e9745-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-268a667b43d6a7419a286727abde2849-0e784683d074c843-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "faad1aa766db7bf63c6e5964a7c04035",
         "x-ms-return-client-request-id": "true"
@@ -163,7 +154,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -173,27 +165,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "702768c9-5d04-469f-8c71-6c7b38bc7dae",
+        "apim-request-id": "c7bace5a-e7af-4c19-81cc-4edea3fa75e7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "749",
-        "X-Request-ID": "702768c9-5d04-469f-8c71-6c7b38bc7dae"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "717",
+        "x-request-id": "c7bace5a-e7af-4c19-81cc-4edea3fa75e7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b07766c8-218f-4973-9e93-bee85243ae90",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-92c57a93b3ab434895da5a55ac6b86b6-fa6efdeba850134d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-352418eee4b78d469723ddc8e1f525b6-9a0d6c61c6f6524e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a3469a9e65d62385b921a9b3970d27f",
         "x-ms-return-client-request-id": "true"
@@ -201,21 +190,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "24933e05-3f62-4684-adcc-fa5bfbeb71c1",
-        "Content-Length": "1167",
+        "apim-request-id": "9d9153b2-69c2-46a9-81de-ef313cba3af3",
+        "Content-Length": "1184",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:21 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "470",
-        "X-Request-ID": "24933e05-3f62-4684-adcc-fa5bfbeb71c1"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "9d9153b2-69c2-46a9-81de-ef313cba3af3"
       },
       "ResponseBody": {
-        "dataFeedId": "d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+        "dataFeedId": "b07766c8-218f-4973-9e93-bee85243ae90",
         "dataFeedName": "dataFeedh9eW4KWH",
         "metrics": [
           {
-            "metricId": "aa18c50a-eb36-4d55-9f87-9a3f1ce54d62",
+            "metricId": "868c3249-f150-45d0-8aad-0ac44d5f42a2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -241,6 +230,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -248,7 +238,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:19Z",
+        "createdTime": "2021-02-01T15:41:08Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -261,16 +251,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9b24ce7-307f-40ad-b1a7-ae548ae3e572",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b07766c8-218f-4973-9e93-bee85243ae90",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-514d6004624c8348b2547cfd4d3c6dc2-b56d092e2b50cb41-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-96ac291f5f98e8428284a1574291ef22-74ae33bf54266043-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "edc4b53beac14ceed83fedd7c2b32620",
         "x-ms-return-client-request-id": "true"
@@ -278,19 +265,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3c5ff5bc-391c-40bb-a369-3fb6927373a1",
+        "apim-request-id": "c8679b35-dfe5-4072-9bb2-5c3508c20f81",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:21 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "351",
-        "X-Request-ID": "3c5ff5bc-391c-40bb-a369-3fb6927373a1"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "284",
+        "x-request-id": "c8679b35-dfe5-4072-9bb2-5c3508c20f81"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:21.6420556-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:09.8493568-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b6e15ac5647efc4abde7caef9ca3437b-f596c0576547a142-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-274acb4d0b8da048a900a87b4067b32b-3fc420836b31a84a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "811d90ebacf613b50f8405057c118633",
         "x-ms-return-client-request-id": "true"
@@ -34,33 +37,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "7292f805-8108-41b1-97e7-8e051378f997",
+        "apim-request-id": "15f8fe5a-5657-4af3-b946-faf6b0350ae6",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:31 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
+        "Date": "Mon, 01 Feb 2021 15:52:29 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/070c67c8-9589-45c3-8591-caa2a93dc659",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5553",
-        "x-request-id": "7292f805-8108-41b1-97e7-8e051378f997"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "431",
+        "X-Request-ID": "15f8fe5a-5657-4af3-b946-faf6b0350ae6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/070c67c8-9589-45c3-8591-caa2a93dc659",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f2ab022643db1a47babcd748497a5f7d-3d3510a4d18f844d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-febd43aef67889488481050070d35135-bfb7e00e59e58b43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6954880e1c4ef917813db3f03d101c72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedkHjxYJne",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -78,24 +84,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8e831fc7-3f2e-4807-bcdf-1a71e68494f5",
+        "apim-request-id": "f387c1ed-e7f8-41aa-a717-36849d1cdec6",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "183",
-        "x-request-id": "8e831fc7-3f2e-4807-bcdf-1a71e68494f5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "196",
+        "X-Request-ID": "f387c1ed-e7f8-41aa-a717-36849d1cdec6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/070c67c8-9589-45c3-8591-caa2a93dc659",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-354501256e1b9b4d9fe13d8bb3a84e8c-e5411b98dfd9864b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-944204ccf2e06b489b5018b0ded6adf7-7205fb36f247a64b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1745286542cb1dcaddfd1b820fa94f49",
         "x-ms-return-client-request-id": "true"
@@ -103,21 +112,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6b6a2b05-5f97-4a20-b9bc-ac90d8d4e085",
+        "apim-request-id": "281e1302-bec5-4c77-af8b-1a0f2bc745e4",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "6b6a2b05-5f97-4a20-b9bc-ac90d8d4e085"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "X-Request-ID": "281e1302-bec5-4c77-af8b-1a0f2bc745e4"
       },
       "ResponseBody": {
-        "dataFeedId": "9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
+        "dataFeedId": "070c67c8-9589-45c3-8591-caa2a93dc659",
         "dataFeedName": "dataFeedkHjxYJne",
         "metrics": [
           {
-            "metricId": "807b4f3e-6018-40bc-acfd-ccec61e61b34",
+            "metricId": "42098c31-d4dc-4e67-af9f-aacc1dba2281",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -150,7 +159,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:32Z",
+        "createdTime": "2021-02-01T15:52:30Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -163,13 +172,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/070c67c8-9589-45c3-8591-caa2a93dc659",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-75ee4593dc778d48ba12e46672bfd777-9f8badcc7c5fa743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d0cfb9429242f946ba029b6eb35449b2-041db959bea60048-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "74e2d6b4c173cfaf7923ffb9f9c4d5fe",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +189,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8dd3e835-ee45-45f9-bf1f-6b4c67c26f4c",
+        "apim-request-id": "9eca6b57-f77d-4e9b-ad6e-d2fc336b26a9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "283",
-        "x-request-id": "8dd3e835-ee45-45f9-bf1f-6b4c67c26f4c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "302",
+        "X-Request-ID": "9eca6b57-f77d-4e9b-ad6e-d2fc336b26a9"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:32.9747245-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:30.5813050-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-84110c6f08b33740a840cd26b18d88f8-80084592b458fd49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-88d0a62c05da014db46a5c9f900d153d-16956ac1d0781440-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "52c6924059bb021efd3d84a0c9f43f6f",
+        "x-ms-client-request-id": "a0843dfdf4c96f3f1f7fa348c5f27b8e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,29 +34,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "79ca435e-fd85-4ba2-81e2-90b284ebfb49",
+        "apim-request-id": "6a9a9077-e9ae-4d6b-a15d-c56174a55807",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:14 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+        "Date": "Mon, 01 Feb 2021 13:12:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "358",
-        "x-request-id": "79ca435e-fd85-4ba2-81e2-90b284ebfb49"
+        "x-envoy-upstream-service-time": "579",
+        "x-request-id": "6a9a9077-e9ae-4d6b-a15d-c56174a55807"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "643",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-554d21702927774db29051a47e40a649-27ae46557bddcc4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8f3aa0ed5482874e90c3270989d1b2fa-99695b1b0df67246-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "48a37f1ff2c58e7b3a0405c1a98f22c3",
+        "x-ms-client-request-id": "c105043a8fa9c32278e44bf49105a03a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -68,10 +68,10 @@
           "fileTemplate": "file"
         },
         "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeedR9uSeUfm",
+        "dataFeedName": "dataFeedA8sZMHF4",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -85,53 +85,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3c87c662-355e-4e08-af2a-2bf1e1b46cd0",
+        "apim-request-id": "c2b035ab-7947-4fa8-ad6b-80b7de7be8f7",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:16 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "497",
-        "x-request-id": "3c87c662-355e-4e08-af2a-2bf1e1b46cd0"
+        "x-envoy-upstream-service-time": "675",
+        "x-request-id": "c2b035ab-7947-4fa8-ad6b-80b7de7be8f7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9d472e2b39f77f408cd68f0ebdf56d1b-90de98e98e26f64a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e8cebbf6a289eb4c8323541e01b40d98-cc6ba9f54379b74e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f44be47805913aa05ab4e7680d7034f3",
+        "x-ms-client-request-id": "68e7b45a700df33496056577c227414d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "03481a87-e803-40db-904d-1e3d796429c4",
+        "apim-request-id": "5a12f584-360a-4031-be7a-f5be185929f5",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:16 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "156",
-        "x-request-id": "03481a87-e803-40db-904d-1e3d796429c4"
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "5a12f584-360a-4031-be7a-f5be185929f5"
       },
       "ResponseBody": {
-        "dataFeedId": "c28ff553-6534-4933-b364-64c3616a8666",
-        "dataFeedName": "dataFeedR9uSeUfm",
+        "dataFeedId": "58374dc8-3e45-4313-8d66-763a3cbf2f51",
+        "dataFeedName": "dataFeedA8sZMHF4",
         "metrics": [
           {
-            "metricId": "5bc18261-eb9b-485a-8fe5-98b784021aca",
+            "metricId": "d2981674-0e5f-4fd7-b592-42c02793405e",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataLakeStorageGen2",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -157,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:15Z",
+        "createdTime": "2021-02-01T13:12:34Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,33 +170,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c28ff553-6534-4933-b364-64c3616a8666",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7614167bbd5db438bc4827ad38d14de-477d28d5ad8de442-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-14d6cf1cc5fe1242bddfcbf5926bc5b4-55ae5f795f44dc4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7765059627c24d41173717b6535c596e",
+        "x-ms-client-request-id": "b61737175c536e591bc028e4a94ade19",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "60df2f7d-6842-4f5c-bc8f-16a277f83180",
+        "apim-request-id": "46cb4fc8-b825-46af-bcfd-ccd38cf4e4a2",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:16 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "333",
-        "x-request-id": "60df2f7d-6842-4f5c-bc8f-16a277f83180"
+        "x-envoy-upstream-service-time": "346",
+        "x-request-id": "46cb4fc8-b825-46af-bcfd-ccd38cf4e4a2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:16.5369509-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:35.6161364-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-88d0a62c05da014db46a5c9f900d153d-16956ac1d0781440-00",
+        "traceparent": "00-b6e15ac5647efc4abde7caef9ca3437b-f596c0576547a142-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a0843dfdf4c96f3f1f7fa348c5f27b8e",
+        "x-ms-client-request-id": "811d90ebacf613b50f8405057c118633",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -23,7 +23,7 @@
           "fileTemplate": "file"
         },
         "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeedR9uSeUfm",
+        "dataFeedName": "dataFeedrPZAERmZ",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -34,41 +34,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6a9a9077-e9ae-4d6b-a15d-c56174a55807",
+        "apim-request-id": "7292f805-8108-41b1-97e7-8e051378f997",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:34 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
+        "Date": "Mon, 01 Feb 2021 15:45:31 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "579",
-        "x-request-id": "6a9a9077-e9ae-4d6b-a15d-c56174a55807"
+        "x-envoy-upstream-service-time": "5553",
+        "x-request-id": "7292f805-8108-41b1-97e7-8e051378f997"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "643",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8f3aa0ed5482874e90c3270989d1b2fa-99695b1b0df67246-00",
+        "traceparent": "00-f2ab022643db1a47babcd748497a5f7d-3d3510a4d18f844d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c105043a8fa9c32278e44bf49105a03a",
+        "x-ms-client-request-id": "6954880e1c4ef917813db3f03d101c72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "accountName": "account",
-          "accountKey": "Sanitized",
-          "fileSystemName": "fileSystem",
-          "directoryTemplate": "dir",
-          "fileTemplate": "file"
-        },
-        "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeedA8sZMHF4",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedkHjxYJne",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -85,46 +78,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c2b035ab-7947-4fa8-ad6b-80b7de7be8f7",
+        "apim-request-id": "8e831fc7-3f2e-4807-bcdf-1a71e68494f5",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "675",
-        "x-request-id": "c2b035ab-7947-4fa8-ad6b-80b7de7be8f7"
+        "x-envoy-upstream-service-time": "183",
+        "x-request-id": "8e831fc7-3f2e-4807-bcdf-1a71e68494f5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e8cebbf6a289eb4c8323541e01b40d98-cc6ba9f54379b74e-00",
+        "traceparent": "00-354501256e1b9b4d9fe13d8bb3a84e8c-e5411b98dfd9864b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "68e7b45a700df33496056577c227414d",
+        "x-ms-client-request-id": "1745286542cb1dcaddfd1b820fa94f49",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5a12f584-360a-4031-be7a-f5be185929f5",
+        "apim-request-id": "6b6a2b05-5f97-4a20-b9bc-ac90d8d4e085",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
         "x-envoy-upstream-service-time": "159",
-        "x-request-id": "5a12f584-360a-4031-be7a-f5be185929f5"
+        "x-request-id": "6b6a2b05-5f97-4a20-b9bc-ac90d8d4e085"
       },
       "ResponseBody": {
-        "dataFeedId": "58374dc8-3e45-4313-8d66-763a3cbf2f51",
-        "dataFeedName": "dataFeedA8sZMHF4",
+        "dataFeedId": "9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
+        "dataFeedName": "dataFeedkHjxYJne",
         "metrics": [
           {
-            "metricId": "d2981674-0e5f-4fd7-b592-42c02793405e",
+            "metricId": "807b4f3e-6018-40bc-acfd-ccec61e61b34",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -157,7 +150,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:34Z",
+        "createdTime": "2021-02-01T15:45:32Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,37 +163,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/58374dc8-3e45-4313-8d66-763a3cbf2f51",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9e1ebb8d-3acd-4313-b6df-ee0e8cc87592",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-14d6cf1cc5fe1242bddfcbf5926bc5b4-55ae5f795f44dc4a-00",
+        "traceparent": "00-75ee4593dc778d48ba12e46672bfd777-9f8badcc7c5fa743-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b61737175c536e591bc028e4a94ade19",
+        "x-ms-client-request-id": "74e2d6b4c173cfaf7923ffb9f9c4d5fe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "46cb4fc8-b825-46af-bcfd-ccd38cf4e4a2",
+        "apim-request-id": "8dd3e835-ee45-45f9-bf1f-6b4c67c26f4c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "346",
-        "x-request-id": "46cb4fc8-b825-46af-bcfd-ccd38cf4e4a2"
+        "x-envoy-upstream-service-time": "283",
+        "x-request-id": "8dd3e835-ee45-45f9-bf1f-6b4c67c26f4c"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:35.6161364-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:32.9747245-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "435521816"
+    "RandomSeed": "1619037583"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a519b3bf86fe84458ca2de5a88bc3873-c064777e57c3b446-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-8c4eb23664d95341ab7ef0d9436a9ecd-51de540639c79a4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "16ed1bcc4f7bf962ea44a15fb3ea12e7",
         "x-ms-return-client-request-id": "true"
@@ -37,43 +34,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8e3c7660-6a94-4b7e-8c14-f1990d0b7d45",
+        "apim-request-id": "9519eff6-d053-4ebd-ad82-efd81e0864e8",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
+        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "580",
-        "X-Request-ID": "8e3c7660-6a94-4b7e-8c14-f1990d0b7d45"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "428",
+        "x-request-id": "9519eff6-d053-4ebd-ad82-efd81e0864e8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "643",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a10a961358fa0542887770fd1e71149d-f6c9893a49dc634c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-d5e7cfefee49fa44bb389a0810b00b1e-de088a89ae6e8140-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f06cd8b98383f1bdb5f6389b5397f347",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "accountName": "account",
-          "accountKey": "Sanitized",
-          "fileSystemName": "fileSystem",
-          "directoryTemplate": "dir",
-          "fileTemplate": "file"
-        },
-        "dataSourceType": "AzureDataLakeStorageGen2",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedH5QzBNwc",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -91,27 +78,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "759a2a38-ff62-4e54-be9c-645c37e8e5c9",
+        "apim-request-id": "7af8ffea-f3d6-4668-9b46-4f9c15a7b34b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1089",
-        "X-Request-ID": "759a2a38-ff62-4e54-be9c-645c37e8e5c9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "7af8ffea-f3d6-4668-9b46-4f9c15a7b34b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-af8dd9e8ce4a174c81cc488985994a1d-a3e7161d2d9fb647-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-9c7a0f1eaf081d45a19833286eac84c4-fa49e22ce12d5e47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e19b26376918c3a95dd28aaea7795400",
         "x-ms-return-client-request-id": "true"
@@ -119,21 +103,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "921d70d8-a91e-441d-b6f1-1e669afc9bad",
+        "apim-request-id": "8d03b7d1-b386-4b4e-9253-6fb41eaa45c3",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "176",
-        "X-Request-ID": "921d70d8-a91e-441d-b6f1-1e669afc9bad"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "x-request-id": "8d03b7d1-b386-4b4e-9253-6fb41eaa45c3"
       },
       "ResponseBody": {
-        "dataFeedId": "302216f4-2ee5-4605-8b5f-0c004e2d36d4",
+        "dataFeedId": "46e38d08-66e6-44c9-b409-2550cb0c57a6",
         "dataFeedName": "dataFeedH5QzBNwc",
         "metrics": [
           {
-            "metricId": "8286311d-9108-4a67-9027-8590f7a9cbd2",
+            "metricId": "789971ec-e7e0-4560-b697-a4b3a73024ae",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -166,7 +150,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:22Z",
+        "createdTime": "2021-02-01T15:41:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -179,16 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6d90f7accf674a48a2f1cbad4504546e-b9f29b8453289247-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-b33d7d7dc16e274f8183452650ea422a-7dc7acafa8a7ac41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8900a8129b1049785dfc608516c6a553",
         "x-ms-return-client-request-id": "true"
@@ -196,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ba9a2adb-1408-4e05-81c5-08acc6f9190a",
+        "apim-request-id": "099f7b34-c4a3-4fb0-bec4-e1ce456502ed",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "398",
-        "X-Request-ID": "ba9a2adb-1408-4e05-81c5-08acc6f9190a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "315",
+        "x-request-id": "099f7b34-c4a3-4fb0-bec4-e1ce456502ed"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:23.9875770-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:11.0026349-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9a27a6dcd75ea944824796988ca7d2d6-503636c284a9ae45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a519b3bf86fe84458ca2de5a88bc3873-c064777e57c3b446-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b99024eb7d62fc8ccc1bed167b4f62f9",
+        "x-ms-client-request-id": "16ed1bcc4f7bf962ea44a15fb3ea12e7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,29 +37,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "73c7eb4a-25b1-41f2-97d9-76a04732afea",
+        "apim-request-id": "8e3c7660-6a94-4b7e-8c14-f1990d0b7d45",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+        "Date": "Mon, 01 Feb 2021 13:42:22 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "575",
-        "x-request-id": "73c7eb4a-25b1-41f2-97d9-76a04732afea"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "580",
+        "X-Request-ID": "8e3c7660-6a94-4b7e-8c14-f1990d0b7d45"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "643",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c3272ea6cbae1b4d8044f0555a52da38-2c8299caf676394e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a10a961358fa0542887770fd1e71149d-f6c9893a49dc634c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5fa144eaeab3e712b9d86cf08383bdf1",
+        "x-ms-client-request-id": "f06cd8b98383f1bdb5f6389b5397f347",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -68,10 +74,10 @@
           "fileTemplate": "file"
         },
         "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeedeNqX8GsA",
+        "dataFeedName": "dataFeedH5QzBNwc",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -85,53 +91,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d3d47a63-49f4-4b0f-b26e-a07dc9eeba30",
+        "apim-request-id": "759a2a38-ff62-4e54-be9c-645c37e8e5c9",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:55 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "494",
-        "x-request-id": "d3d47a63-49f4-4b0f-b26e-a07dc9eeba30"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1089",
+        "X-Request-ID": "759a2a38-ff62-4e54-be9c-645c37e8e5c9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d484252d5dedc8499b2d8e2a6c4aba02-bf19544e6baa2140-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-af8dd9e8ce4a174c81cc488985994a1d-a3e7161d2d9fb647-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9b38f6b5975347f337269be11869a9c3",
+        "x-ms-client-request-id": "e19b26376918c3a95dd28aaea7795400",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2710c093-a4ae-4be9-8bfc-d60106db5d96",
+        "apim-request-id": "921d70d8-a91e-441d-b6f1-1e669afc9bad",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:55 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "2710c093-a4ae-4be9-8bfc-d60106db5d96"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "176",
+        "X-Request-ID": "921d70d8-a91e-441d-b6f1-1e669afc9bad"
       },
       "ResponseBody": {
-        "dataFeedId": "f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
-        "dataFeedName": "dataFeedeNqX8GsA",
+        "dataFeedId": "302216f4-2ee5-4605-8b5f-0c004e2d36d4",
+        "dataFeedName": "dataFeedH5QzBNwc",
         "metrics": [
           {
-            "metricId": "bc6624a8-7571-4004-85ba-e984bd415f3f",
+            "metricId": "8286311d-9108-4a67-9027-8590f7a9cbd2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureDataLakeStorageGen2",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -157,7 +166,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:55Z",
+        "createdTime": "2021-02-01T13:42:22Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,33 +179,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f14d38ff-0e7f-46f2-84b6-bbe49201fa0f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/302216f4-2ee5-4605-8b5f-0c004e2d36d4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c5b14e30261d3f469621b1c247189a67-b0babe1c1b3ed34d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6d90f7accf674a48a2f1cbad4504546e-b9f29b8453289247-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ae8ad25d79a7005412a80089109b7849",
+        "x-ms-client-request-id": "8900a8129b1049785dfc608516c6a553",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f756bef9-d753-4f9d-a702-3c5b34cb6bb7",
+        "apim-request-id": "ba9a2adb-1408-4e05-81c5-08acc6f9190a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:56 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "361",
-        "x-request-id": "f756bef9-d753-4f9d-a702-3c5b34cb6bb7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "398",
+        "X-Request-ID": "ba9a2adb-1408-4e05-81c5-08acc6f9190a"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:56.3896999-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:23.9875770-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8c4eb23664d95341ab7ef0d9436a9ecd-51de540639c79a4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-44f0a4b723bbc248af02e0c989486a07-f49552a5c859f24d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "16ed1bcc4f7bf962ea44a15fb3ea12e7",
         "x-ms-return-client-request-id": "true"
@@ -34,33 +37,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "9519eff6-d053-4ebd-ad82-efd81e0864e8",
+        "apim-request-id": "29a74f5a-9c1e-4c66-9708-bb7930c26760",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
+        "Date": "Mon, 01 Feb 2021 15:53:01 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/32a952f1-e28d-4b0b-b6eb-3f1c5b1012e5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "428",
-        "x-request-id": "9519eff6-d053-4ebd-ad82-efd81e0864e8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "355",
+        "X-Request-ID": "29a74f5a-9c1e-4c66-9708-bb7930c26760"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/32a952f1-e28d-4b0b-b6eb-3f1c5b1012e5",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d5e7cfefee49fa44bb389a0810b00b1e-de088a89ae6e8140-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-eeee618aae5a3c48bb814bdcdc5741d1-55eedf253c32564e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f06cd8b98383f1bdb5f6389b5397f347",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedH5QzBNwc",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -78,24 +84,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7af8ffea-f3d6-4668-9b46-4f9c15a7b34b",
+        "apim-request-id": "5a03001d-a2a4-4b46-aae8-0c673839bc21",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "7af8ffea-f3d6-4668-9b46-4f9c15a7b34b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "X-Request-ID": "5a03001d-a2a4-4b46-aae8-0c673839bc21"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/32a952f1-e28d-4b0b-b6eb-3f1c5b1012e5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c7a0f1eaf081d45a19833286eac84c4-fa49e22ce12d5e47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-127fe9d958245d4499d44608d50e8aba-4fbc3b58e9f3fc42-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e19b26376918c3a95dd28aaea7795400",
         "x-ms-return-client-request-id": "true"
@@ -103,21 +112,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8d03b7d1-b386-4b4e-9253-6fb41eaa45c3",
+        "apim-request-id": "4f501cfc-a1e6-4e2a-a51f-7a2a2709ea31",
         "Content-Length": "1167",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "8d03b7d1-b386-4b4e-9253-6fb41eaa45c3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "141",
+        "X-Request-ID": "4f501cfc-a1e6-4e2a-a51f-7a2a2709ea31"
       },
       "ResponseBody": {
-        "dataFeedId": "46e38d08-66e6-44c9-b409-2550cb0c57a6",
+        "dataFeedId": "32a952f1-e28d-4b0b-b6eb-3f1c5b1012e5",
         "dataFeedName": "dataFeedH5QzBNwc",
         "metrics": [
           {
-            "metricId": "789971ec-e7e0-4560-b697-a4b3a73024ae",
+            "metricId": "38eba9fd-baaf-4ea9-b5bd-e433d46d7118",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -150,7 +159,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:10Z",
+        "createdTime": "2021-02-01T15:53:01Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -163,13 +172,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46e38d08-66e6-44c9-b409-2550cb0c57a6",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/32a952f1-e28d-4b0b-b6eb-3f1c5b1012e5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b33d7d7dc16e274f8183452650ea422a-7dc7acafa8a7ac41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-514ecc588e50aa4caed618ad69337628-2e692f9a76ffcc4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8900a8129b1049785dfc608516c6a553",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +189,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "099f7b34-c4a3-4fb0-bec4-e1ce456502ed",
+        "apim-request-id": "016642c5-7047-47c0-8497-aeda0666cde3",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:10 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "315",
-        "x-request-id": "099f7b34-c4a3-4fb0-bec4-e1ce456502ed"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "329",
+        "X-Request-ID": "016642c5-7047-47c0-8497-aeda0666cde3"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:11.0026349-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:02.3478829-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-604f8dbabebc3b4c895c5505faa0c2ae-073de9db77546a4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2b1a6f1c0a634946970392800d5a40a1-583f25306da6c64e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e76080eb30e7e294395d91b7ad3eb4b6",
         "x-ms-return-client-request-id": "true"
@@ -34,55 +37,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "1d9e9a81-d307-4260-a4a8-e3baafc0735c",
+        "apim-request-id": "fabf2def-434d-4eff-8ca7-3b3e97ca486a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
+        "Date": "Mon, 01 Feb 2021 15:52:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5001546f-0852-4166-8a9b-5f6a5832bf76",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "410",
-        "x-request-id": "1d9e9a81-d307-4260-a4a8-e3baafc0735c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "449",
+        "X-Request-ID": "fabf2def-434d-4eff-8ca7-3b3e97ca486a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5001546f-0852-4166-8a9b-5f6a5832bf76",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a6702c78f85bdd4886abb6ad9bdcefad-71430bde32361143-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-aef452bb1dea3747a8cc0b6b2dbedeb7-6b77e6715059f54c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4696669ac90fb621c95c4f30c69a6471",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7332cec1-812c-471f-bbf0-0c6a97827eff",
+        "apim-request-id": "dabcb8c4-74ea-4567-a864-86307e8abcd1",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "7332cec1-812c-471f-bbf0-0c6a97827eff"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "202",
+        "X-Request-ID": "dabcb8c4-74ea-4567-a864-86307e8abcd1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5001546f-0852-4166-8a9b-5f6a5832bf76",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-162ce4fcc8cf224fa26417c237a87223-fd04ca022407b942-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2264f03cafd36a49ab4404229ef29019-f39f882a5134564f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6ed57c3bddedef7ea95d6701e3f1cc97",
         "x-ms-return-client-request-id": "true"
@@ -90,21 +99,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7888144e-9b0d-4edf-84a1-de9a3629a9f2",
+        "apim-request-id": "e37cfb0f-4eab-4809-bb23-12e48acdf2b5",
         "Content-Length": "1092",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "145",
-        "x-request-id": "7888144e-9b0d-4edf-84a1-de9a3629a9f2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "148",
+        "X-Request-ID": "e37cfb0f-4eab-4809-bb23-12e48acdf2b5"
       },
       "ResponseBody": {
-        "dataFeedId": "a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
+        "dataFeedId": "5001546f-0852-4166-8a9b-5f6a5832bf76",
         "dataFeedName": "dataFeedd1DcWx57",
         "metrics": [
           {
-            "metricId": "8c2ea8e4-0457-4f0b-acc2-135b4c7ddb54",
+            "metricId": "2ac38b77-4d7e-451f-b97e-d346a6fa0f09",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -135,7 +144,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:31Z",
+        "createdTime": "2021-02-01T15:52:31Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +157,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5001546f-0852-4166-8a9b-5f6a5832bf76",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a5bd1e60cb77ca46bb4bfe57e8cf143b-840722ec4f697b40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-958d4ed88a9f4846a789173faed9f406-2d2df8a36de18a4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ffeebdb1c98a21a95faa1e8ae1631c9f",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +174,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b6d728bb-ff91-44fd-b7e6-5b5e3c183043",
+        "apim-request-id": "39ad59be-3dfe-4091-9816-e6d6a0fdc151",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "302",
-        "x-request-id": "b6d728bb-ff91-44fd-b7e6-5b5e3c183043"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "317",
+        "X-Request-ID": "39ad59be-3dfe-4091-9816-e6d6a0fdc151"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:32.3686203-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:31.8048426-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a2bbb1c5aac1ad4da74e675bc32f4288-63040a68c8ad4942-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-604f8dbabebc3b4c895c5505faa0c2ae-073de9db77546a4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e76080eb30e7e294395d91b7ad3eb4b6",
         "x-ms-return-client-request-id": "true"
@@ -34,64 +34,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "456d92cc-fbe5-4ea6-acdd-07619ce74008",
+        "apim-request-id": "1d9e9a81-d307-4260-a4a8-e3baafc0735c",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:14 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f1da2e5c-6d9c-4880-ba5e-0fcf2cc7d209",
+        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "392",
-        "x-request-id": "456d92cc-fbe5-4ea6-acdd-07619ce74008"
+        "x-envoy-upstream-service-time": "410",
+        "x-request-id": "1d9e9a81-d307-4260-a4a8-e3baafc0735c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f1da2e5c-6d9c-4880-ba5e-0fcf2cc7d209",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "345",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c937507c02f1e46bf92af03ce2b06b7-4412d3f783180545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a6702c78f85bdd4886abb6ad9bdcefad-71430bde32361143-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4696669ac90fb621c95c4f30c69a6471",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "accountName": "account",
-          "accountKey": "Sanitized",
-          "fileSystemName": "fileSystem",
-          "directoryTemplate": "dir",
-          "fileTemplate": "file"
-        },
-        "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeedd1DcWx57",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2cdb4ba0-252f-4a3d-96dc-f112c34df28b",
+        "apim-request-id": "7332cec1-812c-471f-bbf0-0c6a97827eff",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:15 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "479",
-        "x-request-id": "2cdb4ba0-252f-4a3d-96dc-f112c34df28b"
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "7332cec1-812c-471f-bbf0-0c6a97827eff"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f1da2e5c-6d9c-4880-ba5e-0fcf2cc7d209",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3b3899a8285dc74980e72d3d81fda06f-e67c8564ea16364e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-162ce4fcc8cf224fa26417c237a87223-fd04ca022407b942-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6ed57c3bddedef7ea95d6701e3f1cc97",
         "x-ms-return-client-request-id": "true"
@@ -99,21 +90,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "75735ee3-65a5-44a7-ae25-acc0a62f4c43",
+        "apim-request-id": "7888144e-9b0d-4edf-84a1-de9a3629a9f2",
         "Content-Length": "1092",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:15 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "75735ee3-65a5-44a7-ae25-acc0a62f4c43"
+        "x-envoy-upstream-service-time": "145",
+        "x-request-id": "7888144e-9b0d-4edf-84a1-de9a3629a9f2"
       },
       "ResponseBody": {
-        "dataFeedId": "f1da2e5c-6d9c-4880-ba5e-0fcf2cc7d209",
+        "dataFeedId": "a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
         "dataFeedName": "dataFeedd1DcWx57",
         "metrics": [
           {
-            "metricId": "99085f04-12d5-419a-9308-40d99c46653d",
+            "metricId": "8c2ea8e4-0457-4f0b-acc2-135b4c7ddb54",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -144,7 +135,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:15Z",
+        "createdTime": "2021-02-01T12:46:31Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -157,13 +148,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f1da2e5c-6d9c-4880-ba5e-0fcf2cc7d209",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0a8c824-1a73-4ae8-9bb7-58df57c0d4eb",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-de9a435c7a072647af75f944019270dc-1e51b8accdd8d445-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a5bd1e60cb77ca46bb4bfe57e8cf143b-840722ec4f697b40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ffeebdb1c98a21a95faa1e8ae1631c9f",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +162,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2cb5f6ee-f2e2-48e8-9479-539690fa28f0",
+        "apim-request-id": "b6d728bb-ff91-44fd-b7e6-5b5e3c183043",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:15 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "327",
-        "x-request-id": "2cb5f6ee-f2e2-48e8-9479-539690fa28f0"
+        "x-envoy-upstream-service-time": "302",
+        "x-request-id": "b6d728bb-ff91-44fd-b7e6-5b5e3c183043"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:16.0205698-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:32.3686203-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bcace9a7500c024baf316d76a825fb9e-1852f4866ebae845-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1e62c93e02f74a41a4c0bee35bdb1aa6-01f537b62a2bf747-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "09fe128f2bb7a6fb1506e62c992e18f0",
         "x-ms-return-client-request-id": "true"
@@ -34,64 +37,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "54afb197-91a2-4911-95ea-4a2033ee271e",
+        "apim-request-id": "f30affcc-e1e3-45b6-b982-7583cae1e85e",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:22 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c6bf3bd-07e5-476f-833c-2daf43430698",
+        "Date": "Mon, 01 Feb 2021 13:42:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "564",
-        "x-request-id": "54afb197-91a2-4911-95ea-4a2033ee271e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "678",
+        "X-Request-ID": "f30affcc-e1e3-45b6-b982-7583cae1e85e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c6bf3bd-07e5-476f-833c-2daf43430698",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "345",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7defbe8e643d148bae9c1fa7f270867-029ba6dd4d965546-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-85aed38cc23a804398399d1bb87ebd67-c0f30436ae663c41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "60902c671b6f927f8026dde63fe7aeeb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "accountName": "account",
-          "accountKey": "Sanitized",
-          "fileSystemName": "fileSystem",
-          "directoryTemplate": "dir",
-          "fileTemplate": "file"
-        },
-        "dataSourceType": "AzureDataLakeStorageGen2",
-        "dataFeedName": "dataFeedYunOXyZy",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fcb78a58-d3c3-40ea-9ca5-46d70077f6c3",
+        "apim-request-id": "71b2fc11-19dd-4f06-9864-f9aafef2c334",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:23 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "638",
-        "x-request-id": "fcb78a58-d3c3-40ea-9ca5-46d70077f6c3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "482",
+        "X-Request-ID": "71b2fc11-19dd-4f06-9864-f9aafef2c334"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c6bf3bd-07e5-476f-833c-2daf43430698",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6dc4c273bb044c43a659101479941d25-901171283dfb4b43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-25b5d44661b293459594a5527361d0fe-ac44b0acd9a7e947-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "008d38644bddd1708dcdfab55295350b",
         "x-ms-return-client-request-id": "true"
@@ -99,21 +99,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04c2b1d5-27ab-41b1-b42d-d1b40a3d179e",
+        "apim-request-id": "94166b8b-baf8-436c-abbd-b05a909d9655",
         "Content-Length": "1092",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:23 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "204",
-        "x-request-id": "04c2b1d5-27ab-41b1-b42d-d1b40a3d179e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "220",
+        "X-Request-ID": "94166b8b-baf8-436c-abbd-b05a909d9655"
       },
       "ResponseBody": {
-        "dataFeedId": "3c6bf3bd-07e5-476f-833c-2daf43430698",
+        "dataFeedId": "51057ba2-9a13-43d6-b781-16c0806b9b98",
         "dataFeedName": "dataFeedYunOXyZy",
         "metrics": [
           {
-            "metricId": "6c96d0b4-47e2-4461-af82-6a2b60d329eb",
+            "metricId": "3a07e03d-21e9-4105-8c51-81664130f202",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -144,7 +144,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:22Z",
+        "createdTime": "2021-02-01T13:42:25Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -157,13 +157,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3c6bf3bd-07e5-476f-833c-2daf43430698",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2d6e58b97f96db49901540615f686dde-25969617b9d28245-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f48a4f9f8710f84384375192393b2208-8da6b03a29bfe84c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "44fccf0446dc743a936b88904d14672e",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +174,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "24de1393-c155-4edb-83f4-4f522d76757e",
+        "apim-request-id": "59d787cb-72dd-4563-8d50-68f17784c296",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:23 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "280",
-        "x-request-id": "24de1393-c155-4edb-83f4-4f522d76757e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "477",
+        "X-Request-ID": "59d787cb-72dd-4563-8d50-68f17784c296"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:23.9868885-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:25.9926718-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureDataLakeStorageGen2DataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "329",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1e62c93e02f74a41a4c0bee35bdb1aa6-01f537b62a2bf747-00",
+        "traceparent": "00-f996a2acc45587498c0ebaf8ae28830d-fd367e29bcb6e94b-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -37,26 +37,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f30affcc-e1e3-45b6-b982-7583cae1e85e",
+        "apim-request-id": "ddc333ca-8f59-4565-b204-bff19ce91e7e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:24 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
+        "Date": "Mon, 01 Feb 2021 15:53:03 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4796f94-6cc4-4225-908a-942c2d6e69e1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "678",
-        "X-Request-ID": "f30affcc-e1e3-45b6-b982-7583cae1e85e"
+        "x-envoy-upstream-service-time": "436",
+        "X-Request-ID": "ddc333ca-8f59-4565-b204-bff19ce91e7e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4796f94-6cc4-4225-908a-942c2d6e69e1",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-85aed38cc23a804398399d1bb87ebd67-c0f30436ae663c41-00",
+        "traceparent": "00-8117ce9a3237334aa6c0b419ce56d7dc-0d951de315f81d4d-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -66,28 +66,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "71b2fc11-19dd-4f06-9864-f9aafef2c334",
+        "apim-request-id": "c647c8bb-b379-4636-a04e-fec32ea4abe9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:24 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "482",
-        "X-Request-ID": "71b2fc11-19dd-4f06-9864-f9aafef2c334"
+        "x-envoy-upstream-service-time": "167",
+        "X-Request-ID": "c647c8bb-b379-4636-a04e-fec32ea4abe9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4796f94-6cc4-4225-908a-942c2d6e69e1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-25b5d44661b293459594a5527361d0fe-ac44b0acd9a7e947-00",
+        "traceparent": "00-dae1101e95fa244d9f08ce26f35e9c6a-1e8c8cf3acae3443-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -99,21 +99,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "94166b8b-baf8-436c-abbd-b05a909d9655",
+        "apim-request-id": "841dac64-95ce-4d8a-82ed-61c0766e1818",
         "Content-Length": "1092",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:25 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "220",
-        "X-Request-ID": "94166b8b-baf8-436c-abbd-b05a909d9655"
+        "x-envoy-upstream-service-time": "164",
+        "X-Request-ID": "841dac64-95ce-4d8a-82ed-61c0766e1818"
       },
       "ResponseBody": {
-        "dataFeedId": "51057ba2-9a13-43d6-b781-16c0806b9b98",
+        "dataFeedId": "c4796f94-6cc4-4225-908a-942c2d6e69e1",
         "dataFeedName": "dataFeedYunOXyZy",
         "metrics": [
           {
-            "metricId": "3a07e03d-21e9-4105-8c51-81664130f202",
+            "metricId": "6b706651-0ae8-4846-bed8-1b1a55d820f2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -144,7 +144,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:25Z",
+        "createdTime": "2021-02-01T15:53:03Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -157,12 +157,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51057ba2-9a13-43d6-b781-16c0806b9b98",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c4796f94-6cc4-4225-908a-942c2d6e69e1",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f48a4f9f8710f84384375192393b2208-8da6b03a29bfe84c-00",
+        "traceparent": "00-5300638ebf94014aa505e4919100c23c-ed7dc4738b2bcf4d-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -174,19 +174,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "59d787cb-72dd-4563-8d50-68f17784c296",
+        "apim-request-id": "11b296d2-5c82-4777-8434-4df5e16750f2",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:25 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "477",
-        "X-Request-ID": "59d787cb-72dd-4563-8d50-68f17784c296"
+        "x-envoy-upstream-service-time": "297",
+        "X-Request-ID": "11b296d2-5c82-4777-8434-4df5e16750f2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:25.9926718-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:03.5463843-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bdbd795fa9ed5a4e85d52b8d908fc001-78a56615284b3c4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-245b2a623a801b48a03c019cf8d02394-8909f8ed78f6344c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d03f3143449edf1db57db1fdf6214611",
         "x-ms-return-client-request-id": "true"
@@ -32,25 +35,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "10032ff2-b56a-4fa3-a2bd-6a840456bfeb",
+        "apim-request-id": "c36973d7-8081-44d2-b338-e7ce2d38c5f3",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+        "Date": "Mon, 01 Feb 2021 14:24:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cc1f365-1028-476c-a81e-3ac3ff3385f7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "577",
-        "x-request-id": "10032ff2-b56a-4fa3-a2bd-6a840456bfeb"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "711",
+        "X-Request-ID": "c36973d7-8081-44d2-b338-e7ce2d38c5f3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cc1f365-1028-476c-a81e-3ac3ff3385f7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bd9d455d69ff2d4a9e26943bb3f51266-b6fc7c052b87364f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d339257478588143a9da638b331a8809-3c77347563a2f04f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1dbed3bf509c6e5cc25b2879bd020c6e",
         "x-ms-return-client-request-id": "true"
@@ -58,21 +64,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5c45cd54-c2dd-4085-8c46-6af8df9cf2e0",
+        "apim-request-id": "1139b6c5-e096-497e-aaa2-5860585ac1e0",
         "Content-Length": "963",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:36 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "179",
-        "x-request-id": "5c45cd54-c2dd-4085-8c46-6af8df9cf2e0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "145",
+        "X-Request-ID": "1139b6c5-e096-497e-aaa2-5860585ac1e0"
       },
       "ResponseBody": {
-        "dataFeedId": "cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+        "dataFeedId": "1cc1f365-1028-476c-a81e-3ac3ff3385f7",
         "dataFeedName": "dataFeedbvrHP8sF",
         "metrics": [
           {
-            "metricId": "908fb0e7-4777-4a22-871c-c2443af64d85",
+            "metricId": "3d7c2e40-fe6a-48b0-bf20-95c23fe1cc16",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +109,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:36Z",
+        "createdTime": "2021-02-01T14:24:51Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,15 +120,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cc1f365-1028-476c-a81e-3ac3ff3385f7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "677",
+        "Content-Length": "694",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0cd6cbf9ef56a34a86756164ae25fbc1-1e9be1a8a6502d4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-58bb513e972b4e4dbd63569144bd1ff1-b4f80a2fd7ef1645-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1b0fedef9991aceb8149c530f64103b1",
         "x-ms-return-client-request-id": "true"
@@ -148,7 +157,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -158,24 +168,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "95b62998-ec15-4672-9b5a-35123374333e",
+        "apim-request-id": "f3299fac-145d-494b-b8a0-ee9afe3d6914",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:37 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1156",
-        "x-request-id": "95b62998-ec15-4672-9b5a-35123374333e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "648",
+        "X-Request-ID": "f3299fac-145d-494b-b8a0-ee9afe3d6914"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cc1f365-1028-476c-a81e-3ac3ff3385f7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-456a590ed4c2ab4d9407988230e9435f-a696d474549e4547-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-995883824b274a48ac1b2e0edd3c84cf-26a5b41abf0da945-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b0360baf2f37f314d4d10e421ca321b3",
         "x-ms-return-client-request-id": "true"
@@ -183,21 +196,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "613d3c41-b75d-4800-a703-0734c0939fc0",
-        "Content-Length": "1089",
+        "apim-request-id": "627ca8b3-a147-4053-abe1-d4120ec7e77b",
+        "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:38 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "173",
-        "x-request-id": "613d3c41-b75d-4800-a703-0734c0939fc0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "167",
+        "X-Request-ID": "627ca8b3-a147-4053-abe1-d4120ec7e77b"
       },
       "ResponseBody": {
-        "dataFeedId": "cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+        "dataFeedId": "1cc1f365-1028-476c-a81e-3ac3ff3385f7",
         "dataFeedName": "dataFeedvx6FuHYo",
         "metrics": [
           {
-            "metricId": "908fb0e7-4777-4a22-871c-c2443af64d85",
+            "metricId": "3d7c2e40-fe6a-48b0-bf20-95c23fe1cc16",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -223,6 +236,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -230,7 +244,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:36Z",
+        "createdTime": "2021-02-01T14:24:51Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,13 +255,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1cc1f365-1028-476c-a81e-3ac3ff3385f7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d3d7db42379f1b42913ba94a2a6dafa4-c23b1e8129a2f440-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5c26d138a373a34881e9aed3a0bd43f3-8468cf0fae3f8343-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "080e43702a11257fe8119b538a2c7881",
         "x-ms-return-client-request-id": "true"
@@ -255,19 +272,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f14f6a01-30e2-4d30-bd7f-99fdc63fdac0",
+        "apim-request-id": "d02428c6-145c-4faa-8c81-251fefe39412",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:38 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "324",
-        "x-request-id": "f14f6a01-30e2-4d30-bd7f-99fdc63fdac0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "287",
+        "X-Request-ID": "d02428c6-145c-4faa-8c81-251fefe39412"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:38.2147760-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:24:52.6110124-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0612936691546041bda78ec4de2edf1b-55a3eed4fc4b2c49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bdbd795fa9ed5a4e85d52b8d908fc001-78a56615284b3c4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f61cf5d2f683b04c43313fd09e441ddf",
+        "x-ms-client-request-id": "d03f3143449edf1db57db1fdf6214611",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,47 +32,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3953a730-ae68-40f4-aeae-356a0ba4dca7",
+        "apim-request-id": "10032ff2-b56a-4fa3-a2bd-6a840456bfeb",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:17 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+        "Date": "Mon, 01 Feb 2021 13:12:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "347",
-        "x-request-id": "3953a730-ae68-40f4-aeae-356a0ba4dca7"
+        "x-envoy-upstream-service-time": "577",
+        "x-request-id": "10032ff2-b56a-4fa3-a2bd-6a840456bfeb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0fcb5b880a15554595018674d6f551d5-ed401045096d8543-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bd9d455d69ff2d4a9e26943bb3f51266-b6fc7c052b87364f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fdb17db521f61146bfd3be1d9c505c6e",
+        "x-ms-client-request-id": "1dbed3bf509c6e5cc25b2879bd020c6e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a2e3276d-0a06-4717-8081-ca7bcbbee0a0",
+        "apim-request-id": "5c45cd54-c2dd-4085-8c46-6af8df9cf2e0",
         "Content-Length": "963",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:17 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "148",
-        "x-request-id": "a2e3276d-0a06-4717-8081-ca7bcbbee0a0"
+        "x-envoy-upstream-service-time": "179",
+        "x-request-id": "5c45cd54-c2dd-4085-8c46-6af8df9cf2e0"
       },
       "ResponseBody": {
-        "dataFeedId": "873ac113-6fce-4756-b096-bd8acf6ec45e",
+        "dataFeedId": "cd590fbd-554c-4c04-bb71-fcb6b13767f9",
         "dataFeedName": "dataFeedbvrHP8sF",
         "metrics": [
           {
-            "metricId": "7b8342fa-c14e-4bc7-9a3a-f170cd51795d",
+            "metricId": "908fb0e7-4777-4a22-871c-c2443af64d85",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +103,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:17Z",
+        "createdTime": "2021-02-01T13:12:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,17 +114,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "677",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a26fe626e51e514facafbb129570af1d-df188b245258854c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0cd6cbf9ef56a34a86756164ae25fbc1-1e9be1a8a6502d4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "79285bc202bd6e0cefed0f1b9199ebac",
+        "x-ms-client-request-id": "1b0fedef9991aceb8149c530f64103b1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -134,10 +134,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeedbvrHP8sF",
+        "dataFeedName": "dataFeedvx6FuHYo",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -158,53 +158,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b1219e19-f7ea-403c-ba60-322fdbe3adfd",
+        "apim-request-id": "95b62998-ec15-4672-9b5a-35123374333e",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:18 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "456",
-        "x-request-id": "b1219e19-f7ea-403c-ba60-322fdbe3adfd"
+        "x-envoy-upstream-service-time": "1156",
+        "x-request-id": "95b62998-ec15-4672-9b5a-35123374333e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4e3d2c2c31b34440a0213507a02cda78-c4f7edc15d87dc4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-456a590ed4c2ab4d9407988230e9435f-a696d474549e4547-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "30c5498141f6b103af0b36b0372f14f3",
+        "x-ms-client-request-id": "b0360baf2f37f314d4d10e421ca321b3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "80cc0c89-e445-4872-8889-2d3ccc60dcc3",
+        "apim-request-id": "613d3c41-b75d-4800-a703-0734c0939fc0",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:18 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "141",
-        "x-request-id": "80cc0c89-e445-4872-8889-2d3ccc60dcc3"
+        "x-envoy-upstream-service-time": "173",
+        "x-request-id": "613d3c41-b75d-4800-a703-0734c0939fc0"
       },
       "ResponseBody": {
-        "dataFeedId": "873ac113-6fce-4756-b096-bd8acf6ec45e",
-        "dataFeedName": "dataFeedbvrHP8sF",
+        "dataFeedId": "cd590fbd-554c-4c04-bb71-fcb6b13767f9",
+        "dataFeedName": "dataFeedvx6FuHYo",
         "metrics": [
           {
-            "metricId": "7b8342fa-c14e-4bc7-9a3a-f170cd51795d",
+            "metricId": "908fb0e7-4777-4a22-871c-c2443af64d85",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureTable",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -230,7 +230,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:17Z",
+        "createdTime": "2021-02-01T13:12:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,33 +241,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/873ac113-6fce-4756-b096-bd8acf6ec45e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cd590fbd-554c-4c04-bb71-fcb6b13767f9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-efdafb7649679d41a8fbb21f2ea82c80-621e84941d29854c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d3d7db42379f1b42913ba94a2a6dafa4-c23b1e8129a2f440-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "420ed1d4a31cb32170430e08112a7f25",
+        "x-ms-client-request-id": "080e43702a11257fe8119b538a2c7881",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4520a83d-2b2e-46d7-a5b7-09b875aa900e",
+        "apim-request-id": "f14f6a01-30e2-4d30-bd7f-99fdc63fdac0",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:18 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "268",
-        "x-request-id": "4520a83d-2b2e-46d7-a5b7-09b875aa900e"
+        "x-envoy-upstream-service-time": "324",
+        "x-request-id": "f14f6a01-30e2-4d30-bd7f-99fdc63fdac0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:18.2489515-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:38.2147760-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-866835fdcc2fb3469b7334bc87634ecb-ddf320933c77844d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-2c4699df4567b648a6b0f8be98e1e09c-64b37932c265694e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d9ac92169ecd94f8de47b1d36d9cba27",
         "x-ms-return-client-request-id": "true"
@@ -35,28 +32,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e3903ba0-e165-441d-83bf-68b2e7777784",
+        "apim-request-id": "556eef8c-9a3d-4504-a2dd-c685aa37a430",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+        "Date": "Mon, 01 Feb 2021 15:41:11 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fed5781f-8e5d-41bb-afe5-d95c66122c72",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "489",
-        "X-Request-ID": "e3903ba0-e165-441d-83bf-68b2e7777784"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "711",
+        "x-request-id": "556eef8c-9a3d-4504-a2dd-c685aa37a430"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fed5781f-8e5d-41bb-afe5-d95c66122c72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c225020f4fb42a4cb8fec8652746b319-5f2a1b5c5d264549-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-248e3a5956e7c7449f7896e5f53036cd-2590de241436c747-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ee463468903463dcbf39395816f3f376",
         "x-ms-return-client-request-id": "true"
@@ -64,21 +58,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0311f2ba-a622-473d-9038-9ecf90ac1c0f",
+        "apim-request-id": "672464c2-82d2-46d2-a888-dc2b2bff8716",
         "Content-Length": "963",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:27 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "215",
-        "X-Request-ID": "0311f2ba-a622-473d-9038-9ecf90ac1c0f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "672464c2-82d2-46d2-a888-dc2b2bff8716"
       },
       "ResponseBody": {
-        "dataFeedId": "5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+        "dataFeedId": "fed5781f-8e5d-41bb-afe5-d95c66122c72",
         "dataFeedName": "dataFeedDnn54WoG",
         "metrics": [
           {
-            "metricId": "d1a42a5a-7e4d-4a7f-b3fa-55b1ca0e305d",
+            "metricId": "2ef4d987-8b67-4585-956d-8fee70da464b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -109,7 +103,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:26Z",
+        "createdTime": "2021-02-01T15:41:12Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -120,18 +114,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fed5781f-8e5d-41bb-afe5-d95c66122c72",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "677",
+        "Content-Length": "694",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0c70e36be28241469462a1cefc0adfdb-f81505a31e78dd48-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-d16ac47c17e74648818b1226d628cce8-f7e7cb29baebd34b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f5e9be7050985462b3455de9a6e2b145",
         "x-ms-return-client-request-id": "true"
@@ -157,7 +148,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -167,27 +159,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "251a3e86-d3d6-4492-81bf-f5c5b2d19bd2",
+        "apim-request-id": "b13e13bc-6203-4182-bc6c-e3b8184c5be5",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:28 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1019",
-        "X-Request-ID": "251a3e86-d3d6-4492-81bf-f5c5b2d19bd2"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "739",
+        "x-request-id": "b13e13bc-6203-4182-bc6c-e3b8184c5be5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fed5781f-8e5d-41bb-afe5-d95c66122c72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ad72f9f85ce23144b3d5527762677499-86a72f5f0a98e340-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-66a6d0241e2ad8429c2a49591ddc7b39-30ae3f14fde2ec46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ee495fc6d5f9866ab6491993659f7deb",
         "x-ms-return-client-request-id": "true"
@@ -195,21 +184,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4b393bd1-030a-4802-b871-ea782b717d5b",
-        "Content-Length": "1089",
+        "apim-request-id": "e39777a2-c458-4942-94a4-7dfeba765b5c",
+        "Content-Length": "1106",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:28 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "239",
-        "X-Request-ID": "4b393bd1-030a-4802-b871-ea782b717d5b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "e39777a2-c458-4942-94a4-7dfeba765b5c"
       },
       "ResponseBody": {
-        "dataFeedId": "5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+        "dataFeedId": "fed5781f-8e5d-41bb-afe5-d95c66122c72",
         "dataFeedName": "dataFeedpUyOpBSF",
         "metrics": [
           {
-            "metricId": "d1a42a5a-7e4d-4a7f-b3fa-55b1ca0e305d",
+            "metricId": "2ef4d987-8b67-4585-956d-8fee70da464b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -235,6 +224,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -242,7 +232,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:26Z",
+        "createdTime": "2021-02-01T15:41:12Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -253,16 +243,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fed5781f-8e5d-41bb-afe5-d95c66122c72",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e40c3fccb12c32418f988033b0221835-10625ff6655b6a47-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-8332336c4bce6742a2ff91437effd9ba-13cc119a9fe0a947-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "af623b54c5b2188ed2f23bef32f2bcdd",
         "x-ms-return-client-request-id": "true"
@@ -270,19 +257,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d67ca3b9-f84f-4f00-8d22-afd7fef36dc1",
+        "apim-request-id": "e4e99e00-5c47-4d09-8193-367eed27cfa7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:28 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "463",
-        "X-Request-ID": "d67ca3b9-f84f-4f00-8d22-afd7fef36dc1"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "341",
+        "x-request-id": "e4e99e00-5c47-4d09-8193-367eed27cfa7"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:28.6921889-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:13.3162115-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7772e34481aa9c4087cc46d3dc243564-dc48057e0ee53e49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-866835fdcc2fb3469b7334bc87634ecb-ddf320933c77844d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b28681e140239fc41692acd9cd9ef894",
+        "x-ms-client-request-id": "d9ac92169ecd94f8de47b1d36d9cba27",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,47 +35,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "18660659-76a3-482b-810a-f126324af21f",
+        "apim-request-id": "e3903ba0-e165-441d-83bf-68b2e7777784",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+        "Date": "Mon, 01 Feb 2021 13:42:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "578",
-        "x-request-id": "18660659-76a3-482b-810a-f126324af21f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "489",
+        "X-Request-ID": "e3903ba0-e165-441d-83bf-68b2e7777784"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c243431ec879324aaeca03de1bdfcfe0-cd01538124836d4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c225020f4fb42a4cb8fec8652746b319-5f2a1b5c5d264549-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d3b147de9c6d27ba683446ee3490dc63",
+        "x-ms-client-request-id": "ee463468903463dcbf39395816f3f376",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "50a4fab7-82ed-44b8-bdd7-294ed7b89677",
+        "apim-request-id": "0311f2ba-a622-473d-9038-9ecf90ac1c0f",
         "Content-Length": "963",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:57 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "50a4fab7-82ed-44b8-bdd7-294ed7b89677"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "215",
+        "X-Request-ID": "0311f2ba-a622-473d-9038-9ecf90ac1c0f"
       },
       "ResponseBody": {
-        "dataFeedId": "13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+        "dataFeedId": "5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
         "dataFeedName": "dataFeedDnn54WoG",
         "metrics": [
           {
-            "metricId": "0ff799c4-fa67-4f1c-afcb-a223392c13da",
+            "metricId": "d1a42a5a-7e4d-4a7f-b3fa-55b1ca0e305d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +109,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:57Z",
+        "createdTime": "2021-02-01T13:42:26Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,17 +120,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "677",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-be0531722f46d34ea4fe451bd9e9f921-a903fe06bed1d34b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0c70e36be28241469462a1cefc0adfdb-f81505a31e78dd48-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "583939bff31676f370bee9f598506254",
+        "x-ms-client-request-id": "f5e9be7050985462b3455de9a6e2b145",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -134,10 +143,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeedDnn54WoG",
+        "dataFeedName": "dataFeedpUyOpBSF",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -158,53 +167,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6878ee72-97d1-4f60-9969-a61ea99b28e8",
+        "apim-request-id": "251a3e86-d3d6-4492-81bf-f5c5b2d19bd2",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:57 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "688",
-        "x-request-id": "6878ee72-97d1-4f60-9969-a61ea99b28e8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1019",
+        "X-Request-ID": "251a3e86-d3d6-4492-81bf-f5c5b2d19bd2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-20295f05c2cd0742a9abb5624a204ced-406c994a5d54004a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ad72f9f85ce23144b3d5527762677499-86a72f5f0a98e340-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e95d45b3e2a645b1c65f49eef9d56a86",
+        "x-ms-client-request-id": "ee495fc6d5f9866ab6491993659f7deb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b867fbdd-cb4d-41d2-8799-9b868670d922",
+        "apim-request-id": "4b393bd1-030a-4802-b871-ea782b717d5b",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:58 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "190",
-        "x-request-id": "b867fbdd-cb4d-41d2-8799-9b868670d922"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "239",
+        "X-Request-ID": "4b393bd1-030a-4802-b871-ea782b717d5b"
       },
       "ResponseBody": {
-        "dataFeedId": "13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
-        "dataFeedName": "dataFeedDnn54WoG",
+        "dataFeedId": "5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
+        "dataFeedName": "dataFeedpUyOpBSF",
         "metrics": [
           {
-            "metricId": "0ff799c4-fa67-4f1c-afcb-a223392c13da",
+            "metricId": "d1a42a5a-7e4d-4a7f-b3fa-55b1ca0e305d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureTable",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -230,7 +242,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:57Z",
+        "createdTime": "2021-02-01T13:42:26Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,33 +253,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/13c90755-2823-4a0b-b1f9-ff76b2d85ec7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5ae1799e-a8a7-4a64-bf5d-e66b7793d3dd",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9011853ee574194686f0a62f6cf2c17e-2b975106e123c341-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e40c3fccb12c32418f988033b0221835-10625ff6655b6a47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "931949b69f65eb7d543b62afb2c58e18",
+        "x-ms-client-request-id": "af623b54c5b2188ed2f23bef32f2bcdd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e9dc5554-4c61-4ef5-937f-110dd3252dd6",
+        "apim-request-id": "d67ca3b9-f84f-4f00-8d22-afd7fef36dc1",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:58 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "283",
-        "x-request-id": "e9dc5554-4c61-4ef5-937f-110dd3252dd6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "463",
+        "X-Request-ID": "d67ca3b9-f84f-4f00-8d22-afd7fef36dc1"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:58.6800669-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:28.6921889-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3e9a499993713c409a72def49836b89a-0cc4e7c37ca5e344-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-219c9a09eb336546b435e9b24b9d5893-232fca3598573d4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7407859edd6985736e29c548d36fd331",
         "x-ms-return-client-request-id": "true"
@@ -32,33 +35,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2f242b7c-0044-42d5-b7e4-886aed2d5b60",
+        "apim-request-id": "c393cefc-9c66-44e0-9907-b1c496349ebf",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
+        "Date": "Mon, 01 Feb 2021 15:52:31 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f3135b1-19ca-4dea-863e-f30c0625ef80",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "441",
-        "x-request-id": "2f242b7c-0044-42d5-b7e4-886aed2d5b60"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "430",
+        "X-Request-ID": "c393cefc-9c66-44e0-9907-b1c496349ebf"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f3135b1-19ca-4dea-863e-f30c0625ef80",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6896aa463789e645a16a032cb3d0f17d-13913a2be15ed740-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5cebc454ea7c114f9624dcda82563ad1-f08ae436a58e5344-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "aeab749383a54315a313e94ed320d77b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeeddQ1QSlCB",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -76,24 +82,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a1a99c14-05ee-4feb-8992-9354dd07ce1d",
+        "apim-request-id": "b2952950-e3a1-4752-9eab-c53aea878528",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "188",
-        "x-request-id": "a1a99c14-05ee-4feb-8992-9354dd07ce1d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "198",
+        "X-Request-ID": "b2952950-e3a1-4752-9eab-c53aea878528"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f3135b1-19ca-4dea-863e-f30c0625ef80",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4a5a8dcf10d24242a252ff09360addcf-f817e2c4f19e134a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-14e8a22122532946bc7799e27e433cfa-c8596c997473e348-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "18c7e318a9a53b84cd7ce2f2006bd2dd",
         "x-ms-return-client-request-id": "true"
@@ -101,21 +110,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "399618d5-6617-4625-b6af-9d39653b5c98",
+        "apim-request-id": "5e65c2db-c53b-45ee-b7c5-bc7ad6e111ca",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "179",
-        "x-request-id": "399618d5-6617-4625-b6af-9d39653b5c98"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "143",
+        "X-Request-ID": "5e65c2db-c53b-45ee-b7c5-bc7ad6e111ca"
       },
       "ResponseBody": {
-        "dataFeedId": "16d22a89-9bc5-4621-9190-cd88dac1fd35",
+        "dataFeedId": "9f3135b1-19ca-4dea-863e-f30c0625ef80",
         "dataFeedName": "dataFeeddQ1QSlCB",
         "metrics": [
           {
-            "metricId": "aa91b3a6-4870-4c46-8563-116c71d4de49",
+            "metricId": "c48d2f71-b51a-430a-8c84-516c7f72f83f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -148,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:33Z",
+        "createdTime": "2021-02-01T15:52:32Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -159,13 +168,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f3135b1-19ca-4dea-863e-f30c0625ef80",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09e171cb5a1c624dab2da3f64554c107-701558ee436c6b49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f572db806ada934e9a371c9c259d7e2b-9305a55c7c9c0d43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "078a0fd4487c1aa970c4d056f425b24d",
         "x-ms-return-client-request-id": "true"
@@ -173,19 +185,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7af79238-3c31-438d-a8d1-6fd251fba1e4",
+        "apim-request-id": "44661bfc-03e6-47cc-9557-b15b20fc87e8",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "336",
-        "x-request-id": "7af79238-3c31-438d-a8d1-6fd251fba1e4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "297",
+        "X-Request-ID": "44661bfc-03e6-47cc-9557-b15b20fc87e8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:34.1997928-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:33.0364897-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-be2b121e64dec34c95bbbf101ae48e9e-c9a872db50f2eb4a-00",
+        "traceparent": "00-3e9a499993713c409a72def49836b89a-0cc4e7c37ca5e344-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "cf9484f14fd065213181b2b5bb60e544",
+        "x-ms-client-request-id": "7407859edd6985736e29c548d36fd331",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,7 +21,7 @@
           "query": "query"
         },
         "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeed2to4oMyA",
+        "dataFeedName": "dataFeedgCPXJzpZ",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -32,39 +32,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d7927d27-2895-4795-9534-79a43f4f66e4",
+        "apim-request-id": "2f242b7c-0044-42d5-b7e4-886aed2d5b60",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
+        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "605",
-        "x-request-id": "d7927d27-2895-4795-9534-79a43f4f66e4"
+        "x-envoy-upstream-service-time": "441",
+        "x-request-id": "2f242b7c-0044-42d5-b7e4-886aed2d5b60"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "565",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-df803bbd63c9464eabf6acf83dc4b899-b9e9789c60de9647-00",
+        "traceparent": "00-6896aa463789e645a16a032cb3d0f17d-13913a2be15ed740-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3bf32a70fe14cec93795a71f40827d3a",
+        "x-ms-client-request-id": "aeab749383a54315a313e94ed320d77b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "table": "table",
-          "query": "query"
-        },
-        "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeedssk5L1Q0",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeeddQ1QSlCB",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -81,46 +76,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f714f48d-4e9c-4e6e-88c3-9a4a7713847a",
+        "apim-request-id": "a1a99c14-05ee-4feb-8992-9354dd07ce1d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "761",
-        "x-request-id": "f714f48d-4e9c-4e6e-88c3-9a4a7713847a"
+        "x-envoy-upstream-service-time": "188",
+        "x-request-id": "a1a99c14-05ee-4feb-8992-9354dd07ce1d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c05fa1bb8ec624b97e0dd56e78970c5-254e9637dd017244-00",
+        "traceparent": "00-4a5a8dcf10d24242a252ff09360addcf-f817e2c4f19e134a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e2ead65be97f46bbe4ba31fe17050ea5",
+        "x-ms-client-request-id": "18c7e318a9a53b84cd7ce2f2006bd2dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2cd363ae-00d0-4a42-9dba-089aa0a25f48",
+        "apim-request-id": "399618d5-6617-4625-b6af-9d39653b5c98",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:40 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "2cd363ae-00d0-4a42-9dba-089aa0a25f48"
+        "x-envoy-upstream-service-time": "179",
+        "x-request-id": "399618d5-6617-4625-b6af-9d39653b5c98"
       },
       "ResponseBody": {
-        "dataFeedId": "bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
-        "dataFeedName": "dataFeedssk5L1Q0",
+        "dataFeedId": "16d22a89-9bc5-4621-9190-cd88dac1fd35",
+        "dataFeedName": "dataFeeddQ1QSlCB",
         "metrics": [
           {
-            "metricId": "d43cd9b2-3a68-4c4e-ac94-4ce301e4e449",
+            "metricId": "aa91b3a6-4870-4c46-8563-116c71d4de49",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -153,7 +148,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:39Z",
+        "createdTime": "2021-02-01T15:45:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,37 +159,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/16d22a89-9bc5-4621-9190-cd88dac1fd35",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-60e11fe09354eb43bee0c38699e7357d-41b3f6eb48b44d49-00",
+        "traceparent": "00-09e171cb5a1c624dab2da3f64554c107-701558ee436c6b49-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f8b6c6d78d93f2eabbc6983ba80125ae",
+        "x-ms-client-request-id": "078a0fd4487c1aa970c4d056f425b24d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ad2a070d-1b21-4a93-9952-716fcddac2d9",
+        "apim-request-id": "7af79238-3c31-438d-a8d1-6fd251fba1e4",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:40 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "311",
-        "x-request-id": "ad2a070d-1b21-4a93-9952-716fcddac2d9"
+        "x-envoy-upstream-service-time": "336",
+        "x-request-id": "7af79238-3c31-438d-a8d1-6fd251fba1e4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:40.1915691-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:34.1997928-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "1327772396"
+    "RandomSeed": "1420155233"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-971fafe28e86ca49a71f626241c085eb-2abc96fb1d96344d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-be2b121e64dec34c95bbbf101ae48e9e-c9a872db50f2eb4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "260bbd058623fec9f18494cfd04f2165",
+        "x-ms-client-request-id": "cf9484f14fd065213181b2b5bb60e544",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,29 +32,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "dfb1552c-81a4-49ba-b504-178d095ea652",
+        "apim-request-id": "d7927d27-2895-4795-9534-79a43f4f66e4",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+        "Date": "Mon, 01 Feb 2021 13:12:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "510",
-        "x-request-id": "dfb1552c-81a4-49ba-b504-178d095ea652"
+        "x-envoy-upstream-service-time": "605",
+        "x-request-id": "d7927d27-2895-4795-9534-79a43f4f66e4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "565",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-28e99028e367e54a9f760b650257c2da-044d9dd288d9f043-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-df803bbd63c9464eabf6acf83dc4b899-b9e9789c60de9647-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b5b2813160bb44e5702af33b14fec9ce",
+        "x-ms-client-request-id": "3bf32a70fe14cec93795a71f40827d3a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,10 +64,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeed2to4oMyA",
+        "dataFeedName": "dataFeedssk5L1Q0",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -81,53 +81,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "75b82604-0a55-4819-9bf0-afb52d17d302",
+        "apim-request-id": "f714f48d-4e9c-4e6e-88c3-9a4a7713847a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "627",
-        "x-request-id": "75b82604-0a55-4819-9bf0-afb52d17d302"
+        "x-envoy-upstream-service-time": "761",
+        "x-request-id": "f714f48d-4e9c-4e6e-88c3-9a4a7713847a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dc64b7445049c149a6d1c3a3970442ee-9198e8f78511a145-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7c05fa1bb8ec624b97e0dd56e78970c5-254e9637dd017244-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1fa7953782403a7d5bd6eae27fe9bb46",
+        "x-ms-client-request-id": "e2ead65be97f46bbe4ba31fe17050ea5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d38f2020-5d0c-4bd8-a8fc-12637a74c5ac",
+        "apim-request-id": "2cd363ae-00d0-4a42-9dba-089aa0a25f48",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "135",
-        "x-request-id": "d38f2020-5d0c-4bd8-a8fc-12637a74c5ac"
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "2cd363ae-00d0-4a42-9dba-089aa0a25f48"
       },
       "ResponseBody": {
-        "dataFeedId": "8ab702e0-6842-4f5a-9ae8-89f80e89f017",
-        "dataFeedName": "dataFeed2to4oMyA",
+        "dataFeedId": "bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
+        "dataFeedName": "dataFeedssk5L1Q0",
         "metrics": [
           {
-            "metricId": "5b390320-d6c0-4e50-ad56-3b5e1bdc1603",
+            "metricId": "d43cd9b2-3a68-4c4e-ac94-4ce301e4e449",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureTable",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -153,7 +153,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:19Z",
+        "createdTime": "2021-02-01T13:12:39Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,33 +164,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8ab702e0-6842-4f5a-9ae8-89f80e89f017",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bb0f247b-3d1f-42e6-a2ad-42a6403bffa0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6ab14934b74fee4888ba1365c5350816-d0be8cdf2c5e1741-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-60e11fe09354eb43bee0c38699e7357d-41b3f6eb48b44d49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fe31bae40517a50ed7c6b6f8938deaf2",
+        "x-ms-client-request-id": "f8b6c6d78d93f2eabbc6983ba80125ae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f9a54eee-bec2-4021-9010-53c5bfa64299",
+        "apim-request-id": "ad2a070d-1b21-4a93-9952-716fcddac2d9",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:20 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "281",
-        "x-request-id": "f9a54eee-bec2-4021-9010-53c5bfa64299"
+        "x-envoy-upstream-service-time": "311",
+        "x-request-id": "ad2a070d-1b21-4a93-9952-716fcddac2d9"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:19.9287241-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:40.1915691-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c515e395ec4784784f92b2f994fa4f1-78597f5894dfd746-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0ad3f701f57f874c8025f92b2ac8b361-f7e1e655ae556742-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "400c5a43486955a3e3cf49d024d39d60",
         "x-ms-return-client-request-id": "true"
@@ -32,33 +35,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5628e1e4-3f5a-4ac9-9e96-b9deee9b976c",
+        "apim-request-id": "abbb4186-6a6f-445f-831c-25c34231d3cd",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:13 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
+        "Date": "Mon, 01 Feb 2021 15:53:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9bfc4c23-a7e2-41e7-b0d6-6924a2c842e6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "507",
-        "x-request-id": "5628e1e4-3f5a-4ac9-9e96-b9deee9b976c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "404",
+        "X-Request-ID": "abbb4186-6a6f-445f-831c-25c34231d3cd"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9bfc4c23-a7e2-41e7-b0d6-6924a2c842e6",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8830ff990bb70046904519825914fdaa-5eee0b02ec25bc44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bb0199e08df76e4cbfc188fce7906bdd-9fb77c688b14cf40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ce9dc37689ad5bf48002b5b579ea50e8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedqd5JdCmu",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -76,24 +82,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d60046ef-cab7-4e60-aa81-487cdbddd730",
+        "apim-request-id": "aa04f412-1d0f-44f2-ba47-da183724ec21",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:14 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "204",
-        "x-request-id": "d60046ef-cab7-4e60-aa81-487cdbddd730"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "189",
+        "X-Request-ID": "aa04f412-1d0f-44f2-ba47-da183724ec21"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9bfc4c23-a7e2-41e7-b0d6-6924a2c842e6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-14585fd554506d4987f0c4efbc5c93b6-661277d2e8ceb545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-60801793c36c6d4e9071b6e0e46f52a3-b2c2e271f45d924a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ac6f1660d621c63559b8657a5b93c735",
         "x-ms-return-client-request-id": "true"
@@ -101,21 +110,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "85ec53b7-f13e-4b50-bfe3-46ed068c933d",
+        "apim-request-id": "5c22db11-5380-4bd9-919b-66da77de417e",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:14 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "161",
-        "x-request-id": "85ec53b7-f13e-4b50-bfe3-46ed068c933d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "165",
+        "X-Request-ID": "5c22db11-5380-4bd9-919b-66da77de417e"
       },
       "ResponseBody": {
-        "dataFeedId": "123a6c5a-7ac9-447d-be68-e1b054094176",
+        "dataFeedId": "9bfc4c23-a7e2-41e7-b0d6-6924a2c842e6",
         "dataFeedName": "dataFeedqd5JdCmu",
         "metrics": [
           {
-            "metricId": "6d254e33-98d7-4917-be8f-f5ac05749e95",
+            "metricId": "9feeaa17-cbcb-4746-bbb2-8f881c153346",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -148,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:14Z",
+        "createdTime": "2021-02-01T15:53:04Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -159,13 +168,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9bfc4c23-a7e2-41e7-b0d6-6924a2c842e6",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4477f572f305c141950f3246ecffe91d-48b56166e4052f44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fe1bc23464500e4fb2d9338212def02f-6cdc8cfe43c04b45-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "12d980aa9930ba6865b1c06793eedcf8",
         "x-ms-return-client-request-id": "true"
@@ -173,19 +185,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c9e63e4f-6278-4148-90d0-5612ae408943",
+        "apim-request-id": "59c1daf9-6634-459c-b028-ef34a696f2a6",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:14 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "288",
-        "x-request-id": "c9e63e4f-6278-4148-90d0-5612ae408943"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "289",
+        "X-Request-ID": "59c1daf9-6634-459c-b028-ef34a696f2a6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:14.6704530-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:04.6868778-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-20ed30250e7600449515bbc9bd6f6685-d10ba61f6d40104a-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-7c515e395ec4784784f92b2f994fa4f1-78597f5894dfd746-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "400c5a43486955a3e3cf49d024d39d60",
         "x-ms-return-client-request-id": "true"
@@ -35,41 +32,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ddd4d70f-1828-4c38-9d79-adce6ad5d93f",
+        "apim-request-id": "5628e1e4-3f5a-4ac9-9e96-b9deee9b976c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:29 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
+        "Date": "Mon, 01 Feb 2021 15:41:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "733",
-        "X-Request-ID": "ddd4d70f-1828-4c38-9d79-adce6ad5d93f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "507",
+        "x-request-id": "5628e1e4-3f5a-4ac9-9e96-b9deee9b976c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "565",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-458f8ef8d7fe2045a89aa13948747c4e-47ff018bcdaeb64b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-8830ff990bb70046904519825914fdaa-5eee0b02ec25bc44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ce9dc37689ad5bf48002b5b579ea50e8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "table": "table",
-          "query": "query"
-        },
-        "dataSourceType": "AzureTable",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedqd5JdCmu",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -87,27 +76,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "08779a28-bce2-4724-b7e5-41308acce3e6",
+        "apim-request-id": "d60046ef-cab7-4e60-aa81-487cdbddd730",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:29 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "594",
-        "X-Request-ID": "08779a28-bce2-4724-b7e5-41308acce3e6"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "204",
+        "x-request-id": "d60046ef-cab7-4e60-aa81-487cdbddd730"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-32cd688d38615142a6a9029c90058221-67a5589b2954654b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-14585fd554506d4987f0c4efbc5c93b6-661277d2e8ceb545-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ac6f1660d621c63559b8657a5b93c735",
         "x-ms-return-client-request-id": "true"
@@ -115,21 +101,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1f9923de-fa60-49d9-bfd0-c4fe75ccccfd",
+        "apim-request-id": "85ec53b7-f13e-4b50-bfe3-46ed068c933d",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:30 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "190",
-        "X-Request-ID": "1f9923de-fa60-49d9-bfd0-c4fe75ccccfd"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "85ec53b7-f13e-4b50-bfe3-46ed068c933d"
       },
       "ResponseBody": {
-        "dataFeedId": "c8d3d043-e62c-41bd-a798-b7fe8aee084b",
+        "dataFeedId": "123a6c5a-7ac9-447d-be68-e1b054094176",
         "dataFeedName": "dataFeedqd5JdCmu",
         "metrics": [
           {
-            "metricId": "684c2ffe-c83b-4382-ba7f-d3e54579a07c",
+            "metricId": "6d254e33-98d7-4917-be8f-f5ac05749e95",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -162,7 +148,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:29Z",
+        "createdTime": "2021-02-01T15:41:14Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -173,16 +159,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/123a6c5a-7ac9-447d-be68-e1b054094176",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dde512043119d745bac82ebbfb2cebc5-9f1d4e88bb5cce4c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-4477f572f305c141950f3246ecffe91d-48b56166e4052f44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "12d980aa9930ba6865b1c06793eedcf8",
         "x-ms-return-client-request-id": "true"
@@ -190,19 +173,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b6dc23a9-bc82-4d2b-bcaf-6d9112ac464d",
+        "apim-request-id": "c9e63e4f-6278-4148-90d0-5612ae408943",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:30 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "388",
-        "X-Request-ID": "b6dc23a9-bc82-4d2b-bcaf-6d9112ac464d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "288",
+        "x-request-id": "c9e63e4f-6278-4148-90d0-5612ae408943"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:30.9573142-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:14.6704530-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6e6f5350e2530745820fd3954357fc07-2781b437bc27e040-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-20ed30250e7600449515bbc9bd6f6685-d10ba61f6d40104a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "50e04808ced61567435a0c406948a355",
+        "x-ms-client-request-id": "400c5a43486955a3e3cf49d024d39d60",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,29 +35,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "54d7a3e8-70e5-40ea-b806-a0049e9ffb47",
+        "apim-request-id": "ddd4d70f-1828-4c38-9d79-adce6ad5d93f",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:58 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+        "Date": "Mon, 01 Feb 2021 13:42:29 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "351",
-        "x-request-id": "54d7a3e8-70e5-40ea-b806-a0049e9ffb47"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "733",
+        "X-Request-ID": "ddd4d70f-1828-4c38-9d79-adce6ad5d93f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "565",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-887137de5f0f6d4f974c49310fb2df99-3cb11ad5a2304348-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-458f8ef8d7fe2045a89aa13948747c4e-47ff018bcdaeb64b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d049cfe3d324609d76c39dcead89f45b",
+        "x-ms-client-request-id": "ce9dc37689ad5bf48002b5b579ea50e8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,10 +70,10 @@
           "query": "query"
         },
         "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeedf4k9rJBM",
+        "dataFeedName": "dataFeedqd5JdCmu",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -81,53 +87,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c937e8b7-0357-4052-beb6-58c8d74fe9d6",
+        "apim-request-id": "08779a28-bce2-4724-b7e5-41308acce3e6",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:59 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "650",
-        "x-request-id": "c937e8b7-0357-4052-beb6-58c8d74fe9d6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "594",
+        "X-Request-ID": "08779a28-bce2-4724-b7e5-41308acce3e6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-22722f16fdfd354f99af863ef9c3d597-0d547719fc86d440-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-32cd688d38615142a6a9029c90058221-67a5589b2954654b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b5b50280ea79e85060166fac21d635c6",
+        "x-ms-client-request-id": "ac6f1660d621c63559b8657a5b93c735",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7ee0ee94-a657-4cfd-bd66-528fec855dc4",
+        "apim-request-id": "1f9923de-fa60-49d9-bfd0-c4fe75ccccfd",
         "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:59 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165",
-        "x-request-id": "7ee0ee94-a657-4cfd-bd66-528fec855dc4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "190",
+        "X-Request-ID": "1f9923de-fa60-49d9-bfd0-c4fe75ccccfd"
       },
       "ResponseBody": {
-        "dataFeedId": "9c49e989-b279-4a67-84e5-95d5086cca69",
-        "dataFeedName": "dataFeedf4k9rJBM",
+        "dataFeedId": "c8d3d043-e62c-41bd-a798-b7fe8aee084b",
+        "dataFeedName": "dataFeedqd5JdCmu",
         "metrics": [
           {
-            "metricId": "16a26ba0-8c76-4872-a41b-10d1d1d3a1cc",
+            "metricId": "684c2ffe-c83b-4382-ba7f-d3e54579a07c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "AzureTable",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -153,7 +162,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:59Z",
+        "createdTime": "2021-02-01T13:42:29Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,33 +173,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9c49e989-b279-4a67-84e5-95d5086cca69",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c8d3d043-e62c-41bd-a798-b7fe8aee084b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-950306a936591c4dafcc6575297973ce-3c31f786fc991c4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-dde512043119d745bac82ebbfb2cebc5-9f1d4e88bb5cce4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7a65b859935b35c7aa80d912309968ba",
+        "x-ms-client-request-id": "12d980aa9930ba6865b1c06793eedcf8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0406a23a-a6f4-4a4c-b12d-b586773f17d4",
+        "apim-request-id": "b6dc23a9-bc82-4d2b-bcaf-6d9112ac464d",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:00 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "290",
-        "x-request-id": "0406a23a-a6f4-4a4c-b12d-b586773f17d4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "388",
+        "X-Request-ID": "b6dc23a9-bc82-4d2b-bcaf-6d9112ac464d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:00.2686304-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:30.9573142-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a551314c16a7704b80858e3f7ef4b3ae-a7cd1ae1818ddf44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-511eb43c9b16634ab2485f8b0ebd50fd-4f070f588ac62c4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ec2aa99aad954ad2c36ea1b57ce2d500",
         "x-ms-return-client-request-id": "true"
@@ -32,62 +32,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "aafff821-f604-47dc-9490-24a60b71c3c2",
+        "apim-request-id": "a34746a6-4b7a-4f3f-89aa-86e0a346aa14",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:17 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88956e91-65fa-41bc-9e50-42a9cb52d078",
+        "Date": "Mon, 01 Feb 2021 12:46:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "398",
-        "x-request-id": "aafff821-f604-47dc-9490-24a60b71c3c2"
+        "x-envoy-upstream-service-time": "424",
+        "x-request-id": "a34746a6-4b7a-4f3f-89aa-86e0a346aa14"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88956e91-65fa-41bc-9e50-42a9cb52d078",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "267",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-bec50794ceb9ee4c80173dfb639a4db4-a41661d765d0f847-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a515bac742d2d9418b0c237bd902067c-c88f4b9f9e84b645-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cf41fb96013dab61bce36654bf14074f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "table": "table",
-          "query": "query"
-        },
-        "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeedQ88BhUu1",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b8ce2a2c-8637-4258-8718-9872b624acd3",
+        "apim-request-id": "76bfdcfd-53e5-43bd-bf83-eca6abc17937",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:18 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "419",
-        "x-request-id": "b8ce2a2c-8637-4258-8718-9872b624acd3"
+        "x-envoy-upstream-service-time": "166",
+        "x-request-id": "76bfdcfd-53e5-43bd-bf83-eca6abc17937"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88956e91-65fa-41bc-9e50-42a9cb52d078",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-650ac8c02f52e8489a7fadad1d183ca1-3c0419d53b0d9b40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7bff3c65d8e46d44a506342ffc66e982-ccd6073e96e8c649-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5aed25c9446853bb7943fdad0b15c09b",
         "x-ms-return-client-request-id": "true"
@@ -95,21 +88,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9ff998c2-5dcc-4b7c-aeb6-808ace4a05f7",
+        "apim-request-id": "15e674ba-1c4c-4911-8a70-bf429d36a925",
         "Content-Length": "1014",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:18 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "148",
-        "x-request-id": "9ff998c2-5dcc-4b7c-aeb6-808ace4a05f7"
+        "x-envoy-upstream-service-time": "198",
+        "x-request-id": "15e674ba-1c4c-4911-8a70-bf429d36a925"
       },
       "ResponseBody": {
-        "dataFeedId": "88956e91-65fa-41bc-9e50-42a9cb52d078",
+        "dataFeedId": "656c97bd-9e98-4c7b-af3c-a868eacd7050",
         "dataFeedName": "dataFeedQ88BhUu1",
         "metrics": [
           {
-            "metricId": "96c261a2-2980-4f6c-9dde-cd5acb97133a",
+            "metricId": "4285a8f7-316e-4438-9889-02039c5bdfb1",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -140,7 +133,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:18Z",
+        "createdTime": "2021-02-01T12:46:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,13 +144,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88956e91-65fa-41bc-9e50-42a9cb52d078",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9595c21159d0c48bb12910980e52dee-6a506a6b32a2864d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0f37741e066c45408a69984ed51f2b87-e69d5ea12620f446-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2b386e57fc61991f477e30b2477e8baf",
         "x-ms-return-client-request-id": "true"
@@ -165,19 +158,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b14316e9-3e6b-404c-9d7c-9883ab4948f6",
+        "apim-request-id": "0561147f-5bee-40c6-b218-748958235826",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:18 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "300",
-        "x-request-id": "b14316e9-3e6b-404c-9d7c-9883ab4948f6"
+        "x-envoy-upstream-service-time": "436",
+        "x-request-id": "0561147f-5bee-40c6-b218-748958235826"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:19.1117202-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:33.6941743-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-511eb43c9b16634ab2485f8b0ebd50fd-4f070f588ac62c4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-70ee7da286a7e94eb2c0bb9507dbfeaa-41d1acf305668e46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ec2aa99aad954ad2c36ea1b57ce2d500",
         "x-ms-return-client-request-id": "true"
@@ -32,55 +35,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a34746a6-4b7a-4f3f-89aa-86e0a346aa14",
+        "apim-request-id": "7242edb5-b912-480e-b786-1ccc51435dae",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:32 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
+        "Date": "Mon, 01 Feb 2021 15:52:33 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a108f938-04b6-46f2-b417-d5ebb67961c8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "424",
-        "x-request-id": "a34746a6-4b7a-4f3f-89aa-86e0a346aa14"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "432",
+        "X-Request-ID": "7242edb5-b912-480e-b786-1ccc51435dae"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a108f938-04b6-46f2-b417-d5ebb67961c8",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a515bac742d2d9418b0c237bd902067c-c88f4b9f9e84b645-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b34332d3b1094e49a7b825ea6912adcd-9e4ae255cea3484e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cf41fb96013dab61bce36654bf14074f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "76bfdcfd-53e5-43bd-bf83-eca6abc17937",
+        "apim-request-id": "f85a26cc-deeb-416d-9532-1c15d3d7563c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "166",
-        "x-request-id": "76bfdcfd-53e5-43bd-bf83-eca6abc17937"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "X-Request-ID": "f85a26cc-deeb-416d-9532-1c15d3d7563c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a108f938-04b6-46f2-b417-d5ebb67961c8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7bff3c65d8e46d44a506342ffc66e982-ccd6073e96e8c649-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f2ce287d24e87c41a55af8139b2949fe-4c2063cd6f51c147-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5aed25c9446853bb7943fdad0b15c09b",
         "x-ms-return-client-request-id": "true"
@@ -88,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "15e674ba-1c4c-4911-8a70-bf429d36a925",
+        "apim-request-id": "26b3d1dd-14c6-4d9c-8ae7-5309849926de",
         "Content-Length": "1014",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "198",
-        "x-request-id": "15e674ba-1c4c-4911-8a70-bf429d36a925"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "165",
+        "X-Request-ID": "26b3d1dd-14c6-4d9c-8ae7-5309849926de"
       },
       "ResponseBody": {
-        "dataFeedId": "656c97bd-9e98-4c7b-af3c-a868eacd7050",
+        "dataFeedId": "a108f938-04b6-46f2-b417-d5ebb67961c8",
         "dataFeedName": "dataFeedQ88BhUu1",
         "metrics": [
           {
-            "metricId": "4285a8f7-316e-4438-9889-02039c5bdfb1",
+            "metricId": "3fe60f3d-33a7-4f6f-a7cb-054ea4b85b29",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -133,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:33Z",
+        "createdTime": "2021-02-01T15:52:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -144,13 +153,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/656c97bd-9e98-4c7b-af3c-a868eacd7050",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a108f938-04b6-46f2-b417-d5ebb67961c8",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0f37741e066c45408a69984ed51f2b87-e69d5ea12620f446-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a02b41b3f0cb8b4da440ccc85696e92f-61f35d78c24d104c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2b386e57fc61991f477e30b2477e8baf",
         "x-ms-return-client-request-id": "true"
@@ -158,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0561147f-5bee-40c6-b218-748958235826",
+        "apim-request-id": "e3ea20e4-f6a9-4af8-94bd-dda86bd326cd",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:34 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "436",
-        "x-request-id": "0561147f-5bee-40c6-b218-748958235826"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "321",
+        "X-Request-ID": "e3ea20e4-f6a9-4af8-94bd-dda86bd326cd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:33.6941743-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:34.1919649-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3b91750b2d318c4488efbc2a281b60e6-40ff693d19e5b34e-00",
+        "traceparent": "00-e61eb4c270181d48993c029119878c0d-5591377339c57640-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -35,26 +35,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "bbc311e3-e318-4ef4-82fc-dda3476716ad",
+        "apim-request-id": "11085e73-7515-422b-99d6-239a7090c6d5",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:32 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
+        "Date": "Mon, 01 Feb 2021 15:53:05 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d9ae310-68c6-4fc8-9a67-5ea9c86f1124",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "696",
-        "X-Request-ID": "bbc311e3-e318-4ef4-82fc-dda3476716ad"
+        "x-envoy-upstream-service-time": "467",
+        "X-Request-ID": "11085e73-7515-422b-99d6-239a7090c6d5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d9ae310-68c6-4fc8-9a67-5ea9c86f1124",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d2ddadd665016947a5d558eb41a29e28-18463bc56a76e64f-00",
+        "traceparent": "00-8ce830aa93ed4a43b1dce05b3c6621c5-a6120438df097b40-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -64,28 +64,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "01cd662b-e3d9-42aa-9b52-6deeef584258",
+        "apim-request-id": "fdff9b8d-30af-4e09-b939-1566c420a1ee",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "182",
-        "X-Request-ID": "01cd662b-e3d9-42aa-9b52-6deeef584258"
+        "x-envoy-upstream-service-time": "165",
+        "X-Request-ID": "fdff9b8d-30af-4e09-b939-1566c420a1ee"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d9ae310-68c6-4fc8-9a67-5ea9c86f1124",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-545eb9cb88a6b648ac1002636ddd14ae-6bfe46ad2c338e40-00",
+        "traceparent": "00-e354175df98a5240a66793babb390785-4c44d3ccdbc9b049-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -97,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9771f3d4-37a4-416a-923e-80b14535a23b",
+        "apim-request-id": "deed685a-101b-4914-a77b-11f54b465c6b",
         "Content-Length": "1014",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "182",
-        "X-Request-ID": "9771f3d4-37a4-416a-923e-80b14535a23b"
+        "x-envoy-upstream-service-time": "159",
+        "X-Request-ID": "deed685a-101b-4914-a77b-11f54b465c6b"
       },
       "ResponseBody": {
-        "dataFeedId": "73913c65-8f91-4244-a199-62e263ff46c7",
+        "dataFeedId": "0d9ae310-68c6-4fc8-9a67-5ea9c86f1124",
         "dataFeedName": "dataFeed6ugrj57o",
         "metrics": [
           {
-            "metricId": "f98a33dc-a2e9-4295-af9d-c5ec2917add6",
+            "metricId": "44336103-2eda-4cca-8f3d-1617cf20296c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:31Z",
+        "createdTime": "2021-02-01T15:53:05Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -153,12 +153,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d9ae310-68c6-4fc8-9a67-5ea9c86f1124",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-36c89de843cfe048aa6d731cc6713670-4a26c55bdc270044-00",
+        "traceparent": "00-6a01ab6a40458e46a57ec14c413f684b-709fe845bc32c047-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -170,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6044ba6c-2699-4597-b786-061dda793f4d",
+        "apim-request-id": "e788e5f8-27e8-4c46-b737-dbe61e192d6e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:33 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "450",
-        "X-Request-ID": "6044ba6c-2699-4597-b786-061dda793f4d"
+        "x-envoy-upstream-service-time": "390",
+        "X-Request-ID": "e788e5f8-27e8-4c46-b737-dbe61e192d6e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:32.6042762-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:05.9042686-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateAzureTableDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "251",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4490b3882b72cf4bad218414408333c0-486fd5405662874e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3b91750b2d318c4488efbc2a281b60e6-40ff693d19e5b34e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d5c9bdb3c262d0d54d0c6e864c902f61",
         "x-ms-return-client-request-id": "true"
@@ -32,62 +35,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "77a3860f-b11d-4f43-96c2-c9c1b28a523c",
+        "apim-request-id": "bbc311e3-e318-4ef4-82fc-dda3476716ad",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9695dd2-c6a3-4e8b-a97f-42e93f74fef7",
+        "Date": "Mon, 01 Feb 2021 13:42:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "928",
-        "x-request-id": "77a3860f-b11d-4f43-96c2-c9c1b28a523c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "696",
+        "X-Request-ID": "bbc311e3-e318-4ef4-82fc-dda3476716ad"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9695dd2-c6a3-4e8b-a97f-42e93f74fef7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "267",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a76d65c658702d48ae5feb7f340b1ad9-77df527d3a434a45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d2ddadd665016947a5d558eb41a29e28-18463bc56a76e64f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "396afd1e1b2d598e040b38a7f82ba2ef",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "table": "table",
-          "query": "query"
-        },
-        "dataSourceType": "AzureTable",
-        "dataFeedName": "dataFeed6ugrj57o",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0bff95f0-2c1b-428f-9930-3dbcf0e0dfc3",
+        "apim-request-id": "01cd662b-e3d9-42aa-9b52-6deeef584258",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:28 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "653",
-        "x-request-id": "0bff95f0-2c1b-428f-9930-3dbcf0e0dfc3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "182",
+        "X-Request-ID": "01cd662b-e3d9-42aa-9b52-6deeef584258"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9695dd2-c6a3-4e8b-a97f-42e93f74fef7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ef001d47df10964ea4f35add5cbebadf-0f46027b228ecf40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-545eb9cb88a6b648ac1002636ddd14ae-6bfe46ad2c338e40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0557637ec0deb654171e9b35cbc265f3",
         "x-ms-return-client-request-id": "true"
@@ -95,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "17fd2201-b888-410c-b315-41f0872aa33c",
+        "apim-request-id": "9771f3d4-37a4-416a-923e-80b14535a23b",
         "Content-Length": "1014",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:28 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "17fd2201-b888-410c-b315-41f0872aa33c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "182",
+        "X-Request-ID": "9771f3d4-37a4-416a-923e-80b14535a23b"
       },
       "ResponseBody": {
-        "dataFeedId": "d9695dd2-c6a3-4e8b-a97f-42e93f74fef7",
+        "dataFeedId": "73913c65-8f91-4244-a199-62e263ff46c7",
         "dataFeedName": "dataFeed6ugrj57o",
         "metrics": [
           {
-            "metricId": "7085cd67-0fed-40d7-90ad-76ce59b2302b",
+            "metricId": "f98a33dc-a2e9-4295-af9d-c5ec2917add6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -140,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:27Z",
+        "createdTime": "2021-02-01T13:42:31Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,13 +153,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d9695dd2-c6a3-4e8b-a97f-42e93f74fef7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/73913c65-8f91-4244-a199-62e263ff46c7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-33fadb6398e9f94ea0cc673409514a92-3bd00f8180982b42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-36c89de843cfe048aa6d731cc6713670-4a26c55bdc270044-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8fc3c4eb07f198052e6fd0568a2ed822",
         "x-ms-return-client-request-id": "true"
@@ -165,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "082e7ea9-c141-481a-bac1-cbca3640f1a0",
+        "apim-request-id": "6044ba6c-2699-4597-b786-061dda793f4d",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:28 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "285",
-        "x-request-id": "082e7ea9-c141-481a-bac1-cbca3640f1a0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "450",
+        "X-Request-ID": "6044ba6c-2699-4597-b786-061dda793f4d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:28.3904293-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:32.6042762-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6de39bdc4284a9498ece9640d7447235-bec3b96fc35ed64d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fb2615b115919b489cec666f3c1effc6-4395ad04c084fe4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8d74123f5eff5d45789f511cc8c3fb12",
+        "x-ms-client-request-id": "1c519f78c3c812fb6bcb09d7cdb70ac5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +33,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "88a9376e-fa76-43a3-8ab8-68892a9e9958",
+        "apim-request-id": "d8ef7c87-e863-4258-8d44-5317b4fbc56e",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
+        "Date": "Mon, 01 Feb 2021 13:12:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "2509",
-        "x-request-id": "88a9376e-fa76-43a3-8ab8-68892a9e9958"
+        "x-envoy-upstream-service-time": "547",
+        "x-request-id": "d8ef7c87-e863-4258-8d44-5317b4fbc56e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c8606364f506d246894ed21b8913bf29-1877aaf16abb4743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7584b561bf40b544a59db7dd8d187625-7e1588fdda3dbb42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d709cb6bb7cdc50ae87c513d2debf4c7",
+        "x-ms-client-request-id": "3d517ce8eb2dc7f4ddee73ab9d246f26",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6f38fdce-a1e0-42c6-ba17-c05a29fe783b",
+        "apim-request-id": "c26f06ef-f9eb-4cae-911b-908457ea445c",
         "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:37 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "6f38fdce-a1e0-42c6-ba17-c05a29fe783b"
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "c26f06ef-f9eb-4cae-911b-908457ea445c"
       },
       "ResponseBody": {
-        "dataFeedId": "faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
+        "dataFeedId": "9f8a73ee-344f-449d-9a18-734db1b219e0",
         "dataFeedName": "dataFeedzAmjgdIi",
         "metrics": [
           {
-            "metricId": "d3111953-4b92-42aa-887a-1cda5fa1452f",
+            "metricId": "b5cef507-f1b4-4052-a402-e807b85f1f75",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:37Z",
+        "createdTime": "2021-02-01T13:12:40Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +116,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "703",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2d66ca88f9cd414188d13a893fe4cb9d-7a6f3dcb98ac1d40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7ca5503c75d2c146b6033dbe0a161320-2ef7c3defb1db54f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ab73eedd249d266f2921795eddda29c4",
+        "x-ms-client-request-id": "5e792129daddc4293016894a75717287",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +137,10 @@
           "query": "query"
         },
         "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedzAmjgdIi",
+        "dataFeedName": "dataFeedMTQTfC8G",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +161,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "00151a61-8ab8-45a1-b8f9-008d560e9c84",
+        "apim-request-id": "8c37c03d-8029-4bc4-b422-2f354d4dccb6",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:37 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "794",
-        "x-request-id": "00151a61-8ab8-45a1-b8f9-008d560e9c84"
+        "x-envoy-upstream-service-time": "626",
+        "x-request-id": "8c37c03d-8029-4bc4-b422-2f354d4dccb6"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d1209e6e6c3ec44d9805a999758bc550-bbe329133f84334e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cf017ea583db9a4e88b7525d5eae32e1-f67e2474ba0a9f4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "4a8916307175877208aea4820c08308d",
+        "x-ms-client-request-id": "82a4ae08080c8d30ab893fd94f4f7447",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "922c1100-3f04-4056-aae3-17f5c4165f0a",
+        "apim-request-id": "daae7155-3f9e-443a-becb-3f92dcdf1601",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:38 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "154",
-        "x-request-id": "922c1100-3f04-4056-aae3-17f5c4165f0a"
+        "x-envoy-upstream-service-time": "162",
+        "x-request-id": "daae7155-3f9e-443a-becb-3f92dcdf1601"
       },
       "ResponseBody": {
-        "dataFeedId": "faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
-        "dataFeedName": "dataFeedzAmjgdIi",
+        "dataFeedId": "9f8a73ee-344f-449d-9a18-734db1b219e0",
+        "dataFeedName": "dataFeedMTQTfC8G",
         "metrics": [
           {
-            "metricId": "d3111953-4b92-42aa-887a-1cda5fa1452f",
+            "metricId": "b5cef507-f1b4-4052-a402-e807b85f1f75",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "Elasticsearch",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +233,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:37Z",
+        "createdTime": "2021-02-01T13:12:40Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +245,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/faa981ed-9e24-4d38-bb90-5e1d6cf1bc4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e9a70797dffafb44b807092d95835397-8d32d1d00876c041-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ea67f01dc5506d48a69a83eb5cbd341b-7ef1c5718b5d5741-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d93f89ab4f4f47745ce3aeab3eabe80e",
+        "x-ms-client-request-id": "abaee35cab3e0ee8528d0c1661a9526b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "92e6bec0-9125-40ba-9a60-452ab47a3fa1",
+        "apim-request-id": "448209e2-b825-4cf9-bd5b-12d982f7d3d6",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:38 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "261",
-        "x-request-id": "92e6bec0-9125-40ba-9a60-452ab47a3fa1"
+        "x-envoy-upstream-service-time": "314",
+        "x-request-id": "448209e2-b825-4cf9-bd5b-12d982f7d3d6"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:16:39.3360876-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:42.1048497-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fb2615b115919b489cec666f3c1effc6-4395ad04c084fe4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ca34d8b460a448438e6b062a829ae4ad-f17aa9717eb81243-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1c519f78c3c812fb6bcb09d7cdb70ac5",
         "x-ms-return-client-request-id": "true"
@@ -33,25 +36,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d8ef7c87-e863-4258-8d44-5317b4fbc56e",
+        "apim-request-id": "5b39ad40-4b86-4ea8-9ac1-d4d3f732320d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:41 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
+        "Date": "Mon, 01 Feb 2021 14:24:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2670bd66-a2cb-48d9-aee7-0e42ecc2ed9d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "547",
-        "x-request-id": "d8ef7c87-e863-4258-8d44-5317b4fbc56e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "660",
+        "X-Request-ID": "5b39ad40-4b86-4ea8-9ac1-d4d3f732320d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2670bd66-a2cb-48d9-aee7-0e42ecc2ed9d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7584b561bf40b544a59db7dd8d187625-7e1588fdda3dbb42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-13a456d720fb604db0324109cb239e9b-186601cfab25674b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3d517ce8eb2dc7f4ddee73ab9d246f26",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c26f06ef-f9eb-4cae-911b-908457ea445c",
+        "apim-request-id": "5d092498-cc96-4b32-9dda-3bfaccaa917e",
         "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:41 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "146",
-        "x-request-id": "c26f06ef-f9eb-4cae-911b-908457ea445c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "189",
+        "X-Request-ID": "5d092498-cc96-4b32-9dda-3bfaccaa917e"
       },
       "ResponseBody": {
-        "dataFeedId": "9f8a73ee-344f-449d-9a18-734db1b219e0",
+        "dataFeedId": "2670bd66-a2cb-48d9-aee7-0e42ecc2ed9d",
         "dataFeedName": "dataFeedzAmjgdIi",
         "metrics": [
           {
-            "metricId": "b5cef507-f1b4-4052-a402-e807b85f1f75",
+            "metricId": "9df52b20-6ba2-4fc6-8cd4-ec02976959d7",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:40Z",
+        "createdTime": "2021-02-01T14:24:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,15 +122,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2670bd66-a2cb-48d9-aee7-0e42ecc2ed9d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "703",
+        "Content-Length": "720",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7ca5503c75d2c146b6033dbe0a161320-2ef7c3defb1db54f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3baa5bdb453c9d49937dbfbdb5b69308-7ee8a48a574c3647-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5e792129daddc4293016894a75717287",
         "x-ms-return-client-request-id": "true"
@@ -151,7 +160,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -161,24 +171,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8c37c03d-8029-4bc4-b422-2f354d4dccb6",
+        "apim-request-id": "bb84978a-0e43-4534-a1b7-e5a038570110",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:41 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "626",
-        "x-request-id": "8c37c03d-8029-4bc4-b422-2f354d4dccb6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "824",
+        "X-Request-ID": "bb84978a-0e43-4534-a1b7-e5a038570110"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2670bd66-a2cb-48d9-aee7-0e42ecc2ed9d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cf017ea583db9a4e88b7525d5eae32e1-f67e2474ba0a9f4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-65470a340e3f65458c58362e7bc75db3-7b9c60678eeefe4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "82a4ae08080c8d30ab893fd94f4f7447",
         "x-ms-return-client-request-id": "true"
@@ -186,21 +199,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "daae7155-3f9e-443a-becb-3f92dcdf1601",
-        "Content-Length": "1115",
+        "apim-request-id": "ee951b4d-59e6-46fc-ab94-df4be1b3475f",
+        "Content-Length": "1132",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:42 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "x-request-id": "daae7155-3f9e-443a-becb-3f92dcdf1601"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "170",
+        "X-Request-ID": "ee951b4d-59e6-46fc-ab94-df4be1b3475f"
       },
       "ResponseBody": {
-        "dataFeedId": "9f8a73ee-344f-449d-9a18-734db1b219e0",
+        "dataFeedId": "2670bd66-a2cb-48d9-aee7-0e42ecc2ed9d",
         "dataFeedName": "dataFeedMTQTfC8G",
         "metrics": [
           {
-            "metricId": "b5cef507-f1b4-4052-a402-e807b85f1f75",
+            "metricId": "9df52b20-6ba2-4fc6-8cd4-ec02976959d7",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -226,6 +239,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -233,7 +247,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:40Z",
+        "createdTime": "2021-02-01T14:24:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,13 +259,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9f8a73ee-344f-449d-9a18-734db1b219e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2670bd66-a2cb-48d9-aee7-0e42ecc2ed9d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ea67f01dc5506d48a69a83eb5cbd341b-7ef1c5718b5d5741-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-dd4732f2d269764a83f31273990b2e5e-ce07ea83eb27ab40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "abaee35cab3e0ee8528d0c1661a9526b",
         "x-ms-return-client-request-id": "true"
@@ -259,19 +276,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "448209e2-b825-4cf9-bd5b-12d982f7d3d6",
+        "apim-request-id": "0f52f412-11f1-48e3-ab21-90789c4ec706",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:42 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "314",
-        "x-request-id": "448209e2-b825-4cf9-bd5b-12d982f7d3d6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "357",
+        "X-Request-ID": "0f52f412-11f1-48e3-ab21-90789c4ec706"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:42.1048497-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:24:56.8667676-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cfa90e58cc30df439bbedb954f3ee3aa-7b275274b9223b4a-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-3c8d1d247ab00a46a9b5d3ec2f22d8ab-81e8e98f02543c42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bf62410ae62d7b2531fa6ebf5aa9ea12",
         "x-ms-return-client-request-id": "true"
@@ -36,28 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a7eb41f2-a5ca-4251-874b-05f471b44da1",
+        "apim-request-id": "e28267fd-10ef-4b67-a4f1-0aba007c380a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:33 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+        "Date": "Mon, 01 Feb 2021 15:41:15 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7137678-2789-4353-bf44-2188d72354bf",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "494",
-        "X-Request-ID": "a7eb41f2-a5ca-4251-874b-05f471b44da1"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "428",
+        "x-request-id": "e28267fd-10ef-4b67-a4f1-0aba007c380a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7137678-2789-4353-bf44-2188d72354bf",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c00a7565fe18404e9f84f2878191f3ba-f0feec5a1e705a40-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-d990ce4b5da3bf4cb4f076cc0f05b907-2a5f40393993344f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3f25e9a14d3a645ab22dace7943d9092",
         "x-ms-return-client-request-id": "true"
@@ -65,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "7b5d4e0c-77b5-450d-9c45-f4bd01a3e5d2",
+        "apim-request-id": "5bf667f6-d232-41a5-ba54-8e137a54001b",
         "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:33 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "269",
-        "X-Request-ID": "7b5d4e0c-77b5-450d-9c45-f4bd01a3e5d2"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "179",
+        "x-request-id": "5bf667f6-d232-41a5-ba54-8e137a54001b"
       },
       "ResponseBody": {
-        "dataFeedId": "b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+        "dataFeedId": "f7137678-2789-4353-bf44-2188d72354bf",
         "dataFeedName": "dataFeedVnhrJrLK",
         "metrics": [
           {
-            "metricId": "b6e797a4-5d91-476c-acd9-eeb8597d9d42",
+            "metricId": "6cb4dcfa-2640-48a7-a2bd-7ed93b324803",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -110,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:33Z",
+        "createdTime": "2021-02-01T15:41:15Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -122,18 +116,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7137678-2789-4353-bf44-2188d72354bf",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "703",
+        "Content-Length": "720",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7f9a8c345b2f7642a7df1223dde5c965-7852c5a4de8cab4b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-96620bb73363d249b29dd78e3f87ae3a-9e22e2dfde8cb443-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d7838869997cc2e06d32cd9290002365",
         "x-ms-return-client-request-id": "true"
@@ -160,7 +151,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -170,27 +162,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "cd3df428-ef1e-4b0b-bb69-53cd534e9f01",
+        "apim-request-id": "637cde50-2cbf-4ceb-8feb-12e7a47fb41b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:34 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "669",
-        "X-Request-ID": "cd3df428-ef1e-4b0b-bb69-53cd534e9f01"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "567",
+        "x-request-id": "637cde50-2cbf-4ceb-8feb-12e7a47fb41b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7137678-2789-4353-bf44-2188d72354bf",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-557438817a8b9840a15afcfef0a7a50a-5db15e96574f914b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-1021266f337c104c99e66f05392d0564-a816bbf4b951af43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0b41c615cbd6bc01e7fd0c003a3ee6f3",
         "x-ms-return-client-request-id": "true"
@@ -198,21 +187,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "849cc5e4-77e2-47a4-87d6-75135f7a7321",
-        "Content-Length": "1115",
+        "apim-request-id": "fa62fb58-07b9-4240-8a3d-8e72c7d0a7ad",
+        "Content-Length": "1132",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:34 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "265",
-        "X-Request-ID": "849cc5e4-77e2-47a4-87d6-75135f7a7321"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "fa62fb58-07b9-4240-8a3d-8e72c7d0a7ad"
       },
       "ResponseBody": {
-        "dataFeedId": "b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+        "dataFeedId": "f7137678-2789-4353-bf44-2188d72354bf",
         "dataFeedName": "dataFeedARxUv2qN",
         "metrics": [
           {
-            "metricId": "b6e797a4-5d91-476c-acd9-eeb8597d9d42",
+            "metricId": "6cb4dcfa-2640-48a7-a2bd-7ed93b324803",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -238,6 +227,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -245,7 +235,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:33Z",
+        "createdTime": "2021-02-01T15:41:15Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -257,16 +247,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7137678-2789-4353-bf44-2188d72354bf",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1017c0f0496f0743a575fd99483f2273-a616b23b16a2e349-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-afbd68e8655be740b1ca105693065df2-9947bb73747b7b47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d155dc6a122607960863d20880c7d4b2",
         "x-ms-return-client-request-id": "true"
@@ -274,19 +261,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3c7dc414-4795-4f00-bcc9-3e0a7963eb81",
+        "apim-request-id": "ed321bb0-b2f4-4dd3-a90d-1459d23502fa",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "435",
-        "X-Request-ID": "3c7dc414-4795-4f00-bcc9-3e0a7963eb81"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "314",
+        "x-request-id": "ed321bb0-b2f4-4dd3-a90d-1459d23502fa"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:34.9553000-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:16.5610063-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4a8b1ff696163f40b400071dab3b4fd1-b3a54dd93ca69c48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cfa90e58cc30df439bbedb954f3ee3aa-7b275274b9223b4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e2d8000ffbf43c0b0a4162bf2de6257b",
+        "x-ms-client-request-id": "bf62410ae62d7b2531fa6ebf5aa9ea12",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +36,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "832bd935-7abb-4b24-9322-f4dc4d09d674",
+        "apim-request-id": "a7eb41f2-a5ca-4251-874b-05f471b44da1",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:54 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
+        "Date": "Mon, 01 Feb 2021 13:42:33 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "722",
-        "x-request-id": "832bd935-7abb-4b24-9322-f4dc4d09d674"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "494",
+        "X-Request-ID": "a7eb41f2-a5ca-4251-874b-05f471b44da1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-953d6b02ac362540b6b9fa1937ba0192-4915964e1c068a40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c00a7565fe18404e9f84f2878191f3ba-f0feec5a1e705a40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "bf6efa31a95a12eaa1e9253f3a4d5a64",
+        "x-ms-client-request-id": "3f25e9a14d3a645ab22dace7943d9092",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a87a1294-4fe4-4180-b0a6-c37c58f0101c",
+        "apim-request-id": "7b5d4e0c-77b5-450d-9c45-f4bd01a3e5d2",
         "Content-Length": "989",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:54 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "a87a1294-4fe4-4180-b0a6-c37c58f0101c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "269",
+        "X-Request-ID": "7b5d4e0c-77b5-450d-9c45-f4bd01a3e5d2"
       },
       "ResponseBody": {
-        "dataFeedId": "0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
+        "dataFeedId": "b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
         "dataFeedName": "dataFeedVnhrJrLK",
         "metrics": [
           {
-            "metricId": "7fdb78ba-8ab4-419e-b3c2-8881d2dffaf8",
+            "metricId": "b6e797a4-5d91-476c-acd9-eeb8597d9d42",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:54Z",
+        "createdTime": "2021-02-01T13:42:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +122,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "703",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f4b3d675614fd84180e6b7f6cf0efd1e-40068e9de1e5464f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7f9a8c345b2f7642a7df1223dde5c965-7852c5a4de8cab4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e7ac2db23d949290698883d77c99e0c2",
+        "x-ms-client-request-id": "d7838869997cc2e06d32cd9290002365",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +146,10 @@
           "query": "query"
         },
         "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedVnhrJrLK",
+        "dataFeedName": "dataFeedARxUv2qN",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +170,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "98d35c79-3c9e-44ae-9334-a83cff0a285a",
+        "apim-request-id": "cd3df428-ef1e-4b0b-bb69-53cd534e9f01",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:54 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "505",
-        "x-request-id": "98d35c79-3c9e-44ae-9334-a83cff0a285a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "669",
+        "X-Request-ID": "cd3df428-ef1e-4b0b-bb69-53cd534e9f01"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cf18038255986a439d4c556c925e5bf2-5dd7a863c8f19546-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-557438817a8b9840a15afcfef0a7a50a-5db15e96574f914b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "92cd326d0090652315c6410bd6cb01bc",
+        "x-ms-client-request-id": "0b41c615cbd6bc01e7fd0c003a3ee6f3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8ecd4dbd-4f79-44fd-aebd-914097b6c05c",
+        "apim-request-id": "849cc5e4-77e2-47a4-87d6-75135f7a7321",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:55 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165",
-        "x-request-id": "8ecd4dbd-4f79-44fd-aebd-914097b6c05c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "265",
+        "X-Request-ID": "849cc5e4-77e2-47a4-87d6-75135f7a7321"
       },
       "ResponseBody": {
-        "dataFeedId": "0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
-        "dataFeedName": "dataFeedVnhrJrLK",
+        "dataFeedId": "b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
+        "dataFeedName": "dataFeedARxUv2qN",
         "metrics": [
           {
-            "metricId": "7fdb78ba-8ab4-419e-b3c2-8881d2dffaf8",
+            "metricId": "b6e797a4-5d91-476c-acd9-eeb8597d9d42",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "Elasticsearch",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +245,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:54Z",
+        "createdTime": "2021-02-01T13:42:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +257,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0d045f67-ae2a-47d2-a267-b0bd9bd0474c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b8e2db6b-5689-41a8-be9c-f5381bd50ca7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d375f866ae020d4cbc1f152678890439-c6686c77459ea049-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1017c0f0496f0743a575fd99483f2273-a616b23b16a2e349-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "000cfde73e3af3e66adc55d126129607",
+        "x-ms-client-request-id": "d155dc6a122607960863d20880c7d4b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3bb16972-efad-4c35-8913-4326bc1e9d5c",
+        "apim-request-id": "3c7dc414-4795-4f00-bcc9-3e0a7963eb81",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:55 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "333",
-        "x-request-id": "3bb16972-efad-4c35-8913-4326bc1e9d5c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "435",
+        "X-Request-ID": "3c7dc414-4795-4f00-bcc9-3e0a7963eb81"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:16:55.4302081-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:34.9553000-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-07e4f1e7bc8ffb4e85eba0e1ff7df9c6-e01f2938a16b4847-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3c20ca0580b6f946af49ac317f21ee87-362a7062e4d1f745-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ba21f2871bbb167add36cf8e40e138fa",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "96f6676c-02ee-441c-8538-fb84979c6863",
+        "apim-request-id": "ade2c94f-a329-4735-87f6-1c35a2ae358f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:34 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
+        "Date": "Mon, 01 Feb 2021 15:52:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/baa3028e-5477-4c89-8910-04991afe3395",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "435",
-        "x-request-id": "96f6676c-02ee-441c-8538-fb84979c6863"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "463",
+        "X-Request-ID": "ade2c94f-a329-4735-87f6-1c35a2ae358f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/baa3028e-5477-4c89-8910-04991afe3395",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0712fa267600e4429e9e9d99b30524fa-ee3bd1083f18fb4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3cd27ddfbece2143b9b088cfe5be37cb-33af77d8f64b684b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d210707664533b511afd06f82b6c4ae7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedaSHHI6J0",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "493ff76a-ca3e-401e-b5b8-4a1346c847fe",
+        "apim-request-id": "72fae6a2-a267-4b01-8d70-deacbeb90ab2",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:34 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "225",
-        "x-request-id": "493ff76a-ca3e-401e-b5b8-4a1346c847fe"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "188",
+        "X-Request-ID": "72fae6a2-a267-4b01-8d70-deacbeb90ab2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/baa3028e-5477-4c89-8910-04991afe3395",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ddff505db28dc48b3bc96c2d6de6787-c4428a9431c07444-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cc7f9a901306da4a91b5aded1aae6d08-2ae901654cb21345-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "595b1fc4f2d8c592c0d48cfa179282b6",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e7231d35-d5c0-48ff-9163-93edcf387982",
+        "apim-request-id": "baf5698c-3874-455a-b0a4-9b66d8b3be06",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:34 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "193",
-        "x-request-id": "e7231d35-d5c0-48ff-9163-93edcf387982"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "X-Request-ID": "baf5698c-3874-455a-b0a4-9b66d8b3be06"
       },
       "ResponseBody": {
-        "dataFeedId": "d0a9cf11-52d8-416c-9a2d-657712dfae8e",
+        "dataFeedId": "baa3028e-5477-4c89-8910-04991afe3395",
         "dataFeedName": "dataFeedaSHHI6J0",
         "metrics": [
           {
-            "metricId": "22dee19a-a172-4cc1-87a9-82d37d3eaedf",
+            "metricId": "a8c54971-afa7-4c32-a676-5c14bbe3307b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:34Z",
+        "createdTime": "2021-02-01T15:52:34Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/baa3028e-5477-4c89-8910-04991afe3395",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f8fae1eb39633d429b8c80469ba6e49d-87d750ab5c9e754a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-88a0dd31a76d2e418b1e30bbaa61a217-16682b1f17b25c40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "24d6bd617a372341a1e6a0be1482ea71",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "12c96986-bacf-4553-af30-a0fbd28f6317",
+        "apim-request-id": "a1d7505d-4d54-4359-873f-f8fb15122d36",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "330",
-        "x-request-id": "12c96986-bacf-4553-af30-a0fbd28f6317"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "352",
+        "X-Request-ID": "a1d7505d-4d54-4359-873f-f8fb15122d36"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:35.5920622-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:35.5088016-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6a9d95e3a56d4743ab2112e247fa7055-fa27f7d401c0fc4f-00",
+        "traceparent": "00-07e4f1e7bc8ffb4e85eba0e1ff7df9c6-e01f2938a16b4847-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "24127365ee73904d1a88bb9c30c735c4",
+        "x-ms-client-request-id": "ba21f2871bbb167add36cf8e40e138fa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,7 +22,7 @@
           "query": "query"
         },
         "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedAii9hspN",
+        "dataFeedName": "dataFeed8UNnGk7Z",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -33,40 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b4d7b7ef-8342-43ae-b783-718f9065a420",
+        "apim-request-id": "96f6676c-02ee-441c-8538-fb84979c6863",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:43 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
+        "Date": "Mon, 01 Feb 2021 15:45:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "555",
-        "x-request-id": "b4d7b7ef-8342-43ae-b783-718f9065a420"
+        "x-envoy-upstream-service-time": "435",
+        "x-request-id": "96f6676c-02ee-441c-8538-fb84979c6863"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "591",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4a7774f67c6230479dbbda238fb6b826-ebcbb270e5004b48-00",
+        "traceparent": "00-0712fa267600e4429e9e9d99b30524fa-ee3bd1083f18fb4d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "37a7face186fb5077d1ba8b0c53c97b3",
+        "x-ms-client-request-id": "d210707664533b511afd06f82b6c4ae7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "host": "https://fakehost.com/",
-          "port": "port",
-          "authHeader": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedyhpuceTH",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedaSHHI6J0",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -83,46 +77,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "840e8e5e-c712-4fd0-ba50-4dbba34ea621",
+        "apim-request-id": "493ff76a-ca3e-401e-b5b8-4a1346c847fe",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:43 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "651",
-        "x-request-id": "840e8e5e-c712-4fd0-ba50-4dbba34ea621"
+        "x-envoy-upstream-service-time": "225",
+        "x-request-id": "493ff76a-ca3e-401e-b5b8-4a1346c847fe"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dd6719942b9bc8408bee5c7c87f20cfc-0e54a9008e01b64b-00",
+        "traceparent": "00-9ddff505db28dc48b3bc96c2d6de6787-c4428a9431c07444-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "09a106cde980683091b0d77529d6c72b",
+        "x-ms-client-request-id": "595b1fc4f2d8c592c0d48cfa179282b6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d692bd02-c426-4ff8-b1f9-eec26113d810",
+        "apim-request-id": "e7231d35-d5c0-48ff-9163-93edcf387982",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:43 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "d692bd02-c426-4ff8-b1f9-eec26113d810"
+        "x-envoy-upstream-service-time": "193",
+        "x-request-id": "e7231d35-d5c0-48ff-9163-93edcf387982"
       },
       "ResponseBody": {
-        "dataFeedId": "40c6909f-b4c7-4d12-9489-dc31928662e1",
-        "dataFeedName": "dataFeedyhpuceTH",
+        "dataFeedId": "d0a9cf11-52d8-416c-9a2d-657712dfae8e",
+        "dataFeedName": "dataFeedaSHHI6J0",
         "metrics": [
           {
-            "metricId": "b343ca5e-d702-4402-92d1-b65fa5fd3206",
+            "metricId": "22dee19a-a172-4cc1-87a9-82d37d3eaedf",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -155,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:42Z",
+        "createdTime": "2021-02-01T15:45:34Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,37 +161,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d0a9cf11-52d8-416c-9a2d-657712dfae8e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-736ae535be56e14b9d206ea4d8c76cd4-cdba37bfe84ab74c-00",
+        "traceparent": "00-f8fae1eb39633d429b8c80469ba6e49d-87d750ab5c9e754a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9149342b00644dd46c5da658459ccbdd",
+        "x-ms-client-request-id": "24d6bd617a372341a1e6a0be1482ea71",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0adac086-a055-468c-ad01-bf1943b9bc69",
+        "apim-request-id": "12c96986-bacf-4553-af30-a0fbd28f6317",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:44 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "359",
-        "x-request-id": "0adac086-a055-468c-ad01-bf1943b9bc69"
+        "x-envoy-upstream-service-time": "330",
+        "x-request-id": "12c96986-bacf-4553-af30-a0fbd28f6317"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:43.9721946-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:35.5920622-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "693317099"
+    "RandomSeed": "530307810"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-249e97995068284b9c3073add01af497-be7409cd7a18934a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6a9d95e3a56d4743ab2112e247fa7055-fa27f7d401c0fc4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "17f860f20c8c44386573122473ee4d90",
+        "x-ms-client-request-id": "24127365ee73904d1a88bb9c30c735c4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +33,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "af224f5c-ab33-4c39-aefb-28a36b44ea50",
+        "apim-request-id": "b4d7b7ef-8342-43ae-b783-718f9065a420",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
+        "Date": "Mon, 01 Feb 2021 13:12:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "584",
-        "x-request-id": "af224f5c-ab33-4c39-aefb-28a36b44ea50"
+        "x-envoy-upstream-service-time": "555",
+        "x-request-id": "b4d7b7ef-8342-43ae-b783-718f9065a420"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "591",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0787e5f52bfb304596a3921e6a79c559-7c740bb9d25e0449-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4a7774f67c6230479dbbda238fb6b826-ebcbb270e5004b48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9cbb881ac730c435cefaa7376f1807b5",
+        "x-ms-client-request-id": "37a7face186fb5077d1ba8b0c53c97b3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +66,10 @@
           "query": "query"
         },
         "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedAii9hspN",
+        "dataFeedName": "dataFeedyhpuceTH",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +83,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "dabdfed1-5831-40ad-881c-a2b933b59d20",
+        "apim-request-id": "840e8e5e-c712-4fd0-ba50-4dbba34ea621",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1000",
-        "x-request-id": "dabdfed1-5831-40ad-881c-a2b933b59d20"
+        "x-envoy-upstream-service-time": "651",
+        "x-request-id": "840e8e5e-c712-4fd0-ba50-4dbba34ea621"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b6f0170d5228774ba79f9e7b3bb343ca-2bf48c9dd5cb5447-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-dd6719942b9bc8408bee5c7c87f20cfc-0e54a9008e01b64b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b0a81b7d3cc5b397cd06a10980e93068",
+        "x-ms-client-request-id": "09a106cde980683091b0d77529d6c72b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8e83f614-933a-402b-96b8-a275926682fe",
+        "apim-request-id": "d692bd02-c426-4ff8-b1f9-eec26113d810",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
-        "x-request-id": "8e83f614-933a-402b-96b8-a275926682fe"
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "d692bd02-c426-4ff8-b1f9-eec26113d810"
       },
       "ResponseBody": {
-        "dataFeedId": "87104377-5f7f-402d-b247-49af361567d2",
-        "dataFeedName": "dataFeedAii9hspN",
+        "dataFeedId": "40c6909f-b4c7-4d12-9489-dc31928662e1",
+        "dataFeedName": "dataFeedyhpuceTH",
         "metrics": [
           {
-            "metricId": "3cc44bd8-9dc9-4e6f-af3f-8f31b030ac84",
+            "metricId": "b343ca5e-d702-4402-92d1-b65fa5fd3206",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "Elasticsearch",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +155,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:40Z",
+        "createdTime": "2021-02-01T13:12:42Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +167,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/87104377-5f7f-402d-b247-49af361567d2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40c6909f-b4c7-4d12-9489-dc31928662e1",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-83a76a7537bafd4f80e43f7106d9b44a-4cbc6f322eb5e642-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-736ae535be56e14b9d206ea4d8c76cd4-cdba37bfe84ab74c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "75d7b091d6292bc72b3449916400d44d",
+        "x-ms-client-request-id": "9149342b00644dd46c5da658459ccbdd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "95477ed9-ea1f-4021-8326-1caff1558cbc",
+        "apim-request-id": "0adac086-a055-468c-ad01-bf1943b9bc69",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:41 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "280",
-        "x-request-id": "95477ed9-ea1f-4021-8326-1caff1558cbc"
+        "x-envoy-upstream-service-time": "359",
+        "x-request-id": "0adac086-a055-468c-ad01-bf1943b9bc69"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:16:41.7754056-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:43.9721946-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-042dcb03a908c4438e0b27f9cdc2e590-a0047909e6ec3041-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-69f6975dcaac2e42b8c39fcda17c5117-07d6273b4d6ee94e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ae40f5386870161b04ec893cb20c1391",
+        "x-ms-client-request-id": "3c89ec040cb29113121d9865f1db6921",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +36,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "9b79a1e2-553c-48f8-bfeb-64bb990e445c",
+        "apim-request-id": "cb4f88f9-bde7-4a91-8e10-cad7a7047ec9",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
+        "Date": "Mon, 01 Feb 2021 13:42:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "695",
-        "x-request-id": "9b79a1e2-553c-48f8-bfeb-64bb990e445c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "778",
+        "X-Request-ID": "cb4f88f9-bde7-4a91-8e10-cad7a7047ec9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "591",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d948541ba9ba8a4bad92b2e4ef320309-fbbe479531b56c42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-16e81e147a97904d9deeb60480e0f18d-4671caaf5d194a43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "65981d12dbf121699d71d6cd6b823ec6",
+        "x-ms-client-request-id": "cdd6719d826bc63e439e820299e9461b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +72,10 @@
           "query": "query"
         },
         "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedCleLfrR1",
+        "dataFeedName": "dataFeedtdJ6aC0n",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +89,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1e92013b-fb81-4dd0-8185-29a7bc3a2b36",
+        "apim-request-id": "70722daa-2a80-4786-9192-5626f154b348",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:56 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "545",
-        "x-request-id": "1e92013b-fb81-4dd0-8185-29a7bc3a2b36"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1088",
+        "X-Request-ID": "70722daa-2a80-4786-9192-5626f154b348"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9699c8c3cf7c948bda5b2cec3e58f32-813596c3af2b4d41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-43e7b03806260044bcb06dc766d51574-2264a453abba7647-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "02829e43e9991b4667f85c3bffc260d5",
+        "x-ms-client-request-id": "3b5cf867c2ffd560fd9f9003d167875c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2d153ad5-2e62-4a0a-a4e4-5046b180f6c5",
+        "apim-request-id": "f6878ace-a2e2-4d42-bfe8-1cc6e67da097",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:57 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "2d153ad5-2e62-4a0a-a4e4-5046b180f6c5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "221",
+        "X-Request-ID": "f6878ace-a2e2-4d42-bfe8-1cc6e67da097"
       },
       "ResponseBody": {
-        "dataFeedId": "d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
-        "dataFeedName": "dataFeedCleLfrR1",
+        "dataFeedId": "6f4a4384-db79-4bcc-867d-d57cd534f175",
+        "dataFeedName": "dataFeedtdJ6aC0n",
         "metrics": [
           {
-            "metricId": "38152a5d-6a90-48b1-836c-617601b460f6",
+            "metricId": "bcdc509d-fd2f-4107-8815-44c4e56a5e1f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "Elasticsearch",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +164,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:56Z",
+        "createdTime": "2021-02-01T13:42:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +176,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d995eb71-70a7-4d92-b7f2-edc60e43b5f7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e223186fb006564a920a83fa4c34a0e5-1bab2e2a7c380b4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-96e0eea1327a49488ada16daf0e3e49c-e9cdce0dd0728a4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "03909ffd67d15c878b1e11fe914eab82",
+        "x-ms-client-request-id": "fe111e8b4e9182abaec2f8148911f728",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "de2ee0df-c3ac-461a-a706-dd662aac84ce",
+        "apim-request-id": "68edcd26-6ba0-4fc2-92fa-f4c18c62d8d2",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:57 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "295",
-        "x-request-id": "de2ee0df-c3ac-461a-a706-dd662aac84ce"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "439",
+        "X-Request-ID": "68edcd26-6ba0-4fc2-92fa-f4c18c62d8d2"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:16:57.6652980-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:37.6939819-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-69f6975dcaac2e42b8c39fcda17c5117-07d6273b4d6ee94e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-e0ef23eca4896d44b13f81ee8121143a-3666a1c3d146ad45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3c89ec040cb29113121d9865f1db6921",
         "x-ms-return-client-request-id": "true"
@@ -36,42 +33,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "cb4f88f9-bde7-4a91-8e10-cad7a7047ec9",
+        "apim-request-id": "5cf88001-7de4-42e0-9154-caab3544d979",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
+        "Date": "Mon, 01 Feb 2021 15:41:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "778",
-        "X-Request-ID": "cb4f88f9-bde7-4a91-8e10-cad7a7047ec9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "504",
+        "x-request-id": "5cf88001-7de4-42e0-9154-caab3544d979"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "591",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-16e81e147a97904d9deeb60480e0f18d-4671caaf5d194a43-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-305f70f10bb0734d97e2f915dd93ef00-659410a52c17404d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cdd6719d826bc63e439e820299e9461b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "host": "https://fakehost.com/",
-          "port": "port",
-          "authHeader": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "Elasticsearch",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedtdJ6aC0n",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -89,27 +77,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "70722daa-2a80-4786-9192-5626f154b348",
+        "apim-request-id": "a4f22441-a96e-49be-a0f1-1cee7b7a832e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1088",
-        "X-Request-ID": "70722daa-2a80-4786-9192-5626f154b348"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "205",
+        "x-request-id": "a4f22441-a96e-49be-a0f1-1cee7b7a832e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-43e7b03806260044bcb06dc766d51574-2264a453abba7647-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-7b9211ce17937f49b9a11f4956791584-19051011f7bb2b40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3b5cf867c2ffd560fd9f9003d167875c",
         "x-ms-return-client-request-id": "true"
@@ -117,21 +102,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f6878ace-a2e2-4d42-bfe8-1cc6e67da097",
+        "apim-request-id": "37414605-5bcf-4c6c-82bf-246cc651f7da",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "221",
-        "X-Request-ID": "f6878ace-a2e2-4d42-bfe8-1cc6e67da097"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "158",
+        "x-request-id": "37414605-5bcf-4c6c-82bf-246cc651f7da"
       },
       "ResponseBody": {
-        "dataFeedId": "6f4a4384-db79-4bcc-867d-d57cd534f175",
+        "dataFeedId": "e800debb-02af-4e01-b7e7-449e15fa3035",
         "dataFeedName": "dataFeedtdJ6aC0n",
         "metrics": [
           {
-            "metricId": "bcdc509d-fd2f-4107-8815-44c4e56a5e1f",
+            "metricId": "e34450fc-1e15-460c-ab92-50d7c5f753cb",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -164,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:36Z",
+        "createdTime": "2021-02-01T15:41:17Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -176,16 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6f4a4384-db79-4bcc-867d-d57cd534f175",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-96e0eea1327a49488ada16daf0e3e49c-e9cdce0dd0728a4f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-7d2d3e5665fb694981b52feff78f92d2-044741b1a63f4340-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fe111e8b4e9182abaec2f8148911f728",
         "x-ms-return-client-request-id": "true"
@@ -193,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "68edcd26-6ba0-4fc2-92fa-f4c18c62d8d2",
+        "apim-request-id": "55ec5c40-d136-4682-96d5-ae4f94f8f58c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "439",
-        "X-Request-ID": "68edcd26-6ba0-4fc2-92fa-f4c18c62d8d2"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "287",
+        "x-request-id": "55ec5c40-d136-4682-96d5-ae4f94f8f58c"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:37.6939819-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:17.9207483-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0ef23eca4896d44b13f81ee8121143a-3666a1c3d146ad45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d14425f222aab34998af8a1915c54169-2b5c959f320c1148-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3c89ec040cb29113121d9865f1db6921",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "5cf88001-7de4-42e0-9154-caab3544d979",
+        "apim-request-id": "568d3b35-a056-439e-a38d-311c146f771b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
+        "Date": "Mon, 01 Feb 2021 15:53:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/62c87746-882e-419f-831b-e637b2b2889e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "504",
-        "x-request-id": "5cf88001-7de4-42e0-9154-caab3544d979"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "444",
+        "X-Request-ID": "568d3b35-a056-439e-a38d-311c146f771b"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/62c87746-882e-419f-831b-e637b2b2889e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-305f70f10bb0734d97e2f915dd93ef00-659410a52c17404d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f39d9c4b856597479d274f7ce31bd29d-efc78707f5a1954c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cdd6719d826bc63e439e820299e9461b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedtdJ6aC0n",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a4f22441-a96e-49be-a0f1-1cee7b7a832e",
+        "apim-request-id": "440ff300-55e8-453b-84de-dd0a8f8c3c30",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "205",
-        "x-request-id": "a4f22441-a96e-49be-a0f1-1cee7b7a832e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "190",
+        "X-Request-ID": "440ff300-55e8-453b-84de-dd0a8f8c3c30"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/62c87746-882e-419f-831b-e637b2b2889e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b9211ce17937f49b9a11f4956791584-19051011f7bb2b40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-847b5832dc306840af200caa017ed156-4252e72f92733545-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3b5cf867c2ffd560fd9f9003d167875c",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "37414605-5bcf-4c6c-82bf-246cc651f7da",
+        "apim-request-id": "9efb4f62-74cb-45c6-b567-e5370afa05ef",
         "Content-Length": "1115",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "158",
-        "x-request-id": "37414605-5bcf-4c6c-82bf-246cc651f7da"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "X-Request-ID": "9efb4f62-74cb-45c6-b567-e5370afa05ef"
       },
       "ResponseBody": {
-        "dataFeedId": "e800debb-02af-4e01-b7e7-449e15fa3035",
+        "dataFeedId": "62c87746-882e-419f-831b-e637b2b2889e",
         "dataFeedName": "dataFeedtdJ6aC0n",
         "metrics": [
           {
-            "metricId": "e34450fc-1e15-460c-ab92-50d7c5f753cb",
+            "metricId": "30b22401-87ae-477d-a0ed-3e05eeb947a5",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:17Z",
+        "createdTime": "2021-02-01T15:53:06Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e800debb-02af-4e01-b7e7-449e15fa3035",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/62c87746-882e-419f-831b-e637b2b2889e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d2d3e5665fb694981b52feff78f92d2-044741b1a63f4340-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d1bb29f5acb6e74e8155d3d9a5fdeff7-1a9dab8d5d995544-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fe111e8b4e9182abaec2f8148911f728",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "55ec5c40-d136-4682-96d5-ae4f94f8f58c",
+        "apim-request-id": "e19d1ace-7d87-4c6e-b62c-a6bac2ee146d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "287",
-        "x-request-id": "55ec5c40-d136-4682-96d5-ae4f94f8f58c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "354",
+        "X-Request-ID": "e19d1ace-7d87-4c6e-b62c-a6bac2ee146d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:17.9207483-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:07.2313101-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-71290bed7828be4481bafc04f33db4a9-1d0faccbf2bac247-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e292ec939d8da845a0b78332b74e0601-b6d280849a2c8e43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d928acb952047ff4a78eaa975ee6072c",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +33,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6b579bcf-308f-46c9-bb76-81d81acd5e74",
+        "apim-request-id": "daca4341-f0c4-4cca-b7f4-6e06eda9ec75",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
+        "Date": "Mon, 01 Feb 2021 12:46:34 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1018",
-        "x-request-id": "6b579bcf-308f-46c9-bb76-81d81acd5e74"
+        "x-envoy-upstream-service-time": "529",
+        "x-request-id": "daca4341-f0c4-4cca-b7f4-6e06eda9ec75"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "293",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e99e5f697774ba44b1a31d251b116cc9-0a92b58db2da084f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ab369518d81c944fb47d23d460a535c7-810135476824db42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d2391366ca03573b7ce47c596f91e362",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "host": "https://fakehost.com/",
-          "port": "port",
-          "authHeader": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedaa3Dg3AO",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "88e633ad-f534-4f12-a9d4-2847269b0bb3",
+        "apim-request-id": "2125b0ab-59c2-46de-82c5-3e376c1b9d55",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:46 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "753",
-        "x-request-id": "88e633ad-f534-4f12-a9d4-2847269b0bb3"
+        "x-envoy-upstream-service-time": "212",
+        "x-request-id": "2125b0ab-59c2-46de-82c5-3e376c1b9d55"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b7af3feff1b4d74d9c8396db11650df3-16e61d03f1296743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b4be6a52218f254e914c5c2111e9e4a2-d4ccf9f48235a044-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e82c0c1194992fc7691a34c99406b69e",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +89,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "abc320df-ef05-4e33-9e8a-6b298e4579ce",
+        "apim-request-id": "502cd8c4-c1eb-438a-bba0-25ee106f7214",
         "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:16:46 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "abc320df-ef05-4e33-9e8a-6b298e4579ce"
+        "x-envoy-upstream-service-time": "193",
+        "x-request-id": "502cd8c4-c1eb-438a-bba0-25ee106f7214"
       },
       "ResponseBody": {
-        "dataFeedId": "bd1aa724-468b-4249-be0e-3ee7b8f964af",
+        "dataFeedId": "4fdbe15d-52ca-416c-bf6a-6eb137c95869",
         "dataFeedName": "dataFeedaa3Dg3AO",
         "metrics": [
           {
-            "metricId": "a745f6c4-2d5a-46f8-bbdc-eb3ab86ca740",
+            "metricId": "22cf20ed-6484-46aa-af54-879e4c19f662",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +134,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:16:45Z",
+        "createdTime": "2021-02-01T12:46:34Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +146,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bd1aa724-468b-4249-be0e-3ee7b8f964af",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-befe8ec34f2be44ba4f126416f38dfc9-0e04885fc1dbe74d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ee20227036a534428cbe47b58762ae67-acc54e8294ac0549-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "175a60259187ef2370d15d1fd59a1016",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +160,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ae955a3b-1afd-4f71-b150-2347dbdace18",
+        "apim-request-id": "b97c505a-d84b-4850-bffe-fe8f684682ea",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:16:46 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "306",
-        "x-request-id": "ae955a3b-1afd-4f71-b150-2347dbdace18"
+        "x-envoy-upstream-service-time": "366",
+        "x-request-id": "b97c505a-d84b-4850-bffe-fe8f684682ea"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:16:47.6309983-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:35.2117744-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e292ec939d8da845a0b78332b74e0601-b6d280849a2c8e43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-818a6d4b5a5e364aa62e6990d4d84938-bb3f98fd6bd15345-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d928acb952047ff4a78eaa975ee6072c",
         "x-ms-return-client-request-id": "true"
@@ -33,55 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "daca4341-f0c4-4cca-b7f4-6e06eda9ec75",
+        "apim-request-id": "145701c9-74a6-409e-b06b-3eee5d323d66",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:34 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
+        "Date": "Mon, 01 Feb 2021 15:52:35 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be24d1f5-afb8-47cd-b2c4-910f525ec193",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "529",
-        "x-request-id": "daca4341-f0c4-4cca-b7f4-6e06eda9ec75"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "434",
+        "X-Request-ID": "145701c9-74a6-409e-b06b-3eee5d323d66"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be24d1f5-afb8-47cd-b2c4-910f525ec193",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ab369518d81c944fb47d23d460a535c7-810135476824db42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-44b0e6ae793148458db5cf080f466e53-9f76d73c3ccaec47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d2391366ca03573b7ce47c596f91e362",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2125b0ab-59c2-46de-82c5-3e376c1b9d55",
+        "apim-request-id": "4b98b24b-3856-4332-8751-06b5176872ce",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:34 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "212",
-        "x-request-id": "2125b0ab-59c2-46de-82c5-3e376c1b9d55"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "192",
+        "X-Request-ID": "4b98b24b-3856-4332-8751-06b5176872ce"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be24d1f5-afb8-47cd-b2c4-910f525ec193",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b4be6a52218f254e914c5c2111e9e4a2-d4ccf9f48235a044-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-26d2a7c28336ce41bf9f178f0b0d177f-623fbca950085a46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e82c0c1194992fc7691a34c99406b69e",
         "x-ms-return-client-request-id": "true"
@@ -89,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "502cd8c4-c1eb-438a-bba0-25ee106f7214",
+        "apim-request-id": "b32b8009-4e8a-4b67-acf1-10865719099f",
         "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "193",
-        "x-request-id": "502cd8c4-c1eb-438a-bba0-25ee106f7214"
+        "X-Request-ID": "b32b8009-4e8a-4b67-acf1-10865719099f"
       },
       "ResponseBody": {
-        "dataFeedId": "4fdbe15d-52ca-416c-bf6a-6eb137c95869",
+        "dataFeedId": "be24d1f5-afb8-47cd-b2c4-910f525ec193",
         "dataFeedName": "dataFeedaa3Dg3AO",
         "metrics": [
           {
-            "metricId": "22cf20ed-6484-46aa-af54-879e4c19f662",
+            "metricId": "4026eb85-dd05-45b4-805e-437e0289883b",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -134,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:34Z",
+        "createdTime": "2021-02-01T15:52:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -146,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fdbe15d-52ca-416c-bf6a-6eb137c95869",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be24d1f5-afb8-47cd-b2c4-910f525ec193",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee20227036a534428cbe47b58762ae67-acc54e8294ac0549-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-97a9861b685dcf4088f59232f6a36252-cb7e66dca74c1641-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "175a60259187ef2370d15d1fd59a1016",
         "x-ms-return-client-request-id": "true"
@@ -160,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b97c505a-d84b-4850-bffe-fe8f684682ea",
+        "apim-request-id": "4ca01459-954a-4fb6-9db0-3abbd21e1daf",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "366",
-        "x-request-id": "b97c505a-d84b-4850-bffe-fe8f684682ea"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "395",
+        "X-Request-ID": "4ca01459-954a-4fb6-9db0-3abbd21e1daf"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:35.2117744-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:36.7865652-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9634d5c87da3c844a86cc3b78109fec1-134355be3fac714f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7dba85bb795a6249a58ca8fc10403739-022b16c81905f843-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "942b5b68e26e16925102f8c2eb608154",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "bca9b8c4-42dd-4f18-9000-eab45219810a",
+        "apim-request-id": "0a7672d0-26c3-41c5-ba9f-d9dd92e31ad9",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:17:00 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
+        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "491",
-        "x-request-id": "bca9b8c4-42dd-4f18-9000-eab45219810a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1567",
+        "X-Request-ID": "0a7672d0-26c3-41c5-ba9f-d9dd92e31ad9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "293",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b46b2bee6020b640917d31434408a877-b2d549be2065d041-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-06b3a237b0824e4ea17edc5592fbf7ce-6fd46a21a9a17046-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9b09ae620c055ece37c961b652a48414",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "host": "https://fakehost.com/",
-          "port": "port",
-          "authHeader": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "Elasticsearch",
-        "dataFeedName": "dataFeedeoZ83UKE",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "451ec77c-edf1-45ff-a35c-ee54d7bb61af",
+        "apim-request-id": "1cd68ddc-2f1f-41cf-8ed2-0975f06cd319",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:17:01 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "714",
-        "x-request-id": "451ec77c-edf1-45ff-a35c-ee54d7bb61af"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "192",
+        "X-Request-ID": "1cd68ddc-2f1f-41cf-8ed2-0975f06cd319"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d41467f18c9274c95c7c20a2c96c85c-5443b34eb29a5741-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-51ef947dfdfd8f4aa9c725fc3f7e4c84-c057e91acfb5ea4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ccce69ccc2ddd518a94543b1d36bbe51",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4cc54b6b-da69-41e9-a16b-e950c817cbc3",
+        "apim-request-id": "43fa07b5-333e-4bdf-b69a-75ab300fdd14",
         "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 06 Jan 2021 01:17:02 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "4cc54b6b-da69-41e9-a16b-e950c817cbc3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "294",
+        "X-Request-ID": "43fa07b5-333e-4bdf-b69a-75ab300fdd14"
       },
       "ResponseBody": {
-        "dataFeedId": "51255a92-124d-4dd8-aa20-a5a0451bdc38",
+        "dataFeedId": "1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
         "dataFeedName": "dataFeedeoZ83UKE",
         "metrics": [
           {
-            "metricId": "7f11588d-cf7e-4465-8245-814230d81022",
+            "metricId": "c86e9d46-2b94-4aff-b605-7be1e3dec25c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-06T01:17:01Z",
+        "createdTime": "2021-02-01T13:42:38Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/51255a92-124d-4dd8-aa20-a5a0451bdc38",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9464eccac721d94aa5c2c0c578452722-290be0f148c16041-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210105.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7a82cdad33b0e24b8d8f0cd8f776249a-9063f5f0dfcb4445-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1201f18d6dd25b1a8ccc5ca581dbc3ac",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "23bf2f0a-6fdd-4210-830b-417c2b25865b",
+        "apim-request-id": "1bb85f8f-69ca-444e-a7a4-ae6c6247012a",
         "Content-Length": "0",
-        "Date": "Wed, 06 Jan 2021 01:17:02 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "323",
-        "x-request-id": "23bf2f0a-6fdd-4210-830b-417c2b25865b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "394",
+        "X-Request-ID": "1bb85f8f-69ca-444e-a7a4-ae6c6247012a"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-05T17:17:02.7865686-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:40.3216976-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateElasticsearchDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "277",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7dba85bb795a6249a58ca8fc10403739-022b16c81905f843-00",
+        "traceparent": "00-12d1e65be969c84dad20caf12f58e228-b66f3278a0b55c41-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -36,26 +36,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0a7672d0-26c3-41c5-ba9f-d9dd92e31ad9",
+        "apim-request-id": "53be9e79-f384-4b80-a9d5-374f35f31e84",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
+        "Date": "Mon, 01 Feb 2021 15:53:07 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cb0e4634-6d2d-44f2-ba1d-bb935e37a84d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1567",
-        "X-Request-ID": "0a7672d0-26c3-41c5-ba9f-d9dd92e31ad9"
+        "x-envoy-upstream-service-time": "405",
+        "X-Request-ID": "53be9e79-f384-4b80-a9d5-374f35f31e84"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cb0e4634-6d2d-44f2-ba1d-bb935e37a84d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-06b3a237b0824e4ea17edc5592fbf7ce-6fd46a21a9a17046-00",
+        "traceparent": "00-4df7f45b4e68a64ca1f4fdeb0342dcc3-65896e8266b21943-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -65,28 +65,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1cd68ddc-2f1f-41cf-8ed2-0975f06cd319",
+        "apim-request-id": "065ab7a3-d370-484c-8320-c34039b37b3c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "192",
-        "X-Request-ID": "1cd68ddc-2f1f-41cf-8ed2-0975f06cd319"
+        "x-envoy-upstream-service-time": "182",
+        "X-Request-ID": "065ab7a3-d370-484c-8320-c34039b37b3c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cb0e4634-6d2d-44f2-ba1d-bb935e37a84d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-51ef947dfdfd8f4aa9c725fc3f7e4c84-c057e91acfb5ea4f-00",
+        "traceparent": "00-15dfa33a12dbe541adc4aa140c618933-fe75108e018d1242-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -98,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "43fa07b5-333e-4bdf-b69a-75ab300fdd14",
+        "apim-request-id": "f917b904-7ed1-44fa-ab12-3b913176cefc",
         "Content-Length": "1040",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "294",
-        "X-Request-ID": "43fa07b5-333e-4bdf-b69a-75ab300fdd14"
+        "x-envoy-upstream-service-time": "155",
+        "X-Request-ID": "f917b904-7ed1-44fa-ab12-3b913176cefc"
       },
       "ResponseBody": {
-        "dataFeedId": "1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
+        "dataFeedId": "cb0e4634-6d2d-44f2-ba1d-bb935e37a84d",
         "dataFeedName": "dataFeedeoZ83UKE",
         "metrics": [
           {
-            "metricId": "c86e9d46-2b94-4aff-b605-7be1e3dec25c",
+            "metricId": "593d0f64-5d14-4b7f-be3e-f042fbdf82d7",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -143,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:38Z",
+        "createdTime": "2021-02-01T15:53:07Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -155,12 +155,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1983ba8a-d7a3-4d8f-9a9c-00dbeb38be26",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cb0e4634-6d2d-44f2-ba1d-bb935e37a84d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7a82cdad33b0e24b8d8f0cd8f776249a-9063f5f0dfcb4445-00",
+        "traceparent": "00-88430fd4c3bba342a684c5eb854337b0-c9ebbceb210a8643-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -172,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1bb85f8f-69ca-444e-a7a4-ae6c6247012a",
+        "apim-request-id": "7a4ffe49-8fa4-4463-b65c-94965dcc0be8",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "394",
-        "X-Request-ID": "1bb85f8f-69ca-444e-a7a4-ae6c6247012a"
+        "x-envoy-upstream-service-time": "293",
+        "X-Request-ID": "7a4ffe49-8fa4-4463-b65c-94965dcc0be8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:40.3216976-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:08.4331675-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c78c4e48e8509042b5991f0a3f778e44-be864cb9531d1746-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-500f9b47a2064648b5f464d81ed4903d-f7498d50e29c424a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4937c1ad399eb77e41f22cf11f9b3014",
         "x-ms-return-client-request-id": "true"
@@ -33,25 +36,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f5fe74ce-c261-4138-a416-638f4f94444e",
+        "apim-request-id": "d3aab469-2993-407f-855f-64e5f40ecc93",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:44 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
+        "Date": "Mon, 01 Feb 2021 14:24:58 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/05e73a4e-481a-4438-b841-231d614223a9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "599",
-        "x-request-id": "f5fe74ce-c261-4138-a416-638f4f94444e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "592",
+        "X-Request-ID": "d3aab469-2993-407f-855f-64e5f40ecc93"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/05e73a4e-481a-4438-b841-231d614223a9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d706c5bb13fc454a899aa8788093e520-8528ffef1f1a3446-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-449049b53dc01547b9a62013fff0c93d-a58bea425da2de41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c9dc61932d029bf68ca34a87652c29f5",
         "x-ms-return-client-request-id": "true"
@@ -59,21 +65,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c44a39f9-db5f-416b-8fdb-1b068d62cfb5",
+        "apim-request-id": "46ae4c65-0fe5-46cb-a0ae-e151db1927d6",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:45 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "169",
-        "x-request-id": "c44a39f9-db5f-416b-8fdb-1b068d62cfb5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "X-Request-ID": "46ae4c65-0fe5-46cb-a0ae-e151db1927d6"
       },
       "ResponseBody": {
-        "dataFeedId": "57c36f6a-3b28-4182-a8ee-7563d09b919d",
+        "dataFeedId": "05e73a4e-481a-4438-b841-231d614223a9",
         "dataFeedName": "dataFeedFXglzsLV",
         "metrics": [
           {
-            "metricId": "605e8693-c11f-453a-a89c-8d501d885655",
+            "metricId": "573a8ef1-2ba4-46a1-beaa-38c4b68d40ab",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:44Z",
+        "createdTime": "2021-02-01T14:24:59Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,15 +122,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/05e73a4e-481a-4438-b841-231d614223a9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "712",
+        "Content-Length": "729",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-55bbd1b4d5bfc5469d1ca27e9d03e090-0892997a493d3d4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3c2ad9b2d530ac4a93049f6bf7c76741-e7624430124ecb4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d6b0285fffe06966160f20f6cd4033c4",
         "x-ms-return-client-request-id": "true"
@@ -151,7 +160,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -161,24 +171,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6875fa4c-0b78-43f3-85d4-811e0ede66ef",
+        "apim-request-id": "53e626bf-c3fd-4d78-9a71-ab6a2aaef4f9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:45 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "537",
-        "x-request-id": "6875fa4c-0b78-43f3-85d4-811e0ede66ef"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "728",
+        "X-Request-ID": "53e626bf-c3fd-4d78-9a71-ab6a2aaef4f9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/05e73a4e-481a-4438-b841-231d614223a9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-73a38ec2057b604f9a68232cfbbbd757-8748726aa53a5d4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-58b8703aa1a12a46ab4ca3be8820fa4f-1fc651ee52fba946-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d7bebd2ec4b080d7ca9bbcfbeef75114",
         "x-ms-return-client-request-id": "true"
@@ -186,21 +199,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "10b69ee0-c92c-4527-9006-b3efc8ef7eb4",
-        "Content-Length": "1124",
+        "apim-request-id": "954676bc-67dd-4c34-839d-6deae04d3c51",
+        "Content-Length": "1141",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:45 GMT",
+        "Date": "Mon, 01 Feb 2021 14:24:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "211",
-        "x-request-id": "10b69ee0-c92c-4527-9006-b3efc8ef7eb4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "X-Request-ID": "954676bc-67dd-4c34-839d-6deae04d3c51"
       },
       "ResponseBody": {
-        "dataFeedId": "57c36f6a-3b28-4182-a8ee-7563d09b919d",
+        "dataFeedId": "05e73a4e-481a-4438-b841-231d614223a9",
         "dataFeedName": "dataFeedd5KUxBpJ",
         "metrics": [
           {
-            "metricId": "605e8693-c11f-453a-a89c-8d501d885655",
+            "metricId": "573a8ef1-2ba4-46a1-beaa-38c4b68d40ab",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -226,6 +239,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -233,7 +247,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:44Z",
+        "createdTime": "2021-02-01T14:24:59Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,13 +259,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/05e73a4e-481a-4438-b841-231d614223a9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-96346057ea6aaf4aab221340644a086c-1a238d134b7b1749-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d7cfb0e87141854f93a0db3e0e3b5bf1-3bc70ddff5bb4746-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f69136c85aeb9433fa73b2f30c00ce4b",
         "x-ms-return-client-request-id": "true"
@@ -259,19 +276,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "df0f777b-596c-4b6b-9574-e67b7920ee04",
+        "apim-request-id": "72f39f6e-faa8-4d5e-8f83-e13d7247689e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:46 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "375",
-        "x-request-id": "df0f777b-596c-4b6b-9574-e67b7920ee04"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "297",
+        "X-Request-ID": "72f39f6e-faa8-4d5e-8f83-e13d7247689e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:46.0960354-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:25:00.5984548-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ad365564463cb44d87ee96e5a90f5045-1ec94998d1591c4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c78c4e48e8509042b5991f0a3f778e44-be864cb9531d1746-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "52d25f5f8d38da8dadc137499e397eb7",
+        "x-ms-client-request-id": "4937c1ad399eb77e41f22cf11f9b3014",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +33,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "7d328c08-33a8-4f80-8385-fd6fbabbb902",
+        "apim-request-id": "f5fe74ce-c261-4138-a416-638f4f94444e",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:24 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+        "Date": "Mon, 01 Feb 2021 13:12:44 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "538",
-        "x-request-id": "7d328c08-33a8-4f80-8385-fd6fbabbb902"
+        "x-envoy-upstream-service-time": "599",
+        "x-request-id": "f5fe74ce-c261-4138-a416-638f4f94444e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-15ccddb670fda543836a8184dc093423-74e8f2a71b9bbf45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d706c5bb13fc454a899aa8788093e520-8528ffef1f1a3446-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f12cf2419b1f14309361dcc9022df69b",
+        "x-ms-client-request-id": "c9dc61932d029bf68ca34a87652c29f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "89941227-1eb7-4a53-a41c-8278f4fb0fe1",
+        "apim-request-id": "c44a39f9-db5f-416b-8fdb-1b068d62cfb5",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:24 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "184",
-        "x-request-id": "89941227-1eb7-4a53-a41c-8278f4fb0fe1"
+        "x-envoy-upstream-service-time": "169",
+        "x-request-id": "c44a39f9-db5f-416b-8fdb-1b068d62cfb5"
       },
       "ResponseBody": {
-        "dataFeedId": "5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+        "dataFeedId": "57c36f6a-3b28-4182-a8ee-7563d09b919d",
         "dataFeedName": "dataFeedFXglzsLV",
         "metrics": [
           {
-            "metricId": "69a96608-cb95-4513-b66e-12ccd35a4d75",
+            "metricId": "605e8693-c11f-453a-a89c-8d501d885655",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:24Z",
+        "createdTime": "2021-02-01T13:12:44Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +116,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "712",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c6ffb38546638a41af6149517ce1fb56-5c5ab9481542a547-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-55bbd1b4d5bfc5469d1ca27e9d03e090-0892997a493d3d4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "874aa38c2c65f5295f28b0d6e0ff6669",
+        "x-ms-client-request-id": "d6b0285fffe06966160f20f6cd4033c4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +137,10 @@
           "payload": "payload"
         },
         "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeedFXglzsLV",
+        "dataFeedName": "dataFeedd5KUxBpJ",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +161,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "cee7edb1-894e-4875-b7b9-01225b1b10c3",
+        "apim-request-id": "6875fa4c-0b78-43f3-85d4-811e0ede66ef",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:25 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "634",
-        "x-request-id": "cee7edb1-894e-4875-b7b9-01225b1b10c3"
+        "x-envoy-upstream-service-time": "537",
+        "x-request-id": "6875fa4c-0b78-43f3-85d4-811e0ede66ef"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1562a8a81a0ca448a320bc759123d21c-37f43499b6744448-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-73a38ec2057b604f9a68232cfbbbd757-8748726aa53a5d4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f6200f1640cdc4332ebdbed7b0c4d780",
+        "x-ms-client-request-id": "d7bebd2ec4b080d7ca9bbcfbeef75114",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8f2b236e-e2b0-487a-82b6-b08d1d70359b",
+        "apim-request-id": "10b69ee0-c92c-4527-9006-b3efc8ef7eb4",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:25 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "157",
-        "x-request-id": "8f2b236e-e2b0-487a-82b6-b08d1d70359b"
+        "x-envoy-upstream-service-time": "211",
+        "x-request-id": "10b69ee0-c92c-4527-9006-b3efc8ef7eb4"
       },
       "ResponseBody": {
-        "dataFeedId": "5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
-        "dataFeedName": "dataFeedFXglzsLV",
+        "dataFeedId": "57c36f6a-3b28-4182-a8ee-7563d09b919d",
+        "dataFeedName": "dataFeedd5KUxBpJ",
         "metrics": [
           {
-            "metricId": "69a96608-cb95-4513-b66e-12ccd35a4d75",
+            "metricId": "605e8693-c11f-453a-a89c-8d501d885655",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "HttpRequest",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +233,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:24Z",
+        "createdTime": "2021-02-01T13:12:44Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +245,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5c81a0a8-c13c-4c28-a46e-9aa9153e7ee4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57c36f6a-3b28-4182-a8ee-7563d09b919d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6980102ec62c814eae7ac8f09d25b4c6-2433e5f2f407cb4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-96346057ea6aaf4aab221340644a086c-1a238d134b7b1749-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fbbc9bcaf7ee1451c83691f6eb5a3394",
+        "x-ms-client-request-id": "f69136c85aeb9433fa73b2f30c00ce4b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "480e6f5d-fb6e-4670-961a-16c1842a22cb",
+        "apim-request-id": "df0f777b-596c-4b6b-9574-e67b7920ee04",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:25 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "346",
-        "x-request-id": "480e6f5d-fb6e-4670-961a-16c1842a22cb"
+        "x-envoy-upstream-service-time": "375",
+        "x-request-id": "df0f777b-596c-4b6b-9574-e67b7920ee04"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:25.5656577-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:46.0960354-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c99e51c99375bf4fb2d869e8249f5917-778fef6b8135fe4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a65a4d14144e3140a1c6fbd2c8ce3669-b8ad4773dc7cc944-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7829172c4c5b55e66d8182cc1cdf67cf",
+        "x-ms-client-request-id": "cc82816ddf1ccf672a85042fcb93758b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,47 +36,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "27422785-8a9d-46ff-9ad7-3f2835540528",
+        "apim-request-id": "58fbe112-d3f3-4498-8851-8a1354a1102a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:04 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+        "Date": "Mon, 01 Feb 2021 13:42:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "546",
-        "x-request-id": "27422785-8a9d-46ff-9ad7-3f2835540528"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "535",
+        "X-Request-ID": "58fbe112-d3f3-4498-8851-8a1354a1102a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-04207257a9db3844b70ec7344eb16e84-01195c50a8a5b442-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7ad37b72ca27474dae87eb3926d5a14c-6eebf10fa3a63d48-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2f04852a93cb8b755de0561d5e5391d0",
+        "x-ms-client-request-id": "1d56e05d535ed0919b39280dba91fb47",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e1c64701-3576-4037-9a2f-ae1c20b44a45",
+        "apim-request-id": "982a1b89-3128-4817-8ce2-ef736159ad2f",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:04 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "184",
-        "x-request-id": "e1c64701-3576-4037-9a2f-ae1c20b44a45"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "180",
+        "X-Request-ID": "982a1b89-3128-4817-8ce2-ef736159ad2f"
       },
       "ResponseBody": {
-        "dataFeedId": "00f57f43-9508-407c-b44e-3a3fa1f298c4",
+        "dataFeedId": "47a0f69b-a592-49df-82e6-994d56d6085a",
         "dataFeedName": "dataFeedXUbS2vdX",
         "metrics": [
           {
-            "metricId": "cd412711-50b7-4324-8af9-28b9a8cb445b",
+            "metricId": "97e7f48c-4689-43a0-9441-4bc1be51ba77",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -104,7 +110,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:05Z",
+        "createdTime": "2021-02-01T13:42:41Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -116,17 +122,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "712",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-128c21e12691dc4c8420b28ad60d3cc4-ed5d0df6ec0a0743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c6aced70707e3542b3944511ba71b4b6-bdc29c4f78bec443-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0d28399b91ba47fb927868a285246ec5",
+        "x-ms-client-request-id": "a26878922485c56e6a26a75f54199598",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -137,10 +146,10 @@
           "payload": "payload"
         },
         "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeedXUbS2vdX",
+        "dataFeedName": "dataFeedk0coNrgg",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -161,53 +170,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e7ae7779-6026-4e36-a0f8-783dec853a9a",
+        "apim-request-id": "5174dbcc-6d35-447a-9ca1-fea50e74138a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:05 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "718",
-        "x-request-id": "e7ae7779-6026-4e36-a0f8-783dec853a9a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "920",
+        "X-Request-ID": "5174dbcc-6d35-447a-9ca1-fea50e74138a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ee84cbf69b8d24f8a85f8be4a0b3d2e-86c8719dd8493d4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0a3002606a05e94da3dced4a1da7b596-001c59bb142c114e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5fa7266a19549895a29d1a7af6c9f719",
+        "x-ms-client-request-id": "7a1a9da2c9f619f7efb130e3b75a1598",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0af0e6d1-a81e-4433-8d41-d2191040e770",
+        "apim-request-id": "ea7c4f54-f3ca-4ce5-831f-95ebb0e80c71",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:05 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "0af0e6d1-a81e-4433-8d41-d2191040e770"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "276",
+        "X-Request-ID": "ea7c4f54-f3ca-4ce5-831f-95ebb0e80c71"
       },
       "ResponseBody": {
-        "dataFeedId": "00f57f43-9508-407c-b44e-3a3fa1f298c4",
-        "dataFeedName": "dataFeedXUbS2vdX",
+        "dataFeedId": "47a0f69b-a592-49df-82e6-994d56d6085a",
+        "dataFeedName": "dataFeedk0coNrgg",
         "metrics": [
           {
-            "metricId": "cd412711-50b7-4324-8af9-28b9a8cb445b",
+            "metricId": "97e7f48c-4689-43a0-9441-4bc1be51ba77",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "HttpRequest",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -233,7 +245,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:05Z",
+        "createdTime": "2021-02-01T13:42:41Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -245,33 +257,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/00f57f43-9508-407c-b44e-3a3fa1f298c4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-73bcd944494f2a43956fdfd2f123093a-a4ccf5b0f0286e48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-60ef65d676bbab449a7ebbe90cbe9b5f-e73e7b3c82114a43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e330b1ef5ab7981589bc9c522bd30639",
+        "x-ms-client-request-id": "529cbc89d32b39067190b237ab327c81",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ef7cc843-9bde-4b3b-a93d-7e37fb956cad",
+        "apim-request-id": "173d657c-f349-425d-aa76-58c81f631501",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:06 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "332",
-        "x-request-id": "ef7cc843-9bde-4b3b-a93d-7e37fb956cad"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "497",
+        "X-Request-ID": "173d657c-f349-425d-aa76-58c81f631501"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:06.3687870-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:42.7938800-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a65a4d14144e3140a1c6fbd2c8ce3669-b8ad4773dc7cc944-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-5791521b3c94e644940c5047105cc075-ea993488b9aa0041-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cc82816ddf1ccf672a85042fcb93758b",
         "x-ms-return-client-request-id": "true"
@@ -36,28 +33,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "58fbe112-d3f3-4498-8851-8a1354a1102a",
+        "apim-request-id": "49991062-697f-427e-afc2-d33d2a164031",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:41 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
+        "Date": "Mon, 01 Feb 2021 15:41:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7cfabb00-4408-4471-82bd-e2413f199dbd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "535",
-        "X-Request-ID": "58fbe112-d3f3-4498-8851-8a1354a1102a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "432",
+        "x-request-id": "49991062-697f-427e-afc2-d33d2a164031"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7cfabb00-4408-4471-82bd-e2413f199dbd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7ad37b72ca27474dae87eb3926d5a14c-6eebf10fa3a63d48-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a83add196a562a4384ee83c01d9df882-2ad52628bab7554f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1d56e05d535ed0919b39280dba91fb47",
         "x-ms-return-client-request-id": "true"
@@ -65,21 +59,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "982a1b89-3128-4817-8ce2-ef736159ad2f",
+        "apim-request-id": "375e1dd7-0346-42fb-81db-a8421b39ed81",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:41 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "180",
-        "X-Request-ID": "982a1b89-3128-4817-8ce2-ef736159ad2f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "138",
+        "x-request-id": "375e1dd7-0346-42fb-81db-a8421b39ed81"
       },
       "ResponseBody": {
-        "dataFeedId": "47a0f69b-a592-49df-82e6-994d56d6085a",
+        "dataFeedId": "7cfabb00-4408-4471-82bd-e2413f199dbd",
         "dataFeedName": "dataFeedXUbS2vdX",
         "metrics": [
           {
-            "metricId": "97e7f48c-4689-43a0-9441-4bc1be51ba77",
+            "metricId": "82ab7578-57b4-45ce-aa42-f266cb701a2a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -110,7 +104,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:41Z",
+        "createdTime": "2021-02-01T15:41:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -122,18 +116,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7cfabb00-4408-4471-82bd-e2413f199dbd",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "712",
+        "Content-Length": "729",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c6aced70707e3542b3944511ba71b4b6-bdc29c4f78bec443-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-4395a1540ca2f84e9e3c77bea7ac8f90-97d0c75b3d1db449-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a26878922485c56e6a26a75f54199598",
         "x-ms-return-client-request-id": "true"
@@ -160,7 +151,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -170,27 +162,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5174dbcc-6d35-447a-9ca1-fea50e74138a",
+        "apim-request-id": "418d5400-0790-422d-aeea-4a5154b09ac9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:42 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "920",
-        "X-Request-ID": "5174dbcc-6d35-447a-9ca1-fea50e74138a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "503",
+        "x-request-id": "418d5400-0790-422d-aeea-4a5154b09ac9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7cfabb00-4408-4471-82bd-e2413f199dbd",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0a3002606a05e94da3dced4a1da7b596-001c59bb142c114e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c270292d1b829b409d8998454c46a219-71a50361505e7c4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7a1a9da2c9f619f7efb130e3b75a1598",
         "x-ms-return-client-request-id": "true"
@@ -198,21 +187,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ea7c4f54-f3ca-4ce5-831f-95ebb0e80c71",
-        "Content-Length": "1124",
+        "apim-request-id": "d442cea8-6e8f-492c-976b-68d1283f413c",
+        "Content-Length": "1141",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:42 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "276",
-        "X-Request-ID": "ea7c4f54-f3ca-4ce5-831f-95ebb0e80c71"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "142",
+        "x-request-id": "d442cea8-6e8f-492c-976b-68d1283f413c"
       },
       "ResponseBody": {
-        "dataFeedId": "47a0f69b-a592-49df-82e6-994d56d6085a",
+        "dataFeedId": "7cfabb00-4408-4471-82bd-e2413f199dbd",
         "dataFeedName": "dataFeedk0coNrgg",
         "metrics": [
           {
-            "metricId": "97e7f48c-4689-43a0-9441-4bc1be51ba77",
+            "metricId": "82ab7578-57b4-45ce-aa42-f266cb701a2a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -238,6 +227,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -245,7 +235,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:41Z",
+        "createdTime": "2021-02-01T15:41:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -257,16 +247,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/47a0f69b-a592-49df-82e6-994d56d6085a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7cfabb00-4408-4471-82bd-e2413f199dbd",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-60ef65d676bbab449a7ebbe90cbe9b5f-e73e7b3c82114a43-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-7e5b956721781c48a2bdfb9deb9e35df-6348ad5c2b50e54a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "529cbc89d32b39067190b237ab327c81",
         "x-ms-return-client-request-id": "true"
@@ -274,19 +261,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "173d657c-f349-425d-aa76-58c81f631501",
+        "apim-request-id": "6e22120f-2b55-46cf-8223-ca0f2dc601e7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:43 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "497",
-        "X-Request-ID": "173d657c-f349-425d-aa76-58c81f631501"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "283",
+        "x-request-id": "6e22120f-2b55-46cf-8223-ca0f2dc601e7"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:42.7938800-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:19.6117056-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c0252c8f1e9854b8dba98586388a6c8-8de7eae3442e3244-00",
+        "traceparent": "00-89aa9eecce90014aafc00b71411bdf4a-463d23f2ba22cf4b-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b1c6c5a65a7a88beb281be367475e1f0",
+        "x-ms-client-request-id": "6c3df27aeb9f3aff1f69e60c1eea4a42",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -22,7 +22,7 @@
           "payload": "payload"
         },
         "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeedrac2rFls",
+        "dataFeedName": "dataFeed0WLyGoTb",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -33,40 +33,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "980f0905-8dde-48de-814a-f2c250982e43",
+        "apim-request-id": "f75f8d8f-79cf-4c3b-bfcc-d6968e9c9f75",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:51 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
+        "Date": "Mon, 01 Feb 2021 15:45:35 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5625",
-        "x-request-id": "980f0905-8dde-48de-814a-f2c250982e43"
+        "x-envoy-upstream-service-time": "402",
+        "x-request-id": "f75f8d8f-79cf-4c3b-bfcc-d6968e9c9f75"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "600",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9d8df51b7551df4d85f68e2463996125-526523e8c8373e43-00",
+        "traceparent": "00-db4e7cbf0c584d4da31c28ba9a95bd6b-c4404148cf0f5e46-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8c0a8dd0b5d83b90ed25e7fbdecb1088",
+        "x-ms-client-request-id": "48c93ad2590adc8561d99c331c8b8e4a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "url": "https://fakehost.com/",
-          "httpHeader": "Sanitized",
-          "httpMethod": "method",
-          "payload": "payload"
-        },
-        "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeedGpxyPr31",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedvNmU1Yd5",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -83,46 +77,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2eb04e8c-f862-4b90-bb87-ee69a104d32c",
+        "apim-request-id": "41d6b3a9-18d8-401d-97ad-0b08cb889e13",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:52 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "662",
-        "x-request-id": "2eb04e8c-f862-4b90-bb87-ee69a104d32c"
+        "x-envoy-upstream-service-time": "201",
+        "x-request-id": "41d6b3a9-18d8-401d-97ad-0b08cb889e13"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2d073ad9acfb504a8ecbc23a1b1b000e-25b7a9b5a952334d-00",
+        "traceparent": "00-fd1c17d6dd4c5c448af530247cff487f-29e69c763de2794e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5470835b1e40c365418ecc2f76f740ed",
+        "x-ms-client-request-id": "ff39e50cc176b17e644d324d596184cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "34631b0b-28af-483a-b8c9-81ee2d132c9d",
+        "apim-request-id": "283d60fd-68db-40e1-8399-a939abb32a0a",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:52 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "180",
-        "x-request-id": "34631b0b-28af-483a-b8c9-81ee2d132c9d"
+        "x-envoy-upstream-service-time": "183",
+        "x-request-id": "283d60fd-68db-40e1-8399-a939abb32a0a"
       },
       "ResponseBody": {
-        "dataFeedId": "70139fde-a22c-4625-b463-cab7a97edc72",
-        "dataFeedName": "dataFeedGpxyPr31",
+        "dataFeedId": "19f39a14-125f-4374-976c-8a302c4a0361",
+        "dataFeedName": "dataFeedvNmU1Yd5",
         "metrics": [
           {
-            "metricId": "ae3729a4-14ce-46bb-ad8f-d532bf829a1d",
+            "metricId": "0e098287-3aab-47a2-85be-88c6f2bb205c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -155,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:52Z",
+        "createdTime": "2021-02-01T15:45:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,37 +161,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-25eb98d5de2c9f4082025ff3d554ba45-0b8fceb9f82cb745-00",
+        "traceparent": "00-71f6100e53937142be7248cc864bb584-0cd0f3c7968e5d47-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "01e5cc0738d2f1c4358bc45573c3a9e7",
+        "x-ms-client-request-id": "ef0af52d813c20a76c600bc64fcc1e93",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "794fc747-4610-491b-8e99-d18e0401961f",
+        "apim-request-id": "951d3fd4-0cc4-4888-91ad-0801f8cb25fd",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:52 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "374",
-        "x-request-id": "794fc747-4610-491b-8e99-d18e0401961f"
+        "x-envoy-upstream-service-time": "397",
+        "x-request-id": "951d3fd4-0cc4-4888-91ad-0801f8cb25fd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:53.1377451-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:36.8613263-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "1084445630"
+    "RandomSeed": "2019828317"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e61020782e5bde4d936408986edb8cba-794e909d8c70734c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7c0252c8f1e9854b8dba98586388a6c8-8de7eae3442e3244-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b5bce963dc8e9cc4a6c5c6b17a5abe88",
+        "x-ms-client-request-id": "b1c6c5a65a7a88beb281be367475e1f0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +33,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e5bd1c42-36d7-4d6a-a43f-fafc7316c270",
+        "apim-request-id": "980f0905-8dde-48de-814a-f2c250982e43",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+        "Date": "Mon, 01 Feb 2021 13:12:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "547",
-        "x-request-id": "e5bd1c42-36d7-4d6a-a43f-fafc7316c270"
+        "x-envoy-upstream-service-time": "5625",
+        "x-request-id": "980f0905-8dde-48de-814a-f2c250982e43"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "600",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cf4ca23b19477242b436e9f09fb911cc-84ef17d939682f4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9d8df51b7551df4d85f68e2463996125-526523e8c8373e43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "36be81b27574f0e1d08d0a8cd8b5903b",
+        "x-ms-client-request-id": "8c0a8dd0b5d83b90ed25e7fbdecb1088",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +66,10 @@
           "payload": "payload"
         },
         "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeedrac2rFls",
+        "dataFeedName": "dataFeedGpxyPr31",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +83,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4dce7d37-f99c-48f3-843f-d6f21d821baa",
+        "apim-request-id": "2eb04e8c-f862-4b90-bb87-ee69a104d32c",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:27 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "676",
-        "x-request-id": "4dce7d37-f99c-48f3-843f-d6f21d821baa"
+        "x-envoy-upstream-service-time": "662",
+        "x-request-id": "2eb04e8c-f862-4b90-bb87-ee69a104d32c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b08c2b4158b4b4f8a685339cbf26b29-1f420d1e1dbf5544-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2d073ad9acfb504a8ecbc23a1b1b000e-25b7a9b5a952334d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fbe725edcbde88105b837054401e65c3",
+        "x-ms-client-request-id": "5470835b1e40c365418ecc2f76f740ed",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f9644196-078e-4b44-ae91-f410a7b3a2c4",
+        "apim-request-id": "34631b0b-28af-483a-b8c9-81ee2d132c9d",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:27 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "f9644196-078e-4b44-ae91-f410a7b3a2c4"
+        "x-envoy-upstream-service-time": "180",
+        "x-request-id": "34631b0b-28af-483a-b8c9-81ee2d132c9d"
       },
       "ResponseBody": {
-        "dataFeedId": "8327756a-5b63-4a73-b0c5-b234aa36a3f8",
-        "dataFeedName": "dataFeedrac2rFls",
+        "dataFeedId": "70139fde-a22c-4625-b463-cab7a97edc72",
+        "dataFeedName": "dataFeedGpxyPr31",
         "metrics": [
           {
-            "metricId": "b8a7ac6d-ff9b-4889-8048-e4f53d1c2244",
+            "metricId": "ae3729a4-14ce-46bb-ad8f-d532bf829a1d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "HttpRequest",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +155,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:26Z",
+        "createdTime": "2021-02-01T13:12:52Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +167,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8327756a-5b63-4a73-b0c5-b234aa36a3f8",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/70139fde-a22c-4625-b463-cab7a97edc72",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-369f67c10767fc4ba68cd5c915772a19-545307b45e18cb45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-25eb98d5de2c9f4082025ff3d554ba45-0b8fceb9f82cb745-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2fcc8e41f776ed4007cce501d238c4f1",
+        "x-ms-client-request-id": "01e5cc0738d2f1c4358bc45573c3a9e7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ca77d3d3-63db-402a-bd78-ca3263f29d1d",
+        "apim-request-id": "794fc747-4610-491b-8e99-d18e0401961f",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:27 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "274",
-        "x-request-id": "ca77d3d3-63db-402a-bd78-ca3263f29d1d"
+        "x-envoy-upstream-service-time": "374",
+        "x-request-id": "794fc747-4610-491b-8e99-d18e0401961f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:27.4403536-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:53.1377451-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-89aa9eecce90014aafc00b71411bdf4a-463d23f2ba22cf4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-79101b71c38d934092af9fff18f6c557-c17e92833f987a49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6c3df27aeb9f3aff1f69e60c1eea4a42",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f75f8d8f-79cf-4c3b-bfcc-d6968e9c9f75",
+        "apim-request-id": "ad44dbe8-227f-4a49-b8cf-016c5bd20265",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:35 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
+        "Date": "Mon, 01 Feb 2021 15:52:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b7ab60b4-1be5-4f5d-8376-a29242662e59",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "402",
-        "x-request-id": "f75f8d8f-79cf-4c3b-bfcc-d6968e9c9f75"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "476",
+        "X-Request-ID": "ad44dbe8-227f-4a49-b8cf-016c5bd20265"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b7ab60b4-1be5-4f5d-8376-a29242662e59",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-db4e7cbf0c584d4da31c28ba9a95bd6b-c4404148cf0f5e46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e2328a2f77df6e4287e6cea3bebcd457-d8bc59216ab80546-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "48c93ad2590adc8561d99c331c8b8e4a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedvNmU1Yd5",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "41d6b3a9-18d8-401d-97ad-0b08cb889e13",
+        "apim-request-id": "34136b0a-33e2-4423-b462-abf9c9e1ff21",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "201",
-        "x-request-id": "41d6b3a9-18d8-401d-97ad-0b08cb889e13"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "180",
+        "X-Request-ID": "34136b0a-33e2-4423-b462-abf9c9e1ff21"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b7ab60b4-1be5-4f5d-8376-a29242662e59",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fd1c17d6dd4c5c448af530247cff487f-29e69c763de2794e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2f1b49fa667fdc448fa06c454e7f0acc-49ed83d108d7bd49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ff39e50cc176b17e644d324d596184cc",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "283d60fd-68db-40e1-8399-a939abb32a0a",
+        "apim-request-id": "941cffc8-ee80-4e7b-893c-f15e38997015",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:36 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "183",
-        "x-request-id": "283d60fd-68db-40e1-8399-a939abb32a0a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "167",
+        "X-Request-ID": "941cffc8-ee80-4e7b-893c-f15e38997015"
       },
       "ResponseBody": {
-        "dataFeedId": "19f39a14-125f-4374-976c-8a302c4a0361",
+        "dataFeedId": "b7ab60b4-1be5-4f5d-8376-a29242662e59",
         "dataFeedName": "dataFeedvNmU1Yd5",
         "metrics": [
           {
-            "metricId": "0e098287-3aab-47a2-85be-88c6f2bb205c",
+            "metricId": "54b88e72-2667-4214-ab3f-1797cefab062",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:36Z",
+        "createdTime": "2021-02-01T15:52:37Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/19f39a14-125f-4374-976c-8a302c4a0361",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b7ab60b4-1be5-4f5d-8376-a29242662e59",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-71f6100e53937142be7248cc864bb584-0cd0f3c7968e5d47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-309d81bc64a04f4eac2d5fb55848b92c-bd4bb05aef22884d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ef0af52d813c20a76c600bc64fcc1e93",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "951d3fd4-0cc4-4888-91ad-0801f8cb25fd",
+        "apim-request-id": "0b311643-f971-40e1-af6e-4b8985742137",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:36 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "397",
-        "x-request-id": "951d3fd4-0cc4-4888-91ad-0801f8cb25fd"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "310",
+        "X-Request-ID": "0b311643-f971-40e1-af6e-4b8985742137"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:36.8613263-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:38.1549465-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b5dbc42afd619148ad4936eb4c296df2-1fa6a1b764a54f47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f2746b03491ed5439dfff3770564e6c7-93be71349eb1ec4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5ae17fff40f041d4467a061049028285",
         "x-ms-return-client-request-id": "true"
@@ -33,33 +36,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b5711a2c-30a4-4f53-a893-ad69deecda70",
+        "apim-request-id": "49c84d15-a997-46f8-b250-9070e03a9c45",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:19 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
+        "Date": "Mon, 01 Feb 2021 15:53:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d046a1c8-604c-426c-b2a1-43a7dde76b1a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "495",
-        "x-request-id": "b5711a2c-30a4-4f53-a893-ad69deecda70"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "352",
+        "X-Request-ID": "49c84d15-a997-46f8-b250-9070e03a9c45"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d046a1c8-604c-426c-b2a1-43a7dde76b1a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-660f097b28f5474faeccb54180262313-7ad9dad8929c334d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fe408606ebc774469e46a43cf480bf35-df4eaca556cecc43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "53831aae414ef6ae9608e8b1519f0251",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeed5C72jKOD",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -77,24 +83,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "41bcbb5e-529e-4cb2-8bec-ec6e413d3f68",
+        "apim-request-id": "94e29535-f47b-4094-8897-7a508f708fad",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "166",
-        "x-request-id": "41bcbb5e-529e-4cb2-8bec-ec6e413d3f68"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "173",
+        "X-Request-ID": "94e29535-f47b-4094-8897-7a508f708fad"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d046a1c8-604c-426c-b2a1-43a7dde76b1a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-573891621af53a4d949fb7b31d6c14a0-219f759564095b45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f43931b3c6165144babea770d60cd02c-66294fc375e7eb4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "275d0cb30a5886d3b892314b80750366",
         "x-ms-return-client-request-id": "true"
@@ -102,21 +111,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f44434e8-6103-4007-ba22-2ec660bccd45",
+        "apim-request-id": "d1c20d62-6bf1-4385-b9aa-060b689d527d",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "f44434e8-6103-4007-ba22-2ec660bccd45"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "135",
+        "X-Request-ID": "d1c20d62-6bf1-4385-b9aa-060b689d527d"
       },
       "ResponseBody": {
-        "dataFeedId": "4d0e34be-3752-4a58-b024-13e8e29cb2e5",
+        "dataFeedId": "d046a1c8-604c-426c-b2a1-43a7dde76b1a",
         "dataFeedName": "dataFeed5C72jKOD",
         "metrics": [
           {
-            "metricId": "e3ae07ed-8f8e-43ab-b3d8-951a0cb5635c",
+            "metricId": "7dbaf6ef-4362-49f3-84bc-ee751c91afb4",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -149,7 +158,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:20Z",
+        "createdTime": "2021-02-01T15:53:09Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,13 +170,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d046a1c8-604c-426c-b2a1-43a7dde76b1a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3004c486803d814981731b4f62992fe2-7eeda0ed062ab849-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-af205abd99d7e340966cdd2e5cfb96e4-c2f2bd0fa02bb341-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a2377956a208be11d1eac4e75823efa6",
         "x-ms-return-client-request-id": "true"
@@ -175,19 +187,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d8a7677b-9240-4017-ad48-d46311eb0797",
+        "apim-request-id": "aaa40109-0e4e-4afb-b6e1-571a279e294b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "283",
-        "x-request-id": "d8a7677b-9240-4017-ad48-d46311eb0797"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "298",
+        "X-Request-ID": "aaa40109-0e4e-4afb-b6e1-571a279e294b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:21.1137479-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:09.5693976-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-06ed3ef79a04d449bccb5a945a098526-d2f60aa46e24914e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-b5dbc42afd619148ad4936eb4c296df2-1fa6a1b764a54f47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5ae17fff40f041d4467a061049028285",
         "x-ms-return-client-request-id": "true"
@@ -36,42 +33,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e2244d9d-3f6c-4cf4-9b0f-2aeb17a2808c",
+        "apim-request-id": "b5711a2c-30a4-4f53-a893-ad69deecda70",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:43 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
+        "Date": "Mon, 01 Feb 2021 15:41:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "616",
-        "X-Request-ID": "e2244d9d-3f6c-4cf4-9b0f-2aeb17a2808c"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "495",
+        "x-request-id": "b5711a2c-30a4-4f53-a893-ad69deecda70"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "600",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-903d1ee2cba2ac4a995d6cb258777a99-6af56fa70b4cb54d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-660f097b28f5474faeccb54180262313-7ad9dad8929c334d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "53831aae414ef6ae9608e8b1519f0251",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "url": "https://fakehost.com/",
-          "httpHeader": "Sanitized",
-          "httpMethod": "method",
-          "payload": "payload"
-        },
-        "dataSourceType": "HttpRequest",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeed5C72jKOD",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -89,27 +77,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "949423df-0ed9-42e8-b060-461207558627",
+        "apim-request-id": "41bcbb5e-529e-4cb2-8bec-ec6e413d3f68",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:44 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "683",
-        "X-Request-ID": "949423df-0ed9-42e8-b060-461207558627"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "x-request-id": "41bcbb5e-529e-4cb2-8bec-ec6e413d3f68"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-82e639d25e7e9b49ba3db1d2868469ec-025782f958257944-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-573891621af53a4d949fb7b31d6c14a0-219f759564095b45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "275d0cb30a5886d3b892314b80750366",
         "x-ms-return-client-request-id": "true"
@@ -117,21 +102,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c3e6d2b0-9b46-4a80-82df-827365e7a168",
+        "apim-request-id": "f44434e8-6103-4007-ba22-2ec660bccd45",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:44 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "212",
-        "X-Request-ID": "c3e6d2b0-9b46-4a80-82df-827365e7a168"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "155",
+        "x-request-id": "f44434e8-6103-4007-ba22-2ec660bccd45"
       },
       "ResponseBody": {
-        "dataFeedId": "feb1a0a8-e8f1-4dd3-935e-54d878a27835",
+        "dataFeedId": "4d0e34be-3752-4a58-b024-13e8e29cb2e5",
         "dataFeedName": "dataFeed5C72jKOD",
         "metrics": [
           {
-            "metricId": "a84f34ef-029e-4898-b097-bec82cfdd25a",
+            "metricId": "e3ae07ed-8f8e-43ab-b3d8-951a0cb5635c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -164,7 +149,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:43Z",
+        "createdTime": "2021-02-01T15:41:20Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -176,16 +161,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d0e34be-3752-4a58-b024-13e8e29cb2e5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8174d8b3f53be740b02141595fdd73a5-23e40a9758c1e641-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-3004c486803d814981731b4f62992fe2-7eeda0ed062ab849-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a2377956a208be11d1eac4e75823efa6",
         "x-ms-return-client-request-id": "true"
@@ -193,19 +175,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c5074d7b-14e0-41f0-8806-979fbcd60079",
+        "apim-request-id": "d8a7677b-9240-4017-ad48-d46311eb0797",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:45 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "424",
-        "X-Request-ID": "c5074d7b-14e0-41f0-8806-979fbcd60079"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "283",
+        "x-request-id": "d8a7677b-9240-4017-ad48-d46311eb0797"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:44.9253917-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:21.1137479-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0fc9be5a4508e489d846b4bc5d348f5-68b5f607e5a34d47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-06ed3ef79a04d449bccb5a945a098526-d2f60aa46e24914e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e5fed9698cbd60f6ff7fe15af040d441",
+        "x-ms-client-request-id": "5ae17fff40f041d4467a061049028285",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -33,29 +36,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "07533a52-1229-41b7-b08b-97fe6e579b25",
+        "apim-request-id": "e2244d9d-3f6c-4cf4-9b0f-2aeb17a2808c",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:06 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+        "Date": "Mon, 01 Feb 2021 13:42:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "574",
-        "x-request-id": "07533a52-1229-41b7-b08b-97fe6e579b25"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "616",
+        "X-Request-ID": "e2244d9d-3f6c-4cf4-9b0f-2aeb17a2808c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "600",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0d463d0b342eab439d4910ebc13caffd-ccf974314a299f42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-903d1ee2cba2ac4a995d6cb258777a99-6af56fa70b4cb54d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "10067a4602498582ae1a83534e41aef6",
+        "x-ms-client-request-id": "53831aae414ef6ae9608e8b1519f0251",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -66,10 +72,10 @@
           "payload": "payload"
         },
         "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeednOXZo4U6",
+        "dataFeedName": "dataFeed5C72jKOD",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -83,53 +89,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "40576f00-2d26-4582-955c-20efc833875c",
+        "apim-request-id": "949423df-0ed9-42e8-b060-461207558627",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:07 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "688",
-        "x-request-id": "40576f00-2d26-4582-955c-20efc833875c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "683",
+        "X-Request-ID": "949423df-0ed9-42e8-b060-461207558627"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3b9c17e22b5a9244bcd609eaa554b35f-60d7a4246a8a0749-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-82e639d25e7e9b49ba3db1d2868469ec-025782f958257944-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b1e808969f515102b30c5d27580ad386",
+        "x-ms-client-request-id": "275d0cb30a5886d3b892314b80750366",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "00f8b323-95a4-4d17-9ebf-2826c1916eb6",
+        "apim-request-id": "c3e6d2b0-9b46-4a80-82df-827365e7a168",
         "Content-Length": "1124",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:07 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "00f8b323-95a4-4d17-9ebf-2826c1916eb6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "212",
+        "X-Request-ID": "c3e6d2b0-9b46-4a80-82df-827365e7a168"
       },
       "ResponseBody": {
-        "dataFeedId": "5e04f39a-1e56-4a34-8692-7f9aa9787279",
-        "dataFeedName": "dataFeednOXZo4U6",
+        "dataFeedId": "feb1a0a8-e8f1-4dd3-935e-54d878a27835",
+        "dataFeedName": "dataFeed5C72jKOD",
         "metrics": [
           {
-            "metricId": "c50488c4-93d6-446f-bcd0-9472fd2b2496",
+            "metricId": "a84f34ef-029e-4898-b097-bec82cfdd25a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "HttpRequest",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -155,7 +164,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:07Z",
+        "createdTime": "2021-02-01T13:42:43Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -167,33 +176,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/5e04f39a-1e56-4a34-8692-7f9aa9787279",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/feb1a0a8-e8f1-4dd3-935e-54d878a27835",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9341d7567564434dabb6917a96540bba-be4c326e60749644-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8174d8b3f53be740b02141595fdd73a5-23e40a9758c1e641-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "4b3192b875806603567937a208a211be",
+        "x-ms-client-request-id": "a2377956a208be11d1eac4e75823efa6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b50b11e0-1f1b-44cc-ac36-65e59938d5fe",
+        "apim-request-id": "c5074d7b-14e0-41f0-8806-979fbcd60079",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:07 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "284",
-        "x-request-id": "b50b11e0-1f1b-44cc-ac36-65e59938d5fe"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "424",
+        "X-Request-ID": "c5074d7b-14e0-41f0-8806-979fbcd60079"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:08.2853052-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:44.9253917-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-86fc6db054fda94f9c76d2e9d815a06e-6edd2c6136f66947-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ac653b8d5fff974892c8022ab1fef60d-6edd2ce2dc7a5741-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d9fc404cd6b443c6f2a25316326a92ac",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +33,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "341bde3d-8917-4dc6-b5fd-4efaa2b40c47",
+        "apim-request-id": "ee76322f-761c-4315-9f97-91357f13eb5a",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:23 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7ea56de8-a12b-495b-a105-6a28f9ab7193",
+        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "360",
-        "x-request-id": "341bde3d-8917-4dc6-b5fd-4efaa2b40c47"
+        "x-envoy-upstream-service-time": "431",
+        "x-request-id": "ee76322f-761c-4315-9f97-91357f13eb5a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7ea56de8-a12b-495b-a105-6a28f9ab7193",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "302",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-79b5d40173db2742ba679afc3b00e9d5-d262825cadf6ef4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-31d7eb93998ae34fafd5303a19389eed-369b0591d399d040-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0d3bf58cb71d3ece65de934460d9c57c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "url": "https://fakehost.com/",
-          "httpHeader": "Sanitized",
-          "httpMethod": "method",
-          "payload": "payload"
-        },
-        "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeed4lysRCIB",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6a425829-a98f-447f-a33d-5ae567b4e58d",
+        "apim-request-id": "51d5c5d3-8b50-4f65-b6ed-8be76a62f0b8",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:24 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "444",
-        "x-request-id": "6a425829-a98f-447f-a33d-5ae567b4e58d"
+        "x-envoy-upstream-service-time": "173",
+        "x-request-id": "51d5c5d3-8b50-4f65-b6ed-8be76a62f0b8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7ea56de8-a12b-495b-a105-6a28f9ab7193",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2d8596737a468c47bd779b55d949ca1b-efdeb93b5bc5b645-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fc5824942d95eb459879a9c285af3c9e-9cead5853faa7e4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b4b18e3ec305c8eba563a4f20333746f",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +89,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "38f9e654-9809-4ea1-8760-7c61cd314e88",
+        "apim-request-id": "d5a9d856-a760-425b-b8b8-922ef8fa8393",
         "Content-Length": "1049",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:24 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "145",
-        "x-request-id": "38f9e654-9809-4ea1-8760-7c61cd314e88"
+        "x-envoy-upstream-service-time": "184",
+        "x-request-id": "d5a9d856-a760-425b-b8b8-922ef8fa8393"
       },
       "ResponseBody": {
-        "dataFeedId": "7ea56de8-a12b-495b-a105-6a28f9ab7193",
+        "dataFeedId": "fc6a0f25-7f15-47dc-b6c8-16614264461a",
         "dataFeedName": "dataFeed4lysRCIB",
         "metrics": [
           {
-            "metricId": "8602a3ea-2565-478f-949a-013c085f8a2e",
+            "metricId": "ff9d0ada-f94e-44ec-bf7a-50004b266c91",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +134,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:24Z",
+        "createdTime": "2021-02-01T12:46:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +146,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7ea56de8-a12b-495b-a105-6a28f9ab7193",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-77fb7d9c54a83c45898454da345e3592-2f406663fad6694e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f162b0d5d394714fb44adfc05aa8fa49-5af558bac254a543-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "69360d39728e95e872be74d54382e219",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +160,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "eeffacea-c3c9-4cd5-ab7e-2f612657a8a6",
+        "apim-request-id": "1fdc584b-41f5-48fd-9890-8809d0d1a377",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:24 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "326",
-        "x-request-id": "eeffacea-c3c9-4cd5-ab7e-2f612657a8a6"
+        "x-envoy-upstream-service-time": "353",
+        "x-request-id": "1fdc584b-41f5-48fd-9890-8809d0d1a377"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:25.3011387-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:36.6593332-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ac653b8d5fff974892c8022ab1fef60d-6edd2ce2dc7a5741-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7638d5aea008b24d9e2cc91865343800-e3ce69333872f44c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d9fc404cd6b443c6f2a25316326a92ac",
         "x-ms-return-client-request-id": "true"
@@ -33,55 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ee76322f-761c-4315-9f97-91357f13eb5a",
+        "apim-request-id": "cbbc95e2-91f4-45b7-9428-fce46bdccd2c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
+        "Date": "Mon, 01 Feb 2021 15:52:37 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d5d9b39-ccdc-495c-9fef-39764190f20e",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "431",
-        "x-request-id": "ee76322f-761c-4315-9f97-91357f13eb5a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "396",
+        "X-Request-ID": "cbbc95e2-91f4-45b7-9428-fce46bdccd2c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d5d9b39-ccdc-495c-9fef-39764190f20e",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-31d7eb93998ae34fafd5303a19389eed-369b0591d399d040-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9f6deb0e7c491f45a4ca2de8b29f5335-02377a75b3d85a44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0d3bf58cb71d3ece65de934460d9c57c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "51d5c5d3-8b50-4f65-b6ed-8be76a62f0b8",
+        "apim-request-id": "983d3b1f-7899-4968-a1d1-2a1ba899512d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "173",
-        "x-request-id": "51d5c5d3-8b50-4f65-b6ed-8be76a62f0b8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "X-Request-ID": "983d3b1f-7899-4968-a1d1-2a1ba899512d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d5d9b39-ccdc-495c-9fef-39764190f20e",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fc5824942d95eb459879a9c285af3c9e-9cead5853faa7e4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e931af312b03294180e4263632191501-87704baa9e6efb46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b4b18e3ec305c8eba563a4f20333746f",
         "x-ms-return-client-request-id": "true"
@@ -89,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d5a9d856-a760-425b-b8b8-922ef8fa8393",
+        "apim-request-id": "2595b356-3b0a-4f07-b103-d94b9cff19ac",
         "Content-Length": "1049",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "184",
-        "x-request-id": "d5a9d856-a760-425b-b8b8-922ef8fa8393"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "161",
+        "X-Request-ID": "2595b356-3b0a-4f07-b103-d94b9cff19ac"
       },
       "ResponseBody": {
-        "dataFeedId": "fc6a0f25-7f15-47dc-b6c8-16614264461a",
+        "dataFeedId": "2d5d9b39-ccdc-495c-9fef-39764190f20e",
         "dataFeedName": "dataFeed4lysRCIB",
         "metrics": [
           {
-            "metricId": "ff9d0ada-f94e-44ec-bf7a-50004b266c91",
+            "metricId": "5e8a22ca-9cd1-488f-8efa-6432243e4130",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -134,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:36Z",
+        "createdTime": "2021-02-01T15:52:38Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -146,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fc6a0f25-7f15-47dc-b6c8-16614264461a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d5d9b39-ccdc-495c-9fef-39764190f20e",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f162b0d5d394714fb44adfc05aa8fa49-5af558bac254a543-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3d370e7af907cf43a2b8526ae49672f6-baa85c7020e12c44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "69360d39728e95e872be74d54382e219",
         "x-ms-return-client-request-id": "true"
@@ -160,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1fdc584b-41f5-48fd-9890-8809d0d1a377",
+        "apim-request-id": "cd42af31-ea30-4df0-883d-6f6935800219",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:36 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "353",
-        "x-request-id": "1fdc584b-41f5-48fd-9890-8809d0d1a377"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "287",
+        "X-Request-ID": "cd42af31-ea30-4df0-883d-6f6935800219"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:36.6593332-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:39.2867207-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9c622c7bdf20524ba40c35348b99bddd-dfe538274272b046-00",
+        "traceparent": "00-d2caf33fa0cce04fa0c1599ff4c07b7e-f58710aff54de94b-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -36,26 +36,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3cfabcba-a9c5-4ae8-8858-0fc2c3c2f058",
+        "apim-request-id": "18be1265-dda4-49f0-9c93-c0f2f5d1b80c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
+        "Date": "Mon, 01 Feb 2021 15:53:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/405fe672-6f3c-4a90-9a39-1cedbafd218a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "678",
-        "X-Request-ID": "3cfabcba-a9c5-4ae8-8858-0fc2c3c2f058"
+        "x-envoy-upstream-service-time": "604",
+        "X-Request-ID": "18be1265-dda4-49f0-9c93-c0f2f5d1b80c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/405fe672-6f3c-4a90-9a39-1cedbafd218a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-faa5df479cbc7446815f68f737428930-5cd61a964fa75740-00",
+        "traceparent": "00-dbbf3fe7a0dd3c4f80b1c1628309d449-70f4837bd5901845-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -65,28 +65,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6ed4cccb-6ac7-44e7-afe0-2ceaf6855ef8",
+        "apim-request-id": "fc302d72-93e7-43f1-ae55-5b037a361f79",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:46 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "324",
-        "X-Request-ID": "6ed4cccb-6ac7-44e7-afe0-2ceaf6855ef8"
+        "x-envoy-upstream-service-time": "147",
+        "X-Request-ID": "fc302d72-93e7-43f1-ae55-5b037a361f79"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/405fe672-6f3c-4a90-9a39-1cedbafd218a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9dfdb47a43a91049af717169af4869ad-eaf6f9b260f7234d-00",
+        "traceparent": "00-ecabed061ee3cb4cba8e60acc8395f13-7116394399119449-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -98,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "89dd4bb0-e3b3-467a-a27e-ab9dae5d0a87",
+        "apim-request-id": "333aa5f8-fb83-42f0-bff2-2aa119f95311",
         "Content-Length": "1049",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:46 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "229",
-        "X-Request-ID": "89dd4bb0-e3b3-467a-a27e-ab9dae5d0a87"
+        "x-envoy-upstream-service-time": "139",
+        "X-Request-ID": "333aa5f8-fb83-42f0-bff2-2aa119f95311"
       },
       "ResponseBody": {
-        "dataFeedId": "25da3505-b98b-4f47-8a51-d6405f749fdb",
+        "dataFeedId": "405fe672-6f3c-4a90-9a39-1cedbafd218a",
         "dataFeedName": "dataFeedj7SUje7h",
         "metrics": [
           {
-            "metricId": "f7de6a02-616c-43ca-bca0-40d2bae0ea2c",
+            "metricId": "0bcd0d28-764e-4f14-a0b4-f4bade22a2b6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -143,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:45Z",
+        "createdTime": "2021-02-01T15:53:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -155,12 +155,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/405fe672-6f3c-4a90-9a39-1cedbafd218a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ced61067b5df8c4aa322ffd0a364890e-48840f3888aab949-00",
+        "traceparent": "00-ad8a32466f232c42b660d88ac6d84d70-a09f8e58b6f93f4d-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -172,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4e86939d-a79a-4bc1-86a3-516521e00432",
+        "apim-request-id": "1443bb35-fee7-4cc7-95f7-c570940a403b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:46 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "415",
-        "X-Request-ID": "4e86939d-a79a-4bc1-86a3-516521e00432"
+        "x-envoy-upstream-service-time": "307",
+        "X-Request-ID": "1443bb35-fee7-4cc7-95f7-c570940a403b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:46.8010775-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:10.8442934-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateHttpRequestDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "286",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-efe866a4aaad69479ed47b9b7c5c973b-ff9411d53a984247-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9c622c7bdf20524ba40c35348b99bddd-dfe538274272b046-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "956fb792c0844f6d8bcfe8b1632b6def",
         "x-ms-return-client-request-id": "true"
@@ -33,63 +36,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ee7d95eb-82e4-4ee1-b392-714f88f18860",
+        "apim-request-id": "3cfabcba-a9c5-4ae8-8858-0fc2c3c2f058",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:35 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a85801a-2f8d-42c9-9f71-941f334ceb04",
+        "Date": "Mon, 01 Feb 2021 13:42:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "693",
-        "x-request-id": "ee7d95eb-82e4-4ee1-b392-714f88f18860"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "678",
+        "X-Request-ID": "3cfabcba-a9c5-4ae8-8858-0fc2c3c2f058"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a85801a-2f8d-42c9-9f71-941f334ceb04",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "302",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-915aff6dddeee743a7b523e62b4ee8b3-d78f859d23bbe946-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-faa5df479cbc7446815f68f737428930-5cd61a964fa75740-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dd45c5d71c1173638278e559a72536aa",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "url": "https://fakehost.com/",
-          "httpHeader": "Sanitized",
-          "httpMethod": "method",
-          "payload": "payload"
-        },
-        "dataSourceType": "HttpRequest",
-        "dataFeedName": "dataFeedj7SUje7h",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2dcfa7dc-68a4-4232-8eb6-b44817b1fe04",
+        "apim-request-id": "6ed4cccb-6ac7-44e7-afe0-2ceaf6855ef8",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:36 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1219",
-        "x-request-id": "2dcfa7dc-68a4-4232-8eb6-b44817b1fe04"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "324",
+        "X-Request-ID": "6ed4cccb-6ac7-44e7-afe0-2ceaf6855ef8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a85801a-2f8d-42c9-9f71-941f334ceb04",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3c629e92fc91f440883732eb36406ce2-b12c3a337e20ac48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9dfdb47a43a91049af717169af4869ad-eaf6f9b260f7234d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "90e6b4d057b9c74e95f877e7bbf38e1d",
         "x-ms-return-client-request-id": "true"
@@ -97,21 +98,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c7496de3-38c7-4a45-9345-6a0987c4ed8c",
+        "apim-request-id": "89dd4bb0-e3b3-467a-a27e-ab9dae5d0a87",
         "Content-Length": "1049",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:36 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "153",
-        "x-request-id": "c7496de3-38c7-4a45-9345-6a0987c4ed8c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "229",
+        "X-Request-ID": "89dd4bb0-e3b3-467a-a27e-ab9dae5d0a87"
       },
       "ResponseBody": {
-        "dataFeedId": "7a85801a-2f8d-42c9-9f71-941f334ceb04",
+        "dataFeedId": "25da3505-b98b-4f47-8a51-d6405f749fdb",
         "dataFeedName": "dataFeedj7SUje7h",
         "metrics": [
           {
-            "metricId": "e1e70c5a-459e-4e56-b4ec-139c2ec311a3",
+            "metricId": "f7de6a02-616c-43ca-bca0-40d2bae0ea2c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +143,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:35Z",
+        "createdTime": "2021-02-01T13:42:45Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -154,13 +155,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a85801a-2f8d-42c9-9f71-941f334ceb04",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/25da3505-b98b-4f47-8a51-d6405f749fdb",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b168423c26f60c468f327ae8500f8d9b-66731f6cfeba3449-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ced61067b5df8c4aa322ffd0a364890e-48840f3888aab949-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dcb5d55ed421763e54fc130cda13a865",
         "x-ms-return-client-request-id": "true"
@@ -168,19 +172,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a6c4050d-7d45-4569-9e4a-f4ac9f683b89",
+        "apim-request-id": "4e86939d-a79a-4bc1-86a3-516521e00432",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:36 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "261",
-        "x-request-id": "a6c4050d-7d45-4569-9e4a-f4ac9f683b89"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "415",
+        "X-Request-ID": "4e86939d-a79a-4bc1-86a3-516521e00432"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:37.0447321-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:46.8010775-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d3077d0ea14ff4b9ff013e74b058a62-780573f38b544946-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-11d9e210027f9e46bd12c0aac66fbe53-fb8b541ae69d1647-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cc86d0ed3b5db4d278abd5e09fbf36af",
         "x-ms-return-client-request-id": "true"
@@ -34,25 +37,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "966b0f7c-0a08-45f0-8445-f695f57ddbd4",
+        "apim-request-id": "23e518a5-3317-4f97-9b78-755ddf3a5692",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:53 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
+        "Date": "Mon, 01 Feb 2021 14:25:03 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ac8b68d-d2b4-41da-ac50-898caaa478fc",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "565",
-        "x-request-id": "966b0f7c-0a08-45f0-8445-f695f57ddbd4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "715",
+        "X-Request-ID": "23e518a5-3317-4f97-9b78-755ddf3a5692"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ac8b68d-d2b4-41da-ac50-898caaa478fc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6a9ee88489a9984584f33dab3b06640c-5729f6152899324b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-97ee36bb75973d4d8d3e88c5b842260b-3dc3f28798c30c4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dd37c2f8d89358a7dc595f533afaeeb4",
         "x-ms-return-client-request-id": "true"
@@ -60,21 +66,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "19d3bd12-2e98-4fa1-b147-182c22c6090e",
+        "apim-request-id": "f52a13ef-07d0-4561-b6f1-a2ad499368da",
         "Content-Length": "1007",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:53 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "173",
-        "x-request-id": "19d3bd12-2e98-4fa1-b147-182c22c6090e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "X-Request-ID": "f52a13ef-07d0-4561-b6f1-a2ad499368da"
       },
       "ResponseBody": {
-        "dataFeedId": "df263e11-faa9-4794-8264-976e0b352368",
+        "dataFeedId": "3ac8b68d-d2b4-41da-ac50-898caaa478fc",
         "dataFeedName": "dataFeedplZVrok1",
         "metrics": [
           {
-            "metricId": "cd03ed77-4a38-4de9-a087-1278650ab005",
+            "metricId": "4a52eca0-b438-4a6b-bb71-5d8a06d2e0b0",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -105,7 +111,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:54Z",
+        "createdTime": "2021-02-01T14:25:03Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,15 +124,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ac8b68d-d2b4-41da-ac50-898caaa478fc",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "721",
+        "Content-Length": "738",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1af5c3cbc56e9f4d9d1252b5a0665c73-109ae13a83920a41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7a31528a5b9428418fc1d038b67bc7e6-bae9d03fc9981e4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cc11a330a02db6fd49239bb4a408ed6d",
         "x-ms-return-client-request-id": "true"
@@ -154,7 +163,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -164,24 +174,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "14421398-4491-452d-b6f6-44d50630dcc4",
+        "apim-request-id": "e28f9e27-1fa4-4b81-ba3d-5d9c049cc04d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:54 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "731",
-        "x-request-id": "14421398-4491-452d-b6f6-44d50630dcc4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "656",
+        "X-Request-ID": "e28f9e27-1fa4-4b81-ba3d-5d9c049cc04d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ac8b68d-d2b4-41da-ac50-898caaa478fc",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ce639cba1e8fcb49b3c5ffbc72c0e5e0-8865b52bbdaaee48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a1549ad30eff684cbe1c4645de4a931c-818ea4f6320f0042-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fc160df146051584292eef03dc7f7a7e",
         "x-ms-return-client-request-id": "true"
@@ -189,21 +202,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c99465fc-0c22-4bf8-9fbe-66bd81cabbad",
-        "Content-Length": "1133",
+        "apim-request-id": "cd350498-9a57-4569-b92f-2639fc63a9bb",
+        "Content-Length": "1150",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:54 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "c99465fc-0c22-4bf8-9fbe-66bd81cabbad"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "194",
+        "X-Request-ID": "cd350498-9a57-4569-b92f-2639fc63a9bb"
       },
       "ResponseBody": {
-        "dataFeedId": "df263e11-faa9-4794-8264-976e0b352368",
+        "dataFeedId": "3ac8b68d-d2b4-41da-ac50-898caaa478fc",
         "dataFeedName": "dataFeedB7kjvllu",
         "metrics": [
           {
-            "metricId": "cd03ed77-4a38-4de9-a087-1278650ab005",
+            "metricId": "4a52eca0-b438-4a6b-bb71-5d8a06d2e0b0",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -229,6 +242,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -236,7 +250,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:54Z",
+        "createdTime": "2021-02-01T14:25:03Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,13 +263,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3ac8b68d-d2b4-41da-ac50-898caaa478fc",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0abc59648d17b248868fb29074451bee-2ff5301f80a3544a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-01d390f9f4caba48964ee9e1a7247ca9-54854ef5cb003e45-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fbb020bc69ad5882c580946f3cf2b4d3",
         "x-ms-return-client-request-id": "true"
@@ -263,19 +280,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "307ea4d8-c714-4519-ad6c-c1bdac0f83b8",
+        "apim-request-id": "19cf4503-0b73-4c8a-ad8b-29ee524d569e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:55 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "362",
-        "x-request-id": "307ea4d8-c714-4519-ad6c-c1bdac0f83b8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "332",
+        "X-Request-ID": "19cf4503-0b73-4c8a-ad8b-29ee524d569e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:55.2972194-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:25:04.6559268-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9df4378980b17e418d1e54493e1e880d-13a179d36b7f7b4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7d3077d0ea14ff4b9ff013e74b058a62-780573f38b544946-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0fbc272d3cbe1723edd086cc5d3bd2b4",
+        "x-ms-client-request-id": "cc86d0ed3b5db4d278abd5e09fbf36af",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,47 +34,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d2dacc5b-b47f-42a8-98cf-94aee79162e4",
+        "apim-request-id": "966b0f7c-0a08-45f0-8445-f695f57ddbd4",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:28 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+        "Date": "Mon, 01 Feb 2021 13:12:53 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "572",
-        "x-request-id": "d2dacc5b-b47f-42a8-98cf-94aee79162e4"
+        "x-envoy-upstream-service-time": "565",
+        "x-request-id": "966b0f7c-0a08-45f0-8445-f695f57ddbd4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5dad4576ced3214598c48d06f1b22fa0-2dd973652dbbfc44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6a9ee88489a9984584f33dab3b06640c-5729f6152899324b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e0d5ab78bf9faf36f8c237dd93d8a758",
+        "x-ms-client-request-id": "dd37c2f8d89358a7dc595f533afaeeb4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fe87ae4a-36f7-4326-803d-5ad2a3fa92a2",
+        "apim-request-id": "19d3bd12-2e98-4fa1-b147-182c22c6090e",
         "Content-Length": "1007",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:28 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:53 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "145",
-        "x-request-id": "fe87ae4a-36f7-4326-803d-5ad2a3fa92a2"
+        "x-envoy-upstream-service-time": "173",
+        "x-request-id": "19d3bd12-2e98-4fa1-b147-182c22c6090e"
       },
       "ResponseBody": {
-        "dataFeedId": "724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+        "dataFeedId": "df263e11-faa9-4794-8264-976e0b352368",
         "dataFeedName": "dataFeedplZVrok1",
         "metrics": [
           {
-            "metricId": "c931eb3f-61fd-40ee-9aea-8d067087004b",
+            "metricId": "cd03ed77-4a38-4de9-a087-1278650ab005",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -105,7 +105,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:28Z",
+        "createdTime": "2021-02-01T13:12:54Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,17 +118,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "721",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e71ec3955f4748498d79acd167d9a3e7-6ef1ae6075dc4147-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1af5c3cbc56e9f4d9d1252b5a0665c73-109ae13a83920a41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "535f59dcfa3ab4ee30a311cc2da0fdb6",
+        "x-ms-client-request-id": "cc11a330a02db6fd49239bb4a408ed6d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -140,10 +140,10 @@
           "query": "query"
         },
         "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeedplZVrok1",
+        "dataFeedName": "dataFeedB7kjvllu",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -164,53 +164,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a28f6798-d7be-4011-8418-ceec984fc9c0",
+        "apim-request-id": "14421398-4491-452d-b6f6-44d50630dcc4",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:29 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "644",
-        "x-request-id": "a28f6798-d7be-4011-8418-ceec984fc9c0"
+        "x-envoy-upstream-service-time": "731",
+        "x-request-id": "14421398-4491-452d-b6f6-44d50630dcc4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e82670e89b0142488c6df5cf04a0bc7c-2981e2164e82214f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ce639cba1e8fcb49b3c5ffbc72c0e5e0-8865b52bbdaaee48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "b49b234908a46dedf10d16fc05468415",
+        "x-ms-client-request-id": "fc160df146051584292eef03dc7f7a7e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4dabf14b-3a7f-4abb-bdba-36f3b4a723f7",
+        "apim-request-id": "c99465fc-0c22-4bf8-9fbe-66bd81cabbad",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:29 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "161",
-        "x-request-id": "4dabf14b-3a7f-4abb-bdba-36f3b4a723f7"
+        "x-envoy-upstream-service-time": "160",
+        "x-request-id": "c99465fc-0c22-4bf8-9fbe-66bd81cabbad"
       },
       "ResponseBody": {
-        "dataFeedId": "724bc5d3-a6ae-460b-bfa1-26a290d1af38",
-        "dataFeedName": "dataFeedplZVrok1",
+        "dataFeedId": "df263e11-faa9-4794-8264-976e0b352368",
+        "dataFeedName": "dataFeedB7kjvllu",
         "metrics": [
           {
-            "metricId": "c931eb3f-61fd-40ee-9aea-8d067087004b",
+            "metricId": "cd03ed77-4a38-4de9-a087-1278650ab005",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "InfluxDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -236,7 +236,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:28Z",
+        "createdTime": "2021-02-01T13:12:54Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,33 +249,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/724bc5d3-a6ae-460b-bfa1-26a290d1af38",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/df263e11-faa9-4794-8264-976e0b352368",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e433347f1cf25c4c9a7f788fc00ae9f8-175d37b3f650ad45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0abc59648d17b248868fb29074451bee-2ff5301f80a3544a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "03ef2e297fdc7e7abc20b0fbad698258",
+        "x-ms-client-request-id": "fbb020bc69ad5882c580946f3cf2b4d3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0273fb06-ee90-42f9-9693-0ca941bed223",
+        "apim-request-id": "307ea4d8-c714-4519-ad6c-c1bdac0f83b8",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:29 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "311",
-        "x-request-id": "0273fb06-ee90-42f9-9693-0ca941bed223"
+        "x-envoy-upstream-service-time": "362",
+        "x-request-id": "307ea4d8-c714-4519-ad6c-c1bdac0f83b8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:29.5755922-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:55.2972194-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-af30eb8c456b9743ace15d5545908777-9d42c038d513214e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e632acb7184dbd4e8dc937a5fd265bfc-e3f8a2c65dd6184f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0e7a2d4a9dbf6ec1c8c0a1ce0ad9a91e",
+        "x-ms-client-request-id": "cea1c0c8d90a1ea923108d9f3d7e0004",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,47 +37,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "cb8cb168-1dc8-4374-995c-5772a2e1f0df",
+        "apim-request-id": "6300e097-8684-4b79-b269-c7672bd3b5eb",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:08 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+        "Date": "Mon, 01 Feb 2021 13:42:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "519",
-        "x-request-id": "cb8cb168-1dc8-4374-995c-5772a2e1f0df"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "693",
+        "X-Request-ID": "6300e097-8684-4b79-b269-c7672bd3b5eb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cbabc195d48fc04b8d7e2ab251ec0b08-f31174c8ce4f184e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-50baa76c36640044b6cf0735ee317e0c-63c587f58e1e3d42-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9f8d10237e3d04001ad787fa7b59c83c",
+        "x-ms-client-request-id": "fa87d71a597b3cc88e44a535e0e56908",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d4373b2d-7c8a-46a2-9c7f-3de7d20a6138",
+        "apim-request-id": "c5b73b2e-a642-4eb4-92db-91e7dadd060e",
         "Content-Length": "1007",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:08 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "176",
-        "x-request-id": "d4373b2d-7c8a-46a2-9c7f-3de7d20a6138"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "202",
+        "X-Request-ID": "c5b73b2e-a642-4eb4-92db-91e7dadd060e"
       },
       "ResponseBody": {
-        "dataFeedId": "46dd08e9-574c-439e-99d0-ae3292011143",
+        "dataFeedId": "d673eea5-ef9c-476d-9129-aa168b225d77",
         "dataFeedName": "dataFeedYBU4mzwj",
         "metrics": [
           {
-            "metricId": "09c9656b-6cf6-49a4-975a-08b0697a6082",
+            "metricId": "8c858f89-67f1-455f-86d6-2aa13244b334",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -105,7 +111,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:09Z",
+        "createdTime": "2021-02-01T13:42:47Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,17 +124,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "721",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ab283b127f75fd49b91c56b24cad02ca-3e9506398e0f4f4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-789e9d508163694bbff1d05e258d9512-fcdf2347710a334c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "35a5448ee5e00869bb68566c8eb9fec9",
+        "x-ms-client-request-id": "6c5668bbb98ec9fe6727822b243208cb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -140,10 +149,10 @@
           "query": "query"
         },
         "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeedYBU4mzwj",
+        "dataFeedName": "dataFeedKYH7ogWy",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -164,53 +173,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b6412c3f-1f5d-44a9-9a93-1ee633160623",
+        "apim-request-id": "dcbacdfc-f8b5-427e-8c9b-f5033993a2f3",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:09 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "683",
-        "x-request-id": "b6412c3f-1f5d-44a9-9a93-1ee633160623"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "847",
+        "X-Request-ID": "dcbacdfc-f8b5-427e-8c9b-f5033993a2f3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7d13fdc823ff7498647e3b661f67bee-b6bf25e7f71a7247-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f196c69536458f499542adf8d23c5267-77b2664ec720a243-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2b8227673224cb082c75f4e716c6f36f",
+        "x-ms-client-request-id": "e7f4752cc6166ff3f86440c534743d3e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5a64bb8b-472d-44e8-a0f6-0bfeb0565817",
+        "apim-request-id": "3994fcf5-011e-46c3-86fe-2be631570faa",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:09 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "5a64bb8b-472d-44e8-a0f6-0bfeb0565817"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1237",
+        "X-Request-ID": "3994fcf5-011e-46c3-86fe-2be631570faa"
       },
       "ResponseBody": {
-        "dataFeedId": "46dd08e9-574c-439e-99d0-ae3292011143",
-        "dataFeedName": "dataFeedYBU4mzwj",
+        "dataFeedId": "d673eea5-ef9c-476d-9129-aa168b225d77",
+        "dataFeedName": "dataFeedKYH7ogWy",
         "metrics": [
           {
-            "metricId": "09c9656b-6cf6-49a4-975a-08b0697a6082",
+            "metricId": "8c858f89-67f1-455f-86d6-2aa13244b334",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "InfluxDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -236,7 +248,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:09Z",
+        "createdTime": "2021-02-01T13:42:47Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,33 +261,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/46dd08e9-574c-439e-99d0-ae3292011143",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cfa8c2cefb07d64cb87a06aa31b75e4a-829041c3ca896f4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-29fb97b82357444198597d20f168d702-fed2c9f7e252e549-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c54064f874343e3da785e4d427947560",
+        "x-ms-client-request-id": "d4e485a794276075d8be9354d69d175b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d0edea10-1070-4dc6-aeff-d5372fb1f28b",
+        "apim-request-id": "9e217655-db4f-453a-b993-d73485e871e7",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:09 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "297",
-        "x-request-id": "d0edea10-1070-4dc6-aeff-d5372fb1f28b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "380",
+        "X-Request-ID": "9e217655-db4f-453a-b993-d73485e871e7"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:10.3099084-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:50.4687082-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e632acb7184dbd4e8dc937a5fd265bfc-e3f8a2c65dd6184f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c92b3e06b9fcc3458d544781053edfaa-fc9798486103dc46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cea1c0c8d90a1ea923108d9f3d7e0004",
         "x-ms-return-client-request-id": "true"
@@ -37,28 +34,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6300e097-8684-4b79-b269-c7672bd3b5eb",
+        "apim-request-id": "aff11f31-dc60-4def-834c-c7db72c6866c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:47 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
+        "Date": "Mon, 01 Feb 2021 15:41:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b506be88-0866-4e2d-bc9f-24ccc2f8b64f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "693",
-        "X-Request-ID": "6300e097-8684-4b79-b269-c7672bd3b5eb"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "329",
+        "x-request-id": "aff11f31-dc60-4def-834c-c7db72c6866c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b506be88-0866-4e2d-bc9f-24ccc2f8b64f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-50baa76c36640044b6cf0735ee317e0c-63c587f58e1e3d42-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-6de392849e55a349a1d945ba42d6f387-ed35e1ba1672cf48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fa87d71a597b3cc88e44a535e0e56908",
         "x-ms-return-client-request-id": "true"
@@ -66,21 +60,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c5b73b2e-a642-4eb4-92db-91e7dadd060e",
+        "apim-request-id": "245e3ad3-1fc8-4134-81f4-0f654755a991",
         "Content-Length": "1007",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:47 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "202",
-        "X-Request-ID": "c5b73b2e-a642-4eb4-92db-91e7dadd060e"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "140",
+        "x-request-id": "245e3ad3-1fc8-4134-81f4-0f654755a991"
       },
       "ResponseBody": {
-        "dataFeedId": "d673eea5-ef9c-476d-9129-aa168b225d77",
+        "dataFeedId": "b506be88-0866-4e2d-bc9f-24ccc2f8b64f",
         "dataFeedName": "dataFeedYBU4mzwj",
         "metrics": [
           {
-            "metricId": "8c858f89-67f1-455f-86d6-2aa13244b334",
+            "metricId": "98a16010-0f7f-4e58-b1ac-8101cc8f1b50",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -111,7 +105,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:47Z",
+        "createdTime": "2021-02-01T15:41:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -124,18 +118,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b506be88-0866-4e2d-bc9f-24ccc2f8b64f",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "721",
+        "Content-Length": "738",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-789e9d508163694bbff1d05e258d9512-fcdf2347710a334c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-8cfa380fa03187409e7c300d15b08c2b-6f4b5f272604ef4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6c5668bbb98ec9fe6727822b243208cb",
         "x-ms-return-client-request-id": "true"
@@ -163,7 +154,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -173,27 +165,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "dcbacdfc-f8b5-427e-8c9b-f5033993a2f3",
+        "apim-request-id": "94bf2b86-1e57-41c4-98b3-a9cca77840d4",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:48 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "847",
-        "X-Request-ID": "dcbacdfc-f8b5-427e-8c9b-f5033993a2f3"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "628",
+        "x-request-id": "94bf2b86-1e57-41c4-98b3-a9cca77840d4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b506be88-0866-4e2d-bc9f-24ccc2f8b64f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f196c69536458f499542adf8d23c5267-77b2664ec720a243-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-3c76074958fceb43b9a65d9583622351-8c76754fc84eb844-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e7f4752cc6166ff3f86440c534743d3e",
         "x-ms-return-client-request-id": "true"
@@ -201,21 +190,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3994fcf5-011e-46c3-86fe-2be631570faa",
-        "Content-Length": "1133",
+        "apim-request-id": "16fe6d56-e5cc-494e-a30b-17482bf056d2",
+        "Content-Length": "1150",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:49 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1237",
-        "X-Request-ID": "3994fcf5-011e-46c3-86fe-2be631570faa"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "16fe6d56-e5cc-494e-a30b-17482bf056d2"
       },
       "ResponseBody": {
-        "dataFeedId": "d673eea5-ef9c-476d-9129-aa168b225d77",
+        "dataFeedId": "b506be88-0866-4e2d-bc9f-24ccc2f8b64f",
         "dataFeedName": "dataFeedKYH7ogWy",
         "metrics": [
           {
-            "metricId": "8c858f89-67f1-455f-86d6-2aa13244b334",
+            "metricId": "98a16010-0f7f-4e58-b1ac-8101cc8f1b50",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -241,6 +230,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -248,7 +238,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:47Z",
+        "createdTime": "2021-02-01T15:41:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -261,16 +251,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d673eea5-ef9c-476d-9129-aa168b225d77",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b506be88-0866-4e2d-bc9f-24ccc2f8b64f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-29fb97b82357444198597d20f168d702-fed2c9f7e252e549-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ea9d666244968c48947cc778cebb431f-25ff89aba183c743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d4e485a794276075d8be9354d69d175b",
         "x-ms-return-client-request-id": "true"
@@ -278,19 +265,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9e217655-db4f-453a-b993-d73485e871e7",
+        "apim-request-id": "26b309d1-b083-4af4-95ee-530d07f451ac",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:50 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "380",
-        "X-Request-ID": "9e217655-db4f-453a-b993-d73485e871e7"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "366",
+        "x-request-id": "26b309d1-b083-4af4-95ee-530d07f451ac"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:50.4687082-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:22.8582428-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a6679b125d5b6741bc91f8bcaafb1b4a-447c3634a7b5404f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-aac649a9945a1047a8f55651eb431c62-525f136c0c828843-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6c901ffed2ae9408f721c35702019077",
         "x-ms-return-client-request-id": "true"
@@ -34,33 +37,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8159ea03-8fa7-40d5-8d0b-49a59a59d396",
+        "apim-request-id": "71712dd8-6447-48ff-ae32-759432926f67",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
+        "Date": "Mon, 01 Feb 2021 15:52:40 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40042025-2302-4238-a973-bd9317658031",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "426",
-        "x-request-id": "8159ea03-8fa7-40d5-8d0b-49a59a59d396"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "392",
+        "X-Request-ID": "71712dd8-6447-48ff-ae32-759432926f67"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40042025-2302-4238-a973-bd9317658031",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-da503403ce46da43a2f4019fc095128b-246bd59bf7af6949-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3dc3ec5a40eaba459701d6f2b2afe9b4-0c43fba8a48db042-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c1580e90dd6eec025c302bcd6d67733a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeed8Xxdg75m",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -78,24 +84,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "12f6e4a7-49f1-4bd9-a0fc-687b3d4f4115",
+        "apim-request-id": "0ae3ea41-fa23-44ff-a376-5802090e18c7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "197",
-        "x-request-id": "12f6e4a7-49f1-4bd9-a0fc-687b3d4f4115"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "165",
+        "X-Request-ID": "0ae3ea41-fa23-44ff-a376-5802090e18c7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40042025-2302-4238-a973-bd9317658031",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fa0c507e244c5048a25435ed79be0c57-e7b2f0e51df1474e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bfaa6845eebd224a917e5f0b24e322ac-5302d762093a7949-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fc95bd3f2b8b86916582a6872cd4ee42",
         "x-ms-return-client-request-id": "true"
@@ -103,21 +112,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a6b213ca-c013-4feb-8119-c5c34d615416",
+        "apim-request-id": "2130f175-de33-4d20-9db8-36979cb5cfa1",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "148",
-        "x-request-id": "a6b213ca-c013-4feb-8119-c5c34d615416"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "153",
+        "X-Request-ID": "2130f175-de33-4d20-9db8-36979cb5cfa1"
       },
       "ResponseBody": {
-        "dataFeedId": "10a50439-03af-4cb2-9c57-1f6c713de453",
+        "dataFeedId": "40042025-2302-4238-a973-bd9317658031",
         "dataFeedName": "dataFeed8Xxdg75m",
         "metrics": [
           {
-            "metricId": "bf792f38-f9e6-4658-92cc-c8228d274a12",
+            "metricId": "bc28943c-be55-4a4b-b28f-8410bcd72fe2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -150,7 +159,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:37Z",
+        "createdTime": "2021-02-01T15:52:39Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -163,13 +172,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/40042025-2302-4238-a973-bd9317658031",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b1a544207efe85499281ee5e833f5403-465af56748794443-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3fa474a9c305544890b0e5db495d162c-67c4eeafa5f9d74f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "acba9dc3370321e11da30f7ea63b2790",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +189,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "95d2f648-fb92-4739-87f9-286d59fb49d8",
+        "apim-request-id": "284d1efc-7374-45f2-b938-f713b66fefb0",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "310",
-        "x-request-id": "95d2f648-fb92-4739-87f9-286d59fb49d8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "302",
+        "X-Request-ID": "284d1efc-7374-45f2-b938-f713b66fefb0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:38.3226407-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:40.4541793-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-db0451042d2a254abc39fd8f686d5f1a-4940707104631d4b-00",
+        "traceparent": "00-a6679b125d5b6741bc91f8bcaafb1b4a-447c3634a7b5404f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "83e6ce979c312a3f949fe3c21d2a43a8",
+        "x-ms-client-request-id": "6c901ffed2ae9408f721c35702019077",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -23,7 +23,7 @@
           "query": "query"
         },
         "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeed5eWbcxab",
+        "dataFeedName": "dataFeeddyIvZPRR",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -34,41 +34,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "fb73747b-ac90-4694-8a64-a2660edd3480",
+        "apim-request-id": "8159ea03-8fa7-40d5-8d0b-49a59a59d396",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
+        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "595",
-        "x-request-id": "fb73747b-ac90-4694-8a64-a2660edd3480"
+        "x-envoy-upstream-service-time": "426",
+        "x-request-id": "8159ea03-8fa7-40d5-8d0b-49a59a59d396"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "609",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2ed34d1aa0da184dbf1e6f6ec1eea73d-2edb77bb2f128745-00",
+        "traceparent": "00-da503403ce46da43a2f4019fc095128b-246bd59bf7af6949-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1364e549c5837ac4b0291fe3d108deae",
+        "x-ms-client-request-id": "c1580e90dd6eec025c302bcd6d67733a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "userName": "username",
-          "password": "pass",
-          "query": "query"
-        },
-        "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeedWKEyHEUR",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeed8Xxdg75m",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -85,46 +78,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8c3ea3c9-854c-4a83-bb92-c17595e04192",
+        "apim-request-id": "12f6e4a7-49f1-4bd9-a0fc-687b3d4f4115",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "668",
-        "x-request-id": "8c3ea3c9-854c-4a83-bb92-c17595e04192"
+        "x-envoy-upstream-service-time": "197",
+        "x-request-id": "12f6e4a7-49f1-4bd9-a0fc-687b3d4f4115"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2e611adb81d28142b75c9073ca7ae72d-7f49974c9fb80e44-00",
+        "traceparent": "00-fa0c507e244c5048a25435ed79be0c57-e7b2f0e51df1474e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "51f237525eff7761968b25a0c8655b3f",
+        "x-ms-client-request-id": "fc95bd3f2b8b86916582a6872cd4ee42",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4c6c3cf6-f075-44e7-a307-f060926f9f28",
+        "apim-request-id": "a6b213ca-c013-4feb-8119-c5c34d615416",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "199",
-        "x-request-id": "4c6c3cf6-f075-44e7-a307-f060926f9f28"
+        "x-envoy-upstream-service-time": "148",
+        "x-request-id": "a6b213ca-c013-4feb-8119-c5c34d615416"
       },
       "ResponseBody": {
-        "dataFeedId": "de9811f2-292e-4f23-8300-45a6a3fd2658",
-        "dataFeedName": "dataFeedWKEyHEUR",
+        "dataFeedId": "10a50439-03af-4cb2-9c57-1f6c713de453",
+        "dataFeedName": "dataFeed8Xxdg75m",
         "metrics": [
           {
-            "metricId": "46d511c8-95f8-49cb-813b-179faf90bfee",
+            "metricId": "bf792f38-f9e6-4658-92cc-c8228d274a12",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -157,7 +150,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:56Z",
+        "createdTime": "2021-02-01T15:45:37Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,37 +163,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/10a50439-03af-4cb2-9c57-1f6c713de453",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-76d8d0dacdd5ca48a2eca6cbb244d6a8-0a963401671a344c-00",
+        "traceparent": "00-b1a544207efe85499281ee5e833f5403-465af56748794443-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5433e9b92017d19e0a6bd3077d5c598c",
+        "x-ms-client-request-id": "acba9dc3370321e11da30f7ea63b2790",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "44191204-fa11-4232-ad7a-39bddb621e25",
+        "apim-request-id": "95d2f648-fb92-4739-87f9-286d59fb49d8",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "294",
-        "x-request-id": "44191204-fa11-4232-ad7a-39bddb621e25"
+        "x-envoy-upstream-service-time": "310",
+        "x-request-id": "95d2f648-fb92-4739-87f9-286d59fb49d8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:57.2238378-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:38.3226407-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "442899400"
+    "RandomSeed": "1429649323"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a64003231e99274e92787fca2ca2137a-1181506615a61840-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-db0451042d2a254abc39fd8f686d5f1a-4940707104631d4b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7c92fd6a7c39223397cee683319c3f2a",
+        "x-ms-client-request-id": "83e6ce979c312a3f949fe3c21d2a43a8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,29 +34,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "2d353b6b-eddd-4464-97e9-a18523a4a4f3",
+        "apim-request-id": "fb73747b-ac90-4694-8a64-a2660edd3480",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:30 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+        "Date": "Mon, 01 Feb 2021 13:12:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "557",
-        "x-request-id": "2d353b6b-eddd-4464-97e9-a18523a4a4f3"
+        "x-envoy-upstream-service-time": "595",
+        "x-request-id": "fb73747b-ac90-4694-8a64-a2660edd3480"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "609",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-48cadb117149554aad5779745890164b-53e148c6c7cc464a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2ed34d1aa0da184dbf1e6f6ec1eea73d-2edb77bb2f128745-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c2e39f942a1da84349e5641383c5c47a",
+        "x-ms-client-request-id": "1364e549c5837ac4b0291fe3d108deae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -68,10 +68,10 @@
           "query": "query"
         },
         "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeed5eWbcxab",
+        "dataFeedName": "dataFeedWKEyHEUR",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -85,53 +85,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c0bfda5e-53a5-4b79-a4ce-b353953660cd",
+        "apim-request-id": "8c3ea3c9-854c-4a83-bb92-c17595e04192",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:31 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "672",
-        "x-request-id": "c0bfda5e-53a5-4b79-a4ce-b353953660cd"
+        "x-envoy-upstream-service-time": "668",
+        "x-request-id": "8c3ea3c9-854c-4a83-bb92-c17595e04192"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c7f797bf19859047b5dfce5177b9a541-b26f9c81a514774f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2e611adb81d28142b75c9073ca7ae72d-7f49974c9fb80e44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e31f29b008d1aede5237f251ff5e6177",
+        "x-ms-client-request-id": "51f237525eff7761968b25a0c8655b3f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "10f661f5-4620-4d9e-b9ca-7e99dd08891d",
+        "apim-request-id": "4c6c3cf6-f075-44e7-a307-f060926f9f28",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:31 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "138",
-        "x-request-id": "10f661f5-4620-4d9e-b9ca-7e99dd08891d"
+        "x-envoy-upstream-service-time": "199",
+        "x-request-id": "4c6c3cf6-f075-44e7-a307-f060926f9f28"
       },
       "ResponseBody": {
-        "dataFeedId": "4e357182-011e-4373-b9f8-f9daa9632d54",
-        "dataFeedName": "dataFeed5eWbcxab",
+        "dataFeedId": "de9811f2-292e-4f23-8300-45a6a3fd2658",
+        "dataFeedName": "dataFeedWKEyHEUR",
         "metrics": [
           {
-            "metricId": "ac7c301b-1cf4-4e62-a9a4-c732bfd6a16f",
+            "metricId": "46d511c8-95f8-49cb-813b-179faf90bfee",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "InfluxDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -157,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:30Z",
+        "createdTime": "2021-02-01T13:12:56Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,33 +170,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e357182-011e-4373-b9f8-f9daa9632d54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/de9811f2-292e-4f23-8300-45a6a3fd2658",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e5f1d4142be8814696e224168361514d-0c3d2f477eff714c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-76d8d0dacdd5ca48a2eca6cbb244d6a8-0a963401671a344c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a0258b9665c83f5bb9e9335417209ed1",
+        "x-ms-client-request-id": "5433e9b92017d19e0a6bd3077d5c598c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5ecd766d-56bc-4690-beea-9d964b9e263b",
+        "apim-request-id": "44191204-fa11-4232-ad7a-39bddb621e25",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:31 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "300",
-        "x-request-id": "5ecd766d-56bc-4690-beea-9d964b9e263b"
+        "x-envoy-upstream-service-time": "294",
+        "x-request-id": "44191204-fa11-4232-ad7a-39bddb621e25"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:31.4126660-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:57.2238378-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-541ac8dd759296439acb55255035a784-c610526f22d3284d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7f76abf138886141b24bc26d94997006-e5178af22763874d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fc318f4f43ae3c287d33af00ca22881f",
         "x-ms-return-client-request-id": "true"
@@ -34,33 +37,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "da33e1a7-342b-4b44-82d1-c2624cca8d07",
+        "apim-request-id": "69ee365e-4066-47b5-9490-63249f110404",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
+        "Date": "Mon, 01 Feb 2021 15:53:11 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8f610b5b-315c-4330-8424-5dcd8a064021",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "417",
-        "x-request-id": "da33e1a7-342b-4b44-82d1-c2624cca8d07"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "405",
+        "X-Request-ID": "69ee365e-4066-47b5-9490-63249f110404"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8f610b5b-315c-4330-8424-5dcd8a064021",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-97a7c2f3dd31c8448e117f5626293c62-091549d529e54f4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-90f58eace79fd741b129c94d8a2dae8d-df5ce4aade539646-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "67dd6413ecd9af5ec8bffd6b266cb10c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeeddFXIhuLo",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -78,24 +84,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0457a6f2-0faf-4002-853a-736ae196943a",
+        "apim-request-id": "64a68c50-97ca-4c6b-bc71-1a722d3439a2",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "x-request-id": "0457a6f2-0faf-4002-853a-736ae196943a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "175",
+        "X-Request-ID": "64a68c50-97ca-4c6b-bc71-1a722d3439a2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8f610b5b-315c-4330-8424-5dcd8a064021",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-52909400d2e1ad4e8247ac5370d3cfbe-5c95984d234b0b45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4b8cfa59b25c8149a3d4b80e63bf0c0b-c988f506eb44ef4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1db287858da4d46beaafac095b3dbe14",
         "x-ms-return-client-request-id": "true"
@@ -103,21 +112,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c726519d-f67d-4db7-976f-c3f1ae6a9bff",
+        "apim-request-id": "1858c560-e0dc-4438-8be0-00558ec95740",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "c726519d-f67d-4db7-976f-c3f1ae6a9bff"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "151",
+        "X-Request-ID": "1858c560-e0dc-4438-8be0-00558ec95740"
       },
       "ResponseBody": {
-        "dataFeedId": "2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
+        "dataFeedId": "8f610b5b-315c-4330-8424-5dcd8a064021",
         "dataFeedName": "dataFeeddFXIhuLo",
         "metrics": [
           {
-            "metricId": "4fe3cc58-cce2-4bbf-8342-7a3751d8e00d",
+            "metricId": "2ee09729-5d98-4d3a-9848-dd5ea764c039",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -150,7 +159,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:23Z",
+        "createdTime": "2021-02-01T15:53:11Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -163,13 +172,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8f610b5b-315c-4330-8424-5dcd8a064021",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-78e23d7bd150d54f9c93113d5719b76f-70c05043f5d40545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c305082942d0f741871e8444654a587c-5c6772ea8a3dcc45-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f58fc92a245d62c4308133ef46bd1610",
         "x-ms-return-client-request-id": "true"
@@ -177,19 +189,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b154dcee-606b-4526-8817-18925b4af058",
+        "apim-request-id": "7dec3935-ec68-4c16-b8b1-3cb11fd6c487",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "340",
-        "x-request-id": "b154dcee-606b-4526-8817-18925b4af058"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "298",
+        "X-Request-ID": "7dec3935-ec68-4c16-b8b1-3cb11fd6c487"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:24.1244927-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:12.0282935-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-61f25fb37c9f834b833daa0039b6ee86-f767af09be6f3b4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-58fe70f0573fd54c89adba93945fb0e6-3925a0960875564d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a3e9b3373b599d8c4f8f31fcae43283c",
+        "x-ms-client-request-id": "fc318f4f43ae3c287d33af00ca22881f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -34,29 +37,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "bcea8290-7599-49f9-a490-bc00c0f6335c",
+        "apim-request-id": "49ae75e2-a148-4865-a7ae-b82ad2e8b1a4",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:10 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+        "Date": "Mon, 01 Feb 2021 13:42:51 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "536",
-        "x-request-id": "bcea8290-7599-49f9-a490-bc00c0f6335c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1831",
+        "X-Request-ID": "49ae75e2-a148-4865-a7ae-b82ad2e8b1a4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "609",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9ce79c57b6638a48a30fbbec99a0529c-57fd0dcbdbdd9c47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7f282a99a2fae64eb5e2bad16eedf604-d299dd4f6b2f064d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "00af337d22ca1f881364dd67d9ec5eaf",
+        "x-ms-client-request-id": "67dd6413ecd9af5ec8bffd6b266cb10c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -68,10 +74,10 @@
           "query": "query"
         },
         "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeedNbRJf0tc",
+        "dataFeedName": "dataFeeddFXIhuLo",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -85,53 +91,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "420143d3-e9b3-4893-982a-1bcaa4c25ab1",
+        "apim-request-id": "360ebb3c-6ebe-450d-a1e6-825a767cd146",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:11 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:52 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "615",
-        "x-request-id": "420143d3-e9b3-4893-982a-1bcaa4c25ab1"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "981",
+        "X-Request-ID": "360ebb3c-6ebe-450d-a1e6-825a767cd146"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e9144ae825a54347a2c01dfdf81c5cbc-7b77399b765d0643-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-526972134a99a84cb95fd8f649189fad-b4b6bf569ae59e4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6bfdbfc86c260cb18587b21da48d6bd4",
+        "x-ms-client-request-id": "1db287858da4d46beaafac095b3dbe14",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e52c5577-dfa2-4993-9820-b700a3beedab",
+        "apim-request-id": "abdcf341-4f4e-4434-b806-622f552ea65c",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:11 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "143",
-        "x-request-id": "e52c5577-dfa2-4993-9820-b700a3beedab"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "588",
+        "X-Request-ID": "abdcf341-4f4e-4434-b806-622f552ea65c"
       },
       "ResponseBody": {
-        "dataFeedId": "bc7ee08b-96be-44ee-a265-d58d24c9cdec",
-        "dataFeedName": "dataFeedNbRJf0tc",
+        "dataFeedId": "33dae1db-ff29-4e32-9398-e80fd3c43cf7",
+        "dataFeedName": "dataFeeddFXIhuLo",
         "metrics": [
           {
-            "metricId": "db5a897b-aa54-47b2-8288-5c653cd94c58",
+            "metricId": "4b4577ae-49a3-4ffe-ac1f-32bd344e7308",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "InfluxDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -157,7 +166,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:11Z",
+        "createdTime": "2021-02-01T13:42:52Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,33 +179,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/bc7ee08b-96be-44ee-a265-d58d24c9cdec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5c6249e6c6c2fe47994355ffadee7330-9430d521caa7db49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8011ecb9e2afaf49a084b82332d4b047-6a0a276817c3c642-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "09acafea3d5b14be2ac98ff55d24c462",
+        "x-ms-client-request-id": "f58fc92a245d62c4308133ef46bd1610",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "af1dcecf-2a7c-4b39-adaa-a0908d410e4e",
+        "apim-request-id": "c5f30e8f-ae37-4db1-97c3-ee2c6c390a6e",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:11 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "293",
-        "x-request-id": "af1dcecf-2a7c-4b39-adaa-a0908d410e4e"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "686",
+        "X-Request-ID": "c5f30e8f-ae37-4db1-97c3-ee2c6c390a6e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:12.0551167-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:54.4887584-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-58fe70f0573fd54c89adba93945fb0e6-3925a0960875564d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-541ac8dd759296439acb55255035a784-c610526f22d3284d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fc318f4f43ae3c287d33af00ca22881f",
         "x-ms-return-client-request-id": "true"
@@ -37,43 +34,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "49ae75e2-a148-4865-a7ae-b82ad2e8b1a4",
+        "apim-request-id": "da33e1a7-342b-4b44-82d1-c2624cca8d07",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:51 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
+        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1831",
-        "X-Request-ID": "49ae75e2-a148-4865-a7ae-b82ad2e8b1a4"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "417",
+        "x-request-id": "da33e1a7-342b-4b44-82d1-c2624cca8d07"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "609",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7f282a99a2fae64eb5e2bad16eedf604-d299dd4f6b2f064d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-97a7c2f3dd31c8448e117f5626293c62-091549d529e54f4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "67dd6413ecd9af5ec8bffd6b266cb10c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "userName": "username",
-          "password": "pass",
-          "query": "query"
-        },
-        "dataSourceType": "InfluxDB",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeeddFXIhuLo",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -91,27 +78,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "360ebb3c-6ebe-450d-a1e6-825a767cd146",
+        "apim-request-id": "0457a6f2-0faf-4002-853a-736ae196943a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:52 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "981",
-        "X-Request-ID": "360ebb3c-6ebe-450d-a1e6-825a767cd146"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "191",
+        "x-request-id": "0457a6f2-0faf-4002-853a-736ae196943a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-526972134a99a84cb95fd8f649189fad-b4b6bf569ae59e4c-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-52909400d2e1ad4e8247ac5370d3cfbe-5c95984d234b0b45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1db287858da4d46beaafac095b3dbe14",
         "x-ms-return-client-request-id": "true"
@@ -119,21 +103,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "abdcf341-4f4e-4434-b806-622f552ea65c",
+        "apim-request-id": "c726519d-f67d-4db7-976f-c3f1ae6a9bff",
         "Content-Length": "1133",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:54 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "588",
-        "X-Request-ID": "abdcf341-4f4e-4434-b806-622f552ea65c"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "x-request-id": "c726519d-f67d-4db7-976f-c3f1ae6a9bff"
       },
       "ResponseBody": {
-        "dataFeedId": "33dae1db-ff29-4e32-9398-e80fd3c43cf7",
+        "dataFeedId": "2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
         "dataFeedName": "dataFeeddFXIhuLo",
         "metrics": [
           {
-            "metricId": "4b4577ae-49a3-4ffe-ac1f-32bd344e7308",
+            "metricId": "4fe3cc58-cce2-4bbf-8342-7a3751d8e00d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -166,7 +150,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:52Z",
+        "createdTime": "2021-02-01T15:41:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -179,16 +163,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33dae1db-ff29-4e32-9398-e80fd3c43cf7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2f986bdc-78ea-4f22-84eb-d3a817f15fb9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8011ecb9e2afaf49a084b82332d4b047-6a0a276817c3c642-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-78e23d7bd150d54f9c93113d5719b76f-70c05043f5d40545-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f58fc92a245d62c4308133ef46bd1610",
         "x-ms-return-client-request-id": "true"
@@ -196,19 +177,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c5f30e8f-ae37-4db1-97c3-ee2c6c390a6e",
+        "apim-request-id": "b154dcee-606b-4526-8817-18925b4af058",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:55 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "686",
-        "X-Request-ID": "c5f30e8f-ae37-4db1-97c3-ee2c6c390a6e"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "340",
+        "x-request-id": "b154dcee-606b-4526-8817-18925b4af058"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:54.4887584-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:24.1244927-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-55ab23aaaf691044a4733364a23a6f25-1ba5599da88ce44a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b50c3ea20eefa3448837724c35c00877-3fe537bee8e3f143-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a55b8c8a98c732da480fc1dce375b6a",
         "x-ms-return-client-request-id": "true"
@@ -34,55 +37,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "48f70ee1-5ad1-4a79-8040-ba91bf240e52",
+        "apim-request-id": "652f0b3e-2685-4fae-9dbd-227816179be7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:37 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
+        "Date": "Mon, 01 Feb 2021 15:52:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/261efc29-cab4-481a-8e23-f35ddd7094d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "410",
-        "x-request-id": "48f70ee1-5ad1-4a79-8040-ba91bf240e52"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "453",
+        "X-Request-ID": "652f0b3e-2685-4fae-9dbd-227816179be7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/261efc29-cab4-481a-8e23-f35ddd7094d4",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2802164e5806ae4ea1930cb8e90bb847-1e9b72b82fb71243-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-65678d6fd400354a821623027311760b-9c2b79966832a644-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "63a76b9b716f64370b51d3d8cd2ba36d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5538b8e5-6ef7-4bc5-a69b-9d8545e34015",
+        "apim-request-id": "7d882817-3e49-4348-a25d-5e4080d906f9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "161",
-        "x-request-id": "5538b8e5-6ef7-4bc5-a69b-9d8545e34015"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "X-Request-ID": "7d882817-3e49-4348-a25d-5e4080d906f9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/261efc29-cab4-481a-8e23-f35ddd7094d4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c76bb81ebe235a479981d16da2a990f3-43c5265f2781d143-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-58747fa3879c094787806b1132f7c355-2ef58857d7f6464c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5af30981dc3dfa8eaf71d34d2850a5f0",
         "x-ms-return-client-request-id": "true"
@@ -90,21 +99,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4f95e760-2b2a-466e-8f70-c96dc9af30ad",
+        "apim-request-id": "3466f91b-11b7-45f3-95ff-4aaaaa68cdfc",
         "Content-Length": "1058",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:37 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "172",
-        "x-request-id": "4f95e760-2b2a-466e-8f70-c96dc9af30ad"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "X-Request-ID": "3466f91b-11b7-45f3-95ff-4aaaaa68cdfc"
       },
       "ResponseBody": {
-        "dataFeedId": "49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
+        "dataFeedId": "261efc29-cab4-481a-8e23-f35ddd7094d4",
         "dataFeedName": "dataFeedjJtUDzwV",
         "metrics": [
           {
-            "metricId": "b967aa38-25e9-4ae4-9eac-f4a14a024929",
+            "metricId": "b72ce390-4d54-4553-8226-b0a1ac006143",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -135,7 +144,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:37Z",
+        "createdTime": "2021-02-01T15:52:41Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +157,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/261efc29-cab4-481a-8e23-f35ddd7094d4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-00ff29bdaf12844c8a0728e0d117868c-1f64630a933d8641-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8e691d479004884a8ad1ae4389aee469-ff86b1111c3b9045-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6090e0a6a643565681f0ff3ad654a578",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +174,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7b5b43a1-f8a9-4626-af44-3840a90328ec",
+        "apim-request-id": "bbc7b968-6ec7-4310-a397-629569a2d513",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "367",
-        "x-request-id": "7b5b43a1-f8a9-4626-af44-3840a90328ec"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "307",
+        "X-Request-ID": "bbc7b968-6ec7-4310-a397-629569a2d513"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:37.8936880-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:41.6101130-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5efe4cdf20fa5849806fbadb8bf88b39-d7e4c5112810da41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-55ab23aaaf691044a4733364a23a6f25-1ba5599da88ce44a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a55b8c8a98c732da480fc1dce375b6a",
         "x-ms-return-client-request-id": "true"
@@ -34,64 +34,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b9059ac6-3cb9-467c-9135-8bbfee32c434",
+        "apim-request-id": "48f70ee1-5ad1-4a79-8040-ba91bf240e52",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1c17a85-6a4e-44b3-83ad-a5afa4ad9659",
+        "Date": "Mon, 01 Feb 2021 12:46:37 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "370",
-        "x-request-id": "b9059ac6-3cb9-467c-9135-8bbfee32c434"
+        "x-envoy-upstream-service-time": "410",
+        "x-request-id": "48f70ee1-5ad1-4a79-8040-ba91bf240e52"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1c17a85-6a4e-44b3-83ad-a5afa4ad9659",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "311",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2637e3147be3c942b5ca92d9535e4419-20d18236dcf2374a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2802164e5806ae4ea1930cb8e90bb847-1e9b72b82fb71243-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "63a76b9b716f64370b51d3d8cd2ba36d",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "userName": "username",
-          "password": "pass",
-          "query": "query"
-        },
-        "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeedjJtUDzwV",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3e4e35a7-c2ad-4105-ad7b-32a062860369",
+        "apim-request-id": "5538b8e5-6ef7-4bc5-a69b-9d8545e34015",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:28 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "468",
-        "x-request-id": "3e4e35a7-c2ad-4105-ad7b-32a062860369"
+        "x-envoy-upstream-service-time": "161",
+        "x-request-id": "5538b8e5-6ef7-4bc5-a69b-9d8545e34015"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1c17a85-6a4e-44b3-83ad-a5afa4ad9659",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-519e621455a2804fb0ca4a2f42201d3a-fd395b15247a5744-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c76bb81ebe235a479981d16da2a990f3-43c5265f2781d143-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5af30981dc3dfa8eaf71d34d2850a5f0",
         "x-ms-return-client-request-id": "true"
@@ -99,21 +90,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "64de5c52-694b-4cfe-b9b2-6594dec219a7",
+        "apim-request-id": "4f95e760-2b2a-466e-8f70-c96dc9af30ad",
         "Content-Length": "1058",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:28 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:37 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "64de5c52-694b-4cfe-b9b2-6594dec219a7"
+        "x-envoy-upstream-service-time": "172",
+        "x-request-id": "4f95e760-2b2a-466e-8f70-c96dc9af30ad"
       },
       "ResponseBody": {
-        "dataFeedId": "e1c17a85-6a4e-44b3-83ad-a5afa4ad9659",
+        "dataFeedId": "49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
         "dataFeedName": "dataFeedjJtUDzwV",
         "metrics": [
           {
-            "metricId": "515b7d0b-77a1-4598-82ae-c68602a72117",
+            "metricId": "b967aa38-25e9-4ae4-9eac-f4a14a024929",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -144,7 +135,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:27Z",
+        "createdTime": "2021-02-01T12:46:37Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -157,13 +148,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1c17a85-6a4e-44b3-83ad-a5afa4ad9659",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/49f7aa0a-38d1-4e50-9c8e-5e735dd21091",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ebc998a472d8654da468737b2ca8e0ae-e69448d2f1680749-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-00ff29bdaf12844c8a0728e0d117868c-1f64630a933d8641-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6090e0a6a643565681f0ff3ad654a578",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +162,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2800c085-8ed0-4c02-9471-ef1879c23f10",
+        "apim-request-id": "7b5b43a1-f8a9-4626-af44-3840a90328ec",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:28 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "278",
-        "x-request-id": "2800c085-8ed0-4c02-9471-ef1879c23f10"
+        "x-envoy-upstream-service-time": "367",
+        "x-request-id": "7b5b43a1-f8a9-4626-af44-3840a90328ec"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:28.5904701-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:37.8936880-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-802c89f5442e6f4087fe3b77b8175f09-8dbc3ed8aafbdd40-00",
+        "traceparent": "00-faf6c29be715c14993c4adabe42c02f3-bb43e202af1d1a4a-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -37,26 +37,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8aea6ba3-55d4-4e2d-ae30-2a4c885d87c8",
+        "apim-request-id": "e5174bd1-fb2d-4b33-9167-7d69ac00536e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:55 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
+        "Date": "Mon, 01 Feb 2021 15:53:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b36d25a-95b9-41ef-8804-cfe52e225b39",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "776",
-        "X-Request-ID": "8aea6ba3-55d4-4e2d-ae30-2a4c885d87c8"
+        "x-envoy-upstream-service-time": "392",
+        "X-Request-ID": "e5174bd1-fb2d-4b33-9167-7d69ac00536e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b36d25a-95b9-41ef-8804-cfe52e225b39",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9cc9ac8df5342f458e4a4771cda69d29-18c704e3e7df9247-00",
+        "traceparent": "00-38fae90f49bfdd43b37b6f6daeda66ea-d9c3e5ac7acc6d46-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -66,28 +66,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4141b79e-2c0e-457c-a841-ba52c20209c2",
+        "apim-request-id": "119df5c8-2f70-4771-8cdb-725f71e69881",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "339",
-        "X-Request-ID": "4141b79e-2c0e-457c-a841-ba52c20209c2"
+        "x-envoy-upstream-service-time": "157",
+        "X-Request-ID": "119df5c8-2f70-4771-8cdb-725f71e69881"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b36d25a-95b9-41ef-8804-cfe52e225b39",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-004f471d04a5c24cab7047bdbf638f81-285a147574b87d43-00",
+        "traceparent": "00-ce4e4321c8be7040833d43c332c40313-2333bd26d2f18144-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -99,21 +99,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fd59da36-ac60-4809-8edb-b67ec1d9e9d4",
+        "apim-request-id": "ea78280b-3254-49ae-8545-d90a362a807f",
         "Content-Length": "1058",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "305",
-        "X-Request-ID": "fd59da36-ac60-4809-8edb-b67ec1d9e9d4"
+        "x-envoy-upstream-service-time": "173",
+        "X-Request-ID": "ea78280b-3254-49ae-8545-d90a362a807f"
       },
       "ResponseBody": {
-        "dataFeedId": "046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
+        "dataFeedId": "6b36d25a-95b9-41ef-8804-cfe52e225b39",
         "dataFeedName": "dataFeedrxLMSD30",
         "metrics": [
           {
-            "metricId": "23578a7c-2d02-4c10-8b5e-8e9d21cb78d5",
+            "metricId": "85637e0b-9468-4b1a-a0a1-ce9a8b24f8f6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -144,7 +144,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:55Z",
+        "createdTime": "2021-02-01T15:53:12Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -157,12 +157,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b36d25a-95b9-41ef-8804-cfe52e225b39",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d8462bc31430b543b77dff4de736b9b4-cbf40078af80be41-00",
+        "traceparent": "00-eb41449c7b0e5040ba2c7efdf32e6180-83fcf9b0792ec64c-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -174,19 +174,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "25908712-feea-4d60-91ed-914d6333a9cd",
+        "apim-request-id": "fb8d0d22-ee3a-4291-90bd-0a17e6568376",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:56 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "493",
-        "X-Request-ID": "25908712-feea-4d60-91ed-914d6333a9cd"
+        "x-envoy-upstream-service-time": "308",
+        "X-Request-ID": "fb8d0d22-ee3a-4291-90bd-0a17e6568376"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:56.7255318-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:13.1715841-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateInfluxDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "295",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9541e486801101498db7035ee869f659-daa25f81d9e6d747-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-802c89f5442e6f4087fe3b77b8175f09-8dbc3ed8aafbdd40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f53f2d5ab384c5293a19ac1c51363e45",
         "x-ms-return-client-request-id": "true"
@@ -34,64 +37,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d6e5ee0e-b733-47e8-81fd-9c84750b8308",
+        "apim-request-id": "8aea6ba3-55d4-4e2d-ae30-2a4c885d87c8",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd8babec-9f65-4bf3-be18-26264ee57453",
+        "Date": "Mon, 01 Feb 2021 13:42:55 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "556",
-        "x-request-id": "d6e5ee0e-b733-47e8-81fd-9c84750b8308"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "776",
+        "X-Request-ID": "8aea6ba3-55d4-4e2d-ae30-2a4c885d87c8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd8babec-9f65-4bf3-be18-26264ee57453",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "311",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e2771698a7aed348913518cd50ef2bd3-278ce1d8cc6e574c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9cc9ac8df5342f458e4a4771cda69d29-18c704e3e7df9247-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7ace475647d063310adb8b11c8585091",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "userName": "username",
-          "password": "pass",
-          "query": "query"
-        },
-        "dataSourceType": "InfluxDB",
-        "dataFeedName": "dataFeedrxLMSD30",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8f6b4e03-c0d5-4cfc-8f75-221f690f86cb",
+        "apim-request-id": "4141b79e-2c0e-457c-a841-ba52c20209c2",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:39 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "671",
-        "x-request-id": "8f6b4e03-c0d5-4cfc-8f75-221f690f86cb"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "339",
+        "X-Request-ID": "4141b79e-2c0e-457c-a841-ba52c20209c2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd8babec-9f65-4bf3-be18-26264ee57453",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7c2a62d54538d44f898899d2ccae276f-f73ee8caa9f43f42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-004f471d04a5c24cab7047bdbf638f81-285a147574b87d43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d545196bbc4952564b422983133bca28",
         "x-ms-return-client-request-id": "true"
@@ -99,21 +99,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d725dd07-f4e2-4ab5-aaf4-e1827d27d635",
+        "apim-request-id": "fd59da36-ac60-4809-8edb-b67ec1d9e9d4",
         "Content-Length": "1058",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "154",
-        "x-request-id": "d725dd07-f4e2-4ab5-aaf4-e1827d27d635"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "305",
+        "X-Request-ID": "fd59da36-ac60-4809-8edb-b67ec1d9e9d4"
       },
       "ResponseBody": {
-        "dataFeedId": "dd8babec-9f65-4bf3-be18-26264ee57453",
+        "dataFeedId": "046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
         "dataFeedName": "dataFeedrxLMSD30",
         "metrics": [
           {
-            "metricId": "dee75672-96b8-4cdb-bc5e-155082748b30",
+            "metricId": "23578a7c-2d02-4c10-8b5e-8e9d21cb78d5",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -144,7 +144,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:39Z",
+        "createdTime": "2021-02-01T13:42:55Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -157,13 +157,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd8babec-9f65-4bf3-be18-26264ee57453",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/046d3f78-51e8-4f47-bd3a-2d89cd182ec5",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2367c3d9241897478a85a7184f0f53d6-dbaaddb9d5f74a48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d8462bc31430b543b77dff4de736b9b4-cbf40078af80be41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dbb8f3be2fdd135cfcdceaa92818fde2",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +174,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "313c9f1f-eeb7-4bbf-9242-ea76fb82b159",
+        "apim-request-id": "25908712-feea-4d60-91ed-914d6333a9cd",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:56 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "281",
-        "x-request-id": "313c9f1f-eeb7-4bbf-9242-ea76fb82b159"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "493",
+        "X-Request-ID": "25908712-feea-4d60-91ed-914d6333a9cd"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:40.8331393-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:56.7255318-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d96af6f3a2ea134eb7f8210dcf60506f-e81fa1e8d7c33748-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-111b92ff67a82a49bdc0a606a7d49f9e-537eb524457a354a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8b3d497bcc86eb3fb3f026e7c3943cd9",
         "x-ms-return-client-request-id": "true"
@@ -32,25 +35,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8ec8053f-c10e-459c-b17f-ce48e1bd29e4",
+        "apim-request-id": "7506c8d4-6be4-4781-8416-b8d2c8e21fb5",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:57 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
+        "Date": "Mon, 01 Feb 2021 14:25:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8bbe024-1328-4fd1-aa63-d6649a370769",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "580",
-        "x-request-id": "8ec8053f-c10e-459c-b17f-ce48e1bd29e4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "591",
+        "X-Request-ID": "7506c8d4-6be4-4781-8416-b8d2c8e21fb5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8bbe024-1328-4fd1-aa63-d6649a370769",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0a169453c978314badf44ba3d920b8a3-6194e12aa5c9ce47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-52bcbca5aa1707439606ae2933c70acc-53c6b1b4342f4e4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d73ecbeea0212c2194468e99842de23a",
         "x-ms-return-client-request-id": "true"
@@ -58,21 +64,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ccee3176-3e37-4348-a486-301aeb7690f6",
+        "apim-request-id": "a83e9cda-66e8-4951-ae70-c3d214ab1204",
         "Content-Length": "970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:57 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "ccee3176-3e37-4348-a486-301aeb7690f6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "153",
+        "X-Request-ID": "a83e9cda-66e8-4951-ae70-c3d214ab1204"
       },
       "ResponseBody": {
-        "dataFeedId": "c185b492-e364-48bc-8e14-ecd090c8527b",
+        "dataFeedId": "e8bbe024-1328-4fd1-aa63-d6649a370769",
         "dataFeedName": "dataFeedK8TE7pob",
         "metrics": [
           {
-            "metricId": "5828d09f-970f-4e64-9b00-b8d8bc376c9a",
+            "metricId": "b0657db6-4a44-4dcb-b2d9-f7b61b6fb44a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +109,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:58Z",
+        "createdTime": "2021-02-01T14:25:07Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,15 +120,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8bbe024-1328-4fd1-aa63-d6649a370769",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "684",
+        "Content-Length": "701",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d61fcd58e138fa438b9eb7c3a521f56c-db88fd9771e69f47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e2d43b00b7221548b04d393bc0b62b3a-8c57fbdd22eecb44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e13c32f88ac6d5ea5b178902177a07af",
         "x-ms-return-client-request-id": "true"
@@ -148,7 +157,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -158,24 +168,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5bc9922a-6116-4165-b990-7e688d054657",
+        "apim-request-id": "f91b8148-6c30-4815-82c0-18444eb04e2f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:59 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "695",
-        "x-request-id": "5bc9922a-6116-4165-b990-7e688d054657"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "741",
+        "X-Request-ID": "f91b8148-6c30-4815-82c0-18444eb04e2f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8bbe024-1328-4fd1-aa63-d6649a370769",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d4b89af533e9074586d57b10209736b4-fec22bdc74c6d340-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fd7fe522ac79f641b8db3f632c60c338-54e8993f0da38548-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1482b96f2608daff2811f6403da56786",
         "x-ms-return-client-request-id": "true"
@@ -183,21 +196,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c74e07f1-7ad6-4374-8f32-49ed2b69494b",
-        "Content-Length": "1096",
+        "apim-request-id": "c64288e3-ce47-4b44-94a8-1f35b86923e9",
+        "Content-Length": "1113",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:12:59 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "c74e07f1-7ad6-4374-8f32-49ed2b69494b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "193",
+        "X-Request-ID": "c64288e3-ce47-4b44-94a8-1f35b86923e9"
       },
       "ResponseBody": {
-        "dataFeedId": "c185b492-e364-48bc-8e14-ecd090c8527b",
+        "dataFeedId": "e8bbe024-1328-4fd1-aa63-d6649a370769",
         "dataFeedName": "dataFeedD0LVT9lA",
         "metrics": [
           {
-            "metricId": "5828d09f-970f-4e64-9b00-b8d8bc376c9a",
+            "metricId": "b0657db6-4a44-4dcb-b2d9-f7b61b6fb44a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -223,6 +236,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -230,7 +244,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:12:58Z",
+        "createdTime": "2021-02-01T14:25:07Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,13 +255,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8bbe024-1328-4fd1-aa63-d6649a370769",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a4dfa730edcd8449a05b455077bb464e-6b12fc7702db7540-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-65da7b22e32aa84d9fd99c7eb549c871-038f15dea752c244-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "91efec0e5b576413e1697c09161e141a",
         "x-ms-return-client-request-id": "true"
@@ -255,19 +272,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "61466276-9aa7-49f0-9dd9-6a3a37e57850",
+        "apim-request-id": "aec837c6-0f4c-4536-8e20-a1f536cb76ed",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:12:59 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "342",
-        "x-request-id": "61466276-9aa7-49f0-9dd9-6a3a37e57850"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "325",
+        "X-Request-ID": "aec837c6-0f4c-4536-8e20-a1f536cb76ed"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:12:59.3472291-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:25:08.4494973-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a77eedcb224d09489cad27d9b8e24330-f57cac17ee48984a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d96af6f3a2ea134eb7f8210dcf60506f-e81fa1e8d7c33748-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7093ac4446e021fe7b493d8b86cc3feb",
+        "x-ms-client-request-id": "8b3d497bcc86eb3fb3f026e7c3943cd9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,47 +32,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d5d6494d-d094-4ebf-bfc7-0b3c5b78e706",
+        "apim-request-id": "8ec8053f-c10e-459c-b17f-ce48e1bd29e4",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:32 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+        "Date": "Mon, 01 Feb 2021 13:12:57 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "563",
-        "x-request-id": "d5d6494d-d094-4ebf-bfc7-0b3c5b78e706"
+        "x-envoy-upstream-service-time": "580",
+        "x-request-id": "8ec8053f-c10e-459c-b17f-ce48e1bd29e4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3c4b02e133d8f749924bc81036994360-09a4afb11c3a254a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0a169453c978314badf44ba3d920b8a3-6194e12aa5c9ce47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e726f0b394c3d93ceecb3ed721a0212c",
+        "x-ms-client-request-id": "d73ecbeea0212c2194468e99842de23a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c9ed894b-1f9a-487c-942e-70104806dc88",
+        "apim-request-id": "ccee3176-3e37-4348-a486-301aeb7690f6",
         "Content-Length": "970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:32 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "153",
-        "x-request-id": "c9ed894b-1f9a-487c-942e-70104806dc88"
+        "x-envoy-upstream-service-time": "164",
+        "x-request-id": "ccee3176-3e37-4348-a486-301aeb7690f6"
       },
       "ResponseBody": {
-        "dataFeedId": "f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+        "dataFeedId": "c185b492-e364-48bc-8e14-ecd090c8527b",
         "dataFeedName": "dataFeedK8TE7pob",
         "metrics": [
           {
-            "metricId": "cf302122-e219-461a-b840-510c6241d547",
+            "metricId": "5828d09f-970f-4e64-9b00-b8d8bc376c9a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +103,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:32Z",
+        "createdTime": "2021-02-01T13:12:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,17 +114,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "684",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-445d465aaddc9c40b92fd1ac9027ecd8-8d0fe24483cf9f4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d61fcd58e138fa438b9eb7c3a521f56c-db88fd9771e69f47-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "998e46942d843ae2f8323ce1c68aead5",
+        "x-ms-client-request-id": "e13c32f88ac6d5ea5b178902177a07af",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -134,10 +134,10 @@
           "command": "command"
         },
         "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeedK8TE7pob",
+        "dataFeedName": "dataFeedD0LVT9lA",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -158,53 +158,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "848cfc42-8b48-42a6-a244-1a9ba6369c1c",
+        "apim-request-id": "5bc9922a-6116-4165-b990-7e688d054657",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:32 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "478",
-        "x-request-id": "848cfc42-8b48-42a6-a244-1a9ba6369c1c"
+        "x-envoy-upstream-service-time": "695",
+        "x-request-id": "5bc9922a-6116-4165-b990-7e688d054657"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-633a1ca536c59e43b0046c7d46a1db65-87580c6e6bceb04c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d4b89af533e9074586d57b10209736b4-fec22bdc74c6d340-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0289175b7a17af076fb982140826ffda",
+        "x-ms-client-request-id": "1482b96f2608daff2811f6403da56786",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "2bbcb217-a109-4b88-babb-6ba5738ff259",
+        "apim-request-id": "c74e07f1-7ad6-4374-8f32-49ed2b69494b",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:33 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "2bbcb217-a109-4b88-babb-6ba5738ff259"
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "c74e07f1-7ad6-4374-8f32-49ed2b69494b"
       },
       "ResponseBody": {
-        "dataFeedId": "f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
-        "dataFeedName": "dataFeedK8TE7pob",
+        "dataFeedId": "c185b492-e364-48bc-8e14-ecd090c8527b",
+        "dataFeedName": "dataFeedD0LVT9lA",
         "metrics": [
           {
-            "metricId": "cf302122-e219-461a-b840-510c6241d547",
+            "metricId": "5828d09f-970f-4e64-9b00-b8d8bc376c9a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MongoDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -230,7 +230,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:32Z",
+        "createdTime": "2021-02-01T13:12:58Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,33 +241,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f982ac97-15c5-480f-bc6a-aa98aa4bbcad",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c185b492-e364-48bc-8e14-ecd090c8527b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-310ebc5a02c9334ca3ff19d25d1bf7c6-3b5d29b86b70fa4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a4dfa730edcd8449a05b455077bb464e-6b12fc7702db7540-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "40f61128a53d86670eecef91575b1364",
+        "x-ms-client-request-id": "91efec0e5b576413e1697c09161e141a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a59cc77c-2048-47fb-9dd3-ca66a688a130",
+        "apim-request-id": "61466276-9aa7-49f0-9dd9-6a3a37e57850",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:33 GMT",
+        "Date": "Mon, 01 Feb 2021 13:12:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "367",
-        "x-request-id": "a59cc77c-2048-47fb-9dd3-ca66a688a130"
+        "x-envoy-upstream-service-time": "342",
+        "x-request-id": "61466276-9aa7-49f0-9dd9-6a3a37e57850"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:33.3032510-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:12:59.3472291-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ca4d37070904164e88992105c303488d-9be6bd764f5ae741-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-6876593e95fb924c862f8da7485d2bd5-2b8a4032bdf3584d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "21ef7370006e3941a0109b3d144282e0",
         "x-ms-return-client-request-id": "true"
@@ -35,28 +32,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "de05f2f8-6f03-4d2e-ac2b-61528ad19cdb",
+        "apim-request-id": "234ef3d7-4ec9-4134-9ba9-6d3824261d6f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:57 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+        "Date": "Mon, 01 Feb 2021 15:41:24 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a8599f0-12e1-4953-97b6-23bb5fc6594b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "698",
-        "X-Request-ID": "de05f2f8-6f03-4d2e-ac2b-61528ad19cdb"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "434",
+        "x-request-id": "234ef3d7-4ec9-4134-9ba9-6d3824261d6f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a8599f0-12e1-4953-97b6-23bb5fc6594b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c0435159f68c8d4c8b0cdc4bd2e4b1db-1135fcfd7997be4e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-7e33a492c3e17243a59fb7a13ca709bc-c67867217717e54c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "12650a48e37a7b85331186ae50f7f961",
         "x-ms-return-client-request-id": "true"
@@ -64,21 +58,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ae8b2997-170d-4e1e-8cb4-4351868c2087",
+        "apim-request-id": "544847ca-cfa6-4cc6-9f58-1bee2aaa7c3a",
         "Content-Length": "970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:57 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "288",
-        "X-Request-ID": "ae8b2997-170d-4e1e-8cb4-4351868c2087"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "156",
+        "x-request-id": "544847ca-cfa6-4cc6-9f58-1bee2aaa7c3a"
       },
       "ResponseBody": {
-        "dataFeedId": "7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+        "dataFeedId": "8a8599f0-12e1-4953-97b6-23bb5fc6594b",
         "dataFeedName": "dataFeedXFOvZwlg",
         "metrics": [
           {
-            "metricId": "18b1c0f0-1104-47ee-aab9-471f3fe60182",
+            "metricId": "5788bcda-d5a2-42df-9c3d-47d1dd4a6003",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -109,7 +103,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:57Z",
+        "createdTime": "2021-02-01T15:41:24Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -120,18 +114,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a8599f0-12e1-4953-97b6-23bb5fc6594b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "684",
+        "Content-Length": "701",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-63b02235171085428fb2ddee7e68fe2f-2dab36ac54724944-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-56ec0fc16eb52146883850ece32ca1c0-4148f8e558aa924f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cbd395211fb803488f1283fa43fdca18",
         "x-ms-return-client-request-id": "true"
@@ -157,7 +148,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -167,27 +159,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "eb427a13-f49a-44f4-82f7-f5eabd6b945f",
+        "apim-request-id": "5c1012d3-53db-4c58-8061-b27b2205e0c1",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:58 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "853",
-        "X-Request-ID": "eb427a13-f49a-44f4-82f7-f5eabd6b945f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "523",
+        "x-request-id": "5c1012d3-53db-4c58-8061-b27b2205e0c1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a8599f0-12e1-4953-97b6-23bb5fc6594b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8a53755b74042b4ea1708d1a6d4fc37c-20ab7fc37a8c544e-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-df4f02613005be41b712f50e6887544c-6a101b169e59c549-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7bf1f68a8afb8dedee73ee5d7a92e9a8",
         "x-ms-return-client-request-id": "true"
@@ -195,21 +184,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "eb9f5117-873b-4361-a485-e0513181f390",
-        "Content-Length": "1096",
+        "apim-request-id": "d9b0c487-4aa8-4b99-9804-cf7170b565ec",
+        "Content-Length": "1113",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:42:58 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "190",
-        "X-Request-ID": "eb9f5117-873b-4361-a485-e0513181f390"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "166",
+        "x-request-id": "d9b0c487-4aa8-4b99-9804-cf7170b565ec"
       },
       "ResponseBody": {
-        "dataFeedId": "7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+        "dataFeedId": "8a8599f0-12e1-4953-97b6-23bb5fc6594b",
         "dataFeedName": "dataFeedomqLSdeB",
         "metrics": [
           {
-            "metricId": "18b1c0f0-1104-47ee-aab9-471f3fe60182",
+            "metricId": "5788bcda-d5a2-42df-9c3d-47d1dd4a6003",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -235,6 +224,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -242,7 +232,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:42:57Z",
+        "createdTime": "2021-02-01T15:41:24Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -253,16 +243,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8a8599f0-12e1-4953-97b6-23bb5fc6594b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ae043ad0e370ff4e93758f0a63d053ce-7b122f34b8dddf4d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a8068180972c8e4ab5c2e80357c3e0e7-235089c4b9adb54c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7e1c3916b66e2928c26182685f8a3836",
         "x-ms-return-client-request-id": "true"
@@ -270,19 +257,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "00d44c18-9322-4c02-ac0f-b8038631692b",
+        "apim-request-id": "2d572d9e-3c7d-40f0-a436-b910d66df069",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:59 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:25 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "430",
-        "X-Request-ID": "00d44c18-9322-4c02-ac0f-b8038631692b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "342",
+        "x-request-id": "2d572d9e-3c7d-40f0-a436-b910d66df069"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:42:59.3535749-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:25.9090662-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2ad14c0deba5594cafe9e2713bb574ed-5c2db47545e71643-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ca4d37070904164e88992105c303488d-9be6bd764f5ae741-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3ad60d5a6186689c7073ef216e004139",
+        "x-ms-client-request-id": "21ef7370006e3941a0109b3d144282e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,47 +35,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e78466da-0dd7-4828-b699-677ad9fd60f3",
+        "apim-request-id": "de05f2f8-6f03-4d2e-ac2b-61528ad19cdb",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+        "Date": "Mon, 01 Feb 2021 13:42:57 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "591",
-        "x-request-id": "e78466da-0dd7-4828-b699-677ad9fd60f3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "698",
+        "X-Request-ID": "de05f2f8-6f03-4d2e-ac2b-61528ad19cdb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-64310c6f1d02624196777b910ba46fe5-8aa74cfd869df748-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c0435159f68c8d4c8b0cdc4bd2e4b1db-1135fcfd7997be4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3d9b10a04214e082480a65127ae3857b",
+        "x-ms-client-request-id": "12650a48e37a7b85331186ae50f7f961",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6683a0e7-9dc1-45f5-9495-f8bc40504539",
+        "apim-request-id": "ae8b2997-170d-4e1e-8cb4-4351868c2087",
         "Content-Length": "970",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:12 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:57 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "6683a0e7-9dc1-45f5-9495-f8bc40504539"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "288",
+        "X-Request-ID": "ae8b2997-170d-4e1e-8cb4-4351868c2087"
       },
       "ResponseBody": {
-        "dataFeedId": "11e12cbd-2dba-4898-947c-a05b87270813",
+        "dataFeedId": "7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
         "dataFeedName": "dataFeedXFOvZwlg",
         "metrics": [
           {
-            "metricId": "3672b32b-dadc-4bc2-9053-30912b620ea8",
+            "metricId": "18b1c0f0-1104-47ee-aab9-471f3fe60182",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -103,7 +109,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:12Z",
+        "createdTime": "2021-02-01T13:42:57Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -114,17 +120,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "684",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cb40c762db84fc4abf68bd11809d57d6-5ab699431fadf646-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-63b02235171085428fb2ddee7e68fe2f-2dab36ac54724944-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ae861133f75061f92195d3cbb81f4803",
+        "x-ms-client-request-id": "cbd395211fb803488f1283fa43fdca18",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -134,10 +143,10 @@
           "command": "command"
         },
         "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeedXFOvZwlg",
+        "dataFeedName": "dataFeedomqLSdeB",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -158,53 +167,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1fec7879-ec63-4e3d-9558-2ad93b99fd9a",
+        "apim-request-id": "eb427a13-f49a-44f4-82f7-f5eabd6b945f",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:13 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "512",
-        "x-request-id": "1fec7879-ec63-4e3d-9558-2ad93b99fd9a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "853",
+        "X-Request-ID": "eb427a13-f49a-44f4-82f7-f5eabd6b945f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a94db9f41cdd044dab118b4ee0c9d136-a4d1682af7265346-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8a53755b74042b4ea1708d1a6d4fc37c-20ab7fc37a8c544e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fa83128ffd4318ca8af6f17bfb8aed8d",
+        "x-ms-client-request-id": "7bf1f68a8afb8dedee73ee5d7a92e9a8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "509dfbf0-1027-484d-b746-438350535eaa",
+        "apim-request-id": "eb9f5117-873b-4361-a485-e0513181f390",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:13 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:58 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "509dfbf0-1027-484d-b746-438350535eaa"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "190",
+        "X-Request-ID": "eb9f5117-873b-4361-a485-e0513181f390"
       },
       "ResponseBody": {
-        "dataFeedId": "11e12cbd-2dba-4898-947c-a05b87270813",
-        "dataFeedName": "dataFeedXFOvZwlg",
+        "dataFeedId": "7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
+        "dataFeedName": "dataFeedomqLSdeB",
         "metrics": [
           {
-            "metricId": "3672b32b-dadc-4bc2-9053-30912b620ea8",
+            "metricId": "18b1c0f0-1104-47ee-aab9-471f3fe60182",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MongoDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -230,7 +242,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:12Z",
+        "createdTime": "2021-02-01T13:42:57Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -241,33 +253,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/11e12cbd-2dba-4898-947c-a05b87270813",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7a9e8f2a-e4d7-4932-baf3-d3991359fc21",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2a6e148a1b986a4188d80ec1aef12583-3d11ca0c574bf740-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ae043ad0e370ff4e93758f0a63d053ce-7b122f34b8dddf4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "5dee73ee927aa8e916391c7e6eb62829",
+        "x-ms-client-request-id": "7e1c3916b66e2928c26182685f8a3836",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a358a695-ab05-4a98-92c9-8ffa8907b739",
+        "apim-request-id": "00d44c18-9322-4c02-ac0f-b8038631692b",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:13 GMT",
+        "Date": "Mon, 01 Feb 2021 13:42:59 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "328",
-        "x-request-id": "a358a695-ab05-4a98-92c9-8ffa8907b739"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "430",
+        "X-Request-ID": "00d44c18-9322-4c02-ac0f-b8038631692b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:14.0074860-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:42:59.3535749-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6dc36068e701f749b214e57f537ed0bf-be1601a0861e9447-00",
+        "traceparent": "00-5e3691cc9c685e4898b1c5489040a5c7-4ba92ba435f7284e-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9b354ace0d5e9416f932807b2db89bc4",
+        "x-ms-client-request-id": "3112882730fdeea63ce076ec84bfa34f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -21,7 +21,7 @@
           "command": "command"
         },
         "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeedG6PQRZw4",
+        "dataFeedName": "dataFeedPBG6xZRY",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -32,39 +32,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6efb1e58-378b-42b8-a089-8fd797ecfc57",
+        "apim-request-id": "a9e01dac-c8ad-4dad-9e6d-7e927c1f93fb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:00 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
+        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "599",
-        "x-request-id": "6efb1e58-378b-42b8-a089-8fd797ecfc57"
+        "x-envoy-upstream-service-time": "409",
+        "x-request-id": "a9e01dac-c8ad-4dad-9e6d-7e927c1f93fb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "572",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5a8b0a1202e1864099a15e0b527e34c2-0258b767d04a4942-00",
+        "traceparent": "00-5c7e4683d4f19848981b45607a8e3bcc-3bd1eb96dc23ad4a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d46c79355b0a8e7c2fefbc1e0c03d178",
+        "x-ms-client-request-id": "1ebe987def23a8ff3340da96d4ebfe72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "command": "command"
-        },
-        "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeedhUQrNjEn",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedwIeMyLSV",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -81,46 +76,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7e3a94d8-ea34-4269-a150-2d6bb4d82f8e",
+        "apim-request-id": "b9e6d1d9-13d6-443f-9bf0-8bccd2d530d5",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:00 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "611",
-        "x-request-id": "7e3a94d8-ea34-4269-a150-2d6bb4d82f8e"
+        "x-envoy-upstream-service-time": "167",
+        "x-request-id": "b9e6d1d9-13d6-443f-9bf0-8bccd2d530d5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6340107b824d7b4bb22fbe95d98018bf-e41e7e083a36ac4c-00",
+        "traceparent": "00-90bd4b6e04e0e945a315318abdf770b6-3be5e6542cfa6840-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e30a298679df63191780a4147484c5ac",
+        "x-ms-client-request-id": "c150967e6a7643d3e9debe69134d4fed",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "56a43e65-a29c-4806-8852-a2bbe528b312",
+        "apim-request-id": "bed56db7-9584-4ece-b2f4-cf38bef4b9f4",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:01 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "172",
-        "x-request-id": "56a43e65-a29c-4806-8852-a2bbe528b312"
+        "x-envoy-upstream-service-time": "139",
+        "x-request-id": "bed56db7-9584-4ece-b2f4-cf38bef4b9f4"
       },
       "ResponseBody": {
-        "dataFeedId": "3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
-        "dataFeedName": "dataFeedhUQrNjEn",
+        "dataFeedId": "410a637f-2583-4991-8157-f102d31c8241",
+        "dataFeedName": "dataFeedwIeMyLSV",
         "metrics": [
           {
-            "metricId": "94113713-754e-4308-9526-a13f7e3cee69",
+            "metricId": "b373015b-6955-4e40-bb86-e7226c33f9e5",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -153,7 +148,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:00Z",
+        "createdTime": "2021-02-01T15:45:39Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,37 +159,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4e3c4fadc647ef42a3ca3cbba471c216-088371012205614b-00",
+        "traceparent": "00-0c5d95366034c34aacba31ddb2792e77-0af72e4819036e46-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "cba3ae3dcd22737dcea76c6f51f787f6",
+        "x-ms-client-request-id": "3b0132379cb637168869fdbc550f1a51",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "cd30ccaf-43ca-4cba-9a5b-a2a01c4faf26",
+        "apim-request-id": "5354d48e-50ee-4efe-a42b-6878de085f48",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:01 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "307",
-        "x-request-id": "cd30ccaf-43ca-4cba-9a5b-a2a01c4faf26"
+        "x-envoy-upstream-service-time": "311",
+        "x-request-id": "5354d48e-50ee-4efe-a42b-6878de085f48"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:13:01.1910225-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:39.5797478-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "878640460"
+    "RandomSeed": "958957937"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e6a3050a5dcac34abff9c35a5d74a5f2-7c8bc69bec635748-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6dc36068e701f749b214e57f537ed0bf-be1601a0861e9447-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d873d9648e4487a2ce4a359b5e0d1694",
+        "x-ms-client-request-id": "9b354ace0d5e9416f932807b2db89bc4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,29 +32,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3fd29476-717d-417a-887a-22c9a636f584",
+        "apim-request-id": "6efb1e58-378b-42b8-a089-8fd797ecfc57",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:34 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+        "Date": "Mon, 01 Feb 2021 13:13:00 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "373",
-        "x-request-id": "3fd29476-717d-417a-887a-22c9a636f584"
+        "x-envoy-upstream-service-time": "599",
+        "x-request-id": "6efb1e58-378b-42b8-a089-8fd797ecfc57"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "572",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-99cc9fc79a19044382f957d110cefaf0-7d4b059f1a92b341-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5a8b0a1202e1864099a15e0b527e34c2-0258b767d04a4942-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7b8032f9b82dc49b35796cd40a5b7c8e",
+        "x-ms-client-request-id": "d46c79355b0a8e7c2fefbc1e0c03d178",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,10 +64,10 @@
           "command": "command"
         },
         "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeedG6PQRZw4",
+        "dataFeedName": "dataFeedhUQrNjEn",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -81,53 +81,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b76c8152-cdf8-422f-95fd-6053f1312e14",
+        "apim-request-id": "7e3a94d8-ea34-4269-a150-2d6bb4d82f8e",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:34 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:00 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "637",
-        "x-request-id": "b76c8152-cdf8-422f-95fd-6053f1312e14"
+        "x-envoy-upstream-service-time": "611",
+        "x-request-id": "7e3a94d8-ea34-4269-a150-2d6bb4d82f8e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b5a597df8f6e0348a87d73942412e335-227d2af4dcd80d46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6340107b824d7b4bb22fbe95d98018bf-e41e7e083a36ac4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "1ebcef2f030c78d186290ae3df791963",
+        "x-ms-client-request-id": "e30a298679df63191780a4147484c5ac",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "56f18658-87ac-4f06-9829-64ba6892f080",
+        "apim-request-id": "56a43e65-a29c-4806-8852-a2bbe528b312",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:35 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "637",
-        "x-request-id": "56f18658-87ac-4f06-9829-64ba6892f080"
+        "x-envoy-upstream-service-time": "172",
+        "x-request-id": "56a43e65-a29c-4806-8852-a2bbe528b312"
       },
       "ResponseBody": {
-        "dataFeedId": "479cf661-e202-4085-8dcc-2847a0a3b4f5",
-        "dataFeedName": "dataFeedG6PQRZw4",
+        "dataFeedId": "3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
+        "dataFeedName": "dataFeedhUQrNjEn",
         "metrics": [
           {
-            "metricId": "0f25a8bb-10cc-4f0c-9049-35384dba109b",
+            "metricId": "94113713-754e-4308-9526-a13f7e3cee69",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MongoDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -153,7 +153,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:34Z",
+        "createdTime": "2021-02-01T13:13:00Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,33 +164,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/479cf661-e202-4085-8dcc-2847a0a3b4f5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3d40d9b7-279c-49e9-9e5b-dc5e1fbfef54",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e436427cf5299e4986d26e5839857f85-5dfaab48ec31064b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4e3c4fadc647ef42a3ca3cbba471c216-088371012205614b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "14a480178474acc53daea3cb22cd7d73",
+        "x-ms-client-request-id": "cba3ae3dcd22737dcea76c6f51f787f6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2c9b4efa-858d-4c45-bacb-f7cbd6cdb52c",
+        "apim-request-id": "cd30ccaf-43ca-4cba-9a5b-a2a01c4faf26",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:36 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:01 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1073",
-        "x-request-id": "2c9b4efa-858d-4c45-bacb-f7cbd6cdb52c"
+        "x-envoy-upstream-service-time": "307",
+        "x-request-id": "cd30ccaf-43ca-4cba-9a5b-a2a01c4faf26"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:35.5273499-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:13:01.1910225-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5e3691cc9c685e4898b1c5489040a5c7-4ba92ba435f7284e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d86abb93e172634495906cd8f8ed32ef-8fe29bb81a517f47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3112882730fdeea63ce076ec84bfa34f",
         "x-ms-return-client-request-id": "true"
@@ -32,33 +35,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a9e01dac-c8ad-4dad-9e6d-7e927c1f93fb",
+        "apim-request-id": "0a865242-5a7c-4218-b8ac-7179c066cbba",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
+        "Date": "Mon, 01 Feb 2021 15:52:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafadb86-7e8e-4481-bf37-819a26e0bed0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "409",
-        "x-request-id": "a9e01dac-c8ad-4dad-9e6d-7e927c1f93fb"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "398",
+        "X-Request-ID": "0a865242-5a7c-4218-b8ac-7179c066cbba"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafadb86-7e8e-4481-bf37-819a26e0bed0",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5c7e4683d4f19848981b45607a8e3bcc-3bd1eb96dc23ad4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7f9da26b572f7b4b9846237d87f541e3-d71506ed9f5d4d4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1ebe987def23a8ff3340da96d4ebfe72",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedwIeMyLSV",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -76,24 +82,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b9e6d1d9-13d6-443f-9bf0-8bccd2d530d5",
+        "apim-request-id": "4bf4b5ef-6cda-4ec7-81dc-c92dd7426009",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "b9e6d1d9-13d6-443f-9bf0-8bccd2d530d5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "200",
+        "X-Request-ID": "4bf4b5ef-6cda-4ec7-81dc-c92dd7426009"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafadb86-7e8e-4481-bf37-819a26e0bed0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90bd4b6e04e0e945a315318abdf770b6-3be5e6542cfa6840-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-81abf8b7fdd1c2459aabe8775baaa9ab-53f68a2e5a6dcd4c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c150967e6a7643d3e9debe69134d4fed",
         "x-ms-return-client-request-id": "true"
@@ -101,21 +110,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "bed56db7-9584-4ece-b2f4-cf38bef4b9f4",
+        "apim-request-id": "997d79f5-9acf-4d7f-ad08-94072e1d37a5",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "139",
-        "x-request-id": "bed56db7-9584-4ece-b2f4-cf38bef4b9f4"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "140",
+        "X-Request-ID": "997d79f5-9acf-4d7f-ad08-94072e1d37a5"
       },
       "ResponseBody": {
-        "dataFeedId": "410a637f-2583-4991-8157-f102d31c8241",
+        "dataFeedId": "aafadb86-7e8e-4481-bf37-819a26e0bed0",
         "dataFeedName": "dataFeedwIeMyLSV",
         "metrics": [
           {
-            "metricId": "b373015b-6955-4e40-bb86-e7226c33f9e5",
+            "metricId": "0637c53a-287b-45ad-bedc-7433b3145125",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -148,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:39Z",
+        "createdTime": "2021-02-01T15:52:42Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -159,13 +168,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/410a637f-2583-4991-8157-f102d31c8241",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aafadb86-7e8e-4481-bf37-819a26e0bed0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0c5d95366034c34aacba31ddb2792e77-0af72e4819036e46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8df1689b27c313449e2d52c3ee2bf735-895320327f5b5d47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3b0132379cb637168869fdbc550f1a51",
         "x-ms-return-client-request-id": "true"
@@ -173,19 +185,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5354d48e-50ee-4efe-a42b-6878de085f48",
+        "apim-request-id": "1fee1a88-a1ac-4aad-bf5f-af1e1bac935f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:38 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "311",
-        "x-request-id": "5354d48e-50ee-4efe-a42b-6878de085f48"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "293",
+        "X-Request-ID": "1fee1a88-a1ac-4aad-bf5f-af1e1bac935f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:39.5797478-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:42.7913652-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-03d9698f2f03fb4382b902cc16bec5c1-1b44d0ab13a61a4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3db53fb68baebf40b04c5574d340d34e-98bdfcb355df4049-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e3177a0e024e33eb3bed663554d385ae",
         "x-ms-return-client-request-id": "true"
@@ -32,33 +35,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8cdd271b-a1c6-4613-9162-4f9bcccdc96c",
+        "apim-request-id": "ab229759-b674-4087-80c9-38d8e2ea2b3e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
+        "Date": "Mon, 01 Feb 2021 15:53:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d50e95fe-e26a-4dfc-bb81-8b62fdc1e640",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "424",
-        "x-request-id": "8cdd271b-a1c6-4613-9162-4f9bcccdc96c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "643",
+        "X-Request-ID": "ab229759-b674-4087-80c9-38d8e2ea2b3e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d50e95fe-e26a-4dfc-bb81-8b62fdc1e640",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fd03f01c64c03f43819ab6de4756b9d2-d44a0acd34038d44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a1d6b1d3e1165a408eb0b731a7e65b88-01455e04be664349-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9c92b57b393c595d5b6c9011ba5ed849",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedan2yRQdz",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -76,24 +82,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "32edacea-ebe7-4fec-ac24-a5b7d2771bc2",
+        "apim-request-id": "848858d7-55c9-476c-888d-0fbbb1a1cf7f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "207",
-        "x-request-id": "32edacea-ebe7-4fec-ac24-a5b7d2771bc2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "196",
+        "X-Request-ID": "848858d7-55c9-476c-888d-0fbbb1a1cf7f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d50e95fe-e26a-4dfc-bb81-8b62fdc1e640",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-08dae2a160a7b94b85207173e50e95c5-e74e08e5a50ef34a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-84879c62e37e794391a1a7d317e6ff23-fed1d7a2f5de354b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c7875389705e2a1528a7c1593861276e",
         "x-ms-return-client-request-id": "true"
@@ -101,21 +110,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "25c11ce9-ffe7-40bb-be9f-80726d025bd3",
+        "apim-request-id": "c651e9f0-22c9-4275-87e3-7b65a3420e9d",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "25c11ce9-ffe7-40bb-be9f-80726d025bd3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "179",
+        "X-Request-ID": "c651e9f0-22c9-4275-87e3-7b65a3420e9d"
       },
       "ResponseBody": {
-        "dataFeedId": "4e811018-1889-4c7e-905b-a1c0335b1ca7",
+        "dataFeedId": "d50e95fe-e26a-4dfc-bb81-8b62fdc1e640",
         "dataFeedName": "dataFeedan2yRQdz",
         "metrics": [
           {
-            "metricId": "fd2e5a34-b418-4bd8-a4ff-dbe96fc7535c",
+            "metricId": "ccfe64fb-7f63-4f5e-ad36-25112f8d9470",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -148,7 +157,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:26Z",
+        "createdTime": "2021-02-01T15:53:14Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -159,13 +168,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d50e95fe-e26a-4dfc-bb81-8b62fdc1e640",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fa69cce7b86cd240984190824351b8ce-d135fd0083c34545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ef312c3d2e3ae14e804610d9985ff337-222ee523b5c24745-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "171d1d6fca26d5491dbe87e171d979dd",
         "x-ms-return-client-request-id": "true"
@@ -173,19 +185,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "01ced0a7-b2bb-468c-943b-6e2245608bce",
+        "apim-request-id": "4b39839b-80dc-4977-b108-251c4b173407",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "356",
-        "x-request-id": "01ced0a7-b2bb-468c-943b-6e2245608bce"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "323",
+        "X-Request-ID": "4b39839b-80dc-4977-b108-251c4b173407"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:27.1781408-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:14.6182647-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5d232e7e6427de45a9ba018307759aea-2346d860c8768743-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-03d9698f2f03fb4382b902cc16bec5c1-1b44d0ab13a61a4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e3177a0e024e33eb3bed663554d385ae",
         "x-ms-return-client-request-id": "true"
@@ -35,41 +32,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b566dbdb-b354-4151-bd28-c76c40a7b184",
+        "apim-request-id": "8cdd271b-a1c6-4613-9162-4f9bcccdc96c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:42:59 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
+        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "723",
-        "X-Request-ID": "b566dbdb-b354-4151-bd28-c76c40a7b184"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "424",
+        "x-request-id": "8cdd271b-a1c6-4613-9162-4f9bcccdc96c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "572",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-27dcf0b33a654f4ab8058caa6264c541-48b811b7c6950c45-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-fd03f01c64c03f43819ab6de4756b9d2-d44a0acd34038d44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9c92b57b393c595d5b6c9011ba5ed849",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "command": "command"
-        },
-        "dataSourceType": "MongoDB",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedan2yRQdz",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -87,27 +76,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a6921f38-538d-43b7-b2b1-9a90ccd291c7",
+        "apim-request-id": "32edacea-ebe7-4fec-ac24-a5b7d2771bc2",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:02 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "2467",
-        "X-Request-ID": "a6921f38-538d-43b7-b2b1-9a90ccd291c7"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "207",
+        "x-request-id": "32edacea-ebe7-4fec-ac24-a5b7d2771bc2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e65406ca4a10964f9796db1f20727b3e-9ebf2faca8e44f47-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-08dae2a160a7b94b85207173e50e95c5-e74e08e5a50ef34a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c7875389705e2a1528a7c1593861276e",
         "x-ms-return-client-request-id": "true"
@@ -115,21 +101,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "0838f12a-309b-4322-8362-a05889390faa",
+        "apim-request-id": "25c11ce9-ffe7-40bb-be9f-80726d025bd3",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:02 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "249",
-        "X-Request-ID": "0838f12a-309b-4322-8362-a05889390faa"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "25c11ce9-ffe7-40bb-be9f-80726d025bd3"
       },
       "ResponseBody": {
-        "dataFeedId": "e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
+        "dataFeedId": "4e811018-1889-4c7e-905b-a1c0335b1ca7",
         "dataFeedName": "dataFeedan2yRQdz",
         "metrics": [
           {
-            "metricId": "c25555ae-7238-47ff-abdf-3e64dc604585",
+            "metricId": "fd2e5a34-b418-4bd8-a4ff-dbe96fc7535c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -162,7 +148,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:00Z",
+        "createdTime": "2021-02-01T15:41:26Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -173,16 +159,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e811018-1889-4c7e-905b-a1c0335b1ca7",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-abc4723afc4c4741ba4e6716b2959cf4-c42a3d9ebdaddd44-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-fa69cce7b86cd240984190824351b8ce-d135fd0083c34545-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "171d1d6fca26d5491dbe87e171d979dd",
         "x-ms-return-client-request-id": "true"
@@ -190,19 +173,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0fcc4cfe-3a1b-4299-a894-3a78e1687771",
+        "apim-request-id": "01ced0a7-b2bb-468c-943b-6e2245608bce",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:02 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:26 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "457",
-        "X-Request-ID": "0fcc4cfe-3a1b-4299-a894-3a78e1687771"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "356",
+        "x-request-id": "01ced0a7-b2bb-468c-943b-6e2245608bce"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:03.3195680-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:27.1781408-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6599de23c32cb34cad922cf4b37adcfa-7b36c4ad81a1ef44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5d232e7e6427de45a9ba018307759aea-2346d860c8768743-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "98cbf441b9cd86670e7a17e34e02eb33",
+        "x-ms-client-request-id": "e3177a0e024e33eb3bed663554d385ae",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -32,29 +35,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8a371307-8e0a-4f11-807f-a2c1bd5aa198",
+        "apim-request-id": "b566dbdb-b354-4151-bd28-c76c40a7b184",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:14 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+        "Date": "Mon, 01 Feb 2021 13:42:59 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "531",
-        "x-request-id": "8a371307-8e0a-4f11-807f-a2c1bd5aa198"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "723",
+        "X-Request-ID": "b566dbdb-b354-4151-bd28-c76c40a7b184"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "572",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9efefc995987b14e8ebaeee5257e04ae-1a7c24d9d16e2c42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-27dcf0b33a654f4ab8058caa6264c541-48b811b7c6950c45-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3566ed3bd354ae857bb5929c3c395d59",
+        "x-ms-client-request-id": "9c92b57b393c595d5b6c9011ba5ed849",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -64,10 +70,10 @@
           "command": "command"
         },
         "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeedoMLI0uTw",
+        "dataFeedName": "dataFeedan2yRQdz",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -81,53 +87,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "81837249-611b-4d33-a444-d82f795fca8c",
+        "apim-request-id": "a6921f38-538d-43b7-b2b1-9a90ccd291c7",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:14 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "690",
-        "x-request-id": "81837249-611b-4d33-a444-d82f795fca8c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "2467",
+        "X-Request-ID": "a6921f38-538d-43b7-b2b1-9a90ccd291c7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee84f2b0f53d944084756a8e25061bf2-fe1f90f9878c3545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e65406ca4a10964f9796db1f20727b3e-9ebf2faca8e44f47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "11906c5b5eba49d8895387c75e70152a",
+        "x-ms-client-request-id": "c7875389705e2a1528a7c1593861276e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3f6ca674-f39d-460a-ab83-14adbd1a199b",
+        "apim-request-id": "0838f12a-309b-4322-8362-a05889390faa",
         "Content-Length": "1096",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:15 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "192",
-        "x-request-id": "3f6ca674-f39d-460a-ab83-14adbd1a199b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "249",
+        "X-Request-ID": "0838f12a-309b-4322-8362-a05889390faa"
       },
       "ResponseBody": {
-        "dataFeedId": "a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
-        "dataFeedName": "dataFeedoMLI0uTw",
+        "dataFeedId": "e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
+        "dataFeedName": "dataFeedan2yRQdz",
         "metrics": [
           {
-            "metricId": "282165b9-dc24-4ae0-a4a8-aedad8d0a139",
+            "metricId": "c25555ae-7238-47ff-abdf-3e64dc604585",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MongoDB",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -153,7 +162,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:14Z",
+        "createdTime": "2021-02-01T13:43:00Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -164,33 +173,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a0d2bf5a-17d9-498a-a0d3-61e45be0cf6f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e9627e8c-4f48-4d58-9a7a-d9938ca65e2f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6729169fe1b9b9439666f9ec0e363f74-a23cc6193d601b42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-abc4723afc4c4741ba4e6716b2959cf4-c42a3d9ebdaddd44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "59c1a72861386e276f1d1d1726ca49d5",
+        "x-ms-client-request-id": "171d1d6fca26d5491dbe87e171d979dd",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e4c9b985-9a4b-4f34-864d-2e23b48fdaed",
+        "apim-request-id": "0fcc4cfe-3a1b-4299-a894-3a78e1687771",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:15 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "356",
-        "x-request-id": "e4c9b985-9a4b-4f34-864d-2e23b48fdaed"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "457",
+        "X-Request-ID": "0fcc4cfe-3a1b-4299-a894-3a78e1687771"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:15.8884647-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:03.3195680-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e0b5ca1a6feedf469233ea20255e44ce-bc15bf1ec43abf4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-2bb84cc15a3a0849a7e80ab0e597eb5d-7ba521d3e61e4048-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "280f0c5e4c2c277fb3da103e7a4580c8",
         "x-ms-return-client-request-id": "true"
@@ -32,55 +35,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c61f661b-8bec-400c-bd9d-28bf7afe6042",
+        "apim-request-id": "0e9ef26d-1e2c-4868-8a92-b9abb8b3befb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
+        "Date": "Mon, 01 Feb 2021 15:52:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd4d0b70-0898-4f07-aed7-56d4aa783f8a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "371",
-        "x-request-id": "c61f661b-8bec-400c-bd9d-28bf7afe6042"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "413",
+        "X-Request-ID": "0e9ef26d-1e2c-4868-8a92-b9abb8b3befb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd4d0b70-0898-4f07-aed7-56d4aa783f8a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c86ab5cae762fd49882f0a21f63d0f1b-8f5526114c061543-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-668bcdf224142442b86a9cf7f125497c-f71e25266526cf4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "eff2a650bdaeee0af8fed3a485096d0e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a83e2d00-013e-4c7b-80ca-eeb6625c4873",
+        "apim-request-id": "daab41da-06f9-4c60-ac8d-a37accec5ba9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "163",
-        "x-request-id": "a83e2d00-013e-4c7b-80ca-eeb6625c4873"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "185",
+        "X-Request-ID": "daab41da-06f9-4c60-ac8d-a37accec5ba9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd4d0b70-0898-4f07-aed7-56d4aa783f8a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b0e987555d70a847a8d460fff5a47cb4-ddd69d552de49c41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-02e9ba6235657745b790f15b1b7a384e-99a5feddc4ba944f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "556825390ea229413637cae0cc077649",
         "x-ms-return-client-request-id": "true"
@@ -88,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "634b7c30-9ce7-4259-8d22-c68cf78e3dfc",
+        "apim-request-id": "d24e4f5b-1bf8-4622-89e5-97cf62571103",
         "Content-Length": "1021",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "155",
-        "x-request-id": "634b7c30-9ce7-4259-8d22-c68cf78e3dfc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "X-Request-ID": "d24e4f5b-1bf8-4622-89e5-97cf62571103"
       },
       "ResponseBody": {
-        "dataFeedId": "f36bbdae-b917-478b-8ee6-d96554e177ca",
+        "dataFeedId": "dd4d0b70-0898-4f07-aed7-56d4aa783f8a",
         "dataFeedName": "dataFeedRMf7oUHK",
         "metrics": [
           {
-            "metricId": "a5ad60d7-9b9a-466c-b24a-6accb37ec90d",
+            "metricId": "64f99d23-c839-409e-84c6-901431b7801c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -133,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:38Z",
+        "createdTime": "2021-02-01T15:52:43Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -144,13 +153,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dd4d0b70-0898-4f07-aed7-56d4aa783f8a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3fb7d8ce75baff4eafd2a6f29948e806-1a62e4f885f9904d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9f635e9c220c044b839e0c2a553d8fd5-25567301eb425c43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1e0f0238c9c3a02f02202f2e78dba1aa",
         "x-ms-return-client-request-id": "true"
@@ -158,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "8228ed29-1558-4017-baf4-0345dbc80c14",
+        "apim-request-id": "ad693f57-64a9-4938-8065-c7d8612301ad",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "293",
-        "x-request-id": "8228ed29-1558-4017-baf4-0345dbc80c14"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "326",
+        "X-Request-ID": "ad693f57-64a9-4938-8065-c7d8612301ad"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:39.1557594-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:43.9524877-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d01fc454d6e7ef4aac03c93a41bd3c3b-49a9b9feb473e243-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e0b5ca1a6feedf469233ea20255e44ce-bc15bf1ec43abf4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "280f0c5e4c2c277fb3da103e7a4580c8",
         "x-ms-return-client-request-id": "true"
@@ -32,62 +32,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "fffdf77c-e184-48e7-a68e-9a089c3f4219",
+        "apim-request-id": "c61f661b-8bec-400c-bd9d-28bf7afe6042",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:36 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3afc0242-8ae1-48eb-812d-20644cf745ca",
+        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "338",
-        "x-request-id": "fffdf77c-e184-48e7-a68e-9a089c3f4219"
+        "x-envoy-upstream-service-time": "371",
+        "x-request-id": "c61f661b-8bec-400c-bd9d-28bf7afe6042"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3afc0242-8ae1-48eb-812d-20644cf745ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "274",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-776a4a175b9ed7479bdc8e1450263699-4fa4504f53248e4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c86ab5cae762fd49882f0a21f63d0f1b-8f5526114c061543-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "eff2a650bdaeee0af8fed3a485096d0e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "command": "command"
-        },
-        "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeedRMf7oUHK",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e4fb3459-84d5-4694-9652-b7e6b94ed8ba",
+        "apim-request-id": "a83e2d00-013e-4c7b-80ca-eeb6625c4873",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:36 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "477",
-        "x-request-id": "e4fb3459-84d5-4694-9652-b7e6b94ed8ba"
+        "x-envoy-upstream-service-time": "163",
+        "x-request-id": "a83e2d00-013e-4c7b-80ca-eeb6625c4873"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3afc0242-8ae1-48eb-812d-20644cf745ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-862d1c2d8c54f24db0d7b2c4e540af74-d4f19ce5a2402b4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b0e987555d70a847a8d460fff5a47cb4-ddd69d552de49c41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "556825390ea229413637cae0cc077649",
         "x-ms-return-client-request-id": "true"
@@ -95,21 +88,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3c2f5b67-27a7-4e9d-a983-22402f6a8142",
+        "apim-request-id": "634b7c30-9ce7-4259-8d22-c68cf78e3dfc",
         "Content-Length": "1021",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:36 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:38 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "135",
-        "x-request-id": "3c2f5b67-27a7-4e9d-a983-22402f6a8142"
+        "x-envoy-upstream-service-time": "155",
+        "x-request-id": "634b7c30-9ce7-4259-8d22-c68cf78e3dfc"
       },
       "ResponseBody": {
-        "dataFeedId": "3afc0242-8ae1-48eb-812d-20644cf745ca",
+        "dataFeedId": "f36bbdae-b917-478b-8ee6-d96554e177ca",
         "dataFeedName": "dataFeedRMf7oUHK",
         "metrics": [
           {
-            "metricId": "5ca32fc7-c8ba-4357-9c61-3071810d6715",
+            "metricId": "a5ad60d7-9b9a-466c-b24a-6accb37ec90d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -140,7 +133,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:36Z",
+        "createdTime": "2021-02-01T12:46:38Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,13 +144,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3afc0242-8ae1-48eb-812d-20644cf745ca",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f36bbdae-b917-478b-8ee6-d96554e177ca",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-451549ddbd4b9049b4d7a48b4f5bae5c-e12ab1ac9b8e6b43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3fb7d8ce75baff4eafd2a6f29948e806-1a62e4f885f9904d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1e0f0238c9c3a02f02202f2e78dba1aa",
         "x-ms-return-client-request-id": "true"
@@ -165,19 +158,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "55fd95b8-fec6-4590-b5cf-73a458e36d37",
+        "apim-request-id": "8228ed29-1558-4017-baf4-0345dbc80c14",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:37 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "314",
-        "x-request-id": "55fd95b8-fec6-4590-b5cf-73a458e36d37"
+        "x-envoy-upstream-service-time": "293",
+        "x-request-id": "8228ed29-1558-4017-baf4-0345dbc80c14"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:36.9643111-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:39.1557594-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-34f4cedfcad33e47a743120ed2db6a06-3adcbb0d32c2f94a-00",
+        "traceparent": "00-6ed1de2673e2c241b9206fec926d4100-3cec1fa24e54854b-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -35,26 +35,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "df628edf-8897-47f0-af65-eb3b2ff865b0",
+        "apim-request-id": "6e5accd6-5ddd-45ee-a30c-1dd06d5e39c9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:03 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
+        "Date": "Mon, 01 Feb 2021 15:53:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78b6ebee-d656-4c4c-a628-67b29aa6e2ac",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "617",
-        "X-Request-ID": "df628edf-8897-47f0-af65-eb3b2ff865b0"
+        "x-envoy-upstream-service-time": "453",
+        "X-Request-ID": "6e5accd6-5ddd-45ee-a30c-1dd06d5e39c9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78b6ebee-d656-4c4c-a628-67b29aa6e2ac",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6496898f158a8a4ebf51d3f4429d2233-25e1a98048138641-00",
+        "traceparent": "00-4d3aba89972e5547b5101fd725cf5f4a-fefbcac3b6d1604c-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -64,28 +64,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "de222904-7383-4a99-8dd4-32e6577f2a1f",
+        "apim-request-id": "470b9a33-33c6-43d9-aa7f-67ac49c08b82",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:03 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "316",
-        "X-Request-ID": "de222904-7383-4a99-8dd4-32e6577f2a1f"
+        "x-envoy-upstream-service-time": "169",
+        "X-Request-ID": "470b9a33-33c6-43d9-aa7f-67ac49c08b82"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78b6ebee-d656-4c4c-a628-67b29aa6e2ac",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cdb2601ce4b446498420a4203d89d4c6-22690eb7340d214d-00",
+        "traceparent": "00-8e917b3b65b7a544b52297d92021e873-f76d5885ecd1c64d-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -97,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "836637ec-0e82-48a4-8597-72f00ff5c4cb",
+        "apim-request-id": "1f7efc45-15de-4c89-b3fd-ac077426ed4b",
         "Content-Length": "1021",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:04 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "252",
-        "X-Request-ID": "836637ec-0e82-48a4-8597-72f00ff5c4cb"
+        "x-envoy-upstream-service-time": "175",
+        "X-Request-ID": "1f7efc45-15de-4c89-b3fd-ac077426ed4b"
       },
       "ResponseBody": {
-        "dataFeedId": "89ac5bce-4b59-4454-910b-563b55a35c03",
+        "dataFeedId": "78b6ebee-d656-4c4c-a628-67b29aa6e2ac",
         "dataFeedName": "dataFeeddYF4Ln02",
         "metrics": [
           {
-            "metricId": "3b14646a-fb3c-416b-9a2e-636f7c60aab2",
+            "metricId": "2f37b6c5-a284-4761-8686-f747bc50eead",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -142,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:04Z",
+        "createdTime": "2021-02-01T15:53:15Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -153,12 +153,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/78b6ebee-d656-4c4c-a628-67b29aa6e2ac",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d5aeceef692d8b49860b9f1f9577f3c8-ce21a01380fa8e41-00",
+        "traceparent": "00-a1074d03fb93fd4f89897daee3df6057-de00a4dcb334704e-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -170,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1d124707-203e-4cc2-86b8-d0a9535e2be3",
+        "apim-request-id": "ffb0e570-e177-4cf9-9080-a6f4e78914c4",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:04 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "545",
-        "X-Request-ID": "1d124707-203e-4cc2-86b8-d0a9535e2be3"
+        "x-envoy-upstream-service-time": "319",
+        "X-Request-ID": "ffb0e570-e177-4cf9-9080-a6f4e78914c4"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:05.1012389-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:15.8734519-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMongoDbDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "258",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f18906c47225c74a9c6ac199baa07b7e-280ccfd2f0238747-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-34f4cedfcad33e47a743120ed2db6a06-3adcbb0d32c2f94a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e3aefb12b15b6f5214f2fc78d982d193",
         "x-ms-return-client-request-id": "true"
@@ -32,62 +35,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e5fd826c-17e6-48d3-99f7-62cbd68e090d",
+        "apim-request-id": "df628edf-8897-47f0-af65-eb3b2ff865b0",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:43 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac449cd3-70fe-42f5-9217-b9cedd0e5ba5",
+        "Date": "Mon, 01 Feb 2021 13:43:03 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "571",
-        "x-request-id": "e5fd826c-17e6-48d3-99f7-62cbd68e090d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "617",
+        "X-Request-ID": "df628edf-8897-47f0-af65-eb3b2ff865b0"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac449cd3-70fe-42f5-9217-b9cedd0e5ba5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "274",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8e247a78ffe6f34ebd1db6d11156733c-0cf3b44aa8628e41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6496898f158a8a4ebf51d3f4429d2233-25e1a98048138641-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "850c937633883d0c2c910fcee00efd20",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "database": "database",
-          "command": "command"
-        },
-        "dataSourceType": "MongoDB",
-        "dataFeedName": "dataFeeddYF4Ln02",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "81b51e57-c957-4fd0-806d-1318919d35ee",
+        "apim-request-id": "de222904-7383-4a99-8dd4-32e6577f2a1f",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:43 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "691",
-        "x-request-id": "81b51e57-c957-4fd0-806d-1318919d35ee"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "316",
+        "X-Request-ID": "de222904-7383-4a99-8dd4-32e6577f2a1f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac449cd3-70fe-42f5-9217-b9cedd0e5ba5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8d54233d27284c4fa91ff6f44c5556fb-81bbf00d06dedf49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cdb2601ce4b446498420a4203d89d4c6-22690eb7340d214d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "5916c88172ea7a71ea811cac157dcf27",
         "x-ms-return-client-request-id": "true"
@@ -95,21 +97,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4400ca5-b8b8-4c69-956a-7eb195284155",
+        "apim-request-id": "836637ec-0e82-48a4-8597-72f00ff5c4cb",
         "Content-Length": "1021",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:43 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "f4400ca5-b8b8-4c69-956a-7eb195284155"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "252",
+        "X-Request-ID": "836637ec-0e82-48a4-8597-72f00ff5c4cb"
       },
       "ResponseBody": {
-        "dataFeedId": "ac449cd3-70fe-42f5-9217-b9cedd0e5ba5",
+        "dataFeedId": "89ac5bce-4b59-4454-910b-563b55a35c03",
         "dataFeedName": "dataFeeddYF4Ln02",
         "metrics": [
           {
-            "metricId": "8099b9a7-8262-4cd5-9946-552241b73a0a",
+            "metricId": "3b14646a-fb3c-416b-9a2e-636f7c60aab2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -140,7 +142,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:43Z",
+        "createdTime": "2021-02-01T13:43:04Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,13 +153,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/ac449cd3-70fe-42f5-9217-b9cedd0e5ba5",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/89ac5bce-4b59-4454-910b-563b55a35c03",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4873b03b9a5cb649af37fabe40da873a-edf05e3fbdbebd4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d5aeceef692d8b49860b9f1f9577f3c8-ce21a01380fa8e41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3eb20e494b3edebfee71b6c9a2848e05",
         "x-ms-return-client-request-id": "true"
@@ -165,19 +170,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e4640ce3-6796-4fff-9f22-51b0c0c75d66",
+        "apim-request-id": "1d124707-203e-4cc2-86b8-d0a9535e2be3",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:45 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:04 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "282",
-        "x-request-id": "e4640ce3-6796-4fff-9f22-51b0c0c75d66"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "545",
+        "X-Request-ID": "1d124707-203e-4cc2-86b8-d0a9535e2be3"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:44.9076449-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:05.1012389-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f6e6f87e7da970489b35b88911fe109d-e3e477b2055ab948-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4bc9b87a7b21374ab0a2f22e44d46968-995ebc0041a58446-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "695d7bcd8e298708dcd4a57dab9f60f4",
+        "x-ms-client-request-id": "7da5d4dc9fabf460cdd60e9697387700",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +31,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "a87dffde-5e9f-42ec-90ed-94f087bf0b48",
+        "apim-request-id": "ca153d92-9d29-42d4-ab31-acc9ac735445",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:37 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+        "Date": "Mon, 01 Feb 2021 13:13:02 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "1123",
-        "x-request-id": "a87dffde-5e9f-42ec-90ed-94f087bf0b48"
+        "x-envoy-upstream-service-time": "562",
+        "x-request-id": "ca153d92-9d29-42d4-ab31-acc9ac735445"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9977bbccff52bc4ba04ad6ef1b4e81ca-7b5a5ab0aa92214f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d4ce8f835d976546b9a694de77284871-a3976d9136d39e4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "960ed6cd3897007785452fc0b7f421bd",
+        "x-ms-client-request-id": "c02f4585f4b7bd211b0b1545b3b92f31",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "b37271c7-7e57-42d8-b27d-848ba16ecc4a",
+        "apim-request-id": "5ec882ae-af1b-4946-825d-f99c3c878452",
         "Content-Length": "942",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:37 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:02 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "166",
-        "x-request-id": "b37271c7-7e57-42d8-b27d-848ba16ecc4a"
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "5ec882ae-af1b-4946-825d-f99c3c878452"
       },
       "ResponseBody": {
-        "dataFeedId": "c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+        "dataFeedId": "b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
         "dataFeedName": "dataFeedMjKRoDrV",
         "metrics": [
           {
-            "metricId": "72f387ea-9d23-4eba-8e01-17d35048c761",
+            "metricId": "7fd5ad1c-3726-4b8a-ab7e-9a7b551497da",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:37Z",
+        "createdTime": "2021-02-01T13:13:02Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +112,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "656",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b83626d8c082684f8b43c5672170b1c7-ed4c6b19088f1841-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7978d65c05600f47aab8f63908337a64-3ca5d099f92ea14a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "45150b1bb9b3312f6d13281db5ed6537",
+        "x-ms-client-request-id": "1d28136dedb53765c656388f42c32994",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +131,10 @@
           "query": "query"
         },
         "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedMjKRoDrV",
+        "dataFeedName": "dataFeedHOwE4Mow",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +155,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "07e23d89-325d-479e-9bb2-eb232bbf9784",
+        "apim-request-id": "5e156cd6-9fd0-46d5-b137-4241ed9c2f03",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:38 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "657",
-        "x-request-id": "07e23d89-325d-479e-9bb2-eb232bbf9784"
+        "x-envoy-upstream-service-time": "849",
+        "x-request-id": "5e156cd6-9fd0-46d5-b137-4241ed9c2f03"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f4af8790571d4c4e84ce440690e23d0b-ed261029bdbcdb41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-057be9eefef2bc44bfc7c57e7e88904b-b5dd2e7efe8bda44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8f3856c6c3429429045de3e35e48d0e7",
+        "x-ms-client-request-id": "e3e35d04485ee7d0b3e761a08a1a4014",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3ce39036-94b5-4cab-ac70-310fe4c409ee",
+        "apim-request-id": "4ddda9c7-12c7-4930-88af-47b2ed5897a8",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:38 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "136",
-        "x-request-id": "3ce39036-94b5-4cab-ac70-310fe4c409ee"
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "4ddda9c7-12c7-4930-88af-47b2ed5897a8"
       },
       "ResponseBody": {
-        "dataFeedId": "c08ace43-b52b-4fcd-a7f5-f284a88a5088",
-        "dataFeedName": "dataFeedMjKRoDrV",
+        "dataFeedId": "b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+        "dataFeedName": "dataFeedHOwE4Mow",
         "metrics": [
           {
-            "metricId": "72f387ea-9d23-4eba-8e01-17d35048c761",
+            "metricId": "7fd5ad1c-3726-4b8a-ab7e-9a7b551497da",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MySql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +227,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:37Z",
+        "createdTime": "2021-02-01T13:13:02Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +237,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c08ace43-b52b-4fcd-a7f5-f284a88a5088",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c36f69f831c57b4897ced52470bafdb4-d5ed828a8fb52d4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e9841d0d8d749c45a6142b85f47be6f1-3fef87596c57aa45-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a061e7b31a8a1440a7dd28840f594a98",
+        "x-ms-client-request-id": "8428dda7590f984ae0f8fa60bc917b58",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0b39edef-4992-408a-ae22-59b65811c8d1",
+        "apim-request-id": "2aaa6c59-b8c6-43de-a659-21989f312495",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:39 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:03 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "285",
-        "x-request-id": "0b39edef-4992-408a-ae22-59b65811c8d1"
+        "x-envoy-upstream-service-time": "343",
+        "x-request-id": "2aaa6c59-b8c6-43de-a659-21989f312495"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:38.9616796-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:13:03.6969074-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4bc9b87a7b21374ab0a2f22e44d46968-995ebc0041a58446-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-280f70476adc8f4785b67771991335ef-e5cbdcabc984154c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7da5d4dc9fabf460cdd60e9697387700",
         "x-ms-return-client-request-id": "true"
@@ -31,25 +34,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ca153d92-9d29-42d4-ab31-acc9ac735445",
+        "apim-request-id": "f4e8aa9b-7f63-4a2f-9ac8-364caeb4d2fb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:02 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+        "Date": "Mon, 01 Feb 2021 14:25:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cc8641c-9be7-42e8-9134-491642dd7413",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "562",
-        "x-request-id": "ca153d92-9d29-42d4-ab31-acc9ac735445"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "580",
+        "X-Request-ID": "f4e8aa9b-7f63-4a2f-9ac8-364caeb4d2fb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cc8641c-9be7-42e8-9134-491642dd7413",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d4ce8f835d976546b9a694de77284871-a3976d9136d39e4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cb3046357b5c194e87c2cfb2a1643f4c-6617c09a86588342-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "c02f4585f4b7bd211b0b1545b3b92f31",
         "x-ms-return-client-request-id": "true"
@@ -57,21 +63,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5ec882ae-af1b-4946-825d-f99c3c878452",
+        "apim-request-id": "7532c93a-5a67-4a6e-80d7-bd9432d4fd19",
         "Content-Length": "942",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:02 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "5ec882ae-af1b-4946-825d-f99c3c878452"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "141",
+        "X-Request-ID": "7532c93a-5a67-4a6e-80d7-bd9432d4fd19"
       },
       "ResponseBody": {
-        "dataFeedId": "b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+        "dataFeedId": "4cc8641c-9be7-42e8-9134-491642dd7413",
         "dataFeedName": "dataFeedMjKRoDrV",
         "metrics": [
           {
-            "metricId": "7fd5ad1c-3726-4b8a-ab7e-9a7b551497da",
+            "metricId": "3de96960-4283-45fa-b926-1d6873a6eeef",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:02Z",
+        "createdTime": "2021-02-01T14:25:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,15 +118,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cc8641c-9be7-42e8-9134-491642dd7413",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "656",
+        "Content-Length": "673",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7978d65c05600f47aab8f63908337a64-3ca5d099f92ea14a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4b6cf61f0e62914ba33a3ee7f9b89a67-3d3f7099b6cd4141-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1d28136dedb53765c656388f42c32994",
         "x-ms-return-client-request-id": "true"
@@ -145,7 +154,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -155,24 +165,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5e156cd6-9fd0-46d5-b137-4241ed9c2f03",
+        "apim-request-id": "ccaaca43-8ec6-4f5a-9a8f-d3bd1f88e1cd",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:03 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "849",
-        "x-request-id": "5e156cd6-9fd0-46d5-b137-4241ed9c2f03"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "667",
+        "X-Request-ID": "ccaaca43-8ec6-4f5a-9a8f-d3bd1f88e1cd"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cc8641c-9be7-42e8-9134-491642dd7413",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-057be9eefef2bc44bfc7c57e7e88904b-b5dd2e7efe8bda44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e76c8203c855d942ac9554eccb54a75e-b99a789506d9964b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e3e35d04485ee7d0b3e761a08a1a4014",
         "x-ms-return-client-request-id": "true"
@@ -180,21 +193,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4ddda9c7-12c7-4930-88af-47b2ed5897a8",
-        "Content-Length": "1068",
+        "apim-request-id": "410af18a-b34a-4422-92f6-dc2a61e532f9",
+        "Content-Length": "1085",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:03 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "4ddda9c7-12c7-4930-88af-47b2ed5897a8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "142",
+        "X-Request-ID": "410af18a-b34a-4422-92f6-dc2a61e532f9"
       },
       "ResponseBody": {
-        "dataFeedId": "b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+        "dataFeedId": "4cc8641c-9be7-42e8-9134-491642dd7413",
         "dataFeedName": "dataFeedHOwE4Mow",
         "metrics": [
           {
-            "metricId": "7fd5ad1c-3726-4b8a-ab7e-9a7b551497da",
+            "metricId": "3de96960-4283-45fa-b926-1d6873a6eeef",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -220,6 +233,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -227,7 +241,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:02Z",
+        "createdTime": "2021-02-01T14:25:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,13 +251,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b1d44fbd-5dc7-4dec-97b9-a7b51f5c4b21",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4cc8641c-9be7-42e8-9134-491642dd7413",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e9841d0d8d749c45a6142b85f47be6f1-3fef87596c57aa45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4750c2cc5218ad4090a50d7d7ce4aa9e-7e5ff89a57340140-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8428dda7590f984ae0f8fa60bc917b58",
         "x-ms-return-client-request-id": "true"
@@ -251,19 +268,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2aaa6c59-b8c6-43de-a659-21989f312495",
+        "apim-request-id": "51c47616-c1df-42cd-8bbd-0ba19e8ba5ba",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:03 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "343",
-        "x-request-id": "2aaa6c59-b8c6-43de-a659-21989f312495"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "293",
+        "X-Request-ID": "51c47616-c1df-42cd-8bbd-0ba19e8ba5ba"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:13:03.6969074-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:25:11.8401538-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4b28ea90bc9c46438acc402f6bbd0232-1afc99b44badf046-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-71d6f7c3badf2b44b06ec220c79a8e37-dedffbf853fdc743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d4df3f82cce7c42d1527b37f1f5517f5",
         "x-ms-return-client-request-id": "true"
@@ -34,28 +31,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "feef91c9-06c6-49ac-b102-b29716cf5d83",
+        "apim-request-id": "88b91094-1e07-4bdb-bef1-c7f3852f6cdb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:06 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+        "Date": "Mon, 01 Feb 2021 15:41:27 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57503901-429f-46ed-94c1-a377b2ea4b16",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1251",
-        "X-Request-ID": "feef91c9-06c6-49ac-b102-b29716cf5d83"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "467",
+        "x-request-id": "88b91094-1e07-4bdb-bef1-c7f3852f6cdb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57503901-429f-46ed-94c1-a377b2ea4b16",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-79293a202fcc1843a07e957ef60936d9-6e8bc9db47c0f44f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-e91131be34ecab43a04be2a77e565041-49dc2e7cbe668e41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b5e9d29364c21537735c9e8a2c8d4c7b",
         "x-ms-return-client-request-id": "true"
@@ -63,21 +57,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8871a604-9f3d-41f7-9269-603c24d2097b",
+        "apim-request-id": "e6f39923-0815-4ee5-ab5a-dfea0c988f6a",
         "Content-Length": "942",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:06 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:27 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "219",
-        "X-Request-ID": "8871a604-9f3d-41f7-9269-603c24d2097b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "146",
+        "x-request-id": "e6f39923-0815-4ee5-ab5a-dfea0c988f6a"
       },
       "ResponseBody": {
-        "dataFeedId": "cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+        "dataFeedId": "57503901-429f-46ed-94c1-a377b2ea4b16",
         "dataFeedName": "dataFeedbZHGE6Y9",
         "metrics": [
           {
-            "metricId": "602dad1b-98e4-463e-86b0-4a2719148e28",
+            "metricId": "37441283-d5f7-43fb-ad7e-4401b5548f65",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -108,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:06Z",
+        "createdTime": "2021-02-01T15:41:28Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,18 +112,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57503901-429f-46ed-94c1-a377b2ea4b16",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "656",
+        "Content-Length": "673",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-731a00786c692b40a6dc0239eff16a4a-17c87900d45e2d40-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-97815f85be9aac4dabc7438e45429290-694809b322281649-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "012c480ce4a0d01b601237c4b164ed2f",
         "x-ms-return-client-request-id": "true"
@@ -154,7 +145,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -164,27 +156,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1c288905-821a-4293-acce-a5c8b3777860",
+        "apim-request-id": "c36fb8f6-1292-4537-9cc6-a5306f974ae4",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "882",
-        "X-Request-ID": "1c288905-821a-4293-acce-a5c8b3777860"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "492",
+        "x-request-id": "c36fb8f6-1292-4537-9cc6-a5306f974ae4"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57503901-429f-46ed-94c1-a377b2ea4b16",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c1bd29cf0f91fc40b65c7644c12a559e-70367808217e6849-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-e5960ec8546b074aa3ca63324d1d4eff-42c0b1ac3e5c9c4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "aea8253bc1551dde08c9608b2ea29888",
         "x-ms-return-client-request-id": "true"
@@ -192,21 +181,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "aeee51e4-674c-4f0e-a46e-beb13c082fd2",
-        "Content-Length": "1068",
+        "apim-request-id": "60234e08-6f8a-4482-97dd-9ed7d904f294",
+        "Content-Length": "1085",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "212",
-        "X-Request-ID": "aeee51e4-674c-4f0e-a46e-beb13c082fd2"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "60234e08-6f8a-4482-97dd-9ed7d904f294"
       },
       "ResponseBody": {
-        "dataFeedId": "cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+        "dataFeedId": "57503901-429f-46ed-94c1-a377b2ea4b16",
         "dataFeedName": "dataFeedTfakhKCZ",
         "metrics": [
           {
-            "metricId": "602dad1b-98e4-463e-86b0-4a2719148e28",
+            "metricId": "37441283-d5f7-43fb-ad7e-4401b5548f65",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -232,6 +221,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -239,7 +229,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:06Z",
+        "createdTime": "2021-02-01T15:41:28Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,16 +239,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/57503901-429f-46ed-94c1-a377b2ea4b16",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21603f907e71204488e0c648a99a525b-340581225a34fc41-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-ec3cdd195f7eac43a0d14a5cd8bd2a71-8bfb1f74ffe48142-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d77237db1529af55b61954b02d73630f",
         "x-ms-return-client-request-id": "true"
@@ -266,19 +253,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a01a827e-e05c-4e80-9e45-efdcd0bba7d9",
+        "apim-request-id": "cb0069a4-ca10-4b60-ae31-383f1a02dabb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:07 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:28 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "340",
-        "X-Request-ID": "a01a827e-e05c-4e80-9e45-efdcd0bba7d9"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "319",
+        "x-request-id": "cb0069a4-ca10-4b60-ae31-383f1a02dabb"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:08.3152644-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:29.1485392-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-412c67f6fbff3040a6a776c70ca6f0d2-04ffe34f6765274b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4b28ea90bc9c46438acc402f6bbd0232-1afc99b44badf046-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3b1b52853f80a177823fdfd4e7cc2dc4",
+        "x-ms-client-request-id": "d4df3f82cce7c42d1527b37f1f5517f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +34,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "312a5475-e269-4246-b9b6-e37497fdc6b8",
+        "apim-request-id": "feef91c9-06c6-49ac-b102-b29716cf5d83",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+        "Date": "Mon, 01 Feb 2021 13:43:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "394",
-        "x-request-id": "312a5475-e269-4246-b9b6-e37497fdc6b8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1251",
+        "X-Request-ID": "feef91c9-06c6-49ac-b102-b29716cf5d83"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-282fab40f4da2242b8e1c818542ec1cb-746bedc8dcc82e4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-79293a202fcc1843a07e957ef60936d9-6e8bc9db47c0f44f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7fb32715551ff51793d2e9b5c2643715",
+        "x-ms-client-request-id": "b5e9d29364c21537735c9e8a2c8d4c7b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "e4e2085a-43f3-411a-9d43-8a7186c6c7a7",
+        "apim-request-id": "8871a604-9f3d-41f7-9269-603c24d2097b",
         "Content-Length": "942",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:16 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "153",
-        "x-request-id": "e4e2085a-43f3-411a-9d43-8a7186c6c7a7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "219",
+        "X-Request-ID": "8871a604-9f3d-41f7-9269-603c24d2097b"
       },
       "ResponseBody": {
-        "dataFeedId": "513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+        "dataFeedId": "cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
         "dataFeedName": "dataFeedbZHGE6Y9",
         "metrics": [
           {
-            "metricId": "dd02b857-2e32-4b6f-ab1e-7a8faf2e5eca",
+            "metricId": "602dad1b-98e4-463e-86b0-4a2719148e28",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:16Z",
+        "createdTime": "2021-02-01T13:43:06Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +118,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "656",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-75cf4ce664da274e876d31f8bc8fb0fb-3b762b09f32fa942-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-731a00786c692b40a6dc0239eff16a4a-17c87900d45e2d40-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8a9e5c738d2c7b4c0c482c01a0e41bd0",
+        "x-ms-client-request-id": "012c480ce4a0d01b601237c4b164ed2f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +140,10 @@
           "query": "query"
         },
         "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedbZHGE6Y9",
+        "dataFeedName": "dataFeedTfakhKCZ",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +164,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a203a649-9121-462e-afde-80454a1ed322",
+        "apim-request-id": "1c288905-821a-4293-acce-a5c8b3777860",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:17 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "684",
-        "x-request-id": "a203a649-9121-462e-afde-80454a1ed322"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "882",
+        "X-Request-ID": "1c288905-821a-4293-acce-a5c8b3777860"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9e070995af6a564dbcc1cc9259972cc9-587dc191fc856c41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c1bd29cf0f91fc40b65c7644c12a559e-70367808217e6849-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c437126064b12fed3b25a8ae55c1de1d",
+        "x-ms-client-request-id": "aea8253bc1551dde08c9608b2ea29888",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8b116c53-6b8e-4166-9d94-85661af923af",
+        "apim-request-id": "aeee51e4-674c-4f0e-a46e-beb13c082fd2",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:17 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "8b116c53-6b8e-4166-9d94-85661af923af"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "212",
+        "X-Request-ID": "aeee51e4-674c-4f0e-a46e-beb13c082fd2"
       },
       "ResponseBody": {
-        "dataFeedId": "513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
-        "dataFeedName": "dataFeedbZHGE6Y9",
+        "dataFeedId": "cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
+        "dataFeedName": "dataFeedTfakhKCZ",
         "metrics": [
           {
-            "metricId": "dd02b857-2e32-4b6f-ab1e-7a8faf2e5eca",
+            "metricId": "602dad1b-98e4-463e-86b0-4a2719148e28",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MySql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +239,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:16Z",
+        "createdTime": "2021-02-01T13:43:06Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +249,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/513c4914-ae57-4e6d-8a83-325e1d2b6f9b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/cdc5c8b9-2b75-4b3f-a889-5de4f7bfbe34",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-46c9a20b17ce0545b02e215f8198765a-8cfcd35391a25b4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-21603f907e71204488e0c648a99a525b-340581225a34fc41-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8b60c908a22e8898db3772d7291555af",
+        "x-ms-client-request-id": "d77237db1529af55b61954b02d73630f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "18d1e342-cf84-45ff-8e4b-800c6aa1cdab",
+        "apim-request-id": "a01a827e-e05c-4e80-9e45-efdcd0bba7d9",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:17 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "340",
-        "x-request-id": "18d1e342-cf84-45ff-8e4b-800c6aa1cdab"
+        "X-Request-ID": "a01a827e-e05c-4e80-9e45-efdcd0bba7d9"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:18.1291730-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:08.3152644-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-04cb91259b6b6b40b718cfc37817c725-1f98e0d6cbc55c43-00",
+        "traceparent": "00-1991446977ddb64cac0f69f0fed2503b-7f790069a7d7e143-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7fa9dec7127f6a5c6ec20aa463e6c670",
+        "x-ms-client-request-id": "aaf5fe200e5a11ea2bd45c49b356feec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,7 +20,7 @@
           "query": "query"
         },
         "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedilGpZrKB",
+        "dataFeedName": "dataFeedufEdZ9bD",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -31,38 +31,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e8314281-febe-4ac7-a07b-bde573421910",
+        "apim-request-id": "049f930f-ff7d-445b-8a81-ff5602b2cd9a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:04 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
+        "Date": "Mon, 01 Feb 2021 15:45:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "541",
-        "x-request-id": "e8314281-febe-4ac7-a07b-bde573421910"
+        "x-envoy-upstream-service-time": "460",
+        "x-request-id": "049f930f-ff7d-445b-8a81-ff5602b2cd9a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "544",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-42915dc7f386f645ab0c9373b16b0395-b36401bff60e4a4d-00",
+        "traceparent": "00-1f27f7630662bc409385b5a29db53302-3b482328fbcd4641-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d0d1e0a20fa55d20b534b8ffb5d8c609",
+        "x-ms-client-request-id": "9623114137af59f7d6b64306ff904fad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedEyi1EIvI",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedK9dbR1pa",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -79,46 +75,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b7fe0f78-43e5-46bc-93ae-8fd405dc6032",
+        "apim-request-id": "0d113779-74d7-4aa5-a979-e8eb20dddab7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:05 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "661",
-        "x-request-id": "b7fe0f78-43e5-46bc-93ae-8fd405dc6032"
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "0d113779-74d7-4aa5-a979-e8eb20dddab7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-da6f3330ee1afe47ba1007889fb19642-cde4c6640059cc4f-00",
+        "traceparent": "00-ba4d02476a0a8141bb28808e5b1d9377-41b46accb1f51b4c-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "74de021b7cd6007877e9eaaf616143ce",
+        "x-ms-client-request-id": "799dfd701d7c324528491ce4e07bee4c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "ff8b9461-27fa-499e-8b37-461994925058",
+        "apim-request-id": "93c1a035-d252-4a18-9f28-2699dab54821",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:05 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165",
-        "x-request-id": "ff8b9461-27fa-499e-8b37-461994925058"
+        "x-envoy-upstream-service-time": "149",
+        "x-request-id": "93c1a035-d252-4a18-9f28-2699dab54821"
       },
       "ResponseBody": {
-        "dataFeedId": "2d7bec04-7f74-48ff-b607-69938121b65c",
-        "dataFeedName": "dataFeedEyi1EIvI",
+        "dataFeedId": "9816739e-b7ec-4e6c-a656-f86e06f739d3",
+        "dataFeedName": "dataFeedK9dbR1pa",
         "metrics": [
           {
-            "metricId": "8a37c0ee-e697-474c-9d55-1282387c1b59",
+            "metricId": "5351555a-71e9-477e-83fb-3190fd5ac647",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -151,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:04Z",
+        "createdTime": "2021-02-01T15:45:40Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,37 +157,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e4b5696ce2dd9d4a932361ad61bbfca6-71a49174cbabff44-00",
+        "traceparent": "00-c6acb42f6bf1d043a0b3166f0290a468-180dcfb230d9f145-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "51fc42de299eb749bd4bc94a5a5db596",
+        "x-ms-client-request-id": "b95d2cee3689e8e5079bd4a3cbe3119b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b9385672-5168-4087-9763-4d29118e619a",
+        "apim-request-id": "74e72fe5-cd9f-4053-a571-f623f8584910",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:05 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "348",
-        "x-request-id": "b9385672-5168-4087-9763-4d29118e619a"
+        "x-envoy-upstream-service-time": "297",
+        "x-request-id": "74e72fe5-cd9f-4053-a571-f623f8584910"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:13:05.5458230-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:40.8768209-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "1068483484"
+    "RandomSeed": "959126050"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1991446977ddb64cac0f69f0fed2503b-7f790069a7d7e143-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-02d2b667fddd6c49a8e2fbc90a5da406-4c8965c675217d4d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "aaf5fe200e5a11ea2bd45c49b356feec",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "049f930f-ff7d-445b-8a81-ff5602b2cd9a",
+        "apim-request-id": "479809b3-fa23-4624-8140-becdfca4993e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
+        "Date": "Mon, 01 Feb 2021 15:52:44 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c23afa85-b2d7-48fe-8a38-ba2abb9a1da9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "460",
-        "x-request-id": "049f930f-ff7d-445b-8a81-ff5602b2cd9a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "420",
+        "X-Request-ID": "479809b3-fa23-4624-8140-becdfca4993e"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c23afa85-b2d7-48fe-8a38-ba2abb9a1da9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1f27f7630662bc409385b5a29db53302-3b482328fbcd4641-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f366561535f59f448a7e552279b8dc5d-e067016ff2df3043-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9623114137af59f7d6b64306ff904fad",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedK9dbR1pa",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "0d113779-74d7-4aa5-a979-e8eb20dddab7",
+        "apim-request-id": "98cd29de-5356-4a7a-8a7d-606552bce680",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "175",
-        "x-request-id": "0d113779-74d7-4aa5-a979-e8eb20dddab7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "X-Request-ID": "98cd29de-5356-4a7a-8a7d-606552bce680"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c23afa85-b2d7-48fe-8a38-ba2abb9a1da9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ba4d02476a0a8141bb28808e5b1d9377-41b46accb1f51b4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9b27e750a7c7da47aeb08191ee956b05-7e8c09a0afed244e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "799dfd701d7c324528491ce4e07bee4c",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "93c1a035-d252-4a18-9f28-2699dab54821",
+        "apim-request-id": "fe18891a-3036-4101-9b41-ffa90182b507",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "149",
-        "x-request-id": "93c1a035-d252-4a18-9f28-2699dab54821"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "151",
+        "X-Request-ID": "fe18891a-3036-4101-9b41-ffa90182b507"
       },
       "ResponseBody": {
-        "dataFeedId": "9816739e-b7ec-4e6c-a656-f86e06f739d3",
+        "dataFeedId": "c23afa85-b2d7-48fe-8a38-ba2abb9a1da9",
         "dataFeedName": "dataFeedK9dbR1pa",
         "metrics": [
           {
-            "metricId": "5351555a-71e9-477e-83fb-3190fd5ac647",
+            "metricId": "36ad4778-668d-4fe7-b648-3b57ee103e36",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:40Z",
+        "createdTime": "2021-02-01T15:52:44Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/9816739e-b7ec-4e6c-a656-f86e06f739d3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/c23afa85-b2d7-48fe-8a38-ba2abb9a1da9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c6acb42f6bf1d043a0b3166f0290a468-180dcfb230d9f145-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9a5d0193cc072845aaa3542fa11ac589-7bde8f36bb464143-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b95d2cee3689e8e5079bd4a3cbe3119b",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "74e72fe5-cd9f-4053-a571-f623f8584910",
+        "apim-request-id": "e7eb563c-f9bd-4a46-bb01-e820f5a2e474",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:41 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "297",
-        "x-request-id": "74e72fe5-cd9f-4053-a571-f623f8584910"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "360",
+        "X-Request-ID": "e7eb563c-f9bd-4a46-bb01-e820f5a2e474"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:40.8768209-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:45.1649907-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-aa7a558c2f06c54eae566dd6fecdd0f0-f3f8974d18f7754f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-04cb91259b6b6b40b718cfc37817c725-1f98e0d6cbc55c43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9fb2a4b57032eff9c7dea97f7f125c6a",
+        "x-ms-client-request-id": "7fa9dec7127f6a5c6ec20aa463e6c670",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +31,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "9b1c8396-0d7c-4782-a22c-5b17cb65943e",
+        "apim-request-id": "e8314281-febe-4ac7-a07b-bde573421910",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+        "Date": "Mon, 01 Feb 2021 13:13:04 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "367",
-        "x-request-id": "9b1c8396-0d7c-4782-a22c-5b17cb65943e"
+        "x-envoy-upstream-service-time": "541",
+        "x-request-id": "e8314281-febe-4ac7-a07b-bde573421910"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "544",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1bd2426999150643aa84c811fac369bf-cf99fed970164949-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-42915dc7f386f645ab0c9373b16b0395-b36401bff60e4a4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a40ac26ee66370c6a2e0d1d0a50f205d",
+        "x-ms-client-request-id": "d0d1e0a20fa55d20b534b8ffb5d8c609",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +62,10 @@
           "query": "query"
         },
         "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedilGpZrKB",
+        "dataFeedName": "dataFeedEyi1EIvI",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +79,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b7f48ea2-8fce-4458-b5f8-dd8942f7d7f0",
+        "apim-request-id": "b7fe0f78-43e5-46bc-93ae-8fd405dc6032",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "680",
-        "x-request-id": "b7f48ea2-8fce-4458-b5f8-dd8942f7d7f0"
+        "x-envoy-upstream-service-time": "661",
+        "x-request-id": "b7fe0f78-43e5-46bc-93ae-8fd405dc6032"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-80be70bf416746488f5be3743dc9bb21-c7559a6983d12b4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-da6f3330ee1afe47ba1007889fb19642-cde4c6640059cc4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ffb834b5d8b509c61b02de74d67c7800",
+        "x-ms-client-request-id": "74de021b7cd6007877e9eaaf616143ce",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "70cc2c32-00b2-498a-85d0-4579dd32be02",
+        "apim-request-id": "ff8b9461-27fa-499e-8b37-461994925058",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "70cc2c32-00b2-498a-85d0-4579dd32be02"
+        "x-envoy-upstream-service-time": "165",
+        "x-request-id": "ff8b9461-27fa-499e-8b37-461994925058"
       },
       "ResponseBody": {
-        "dataFeedId": "311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
-        "dataFeedName": "dataFeedilGpZrKB",
+        "dataFeedId": "2d7bec04-7f74-48ff-b607-69938121b65c",
+        "dataFeedName": "dataFeedEyi1EIvI",
         "metrics": [
           {
-            "metricId": "0b215087-fb37-4e59-be52-52994817ad58",
+            "metricId": "8a37c0ee-e697-474c-9d55-1282387c1b59",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MySql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:39Z",
+        "createdTime": "2021-02-01T13:13:04Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +161,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/311176ed-2b13-4b94-88f3-cd3ed3fb4ae7",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2d7bec04-7f74-48ff-b607-69938121b65c",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8e67856b4397fd42a3a03e6feae43ae5-87bf0db65669f149-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e4b5696ce2dd9d4a932361ad61bbfca6-71a49174cbabff44-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "afeae9776161ce43de42fc519e2949b7",
+        "x-ms-client-request-id": "51fc42de299eb749bd4bc94a5a5db596",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "766bb71e-26b2-495f-b419-e860304afa86",
+        "apim-request-id": "b9385672-5168-4087-9763-4d29118e619a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:40 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:05 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "300",
-        "x-request-id": "766bb71e-26b2-495f-b419-e860304afa86"
+        "x-envoy-upstream-service-time": "348",
+        "x-request-id": "b9385672-5168-4087-9763-4d29118e619a"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:40.7573988-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:13:05.5458230-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3e1dca6a21b7d44182ddd5d6f71b4998-4de631021ced1248-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-42a9220a59a3a44299d9b69e0ac76960-3b90cfad3511f043-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c69fa038ed0d88696f14a0db93f68042",
+        "x-ms-client-request-id": "dba0146ff6934280c4e46444836542f4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +34,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d0669b24-d8ee-478a-a080-6561a4c5b729",
+        "apim-request-id": "54deccad-3053-4206-894a-176635b092d5",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+        "Date": "Mon, 01 Feb 2021 13:43:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "423",
-        "x-request-id": "d0669b24-d8ee-478a-a080-6561a4c5b729"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "476",
+        "X-Request-ID": "54deccad-3053-4206-894a-176635b092d5"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "544",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ecbd1ac32d790046b8f9b9809ba8759b-18c04923a048ec4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-f2c7f0ddf00f3c4db030b6da2bc03030-acec8ff1b763104a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "4464e4c46583f44278503faf05924a02",
+        "x-ms-client-request-id": "af3f50789205024a1489d29054a57408",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +68,10 @@
           "query": "query"
         },
         "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedl7EhFK5o",
+        "dataFeedName": "dataFeed4uzBfmWa",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +85,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1bb3bdea-fdde-4dba-9481-b01e5e76d3bc",
+        "apim-request-id": "cdd363ba-abe5-4183-b8e5-efe0d98e7366",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:18 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "693",
-        "x-request-id": "1bb3bdea-fdde-4dba-9481-b01e5e76d3bc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "558",
+        "X-Request-ID": "cdd363ba-abe5-4183-b8e5-efe0d98e7366"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-edca074fce48f042a71595944c6d1877-ee4cae0e0e03f34d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c296ba0fe655c14897ca7774298da855-ea586a561647854d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "90d28914a5540874b02d54ab43f22174",
+        "x-ms-client-request-id": "ab542db0f2437421c0ad84ee65ca43d3",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "49325df1-ff55-4b57-b564-2f384d0a6324",
+        "apim-request-id": "99b508a7-dd3a-47f6-a469-49b816cb17e1",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "166",
-        "x-request-id": "49325df1-ff55-4b57-b564-2f384d0a6324"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "162",
+        "X-Request-ID": "99b508a7-dd3a-47f6-a469-49b816cb17e1"
       },
       "ResponseBody": {
-        "dataFeedId": "4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
-        "dataFeedName": "dataFeedl7EhFK5o",
+        "dataFeedId": "b9169327-8a24-40e8-9eec-5fcaef100fc4",
+        "dataFeedName": "dataFeed4uzBfmWa",
         "metrics": [
           {
-            "metricId": "dbb76588-30da-40c1-9d5c-88e7ebb273ae",
+            "metricId": "083205b2-4d51-4893-bfd7-06f33e69f471",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "MySql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +160,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:18Z",
+        "createdTime": "2021-02-01T13:43:09Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +170,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d37a1c1-ef81-4b6f-bdf2-291a7a87f597",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-500f911148cff843953b87581672d450-d0674d952db63841-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fdbf86305c032144a8b6a3fd328acf1f-9b122f6eebc4a342-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ee84adc0ca65d3435eab4dbcadb982dd",
+        "x-ms-client-request-id": "bc4dab5eb9addd82c99dc70924efee1f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "29e48f55-950e-4efb-99c5-a17a83624cc6",
+        "apim-request-id": "9d1fc008-472e-43b8-a233-c7fbb4aed556",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:19 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "313",
-        "x-request-id": "29e48f55-950e-4efb-99c5-a17a83624cc6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "329",
+        "X-Request-ID": "9d1fc008-472e-43b8-a233-c7fbb4aed556"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:19.9872274-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:09.9440739-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8d347132a663d346b3c1c133038de579-766fa98a921c2743-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-13c3948221471a4d925bd300def1b3f2-d83b534b3c07da49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dba0146ff6934280c4e46444836542f4",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6521c2cf-a675-442c-b1d8-4137b6b50260",
+        "apim-request-id": "a1eebb9e-a55f-40c6-bf1e-8d692fa56d18",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:29 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
+        "Date": "Mon, 01 Feb 2021 15:53:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aab2e446-bd7e-441b-a331-1fbacad8851b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "373",
-        "x-request-id": "6521c2cf-a675-442c-b1d8-4137b6b50260"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "574",
+        "X-Request-ID": "a1eebb9e-a55f-40c6-bf1e-8d692fa56d18"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aab2e446-bd7e-441b-a331-1fbacad8851b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8a91c174b258bf409f12120c6614cd20-d37e2bb39637ef4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-43f1ab9ba7450b45889789848ad9ab76-0e5b1bdae448ca46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "af3f50789205024a1489d29054a57408",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeed4uzBfmWa",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f4e1baa7-dc3d-4762-b656-a619a54382b7",
+        "apim-request-id": "3486fc84-90ff-419b-8452-fe936f07c4c1",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:29 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "199",
-        "x-request-id": "f4e1baa7-dc3d-4762-b656-a619a54382b7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "196",
+        "X-Request-ID": "3486fc84-90ff-419b-8452-fe936f07c4c1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aab2e446-bd7e-441b-a331-1fbacad8851b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b8bef6317e31154786fc0285b61788ee-4e5645457e04cc42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5b61970df416154aa0b2f2d4d770ef70-2869fe546893be4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ab542db0f2437421c0ad84ee65ca43d3",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "13a8170b-bc60-49e3-866c-4c0b4c263c7c",
+        "apim-request-id": "97f2ad0e-fe44-4848-ae3e-7468a08bbadc",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:29 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "151",
-        "x-request-id": "13a8170b-bc60-49e3-866c-4c0b4c263c7c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "158",
+        "X-Request-ID": "97f2ad0e-fe44-4848-ae3e-7468a08bbadc"
       },
       "ResponseBody": {
-        "dataFeedId": "34c50c85-a37e-412b-a403-eee8ffff531a",
+        "dataFeedId": "aab2e446-bd7e-441b-a331-1fbacad8851b",
         "dataFeedName": "dataFeed4uzBfmWa",
         "metrics": [
           {
-            "metricId": "de554f1d-2dcd-43d0-a116-500072430ca8",
+            "metricId": "82e7c8a8-c44b-4512-b6ef-02ae11a35052",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:29Z",
+        "createdTime": "2021-02-01T15:53:16Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/aab2e446-bd7e-441b-a331-1fbacad8851b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9d1a9251cb6a1c428269395d7053dd05-6962b6805d2f9f4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-697912870ce17b46a100eb6a9f0acad4-ba3c88f0684dea4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bc4dab5eb9addd82c99dc70924efee1f",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e7884b69-7073-482e-9450-95cbecc5d0fc",
+        "apim-request-id": "70c63c77-85bb-467f-afb5-5e6842166146",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:30 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "295",
-        "x-request-id": "e7884b69-7073-482e-9450-95cbecc5d0fc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "344",
+        "X-Request-ID": "70c63c77-85bb-467f-afb5-5e6842166146"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:30.3258876-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:17.2607130-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-42a9220a59a3a44299d9b69e0ac76960-3b90cfad3511f043-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-8d347132a663d346b3c1c133038de579-766fa98a921c2743-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "dba0146ff6934280c4e46444836542f4",
         "x-ms-return-client-request-id": "true"
@@ -34,40 +31,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "54deccad-3053-4206-894a-176635b092d5",
+        "apim-request-id": "6521c2cf-a675-442c-b1d8-4137b6b50260",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:08 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
+        "Date": "Mon, 01 Feb 2021 15:41:29 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "476",
-        "X-Request-ID": "54deccad-3053-4206-894a-176635b092d5"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "373",
+        "x-request-id": "6521c2cf-a675-442c-b1d8-4137b6b50260"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "544",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f2c7f0ddf00f3c4db030b6da2bc03030-acec8ff1b763104a-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-8a91c174b258bf409f12120c6614cd20-d37e2bb39637ef4e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "af3f50789205024a1489d29054a57408",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "MySql",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeed4uzBfmWa",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -85,27 +75,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "cdd363ba-abe5-4183-b8e5-efe0d98e7366",
+        "apim-request-id": "f4e1baa7-dc3d-4762-b656-a619a54382b7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:08 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "558",
-        "X-Request-ID": "cdd363ba-abe5-4183-b8e5-efe0d98e7366"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "199",
+        "x-request-id": "f4e1baa7-dc3d-4762-b656-a619a54382b7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c296ba0fe655c14897ca7774298da855-ea586a561647854d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-b8bef6317e31154786fc0285b61788ee-4e5645457e04cc42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ab542db0f2437421c0ad84ee65ca43d3",
         "x-ms-return-client-request-id": "true"
@@ -113,21 +100,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "99b508a7-dd3a-47f6-a469-49b816cb17e1",
+        "apim-request-id": "13a8170b-bc60-49e3-866c-4c0b4c263c7c",
         "Content-Length": "1068",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:09 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:29 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "X-Request-ID": "99b508a7-dd3a-47f6-a469-49b816cb17e1"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "151",
+        "x-request-id": "13a8170b-bc60-49e3-866c-4c0b4c263c7c"
       },
       "ResponseBody": {
-        "dataFeedId": "b9169327-8a24-40e8-9eec-5fcaef100fc4",
+        "dataFeedId": "34c50c85-a37e-412b-a403-eee8ffff531a",
         "dataFeedName": "dataFeed4uzBfmWa",
         "metrics": [
           {
-            "metricId": "083205b2-4d51-4893-bfd7-06f33e69f471",
+            "metricId": "de554f1d-2dcd-43d0-a116-500072430ca8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -160,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:09Z",
+        "createdTime": "2021-02-01T15:41:29Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,16 +157,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b9169327-8a24-40e8-9eec-5fcaef100fc4",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c50c85-a37e-412b-a403-eee8ffff531a",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fdbf86305c032144a8b6a3fd328acf1f-9b122f6eebc4a342-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-9d1a9251cb6a1c428269395d7053dd05-6962b6805d2f9f4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "bc4dab5eb9addd82c99dc70924efee1f",
         "x-ms-return-client-request-id": "true"
@@ -187,19 +171,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "9d1fc008-472e-43b8-a233-c7fbb4aed556",
+        "apim-request-id": "e7884b69-7073-482e-9450-95cbecc5d0fc",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:09 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "329",
-        "X-Request-ID": "9d1fc008-472e-43b8-a233-c7fbb4aed556"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "295",
+        "x-request-id": "e7884b69-7073-482e-9450-95cbecc5d0fc"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:09.9440739-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:30.3258876-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1dcc2b5cf398c948beca4dff5cb5af70-ba0a0a23478fb245-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9dfce407f1adbf469087d46af3691d30-5f290131e0af964b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2dd9350dc8db8fbd3dea203c4ae9a211",
         "x-ms-return-client-request-id": "true"
@@ -31,55 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "ea22b49e-c535-4d5e-96cd-d7e778403987",
+        "apim-request-id": "3f22cfe3-066e-4b50-827f-7beaa0ca034c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
+        "Date": "Mon, 01 Feb 2021 15:52:45 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7422368e-4ca0-4e19-a327-5be5b5aaeddb",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "363",
-        "x-request-id": "ea22b49e-c535-4d5e-96cd-d7e778403987"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "403",
+        "X-Request-ID": "3f22cfe3-066e-4b50-827f-7beaa0ca034c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7422368e-4ca0-4e19-a327-5be5b5aaeddb",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cdc9f22697601c4cb5dec30343bd977c-65ee74bd84e21643-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-88f2eefc909f9a4a8b1ff8018155d020-ab3434ac34cc1440-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "789c3b4cf5dce44aeb85eac87e8310ec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "dc8f6242-3a54-47ec-ad47-c35dc0a2b6ae",
+        "apim-request-id": "55c32dff-4458-4307-9035-659149301aab",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "212",
-        "x-request-id": "dc8f6242-3a54-47ec-ad47-c35dc0a2b6ae"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "190",
+        "X-Request-ID": "55c32dff-4458-4307-9035-659149301aab"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7422368e-4ca0-4e19-a327-5be5b5aaeddb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-09553bbb9532d24386002c572f11c340-7d61cd3e77f41749-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-12d4f8bdace542409e868e673f3a0194-f3ff37a917072a4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "417fcec8751e8d7e051d618cf52b694d",
         "x-ms-return-client-request-id": "true"
@@ -87,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "84abd980-a8eb-42b5-9b42-817ad3896bc5",
+        "apim-request-id": "1dcae923-6a1b-4ae5-9f18-f4dff5ed6268",
         "Content-Length": "993",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "174",
-        "x-request-id": "84abd980-a8eb-42b5-9b42-817ad3896bc5"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "155",
+        "X-Request-ID": "1dcae923-6a1b-4ae5-9f18-f4dff5ed6268"
       },
       "ResponseBody": {
-        "dataFeedId": "e1840701-43fb-4114-96fa-5fc497f631c9",
+        "dataFeedId": "7422368e-4ca0-4e19-a327-5be5b5aaeddb",
         "dataFeedName": "dataFeedETZh017F",
         "metrics": [
           {
-            "metricId": "c5c2ab3f-1e93-4ec0-b49f-189d1e1315e1",
+            "metricId": "c2288a18-f739-42d8-9e70-13530fc111eb",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -132,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:39Z",
+        "createdTime": "2021-02-01T15:52:45Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -142,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7422368e-4ca0-4e19-a327-5be5b5aaeddb",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8edd1a27e29f1e47b6dec21351ce059c-5c0cdd944e123147-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-21680a8591c06d42b09048dca6a06508-abe1466067d09e46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4959b4defc9918a4eaf54155def511ba",
         "x-ms-return-client-request-id": "true"
@@ -156,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d5799fca-17a5-4d80-8128-ba349df39b38",
+        "apim-request-id": "365e8f9e-6717-4ab4-813d-4c68f0de87f0",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:46 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "338",
-        "x-request-id": "d5799fca-17a5-4d80-8128-ba349df39b38"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "368",
+        "X-Request-ID": "365e8f9e-6717-4ab4-813d-4c68f0de87f0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:40.3834815-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:46.3591322-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-92b377c8e6a65d45b4a6dbf8cd3e4bbe-cc7dae2b5d53a444-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1dcc2b5cf398c948beca4dff5cb5af70-ba0a0a23478fb245-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2dd9350dc8db8fbd3dea203c4ae9a211",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +31,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "18d3b47f-a9bd-4e89-a655-918511b31591",
+        "apim-request-id": "ea22b49e-c535-4d5e-96cd-d7e778403987",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:39 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b07d3b4-b1af-4577-b00f-7e2fa3baa29c",
+        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "391",
-        "x-request-id": "18d3b47f-a9bd-4e89-a655-918511b31591"
+        "x-envoy-upstream-service-time": "363",
+        "x-request-id": "ea22b49e-c535-4d5e-96cd-d7e778403987"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b07d3b4-b1af-4577-b00f-7e2fa3baa29c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "246",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-64ed462fbadff145bdacb056787a7316-0c28b0cd5b738444-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-cdc9f22697601c4cb5dec30343bd977c-65ee74bd84e21643-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "789c3b4cf5dce44aeb85eac87e8310ec",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedETZh017F",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c3b79e6b-07ad-45e2-a8a1-c5f37c901142",
+        "apim-request-id": "dc8f6242-3a54-47ec-ad47-c35dc0a2b6ae",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:39 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "459",
-        "x-request-id": "c3b79e6b-07ad-45e2-a8a1-c5f37c901142"
+        "x-envoy-upstream-service-time": "212",
+        "x-request-id": "dc8f6242-3a54-47ec-ad47-c35dc0a2b6ae"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b07d3b4-b1af-4577-b00f-7e2fa3baa29c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-334317c351af08409c011173c8931cc0-b55c97df33ad9e47-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-09553bbb9532d24386002c572f11c340-7d61cd3e77f41749-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "417fcec8751e8d7e051d618cf52b694d",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +87,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "988a5a91-70ec-4e7d-ab45-64e749d71011",
+        "apim-request-id": "84abd980-a8eb-42b5-9b42-817ad3896bc5",
         "Content-Length": "993",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:39 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:39 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "144",
-        "x-request-id": "988a5a91-70ec-4e7d-ab45-64e749d71011"
+        "x-envoy-upstream-service-time": "174",
+        "x-request-id": "84abd980-a8eb-42b5-9b42-817ad3896bc5"
       },
       "ResponseBody": {
-        "dataFeedId": "8b07d3b4-b1af-4577-b00f-7e2fa3baa29c",
+        "dataFeedId": "e1840701-43fb-4114-96fa-5fc497f631c9",
         "dataFeedName": "dataFeedETZh017F",
         "metrics": [
           {
-            "metricId": "e8f47bd1-58ba-4349-9f66-1b1477583f45",
+            "metricId": "c5c2ab3f-1e93-4ec0-b49f-189d1e1315e1",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +132,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:39Z",
+        "createdTime": "2021-02-01T12:46:39Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +142,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8b07d3b4-b1af-4577-b00f-7e2fa3baa29c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e1840701-43fb-4114-96fa-5fc497f631c9",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-00068b5f986a8b45a0e76dde11327114-20a43582ffc5434f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8edd1a27e29f1e47b6dec21351ce059c-5c0cdd944e123147-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4959b4defc9918a4eaf54155def511ba",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +156,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "12a270e3-a244-46c3-be31-0567b26b9387",
+        "apim-request-id": "d5799fca-17a5-4d80-8128-ba349df39b38",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:40 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "271",
-        "x-request-id": "12a270e3-a244-46c3-be31-0567b26b9387"
+        "x-envoy-upstream-service-time": "338",
+        "x-request-id": "d5799fca-17a5-4d80-8128-ba349df39b38"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:40.1577587-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:40.3834815-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cd6d19694fb4ff498b14c343387f6fe4-a36f00c315a3e64b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e7c31f1b983bfc4db45c2dc0a4975031-87d86ac26cd07349-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b964ef6f3829e006f6f25417852515a3",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6e215b09-c574-4a32-abd3-975076094643",
+        "apim-request-id": "f336a2d8-d93e-4d17-94ab-c8c7c7aeee0c",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:47 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/22c0ab6d-0ab7-45be-852f-49f405a5e525",
+        "Date": "Mon, 01 Feb 2021 13:43:09 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "544",
-        "x-request-id": "6e215b09-c574-4a32-abd3-975076094643"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "473",
+        "X-Request-ID": "f336a2d8-d93e-4d17-94ab-c8c7c7aeee0c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/22c0ab6d-0ab7-45be-852f-49f405a5e525",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "246",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-80e5e4429c20164ca6a171a5fb98d29f-e2b6241a87da7e4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-daad968635bcd744aea6ab05f4d67acd-53381f4f82af6745-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fa56cad8c4702279c46d6901aeb774a6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "MySql",
-        "dataFeedName": "dataFeedpP8MQhy5",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ab75e318-103f-460f-a1f0-7a0b8adf455f",
+        "apim-request-id": "4e71fc88-0635-4f9c-8e6c-a0394df3fa00",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:48 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "598",
-        "x-request-id": "ab75e318-103f-460f-a1f0-7a0b8adf455f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "234",
+        "X-Request-ID": "4e71fc88-0635-4f9c-8e6c-a0394df3fa00"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/22c0ab6d-0ab7-45be-852f-49f405a5e525",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-601ba469c7b3994889519008be3c9f0c-161fa11e3c511647-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-836c3ef3bf59cb4792a1881f9f0e4d37-514fe21f54813644-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7c0441165609d25f9a0ce43201526676",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "d3bdb741-290c-4780-afed-e61bb2262e8f",
+        "apim-request-id": "08fab56d-edbf-4da9-b664-fecd242d18a1",
         "Content-Length": "993",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:48 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "d3bdb741-290c-4780-afed-e61bb2262e8f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "179",
+        "X-Request-ID": "08fab56d-edbf-4da9-b664-fecd242d18a1"
       },
       "ResponseBody": {
-        "dataFeedId": "22c0ab6d-0ab7-45be-852f-49f405a5e525",
+        "dataFeedId": "d3f2fc87-f885-40cc-9153-82bb33834001",
         "dataFeedName": "dataFeedpP8MQhy5",
         "metrics": [
           {
-            "metricId": "7b6fa1e2-dd10-4eb1-8b2b-f9f5496503ac",
+            "metricId": "478db19d-610b-4552-ac36-6b1ff300ca67",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:47Z",
+        "createdTime": "2021-02-01T13:43:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/22c0ab6d-0ab7-45be-852f-49f405a5e525",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-90b653d073783d4b99411f65c55b1476-91f3aa3958318748-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-43117f3dae861d4c8b2e176bcb756241-11b4faa9709fbf44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "3d56f953b1daabeb7642f4bccf04323f",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "50f8a0a8-9183-4f1f-a579-b3abd2c47d8c",
+        "apim-request-id": "a43e63c2-0bf0-4978-b9c6-5eadce1f9b3f",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:48 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "286",
-        "x-request-id": "50f8a0a8-9183-4f1f-a579-b3abd2c47d8c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "300",
+        "X-Request-ID": "a43e63c2-0bf0-4978-b9c6-5eadce1f9b3f"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:48.8955310-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:11.3042258-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateMySqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "230",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7c31f1b983bfc4db45c2dc0a4975031-87d86ac26cd07349-00",
+        "traceparent": "00-dcf86b702ada6f4a9ad7a24b3df3ea3e-fb736231dbc7874c-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -34,26 +34,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f336a2d8-d93e-4d17-94ab-c8c7c7aeee0c",
+        "apim-request-id": "9f0cd89a-c675-4d97-bf21-1ba1bc13e2fa",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:09 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
+        "Date": "Mon, 01 Feb 2021 15:53:17 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfcf1b2a-abd5-4f78-aa91-7c20bc1e4fb8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "473",
-        "X-Request-ID": "f336a2d8-d93e-4d17-94ab-c8c7c7aeee0c"
+        "x-envoy-upstream-service-time": "572",
+        "X-Request-ID": "9f0cd89a-c675-4d97-bf21-1ba1bc13e2fa"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfcf1b2a-abd5-4f78-aa91-7c20bc1e4fb8",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-daad968635bcd744aea6ab05f4d67acd-53381f4f82af6745-00",
+        "traceparent": "00-63bf48882fea2a499f19386fbf5ed3cb-c4c54eadf8b2034d-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -63,28 +63,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4e71fc88-0635-4f9c-8e6c-a0394df3fa00",
+        "apim-request-id": "2a3fe864-3c5a-4e94-a46a-3d5fb108504c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:10 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "234",
-        "X-Request-ID": "4e71fc88-0635-4f9c-8e6c-a0394df3fa00"
+        "x-envoy-upstream-service-time": "151",
+        "X-Request-ID": "2a3fe864-3c5a-4e94-a46a-3d5fb108504c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfcf1b2a-abd5-4f78-aa91-7c20bc1e4fb8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-836c3ef3bf59cb4792a1881f9f0e4d37-514fe21f54813644-00",
+        "traceparent": "00-d7c22ef2c2d7564ea963946930dc6823-4f8e5de8184ad048-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -96,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "08fab56d-edbf-4da9-b664-fecd242d18a1",
+        "apim-request-id": "6f28d22a-8e71-4497-a82d-60204f4e8444",
         "Content-Length": "993",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:10 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "179",
-        "X-Request-ID": "08fab56d-edbf-4da9-b664-fecd242d18a1"
+        "x-envoy-upstream-service-time": "136",
+        "X-Request-ID": "6f28d22a-8e71-4497-a82d-60204f4e8444"
       },
       "ResponseBody": {
-        "dataFeedId": "d3f2fc87-f885-40cc-9153-82bb33834001",
+        "dataFeedId": "dfcf1b2a-abd5-4f78-aa91-7c20bc1e4fb8",
         "dataFeedName": "dataFeedpP8MQhy5",
         "metrics": [
           {
-            "metricId": "478db19d-610b-4552-ac36-6b1ff300ca67",
+            "metricId": "5411c6af-99cf-4b4f-881d-06ebcb2164c8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -141,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:10Z",
+        "createdTime": "2021-02-01T15:53:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,12 +151,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d3f2fc87-f885-40cc-9153-82bb33834001",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/dfcf1b2a-abd5-4f78-aa91-7c20bc1e4fb8",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-43117f3dae861d4c8b2e176bcb756241-11b4faa9709fbf44-00",
+        "traceparent": "00-d9579573b3207142b83cf6c1dbb4b3a6-ac83e1e2355c3c4a-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -168,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a43e63c2-0bf0-4978-b9c6-5eadce1f9b3f",
+        "apim-request-id": "5e54256c-b49c-48b9-a92c-36ccf0ab3bd7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:10 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "300",
-        "X-Request-ID": "a43e63c2-0bf0-4978-b9c6-5eadce1f9b3f"
+        "x-envoy-upstream-service-time": "285",
+        "X-Request-ID": "5e54256c-b49c-48b9-a92c-36ccf0ab3bd7"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:11.3042258-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:18.5681786-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7085c09b6502cd41ae1205e539db08e8-2ac086748e30a349-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-06713be06044fc46813b43338e6642ff-524e434a80d83249-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4bcfbe40ef3b340a6752ab2fc24c6f3f",
         "x-ms-return-client-request-id": "true"
@@ -31,25 +34,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d5bb28a6-7d8e-496f-97fd-0a30cd9695e2",
+        "apim-request-id": "cd754f7f-e322-40c3-975c-a7cedd5b6d21",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:06 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
+        "Date": "Mon, 01 Feb 2021 14:25:14 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e745b9b-70bc-4dff-adaa-037012d4acf3",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "551",
-        "x-request-id": "d5bb28a6-7d8e-496f-97fd-0a30cd9695e2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "626",
+        "X-Request-ID": "cd754f7f-e322-40c3-975c-a7cedd5b6d21"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e745b9b-70bc-4dff-adaa-037012d4acf3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fcb4b122ce37be46a4627169e6f261d9-195cb0cf9d56d14a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c6f343bd58b2a547b3976e9d845d9687-9124154e760d4d46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b559fbe2394ee90859add24dee9a0e19",
         "x-ms-return-client-request-id": "true"
@@ -57,21 +63,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8f1d5e21-3905-45e3-b4f9-fa2e2471cbad",
+        "apim-request-id": "950aadb4-c650-4560-9d45-30b63de44191",
         "Content-Length": "947",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:06 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "8f1d5e21-3905-45e3-b4f9-fa2e2471cbad"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "X-Request-ID": "950aadb4-c650-4560-9d45-30b63de44191"
       },
       "ResponseBody": {
-        "dataFeedId": "a1357bbd-2490-4375-8292-047061c7792c",
+        "dataFeedId": "7e745b9b-70bc-4dff-adaa-037012d4acf3",
         "dataFeedName": "dataFeedCMDMtCuM",
         "metrics": [
           {
-            "metricId": "350a6d2b-1784-4d22-8bff-bfcf26e8d11d",
+            "metricId": "b92b5d1f-df1c-4271-bd39-3c55e317734d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:06Z",
+        "createdTime": "2021-02-01T14:25:14Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,15 +118,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e745b9b-70bc-4dff-adaa-037012d4acf3",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "661",
+        "Content-Length": "678",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8f88885020e8da4fb734ff2b36dd7876-03b47887671ed64a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-93b9b190df03b74aa73448f231f94b89-a9fa5c876892c145-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "a612ad4bdda46289ae4c2f7a1174ffa8",
         "x-ms-return-client-request-id": "true"
@@ -145,7 +154,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -155,24 +165,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c60efd71-63c1-42d8-8a87-8dbf6f2bec42",
+        "apim-request-id": "74cdea6d-89b2-41e0-a2d6-59b0f605809f",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:07 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:14 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "714",
-        "x-request-id": "c60efd71-63c1-42d8-8a87-8dbf6f2bec42"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "553",
+        "X-Request-ID": "74cdea6d-89b2-41e0-a2d6-59b0f605809f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e745b9b-70bc-4dff-adaa-037012d4acf3",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-12cc27876a230b45b10441c35d2e686e-b27279eb0cbfab4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-064d33cbb28f8e438f749533f18f2d00-486c1814c7a62842-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "79595538c134060fb6e5f28e1cbd46cc",
         "x-ms-return-client-request-id": "true"
@@ -180,21 +193,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6cbffbd8-83d2-40e9-bc6d-288f8394db44",
-        "Content-Length": "1073",
+        "apim-request-id": "5639a179-e35d-4a21-b7c3-f425499f6715",
+        "Content-Length": "1090",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:07 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "159",
-        "x-request-id": "6cbffbd8-83d2-40e9-bc6d-288f8394db44"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "188",
+        "X-Request-ID": "5639a179-e35d-4a21-b7c3-f425499f6715"
       },
       "ResponseBody": {
-        "dataFeedId": "a1357bbd-2490-4375-8292-047061c7792c",
+        "dataFeedId": "7e745b9b-70bc-4dff-adaa-037012d4acf3",
         "dataFeedName": "dataFeedGESwSuUa",
         "metrics": [
           {
-            "metricId": "350a6d2b-1784-4d22-8bff-bfcf26e8d11d",
+            "metricId": "b92b5d1f-df1c-4271-bd39-3c55e317734d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -220,6 +233,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -227,7 +241,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:06Z",
+        "createdTime": "2021-02-01T14:25:14Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,13 +251,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7e745b9b-70bc-4dff-adaa-037012d4acf3",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-dcea007189a3314cb6931b4a529b7a06-2991f642283d3d46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3e8c717d55e2604ba3137ed96af74839-87e64ffe876c9042-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "14e39244c93a059b72f60601098ed8e4",
         "x-ms-return-client-request-id": "true"
@@ -251,19 +268,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "bbad375b-8557-49f6-b966-676a624ed3f0",
+        "apim-request-id": "8b0e229c-cbd7-43be-9e29-b94f164e652e",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:07 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "322",
-        "x-request-id": "bbad375b-8557-49f6-b966-676a624ed3f0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "344",
+        "X-Request-ID": "8b0e229c-cbd7-43be-9e29-b94f164e652e"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:13:07.6039423-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:25:15.9868902-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-13be618805414e4380d5a37a2665c10f-b616da409572a347-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7085c09b6502cd41ae1205e539db08e8-2ac086748e30a349-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3b95a8f58d755d7640becf4b3bef0a34",
+        "x-ms-client-request-id": "4bcfbe40ef3b340a6752ab2fc24c6f3f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +31,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d85a17fd-cfab-4aeb-8e4a-b87fa0f1d1c1",
+        "apim-request-id": "d5bb28a6-7d8e-496f-97fd-0a30cd9695e2",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:41 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+        "Date": "Mon, 01 Feb 2021 13:13:06 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "539",
-        "x-request-id": "d85a17fd-cfab-4aeb-8e4a-b87fa0f1d1c1"
+        "x-envoy-upstream-service-time": "551",
+        "x-request-id": "d5bb28a6-7d8e-496f-97fd-0a30cd9695e2"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3682ff1f5de2ba45866fbdf3959e886c-04e61b648d27df4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-fcb4b122ce37be46a4627169e6f261d9-195cb0cf9d56d14a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2fab52674cc23f6fe2fb59b54e3908e9",
+        "x-ms-client-request-id": "b559fbe2394ee90859add24dee9a0e19",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "24e8371c-1d8c-4e9f-b2cc-cd47bcca3d40",
+        "apim-request-id": "8f1d5e21-3905-45e3-b4f9-fa2e2471cbad",
         "Content-Length": "947",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:41 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:06 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "167",
-        "x-request-id": "24e8371c-1d8c-4e9f-b2cc-cd47bcca3d40"
+        "x-envoy-upstream-service-time": "160",
+        "x-request-id": "8f1d5e21-3905-45e3-b4f9-fa2e2471cbad"
       },
       "ResponseBody": {
-        "dataFeedId": "7d433b14-94ef-40a2-811f-632c79eda68c",
+        "dataFeedId": "a1357bbd-2490-4375-8292-047061c7792c",
         "dataFeedName": "dataFeedCMDMtCuM",
         "metrics": [
           {
-            "metricId": "1c4874ad-0c4d-47cc-ae65-bcbcfe7e12e0",
+            "metricId": "350a6d2b-1784-4d22-8bff-bfcf26e8d11d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:41Z",
+        "createdTime": "2021-02-01T13:13:06Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +112,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "661",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-be493ef3ca4fdd4fb3d032a563fa8a6e-157ea25f1316dc48-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8f88885020e8da4fb734ff2b36dd7876-03b47887671ed64a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "4dd2ad599aee190e4bad12a6a4dd8962",
+        "x-ms-client-request-id": "a612ad4bdda46289ae4c2f7a1174ffa8",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +131,10 @@
           "query": "query"
         },
         "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeedCMDMtCuM",
+        "dataFeedName": "dataFeedGESwSuUa",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +155,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "5d71412b-00b8-423e-a181-7d3de606d234",
+        "apim-request-id": "c60efd71-63c1-42d8-8a87-8dbf6f2bec42",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:42 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "511",
-        "x-request-id": "5d71412b-00b8-423e-a181-7d3de606d234"
+        "x-envoy-upstream-service-time": "714",
+        "x-request-id": "c60efd71-63c1-42d8-8a87-8dbf6f2bec42"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1182ccb460bca840b6d5220597b5d5f9-7d773104bd260e4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-12cc27876a230b45b10441c35d2e686e-b27279eb0cbfab4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7a2f4cae7411a8ff3855597934c10f06",
+        "x-ms-client-request-id": "79595538c134060fb6e5f28e1cbd46cc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a02c588c-6173-4bda-97c4-5cd35b1754fc",
+        "apim-request-id": "6cbffbd8-83d2-40e9-bc6d-288f8394db44",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:42 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "162",
-        "x-request-id": "a02c588c-6173-4bda-97c4-5cd35b1754fc"
+        "x-envoy-upstream-service-time": "159",
+        "x-request-id": "6cbffbd8-83d2-40e9-bc6d-288f8394db44"
       },
       "ResponseBody": {
-        "dataFeedId": "7d433b14-94ef-40a2-811f-632c79eda68c",
-        "dataFeedName": "dataFeedCMDMtCuM",
+        "dataFeedId": "a1357bbd-2490-4375-8292-047061c7792c",
+        "dataFeedName": "dataFeedGESwSuUa",
         "metrics": [
           {
-            "metricId": "1c4874ad-0c4d-47cc-ae65-bcbcfe7e12e0",
+            "metricId": "350a6d2b-1784-4d22-8bff-bfcf26e8d11d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "PostgreSql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +227,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:41Z",
+        "createdTime": "2021-02-01T13:13:06Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +237,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7d433b14-94ef-40a2-811f-632c79eda68c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a1357bbd-2490-4375-8292-047061c7792c",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-fd0cf5cd0d782c4aa6bec9467b69aea2-4d137887e08f0b4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-dcea007189a3314cb6931b4a529b7a06-2991f642283d3d46-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8ef2e5b6bd1ccc464492e3143ac99b05",
+        "x-ms-client-request-id": "14e39244c93a059b72f60601098ed8e4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "28fb3173-f1dc-4ca7-8142-f9ede88eb17e",
+        "apim-request-id": "bbad375b-8557-49f6-b966-676a624ed3f0",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:42 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:07 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "306",
-        "x-request-id": "28fb3173-f1dc-4ca7-8142-f9ede88eb17e"
+        "x-envoy-upstream-service-time": "322",
+        "x-request-id": "bbad375b-8557-49f6-b966-676a624ed3f0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:42.7299704-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:13:07.6039423-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-21e87804ebb5d74e9eefcb68baac55ca-63cb9680814a8841-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-93c185e0ea099f4fa0b827a194ca36fb-7c3bbfe3a4cad74f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ba95ee751347ab5b68d96f6b0c6247e0",
         "x-ms-return-client-request-id": "true"
@@ -34,28 +31,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "7411ecbf-18a1-4ee8-a230-33b8c3718604",
+        "apim-request-id": "174edca9-2bb8-45b9-9361-5a070673cbd8",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:11 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
+        "Date": "Mon, 01 Feb 2021 15:41:30 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a81f32d4-9a08-4b80-8dd9-e2939b8baf35",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "409",
-        "X-Request-ID": "7411ecbf-18a1-4ee8-a230-33b8c3718604"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "466",
+        "x-request-id": "174edca9-2bb8-45b9-9361-5a070673cbd8"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a81f32d4-9a08-4b80-8dd9-e2939b8baf35",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7d55d03f10a5cf42b2bd02775f23fbb2-2cb00979eb9fd94f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-47144e54e9043e429bb33b7c338538b3-6a0736008c090c40-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "06c786cc21c917b5664f1019aad6e997",
         "x-ms-return-client-request-id": "true"
@@ -63,21 +57,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1398d90e-7e31-4a85-9213-4bde163714e6",
+        "apim-request-id": "baee0cc5-c407-444a-8b60-479553b02e97",
         "Content-Length": "947",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:11 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:30 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "196",
-        "X-Request-ID": "1398d90e-7e31-4a85-9213-4bde163714e6"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "151",
+        "x-request-id": "baee0cc5-c407-444a-8b60-479553b02e97"
       },
       "ResponseBody": {
-        "dataFeedId": "f7201992-677a-4fbc-8a36-b1a49f516092",
+        "dataFeedId": "a81f32d4-9a08-4b80-8dd9-e2939b8baf35",
         "dataFeedName": "dataFeeduZB2TS5C",
         "metrics": [
           {
-            "metricId": "50c40091-e4b6-4f70-8502-709b777d050d",
+            "metricId": "53c53d33-201b-448a-ba08-bc23cabc610a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -108,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:11Z",
+        "createdTime": "2021-02-01T15:41:31Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,18 +112,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a81f32d4-9a08-4b80-8dd9-e2939b8baf35",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "661",
+        "Content-Length": "678",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4c11d46fc2c1694f8831a2e542a0ad76-c3e09314ad7c564b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-f5270e67c4abec42a35611efd161ed38-fac8b2e9fa890d49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e4c512052d843e991affa66d9b825f4f",
         "x-ms-return-client-request-id": "true"
@@ -154,7 +145,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -164,27 +156,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a15706be-243e-449d-88ab-0e8215409b9d",
+        "apim-request-id": "4bbf23ed-932a-471e-83b0-4382843b7726",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:11 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "551",
-        "X-Request-ID": "a15706be-243e-449d-88ab-0e8215409b9d"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "521",
+        "x-request-id": "4bbf23ed-932a-471e-83b0-4382843b7726"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a81f32d4-9a08-4b80-8dd9-e2939b8baf35",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5ee934a47bf1a545829f7ef902960c63-45a9619475ad8146-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-bbdfd1d0d3e35a41a1d349e0b3e21e26-536ba1a7e0528c4d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "cb9f8c8ab7335475397e53f802410091",
         "x-ms-return-client-request-id": "true"
@@ -192,21 +181,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9067ca51-02a4-44b0-a98f-e9703651b235",
-        "Content-Length": "1073",
+        "apim-request-id": "e16b26cd-a77d-4de6-9dd1-5fc5a9c105a3",
+        "Content-Length": "1090",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "188",
-        "X-Request-ID": "9067ca51-02a4-44b0-a98f-e9703651b235"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "e16b26cd-a77d-4de6-9dd1-5fc5a9c105a3"
       },
       "ResponseBody": {
-        "dataFeedId": "f7201992-677a-4fbc-8a36-b1a49f516092",
+        "dataFeedId": "a81f32d4-9a08-4b80-8dd9-e2939b8baf35",
         "dataFeedName": "dataFeedpcZqoBah",
         "metrics": [
           {
-            "metricId": "50c40091-e4b6-4f70-8502-709b777d050d",
+            "metricId": "53c53d33-201b-448a-ba08-bc23cabc610a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -232,6 +221,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -239,7 +229,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:11Z",
+        "createdTime": "2021-02-01T15:41:31Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,16 +239,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a81f32d4-9a08-4b80-8dd9-e2939b8baf35",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-976391a1a37e2d44b363694761cfcaaf-0d986f6e461fb647-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-f3a17e87b79f8e45a7d6dbdb0235cd3f-e5ff4fcf1ea74f43-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f965d8f0639d9e5ced89ebc97a477be4",
         "x-ms-return-client-request-id": "true"
@@ -266,19 +253,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "7bbaf3e3-dc5a-4f23-b77f-dae75a738161",
+        "apim-request-id": "13051c3e-78e6-43b0-bd70-c65a662ab6cb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:31 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "353",
-        "X-Request-ID": "7bbaf3e3-dc5a-4f23-b77f-dae75a738161"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "286",
+        "x-request-id": "13051c3e-78e6-43b0-bd70-c65a662ab6cb"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:13.0758818-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:32.2371309-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3f9fba3634b83040a5032693a1665ddc-1067b27c65916649-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-21e87804ebb5d74e9eefcb68baac55ca-63cb9680814a8841-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6b6dd1b2fb513ebe75ee95ba47135bab",
+        "x-ms-client-request-id": "ba95ee751347ab5b68d96f6b0c6247e0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +34,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "63bd73e9-3d96-41ce-9f40-4986daf9e1db",
+        "apim-request-id": "7411ecbf-18a1-4ee8-a230-33b8c3718604",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+        "Date": "Mon, 01 Feb 2021 13:43:11 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "538",
-        "x-request-id": "63bd73e9-3d96-41ce-9f40-4986daf9e1db"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "409",
+        "X-Request-ID": "7411ecbf-18a1-4ee8-a230-33b8c3718604"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d3f66ad2bf61254aba77bbff0ec87e23-519d26f7bc094b40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7d55d03f10a5cf42b2bd02775f23fbb2-2cb00979eb9fd94f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6b6fd968620ce047cc86c706c921b517",
+        "x-ms-client-request-id": "06c786cc21c917b5664f1019aad6e997",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "453fa463-8e48-497d-8df5-d1c9664f676d",
+        "apim-request-id": "1398d90e-7e31-4a85-9213-4bde163714e6",
         "Content-Length": "947",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:20 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "168",
-        "x-request-id": "453fa463-8e48-497d-8df5-d1c9664f676d"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "196",
+        "X-Request-ID": "1398d90e-7e31-4a85-9213-4bde163714e6"
       },
       "ResponseBody": {
-        "dataFeedId": "8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+        "dataFeedId": "f7201992-677a-4fbc-8a36-b1a49f516092",
         "dataFeedName": "dataFeeduZB2TS5C",
         "metrics": [
           {
-            "metricId": "25967e8e-2336-4216-96dc-f6ba62b93aa3",
+            "metricId": "50c40091-e4b6-4f70-8502-709b777d050d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:20Z",
+        "createdTime": "2021-02-01T13:43:11Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +118,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "661",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-73038eeae6523347b824573511e59632-275410b3e6cd484c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4c11d46fc2c1694f8831a2e542a0ad76-c3e09314ad7c564b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "19104f66d6aa97e90512c5e4842d993e",
+        "x-ms-client-request-id": "e4c512052d843e991affa66d9b825f4f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +140,10 @@
           "query": "query"
         },
         "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeeduZB2TS5C",
+        "dataFeedName": "dataFeedpcZqoBah",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +164,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4de45bb0-5ce0-4741-be02-e0453935043f",
+        "apim-request-id": "a15706be-243e-449d-88ab-0e8215409b9d",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:20 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "685",
-        "x-request-id": "4de45bb0-5ce0-4741-be02-e0453935043f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "551",
+        "X-Request-ID": "a15706be-243e-449d-88ab-0e8215409b9d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1e9a4244cc98f841b8f80867960c8a00-6ce31d0b42e30849-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5ee934a47bf1a545829f7ef902960c63-45a9619475ad8146-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6da6ff1a829b4f5f8a8c9fcb33b77554",
+        "x-ms-client-request-id": "cb9f8c8ab7335475397e53f802410091",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "63eb88a8-16e3-4c71-8e5a-acdce5109a3c",
+        "apim-request-id": "9067ca51-02a4-44b0-a98f-e9703651b235",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:21 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "187",
-        "x-request-id": "63eb88a8-16e3-4c71-8e5a-acdce5109a3c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "188",
+        "X-Request-ID": "9067ca51-02a4-44b0-a98f-e9703651b235"
       },
       "ResponseBody": {
-        "dataFeedId": "8c8a8f75-825a-40a8-9f6f-e47561973c4e",
-        "dataFeedName": "dataFeeduZB2TS5C",
+        "dataFeedId": "f7201992-677a-4fbc-8a36-b1a49f516092",
+        "dataFeedName": "dataFeedpcZqoBah",
         "metrics": [
           {
-            "metricId": "25967e8e-2336-4216-96dc-f6ba62b93aa3",
+            "metricId": "50c40091-e4b6-4f70-8502-709b777d050d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "PostgreSql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +239,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:20Z",
+        "createdTime": "2021-02-01T13:43:11Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +249,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/8c8a8f75-825a-40a8-9f6f-e47561973c4e",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f7201992-677a-4fbc-8a36-b1a49f516092",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f025f21240386e4198fef3c1732e0f77-f01cf2dd6c56d54b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-976391a1a37e2d44b363694761cfcaaf-0d986f6e461fb647-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f8537e3941029100f0d865f99d635c9e",
+        "x-ms-client-request-id": "f965d8f0639d9e5ced89ebc97a477be4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1fb64f66-1dbd-47c7-bfeb-83c98f83185c",
+        "apim-request-id": "7bbaf3e3-dc5a-4f23-b77f-dae75a738161",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:21 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "359",
-        "x-request-id": "1fb64f66-1dbd-47c7-bfeb-83c98f83185c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "353",
+        "X-Request-ID": "7bbaf3e3-dc5a-4f23-b77f-dae75a738161"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:22.0699815-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:13.0758818-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-433f65449055d34fa70dfde7bdc62722-0ed41d068cff7c40-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-dbc5c93455de1d429e6015738fa95e91-8070cad1adaa8d44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4f82125dc24a5ff010842907ee3b7e8a",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "e08d9cc6-6ac1-4497-813f-990deccce2eb",
+        "apim-request-id": "71547e6b-fd53-40a9-a0c0-a2c1ab6cd369",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
+        "Date": "Mon, 01 Feb 2021 15:52:47 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/07dd6845-b5df-4f75-bd7e-90a59b8a8d8d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "434",
-        "x-request-id": "e08d9cc6-6ac1-4497-813f-990deccce2eb"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "526",
+        "X-Request-ID": "71547e6b-fd53-40a9-a0c0-a2c1ab6cd369"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/07dd6845-b5df-4f75-bd7e-90a59b8a8d8d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cb2d9b197d65f447bb69f54b3cf05326-4b0fa7655cf7844d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0f93ae634156dd48af6901484c7452a9-e086413d7db43549-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "0a814dce89dcd4a4e45d33a57ba14003",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedWCBjgz2f",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "52054b02-c2e8-45fb-bf4c-4e33c7898fe7",
+        "apim-request-id": "9b57ea73-b366-47a3-9d1b-d4ce5998addd",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "175",
-        "x-request-id": "52054b02-c2e8-45fb-bf4c-4e33c7898fe7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "183",
+        "X-Request-ID": "9b57ea73-b366-47a3-9d1b-d4ce5998addd"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/07dd6845-b5df-4f75-bd7e-90a59b8a8d8d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b5d019923e99ee4db3587549af2288c7-e2d7d4c5f3fead45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6e412f9536483443a6de50a60d9e5219-3962c6a4967dc746-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fb4a8164a34c171c989852e4c18db2d9",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "92dfeba8-47bf-444f-91d7-d45560c63099",
+        "apim-request-id": "107ea4ab-40ea-490f-889e-1bb3577b2bb3",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "152",
-        "x-request-id": "92dfeba8-47bf-444f-91d7-d45560c63099"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "168",
+        "X-Request-ID": "107ea4ab-40ea-490f-889e-1bb3577b2bb3"
       },
       "ResponseBody": {
-        "dataFeedId": "42434a8f-562a-495b-9258-c1ee289bc0b1",
+        "dataFeedId": "07dd6845-b5df-4f75-bd7e-90a59b8a8d8d",
         "dataFeedName": "dataFeedWCBjgz2f",
         "metrics": [
           {
-            "metricId": "26ffd0ee-ad81-4359-a5db-cc6e341af6b7",
+            "metricId": "b366c75f-ca59-495d-9e64-dbfb853460bf",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:42Z",
+        "createdTime": "2021-02-01T15:52:47Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/07dd6845-b5df-4f75-bd7e-90a59b8a8d8d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-62847ae2b7131e4284ae9b168910807d-7b64327d58385147-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3dbf25e15683df4b86f60b025df1b362-5094887c2f2fe94f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8841e11617f1d35d6dae6bec8e4ae46f",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "65149014-367f-4904-b2a8-99112294107b",
+        "apim-request-id": "11138d4c-5e4d-4d92-8614-6c8a3633baff",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:47 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "311",
-        "x-request-id": "65149014-367f-4904-b2a8-99112294107b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "279",
+        "X-Request-ID": "11138d4c-5e4d-4d92-8614-6c8a3633baff"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:42.5910471-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:47.7217261-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9f7590f6a188bf4c8701364d5311f95f-91149a4ba0b0364f-00",
+        "traceparent": "00-433f65449055d34fa70dfde7bdc62722-0ed41d068cff7c40-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f95ef9b2c74ebd0cef4ebb59df5d4adc",
+        "x-ms-client-request-id": "4f82125dc24a5ff010842907ee3b7e8a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,7 +20,7 @@
           "query": "query"
         },
         "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeedc1AgktnD",
+        "dataFeedName": "dataFeedVnB7KDMz",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -31,38 +31,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c9e0125c-50aa-449f-80fd-45dcdfbc8941",
+        "apim-request-id": "e08d9cc6-6ac1-4497-813f-990deccce2eb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:08 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
+        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "606",
-        "x-request-id": "c9e0125c-50aa-449f-80fd-45dcdfbc8941"
+        "x-envoy-upstream-service-time": "434",
+        "x-request-id": "e08d9cc6-6ac1-4497-813f-990deccce2eb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "549",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-767d005b5a36514c98979f7862a0c65a-7c7d47192e9b694a-00",
+        "traceparent": "00-cb2d9b197d65f447bb69f54b3cf05326-4b0fa7655cf7844d-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "ce5dc762b7a1b5a6d636b2fd9a4f902f",
+        "x-ms-client-request-id": "0a814dce89dcd4a4e45d33a57ba14003",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeedC2TlS37A",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedWCBjgz2f",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -79,46 +75,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "745ce4c0-3fef-4ce2-8491-46ceceffb810",
+        "apim-request-id": "52054b02-c2e8-45fb-bf4c-4e33c7898fe7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:08 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "763",
-        "x-request-id": "745ce4c0-3fef-4ce2-8491-46ceceffb810"
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "52054b02-c2e8-45fb-bf4c-4e33c7898fe7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ac0d56ff4b15a04ba891f6d06d526bf2-43b6f7e02b082540-00",
+        "traceparent": "00-b5d019923e99ee4db3587549af2288c7-e2d7d4c5f3fead45-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f22f43783e4d0c1780b65e0e20d764b1",
+        "x-ms-client-request-id": "fb4a8164a34c171c989852e4c18db2d9",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6c30ed44-0b6b-44a1-8790-c439a561adba",
+        "apim-request-id": "92dfeba8-47bf-444f-91d7-d45560c63099",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:09 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "166",
-        "x-request-id": "6c30ed44-0b6b-44a1-8790-c439a561adba"
+        "x-envoy-upstream-service-time": "152",
+        "x-request-id": "92dfeba8-47bf-444f-91d7-d45560c63099"
       },
       "ResponseBody": {
-        "dataFeedId": "63d7dbe3-eb5d-410a-9a1f-40914734cae2",
-        "dataFeedName": "dataFeedC2TlS37A",
+        "dataFeedId": "42434a8f-562a-495b-9258-c1ee289bc0b1",
+        "dataFeedName": "dataFeedWCBjgz2f",
         "metrics": [
           {
-            "metricId": "dba46208-6cd6-4566-945d-3f43b1144218",
+            "metricId": "26ffd0ee-ad81-4359-a5db-cc6e341af6b7",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -151,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:08Z",
+        "createdTime": "2021-02-01T15:45:42Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,37 +157,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/42434a8f-562a-495b-9258-c1ee289bc0b1",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-86b1ab8dc1fe184fb515ebdcf6011def-e2d939bb93116440-00",
+        "traceparent": "00-62847ae2b7131e4284ae9b168910807d-7b64327d58385147-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c10c1eed4a31fb1253a82217140f229f",
+        "x-ms-client-request-id": "8841e11617f1d35d6dae6bec8e4ae46f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "00abc550-862e-432a-8387-2166d8e4b381",
+        "apim-request-id": "65149014-367f-4904-b2a8-99112294107b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:09 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "344",
-        "x-request-id": "00abc550-862e-432a-8387-2166d8e4b381"
+        "x-envoy-upstream-service-time": "311",
+        "x-request-id": "65149014-367f-4904-b2a8-99112294107b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:13:09.6182843-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:42.5910471-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "501812333"
+    "RandomSeed": "1132384051"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f29bd62789dbc14396572c30c92b4318-0bb605904f25ba4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9f7590f6a188bf4c8701364d5311f95f-91149a4ba0b0364f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "6efb370f8e88b419b2f95ef94ec70cbd",
+        "x-ms-client-request-id": "f95ef9b2c74ebd0cef4ebb59df5d4adc",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +31,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0369079c-ab6e-4dd1-8ebd-b30adc161b3e",
+        "apim-request-id": "c9e0125c-50aa-449f-80fd-45dcdfbc8941",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:43 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+        "Date": "Mon, 01 Feb 2021 13:13:08 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "694",
-        "x-request-id": "0369079c-ab6e-4dd1-8ebd-b30adc161b3e"
+        "x-envoy-upstream-service-time": "606",
+        "x-request-id": "c9e0125c-50aa-449f-80fd-45dcdfbc8941"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "549",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9a367762c83f9e4792a142cf82f3680e-b0b1381d2ed76b4d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-767d005b5a36514c98979f7862a0c65a-7c7d47192e9b694a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "59bb4eef5ddfdc4a62c75dcea1b7a6b5",
+        "x-ms-client-request-id": "ce5dc762b7a1b5a6d636b2fd9a4f902f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +62,10 @@
           "query": "query"
         },
         "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeedc1AgktnD",
+        "dataFeedName": "dataFeedC2TlS37A",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +79,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a72d8a04-4211-4434-a2f9-f6a49f276f3d",
+        "apim-request-id": "745ce4c0-3fef-4ce2-8491-46ceceffb810",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:44 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:08 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "713",
-        "x-request-id": "a72d8a04-4211-4434-a2f9-f6a49f276f3d"
+        "x-envoy-upstream-service-time": "763",
+        "x-request-id": "745ce4c0-3fef-4ce2-8491-46ceceffb810"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a308a2ec8334e44fb32df9e946a9d089-55b5bb9289f4064b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ac0d56ff4b15a04ba891f6d06d526bf2-43b6f7e02b082540-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fdb236d64f9a2f9078432ff24d3e170c",
+        "x-ms-client-request-id": "f22f43783e4d0c1780b65e0e20d764b1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "8fd0f3d6-7076-478c-87aa-a95cedc2cf5b",
+        "apim-request-id": "6c30ed44-0b6b-44a1-8790-c439a561adba",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:44 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "195",
-        "x-request-id": "8fd0f3d6-7076-478c-87aa-a95cedc2cf5b"
+        "x-envoy-upstream-service-time": "166",
+        "x-request-id": "6c30ed44-0b6b-44a1-8790-c439a561adba"
       },
       "ResponseBody": {
-        "dataFeedId": "a98986c7-34db-486b-90af-8164897a2c4c",
-        "dataFeedName": "dataFeedc1AgktnD",
+        "dataFeedId": "63d7dbe3-eb5d-410a-9a1f-40914734cae2",
+        "dataFeedName": "dataFeedC2TlS37A",
         "metrics": [
           {
-            "metricId": "1f3bb1a0-db65-4118-9de0-5c862da351dc",
+            "metricId": "dba46208-6cd6-4566-945d-3f43b1144218",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "PostgreSql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:43Z",
+        "createdTime": "2021-02-01T13:13:08Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +161,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a98986c7-34db-486b-90af-8164897a2c4c",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/63d7dbe3-eb5d-410a-9a1f-40914734cae2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-16744d99c8843646b26efefca4df2aa2-87813933f7b1f84f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-86b1ab8dc1fe184fb515ebdcf6011def-e2d939bb93116440-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "0e5eb680d720b164ed1e0cc1314a12fb",
+        "x-ms-client-request-id": "c10c1eed4a31fb1253a82217140f229f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "07171f8c-9afe-4be5-b9ba-0de20624d761",
+        "apim-request-id": "00abc550-862e-432a-8387-2166d8e4b381",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:44 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:09 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "286",
-        "x-request-id": "07171f8c-9afe-4be5-b9ba-0de20624d761"
+        "x-envoy-upstream-service-time": "344",
+        "x-request-id": "00abc550-862e-432a-8387-2166d8e4b381"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:44.8500181-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:13:09.6182843-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d18aa2464ee302468d85e32ee0e82147-735373d3e1255b44-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-a770122aa1d6fa42ac4d188d9affa259-a97e80db2b0a924a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1fcb91e3d8b41ca82f861a141f10e7b2",
         "x-ms-return-client-request-id": "true"
@@ -34,40 +31,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "234f0056-0696-4932-8355-5f38d84161ea",
+        "apim-request-id": "23dc36b8-e319-41f3-a0cf-377524b234eb",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:13 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
+        "Date": "Mon, 01 Feb 2021 15:41:32 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "507",
-        "X-Request-ID": "234f0056-0696-4932-8355-5f38d84161ea"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "571",
+        "x-request-id": "23dc36b8-e319-41f3-a0cf-377524b234eb"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "549",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ecae35267332054a9911b9b2cc7efd70-2b6cda45a0e2364f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-4044a7c291abfb47a7e3c9eea1453005-b1ea8f8ee45ff949-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f7bcd34eecacd829181c0826275823da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "PostgreSql",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeedQdjEvPPT",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -85,27 +75,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "cc80d83a-5839-4bdd-a121-b5d4c2ef4c96",
+        "apim-request-id": "b2e90d43-61f4-4ba1-9a93-0719057d7428",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:15 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "1016",
-        "X-Request-ID": "cc80d83a-5839-4bdd-a121-b5d4c2ef4c96"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "b2e90d43-61f4-4ba1-9a93-0719057d7428"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-46d01afc0a9df74fa495bea95de97865-008bbda63205d440-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-6c8acd4fe347254da957b929a80d34fb-be8ef48118702f4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "997f502b5e9e022259b7782253236924",
         "x-ms-return-client-request-id": "true"
@@ -113,21 +100,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "82fee41f-0418-46d5-972f-1a4273156a0b",
+        "apim-request-id": "6bada4ee-f1e9-4800-8dd8-57198f76a9a2",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:15 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:32 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "201",
-        "X-Request-ID": "82fee41f-0418-46d5-972f-1a4273156a0b"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "x-request-id": "6bada4ee-f1e9-4800-8dd8-57198f76a9a2"
       },
       "ResponseBody": {
-        "dataFeedId": "e8647120-769f-4eaf-9ab0-f49472816612",
+        "dataFeedId": "4e8f13ce-e7b2-43ba-aa70-b87949591cba",
         "dataFeedName": "dataFeedQdjEvPPT",
         "metrics": [
           {
-            "metricId": "e71ce8f9-1568-4199-a73f-4b6adc4f327c",
+            "metricId": "a47fab52-8ff6-4c15-bcdd-5fc4cecafa2d",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -160,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:13Z",
+        "createdTime": "2021-02-01T15:41:33Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,16 +157,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-41dad3c4da6ee04391cf5e1bf434d9a4-d5b7012e97b2af47-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c92d5e928dfc4e4aa70e79af0db58495-8f1aec4e38daab41-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "01ab2dd307cdf68a68f20698d081f5d7",
         "x-ms-return-client-request-id": "true"
@@ -187,19 +171,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "454ed3de-1213-417e-a0f8-33b5728c3643",
+        "apim-request-id": "32dd5521-79fc-4224-abf4-0705c0ea86f7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:15 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "498",
-        "X-Request-ID": "454ed3de-1213-417e-a0f8-33b5728c3643"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "309",
+        "x-request-id": "32dd5521-79fc-4224-abf4-0705c0ea86f7"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:15.2475320-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:33.6125197-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1b6a66f5ce6e3e4093e0702ea7c3ba24-a3260c68d7abe24f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d18aa2464ee302468d85e32ee0e82147-735373d3e1255b44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "fae0bb348ad536fee391cb1fb4d8a81c",
+        "x-ms-client-request-id": "1fcb91e3d8b41ca82f861a141f10e7b2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +34,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "afade726-0f5d-46af-801f-16577aa9f4ee",
+        "apim-request-id": "234f0056-0696-4932-8355-5f38d84161ea",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:23 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+        "Date": "Mon, 01 Feb 2021 13:43:13 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "594",
-        "x-request-id": "afade726-0f5d-46af-801f-16577aa9f4ee"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "507",
+        "X-Request-ID": "234f0056-0696-4932-8355-5f38d84161ea"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "549",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-823b07a21353644caf02c8630723c2cb-7309438bf5848b46-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ecae35267332054a9911b9b2cc7efd70-2b6cda45a0e2364f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "141a862f101fb2e74ed3bcf7acec29d8",
+        "x-ms-client-request-id": "f7bcd34eecacd829181c0826275823da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +68,10 @@
           "query": "query"
         },
         "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeed1V6WOcCi",
+        "dataFeedName": "dataFeedQdjEvPPT",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +85,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3fa912a1-51ce-49f2-8cda-55bc8e4dca5f",
+        "apim-request-id": "cc80d83a-5839-4bdd-a121-b5d4c2ef4c96",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:24 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "729",
-        "x-request-id": "3fa912a1-51ce-49f2-8cda-55bc8e4dca5f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1016",
+        "X-Request-ID": "cc80d83a-5839-4bdd-a121-b5d4c2ef4c96"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4ce992c40227dd4e9787aab37039e43b-46ae38ba62e97143-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-46d01afc0a9df74fa495bea95de97865-008bbda63205d440-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "26081c185827da232b507f999e5e2202",
+        "x-ms-client-request-id": "997f502b5e9e022259b7782253236924",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "efa85d07-639b-4fe7-a213-1d96dc258c7c",
+        "apim-request-id": "82fee41f-0418-46d5-972f-1a4273156a0b",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:24 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "205",
-        "x-request-id": "efa85d07-639b-4fe7-a213-1d96dc258c7c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "201",
+        "X-Request-ID": "82fee41f-0418-46d5-972f-1a4273156a0b"
       },
       "ResponseBody": {
-        "dataFeedId": "6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
-        "dataFeedName": "dataFeed1V6WOcCi",
+        "dataFeedId": "e8647120-769f-4eaf-9ab0-f49472816612",
+        "dataFeedName": "dataFeedQdjEvPPT",
         "metrics": [
           {
-            "metricId": "e682af08-7311-4292-868e-c022fb134ff8",
+            "metricId": "e71ce8f9-1568-4199-a73f-4b6adc4f327c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "PostgreSql",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +160,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:23Z",
+        "createdTime": "2021-02-01T13:43:13Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +170,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6b82cd75-f595-44e2-a1dc-5c8892d1c5e0",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e8647120-769f-4eaf-9ab0-f49472816612",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2fdd7a9d71f0d9449acab7bcb9601071-3c705b7c9e1b8446-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-41dad3c4da6ee04391cf5e1bf434d9a4-d5b7012e97b2af47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2278b75923532469d32dab01cd078af6",
+        "x-ms-client-request-id": "01ab2dd307cdf68a68f20698d081f5d7",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2508be45-b8e9-49a4-b141-8c5c25a4b5c6",
+        "apim-request-id": "454ed3de-1213-417e-a0f8-33b5728c3643",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:25 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:15 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "413",
-        "x-request-id": "2508be45-b8e9-49a4-b141-8c5c25a4b5c6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "498",
+        "X-Request-ID": "454ed3de-1213-417e-a0f8-33b5728c3643"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:24.6097858-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:15.2475320-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a770122aa1d6fa42ac4d188d9affa259-a97e80db2b0a924a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d05e0520fbf58e4b8f7f333e17b7c5f7-4b4a683558bb5a4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1fcb91e3d8b41ca82f861a141f10e7b2",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "23dc36b8-e319-41f3-a0cf-377524b234eb",
+        "apim-request-id": "bdbb8a47-780e-4d68-8ca6-2842dfe1f899",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:32 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
+        "Date": "Mon, 01 Feb 2021 15:53:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d10d949-b359-4dd4-a8dc-6af7b2cee166",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "571",
-        "x-request-id": "23dc36b8-e319-41f3-a0cf-377524b234eb"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "569",
+        "X-Request-ID": "bdbb8a47-780e-4d68-8ca6-2842dfe1f899"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d10d949-b359-4dd4-a8dc-6af7b2cee166",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4044a7c291abfb47a7e3c9eea1453005-b1ea8f8ee45ff949-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a2f03010ea9e1d45854cd44b4a1598a3-142255f0d16b4640-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f7bcd34eecacd829181c0826275823da",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedQdjEvPPT",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "b2e90d43-61f4-4ba1-9a93-0719057d7428",
+        "apim-request-id": "6c683171-9b86-49d7-8f20-b2702e551265",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "b2e90d43-61f4-4ba1-9a93-0719057d7428"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "179",
+        "X-Request-ID": "6c683171-9b86-49d7-8f20-b2702e551265"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d10d949-b359-4dd4-a8dc-6af7b2cee166",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6c8acd4fe347254da957b929a80d34fb-be8ef48118702f4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-23ede088beb54f40b50ec6f8539f1b28-a91b2051b44df342-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "997f502b5e9e022259b7782253236924",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6bada4ee-f1e9-4800-8dd8-57198f76a9a2",
+        "apim-request-id": "38b742ff-4646-4d7a-a502-e7ddb0302af3",
         "Content-Length": "1073",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:32 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "6bada4ee-f1e9-4800-8dd8-57198f76a9a2"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "149",
+        "X-Request-ID": "38b742ff-4646-4d7a-a502-e7ddb0302af3"
       },
       "ResponseBody": {
-        "dataFeedId": "4e8f13ce-e7b2-43ba-aa70-b87949591cba",
+        "dataFeedId": "4d10d949-b359-4dd4-a8dc-6af7b2cee166",
         "dataFeedName": "dataFeedQdjEvPPT",
         "metrics": [
           {
-            "metricId": "a47fab52-8ff6-4c15-bcdd-5fc4cecafa2d",
+            "metricId": "749892cf-87ba-444b-9465-3883d2cd9146",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:33Z",
+        "createdTime": "2021-02-01T15:53:19Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e8f13ce-e7b2-43ba-aa70-b87949591cba",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4d10d949-b359-4dd4-a8dc-6af7b2cee166",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c92d5e928dfc4e4aa70e79af0db58495-8f1aec4e38daab41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6bb3fd2fc049c24ea8a96ed0570b4030-e5d1d5276ff7c540-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "01ab2dd307cdf68a68f20698d081f5d7",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "32dd5521-79fc-4224-abf4-0705c0ea86f7",
+        "apim-request-id": "6ddaf3ee-75a8-4458-89a3-3344b78adcb8",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:33 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "309",
-        "x-request-id": "32dd5521-79fc-4224-abf4-0705c0ea86f7"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "280",
+        "X-Request-ID": "6ddaf3ee-75a8-4458-89a3-3344b78adcb8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:33.6125197-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:19.8818127-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4bbcc972bb2e684f9e17db3f38bdb9d5-2669e045cc7f2044-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-6ca02c1af31be94186f1073fcd2acc9a-2943c8a73cb56741-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f8332099062c43909438603b5804576a",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +31,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "f6d1e0a2-f149-4d25-8e11-bf2367aa9aa2",
+        "apim-request-id": "52a2a480-6943-49c9-adec-83b40c17da2f",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:42 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6ac44034-c301-4f76-81c0-8b330daa7db3",
+        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "551",
-        "x-request-id": "f6d1e0a2-f149-4d25-8e11-bf2367aa9aa2"
+        "x-envoy-upstream-service-time": "383",
+        "x-request-id": "52a2a480-6943-49c9-adec-83b40c17da2f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6ac44034-c301-4f76-81c0-8b330daa7db3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "251",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5b812bda52fe6d4e8a4153c2d9733fbc-afbd20828718f943-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-08c5e9eca523104dab5e7402bc2dde67-6ee70c82f5085842-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4942d8b3d0a87c580da9d7cfd48e3472",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeedAKUUH6zP",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "4796645b-904a-4868-a99b-1e02b8343ed4",
+        "apim-request-id": "57d26ea0-10a7-49ec-add9-7fcacfc0c456",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:43 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "656",
-        "x-request-id": "4796645b-904a-4868-a99b-1e02b8343ed4"
+        "x-envoy-upstream-service-time": "157",
+        "x-request-id": "57d26ea0-10a7-49ec-add9-7fcacfc0c456"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6ac44034-c301-4f76-81c0-8b330daa7db3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-eafce26c31a1b549adb1f97fca106919-d0e1f8dfa5a18943-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0b245d3d956d5e45a06dedd6fe49540e-dd79bf5e0a0a1c4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "44b830f683ae1244e00633fff4e88839",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +87,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "061556ad-2da9-4f1e-ac17-58f9aebb9501",
+        "apim-request-id": "f6abec97-8275-4e2f-8a49-5bd727e907e8",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:43 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "215",
-        "x-request-id": "061556ad-2da9-4f1e-ac17-58f9aebb9501"
+        "x-envoy-upstream-service-time": "153",
+        "x-request-id": "f6abec97-8275-4e2f-8a49-5bd727e907e8"
       },
       "ResponseBody": {
-        "dataFeedId": "6ac44034-c301-4f76-81c0-8b330daa7db3",
+        "dataFeedId": "a9d30c7a-bd58-4744-ac7a-96d2c6993812",
         "dataFeedName": "dataFeedAKUUH6zP",
         "metrics": [
           {
-            "metricId": "a1a2913e-4ef2-4ef9-bf19-17ff203a1c16",
+            "metricId": "808506d8-870e-4f7c-9661-b9ec892c19bf",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +132,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:42Z",
+        "createdTime": "2021-02-01T12:46:41Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +142,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/6ac44034-c301-4f76-81c0-8b330daa7db3",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1141896c58b1b64aad67204759f55cdc-54a76445cf0c3442-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ec1933d428d77149a71c03b29308fd4c-340a732dd08c024b-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1d4871083564c911c7b6ea822fc06f06",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +156,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c3aa6c0e-18d9-4492-946f-2eefa63e6f2a",
+        "apim-request-id": "c05af222-6f5e-4e2b-b5dd-fe1b492af4b8",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:43 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "297",
-        "x-request-id": "c3aa6c0e-18d9-4492-946f-2eefa63e6f2a"
+        "x-envoy-upstream-service-time": "314",
+        "x-request-id": "c05af222-6f5e-4e2b-b5dd-fe1b492af4b8"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:43.7446348-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:41.5294695-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6ca02c1af31be94186f1073fcd2acc9a-2943c8a73cb56741-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-bda770f242869644a249f2d5a29c8e9c-b9f80f7ecae7d144-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f8332099062c43909438603b5804576a",
         "x-ms-return-client-request-id": "true"
@@ -31,55 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "52a2a480-6943-49c9-adec-83b40c17da2f",
+        "apim-request-id": "b1aec5f2-bfce-40dd-bb14-8348505a504d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
+        "Date": "Mon, 01 Feb 2021 15:52:48 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be862d80-9cec-4968-a895-40fd4f1d52e8",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "383",
-        "x-request-id": "52a2a480-6943-49c9-adec-83b40c17da2f"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "438",
+        "X-Request-ID": "b1aec5f2-bfce-40dd-bb14-8348505a504d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be862d80-9cec-4968-a895-40fd4f1d52e8",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-08c5e9eca523104dab5e7402bc2dde67-6ee70c82f5085842-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-10b356946b1b4747a60cd3088399aecb-4582ba54f042cd4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4942d8b3d0a87c580da9d7cfd48e3472",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "57d26ea0-10a7-49ec-add9-7fcacfc0c456",
+        "apim-request-id": "d83c7b81-34f4-4b3f-bf54-4f4f51bc4d35",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "157",
-        "x-request-id": "57d26ea0-10a7-49ec-add9-7fcacfc0c456"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "169",
+        "X-Request-ID": "d83c7b81-34f4-4b3f-bf54-4f4f51bc4d35"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be862d80-9cec-4968-a895-40fd4f1d52e8",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0b245d3d956d5e45a06dedd6fe49540e-dd79bf5e0a0a1c4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0610147fed44f84b9eaf7681814ea613-5b3f7f3feacc0d49-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "44b830f683ae1244e00633fff4e88839",
         "x-ms-return-client-request-id": "true"
@@ -87,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f6abec97-8275-4e2f-8a49-5bd727e907e8",
+        "apim-request-id": "2a2e4a8b-0f4d-4621-9a21-93b3afbb4239",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:40 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "153",
-        "x-request-id": "f6abec97-8275-4e2f-8a49-5bd727e907e8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "134",
+        "X-Request-ID": "2a2e4a8b-0f4d-4621-9a21-93b3afbb4239"
       },
       "ResponseBody": {
-        "dataFeedId": "a9d30c7a-bd58-4744-ac7a-96d2c6993812",
+        "dataFeedId": "be862d80-9cec-4968-a895-40fd4f1d52e8",
         "dataFeedName": "dataFeedAKUUH6zP",
         "metrics": [
           {
-            "metricId": "808506d8-870e-4f7c-9661-b9ec892c19bf",
+            "metricId": "aae2cd09-0749-47f4-95f1-193949d202ce",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -132,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:41Z",
+        "createdTime": "2021-02-01T15:52:48Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -142,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a9d30c7a-bd58-4744-ac7a-96d2c6993812",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/be862d80-9cec-4968-a895-40fd4f1d52e8",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ec1933d428d77149a71c03b29308fd4c-340a732dd08c024b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-0887550c9831964c933b521543e648a3-2d949437ec169f42-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1d4871083564c911c7b6ea822fc06f06",
         "x-ms-return-client-request-id": "true"
@@ -156,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "c05af222-6f5e-4e2b-b5dd-fe1b492af4b8",
+        "apim-request-id": "95b5c87d-d559-4b36-a7fe-292e4b5e399d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:41 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "314",
-        "x-request-id": "c05af222-6f5e-4e2b-b5dd-fe1b492af4b8"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "372",
+        "X-Request-ID": "95b5c87d-d559-4b36-a7fe-292e4b5e399d"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:41.5294695-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:48.8543052-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ffae92bd682e0249889ccf3e30f285e5-b33f7c8b009df246-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d130549a6f894e459d9f9bf348592f12-36630dc817075941-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7ec22d90674e5d4d231439305b9a9850",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "c1e4d6fd-ba5e-41d5-a916-3178c7449024",
+        "apim-request-id": "914249dd-539f-4c42-8779-32246dc68d30",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:56 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33160ac9-b46e-4d99-bd8c-277cf84c3e2a",
+        "Date": "Mon, 01 Feb 2021 13:43:16 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "5690",
-        "x-request-id": "c1e4d6fd-ba5e-41d5-a916-3178c7449024"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "780",
+        "X-Request-ID": "914249dd-539f-4c42-8779-32246dc68d30"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33160ac9-b46e-4d99-bd8c-277cf84c3e2a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "251",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cecc9a15f6c6e04595fa5f14a01818fd-9c70d903b9f69948-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d32e0917719ed9459a98524f67bd0125-b2e588e23bd4eb46-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1384f0aeacc2709f6f69f58d8ff9777e",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "PostgreSql",
-        "dataFeedName": "dataFeed5n2Ojw0t",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f7b064df-d6f4-4df7-bfd2-5b2d5ad20aea",
+        "apim-request-id": "224b3f41-06fc-49b9-85c3-deea63da59fa",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:56 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:16 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "616",
-        "x-request-id": "f7b064df-d6f4-4df7-bfd2-5b2d5ad20aea"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "215",
+        "X-Request-ID": "224b3f41-06fc-49b9-85c3-deea63da59fa"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33160ac9-b46e-4d99-bd8c-277cf84c3e2a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f71b3af7de65634a83989bc04e264e43-b62bd95391d23b4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a4ba3e97707d624cb6fb1ba1038e6817-3e408728ea558c4e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "69dbf6da5fd19a2dd1141faa058aa01b",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "f4acaa06-89d9-45c6-ae25-1db4d32a3327",
+        "apim-request-id": "387ba9a4-f959-4a39-9c20-ef063eb8be6c",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:22:57 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "168",
-        "x-request-id": "f4acaa06-89d9-45c6-ae25-1db4d32a3327"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "227",
+        "X-Request-ID": "387ba9a4-f959-4a39-9c20-ef063eb8be6c"
       },
       "ResponseBody": {
-        "dataFeedId": "33160ac9-b46e-4d99-bd8c-277cf84c3e2a",
+        "dataFeedId": "151b2da3-89be-4a43-9555-84ef4bcb0442",
         "dataFeedName": "dataFeed5n2Ojw0t",
         "metrics": [
           {
-            "metricId": "c2f760b4-a4fa-4762-a3e4-5d321f544fe2",
+            "metricId": "08dc2702-b4cb-4173-90e7-74768dd1ee71",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:22:56Z",
+        "createdTime": "2021-02-01T13:43:16Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/33160ac9-b46e-4d99-bd8c-277cf84c3e2a",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-01f6736c9cf1a2428ed8ef29214acf0e-8559833e3b03a545-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e7da4af0f764674e9b6353b085d7b6df-0859697d1ed79e42-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e8edde398122e3ab8d510ee572c0cd2a",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a4ae9ab8-3b4e-4734-9eed-de2f898105bc",
+        "apim-request-id": "ba6407da-fec0-40f4-86c8-2f5e1d14e412",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:57 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:17 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "298",
-        "x-request-id": "a4ae9ab8-3b4e-4734-9eed-de2f898105bc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "405",
+        "X-Request-ID": "ba6407da-fec0-40f4-86c8-2f5e1d14e412"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:22:57.7467410-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:17.0967932-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdatePostgreSqlDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "235",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d130549a6f894e459d9f9bf348592f12-36630dc817075941-00",
+        "traceparent": "00-52f67bb64e0bde468a58c1c70b211b99-a195b06d7d28434c-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -34,26 +34,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "914249dd-539f-4c42-8779-32246dc68d30",
+        "apim-request-id": "b57d7ccf-bf00-491f-a26d-2e2550376104",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:16 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
+        "Date": "Mon, 01 Feb 2021 15:53:19 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964483b6-bce2-47eb-bceb-08a1a86930e0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "780",
-        "X-Request-ID": "914249dd-539f-4c42-8779-32246dc68d30"
+        "x-envoy-upstream-service-time": "377",
+        "X-Request-ID": "b57d7ccf-bf00-491f-a26d-2e2550376104"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964483b6-bce2-47eb-bceb-08a1a86930e0",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d32e0917719ed9459a98524f67bd0125-b2e588e23bd4eb46-00",
+        "traceparent": "00-05fcc9a3e5ce4845ba70d5c01d831226-561b027a70bab84b-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -63,28 +63,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "224b3f41-06fc-49b9-85c3-deea63da59fa",
+        "apim-request-id": "1785ab16-56f8-4fe8-aa64-1138e2c62397",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:16 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "215",
-        "X-Request-ID": "224b3f41-06fc-49b9-85c3-deea63da59fa"
+        "x-envoy-upstream-service-time": "156",
+        "X-Request-ID": "1785ab16-56f8-4fe8-aa64-1138e2c62397"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964483b6-bce2-47eb-bceb-08a1a86930e0",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a4ba3e97707d624cb6fb1ba1038e6817-3e408728ea558c4e-00",
+        "traceparent": "00-2542f803c4b0cb4694a2f7afc5a4358a-0c2126a585918a40-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -96,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "387ba9a4-f959-4a39-9c20-ef063eb8be6c",
+        "apim-request-id": "4a6ea0e2-b553-4c58-bf6f-f73937fbec36",
         "Content-Length": "998",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "227",
-        "X-Request-ID": "387ba9a4-f959-4a39-9c20-ef063eb8be6c"
+        "x-envoy-upstream-service-time": "166",
+        "X-Request-ID": "4a6ea0e2-b553-4c58-bf6f-f73937fbec36"
       },
       "ResponseBody": {
-        "dataFeedId": "151b2da3-89be-4a43-9555-84ef4bcb0442",
+        "dataFeedId": "964483b6-bce2-47eb-bceb-08a1a86930e0",
         "dataFeedName": "dataFeed5n2Ojw0t",
         "metrics": [
           {
-            "metricId": "08dc2702-b4cb-4173-90e7-74768dd1ee71",
+            "metricId": "d743592b-5761-4d28-8602-16f7f7460e87",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -141,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:16Z",
+        "createdTime": "2021-02-01T15:53:20Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,12 +151,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/151b2da3-89be-4a43-9555-84ef4bcb0442",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/964483b6-bce2-47eb-bceb-08a1a86930e0",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e7da4af0f764674e9b6353b085d7b6df-0859697d1ed79e42-00",
+        "traceparent": "00-fadc289ef24f3f4cabca5d07513190ab-f8cd486f530a6e45-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -168,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ba6407da-fec0-40f4-86c8-2f5e1d14e412",
+        "apim-request-id": "e33b8d65-5525-4e9e-9085-cc654a4692a0",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:17 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "405",
-        "X-Request-ID": "ba6407da-fec0-40f4-86c8-2f5e1d14e412"
+        "x-envoy-upstream-service-time": "289",
+        "X-Request-ID": "e33b8d65-5525-4e9e-9085-cc654a4692a0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:17.0967932-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:21.0126751-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7529e295557b614795bcce64fdbb6e1e-aeb078a13dfbdb4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1c6184f241b25249bc3a895a35f2ef5e-afb7d26c71c05e42-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e1ef91bf7abb24ca32035fd5a4cba737",
         "x-ms-return-client-request-id": "true"
@@ -31,25 +34,28 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "bf457949-47c2-4c41-ad5e-d41241db8af3",
+        "apim-request-id": "122dc37c-2d44-45bf-8780-a286749d4aba",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:10 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+        "Date": "Mon, 01 Feb 2021 14:25:23 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fab30393-471f-4f9c-b4ca-879949ffc357",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "645",
-        "x-request-id": "bf457949-47c2-4c41-ad5e-d41241db8af3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "452",
+        "X-Request-ID": "122dc37c-2d44-45bf-8780-a286749d4aba"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fab30393-471f-4f9c-b4ca-879949ffc357",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b731e641e225794891ffbbb9186781a3-d61baa7d7138814f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5da179feb7c68d42949de980a5872b9a-a46b2a0fae52d44b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "e5ddb4185581fd38f5aac7f7acc03db0",
         "x-ms-return-client-request-id": "true"
@@ -57,21 +63,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "23238ae5-4239-4e35-8939-278034f57e06",
+        "apim-request-id": "59f55d26-f56e-423d-95d2-f8543825999e",
         "Content-Length": "946",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:10 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "165",
-        "x-request-id": "23238ae5-4239-4e35-8939-278034f57e06"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "197",
+        "X-Request-ID": "59f55d26-f56e-423d-95d2-f8543825999e"
       },
       "ResponseBody": {
-        "dataFeedId": "a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+        "dataFeedId": "fab30393-471f-4f9c-b4ca-879949ffc357",
         "dataFeedName": "dataFeeddo7sgZHb",
         "metrics": [
           {
-            "metricId": "8bd176a8-c475-4d59-a32d-3e2d16490ae8",
+            "metricId": "59562288-0478-4c25-852b-c49d576b1da6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:10Z",
+        "createdTime": "2021-02-01T14:25:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,15 +118,18 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fab30393-471f-4f9c-b4ca-879949ffc357",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "660",
+        "Content-Length": "677",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e23ad2d441c17745bb44b2f9f97fc96b-9c72718707f76f4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8c375fd86e8d274a8af3df2b20c08777-01612f2ff08f094c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "d52f2610d119c8f45c530690f036c21a",
         "x-ms-return-client-request-id": "true"
@@ -145,7 +154,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -155,24 +165,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "803ecbbb-da38-4ef0-9c31-0a3ef17a5532",
+        "apim-request-id": "0c1c1cd1-9c0d-4c68-b213-40c85b912b77",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:11 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "724",
-        "x-request-id": "803ecbbb-da38-4ef0-9c31-0a3ef17a5532"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "705",
+        "X-Request-ID": "0c1c1cd1-9c0d-4c68-b213-40c85b912b77"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fab30393-471f-4f9c-b4ca-879949ffc357",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9e1016fffdf0244b97bcac25fd351446-b77a22484a2f624c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1d30ba99c6d17941a77d23fb6121f916-153ec03ea9e3a441-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "b01bb70f939e6acd59f2ec11b3d27771",
         "x-ms-return-client-request-id": "true"
@@ -180,21 +193,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "cb9560da-2d47-4c07-a979-4be0fe65dfc0",
-        "Content-Length": "1072",
+        "apim-request-id": "cc927bb8-20cd-40e5-9238-0bb3db7fee1e",
+        "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:11 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "181",
-        "x-request-id": "cb9560da-2d47-4c07-a979-4be0fe65dfc0"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "152",
+        "X-Request-ID": "cc927bb8-20cd-40e5-9238-0bb3db7fee1e"
       },
       "ResponseBody": {
-        "dataFeedId": "a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+        "dataFeedId": "fab30393-471f-4f9c-b4ca-879949ffc357",
         "dataFeedName": "dataFeedCfLcmpX8",
         "metrics": [
           {
-            "metricId": "8bd176a8-c475-4d59-a32d-3e2d16490ae8",
+            "metricId": "59562288-0478-4c25-852b-c49d576b1da6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -220,6 +233,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -227,7 +241,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:10Z",
+        "createdTime": "2021-02-01T14:25:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,13 +251,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/fab30393-471f-4f9c-b4ca-879949ffc357",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d7b24ebd791be747a09331b4822c0263-202b8264a4e9884a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7a20c4f12e97c6429f2c776f084fb3a2-155b47eb9558fc4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7ec5afc6d29c471dbf14892e4ea70cbe",
         "x-ms-return-client-request-id": "true"
@@ -251,19 +268,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1f9940f2-84c5-48d6-a2ab-c583b929354a",
+        "apim-request-id": "4917db83-838a-474d-afe5-cf7f8c807646",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:11 GMT",
+        "Date": "Mon, 01 Feb 2021 14:25:24 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "322",
-        "x-request-id": "1f9940f2-84c5-48d6-a2ab-c583b929354a"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "330",
+        "X-Request-ID": "4917db83-838a-474d-afe5-cf7f8c807646"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:13:11.8772441-08:00",
+    "DateTimeOffsetNow": "2021-02-01T06:25:24.3503284-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b2521a3ddd32ac48827ebc453aabd996-738c6cbc17245c43-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7529e295557b614795bcce64fdbb6e1e-aeb078a13dfbdb4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "33efb7e67b644e78bf91efe1bb7aca24",
+        "x-ms-client-request-id": "e1ef91bf7abb24ca32035fd5a4cba737",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +31,47 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "8e158bb0-3b93-4343-952d-88c9d0273e11",
+        "apim-request-id": "bf457949-47c2-4c41-ad5e-d41241db8af3",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+        "Date": "Mon, 01 Feb 2021 13:13:10 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "402",
-        "x-request-id": "8e158bb0-3b93-4343-952d-88c9d0273e11"
+        "x-envoy-upstream-service-time": "645",
+        "x-request-id": "bf457949-47c2-4c41-ad5e-d41241db8af3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-499e329e1ee0ed478458b47a74353776-6976d85037bd644e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b731e641e225794891ffbbb9186781a3-d61baa7d7138814f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "d55f0332cba437a718b4dde5815538fd",
+        "x-ms-client-request-id": "e5ddb4185581fd38f5aac7f7acc03db0",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a8452660-2c51-4968-b068-cb6f51b1abf4",
+        "apim-request-id": "23238ae5-4239-4e35-8939-278034f57e06",
         "Content-Length": "946",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:45 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:10 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "164",
-        "x-request-id": "a8452660-2c51-4968-b068-cb6f51b1abf4"
+        "x-envoy-upstream-service-time": "165",
+        "x-request-id": "23238ae5-4239-4e35-8939-278034f57e06"
       },
       "ResponseBody": {
-        "dataFeedId": "2bb9edf9-25be-4161-bdf7-194454ec7277",
+        "dataFeedId": "a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
         "dataFeedName": "dataFeeddo7sgZHb",
         "metrics": [
           {
-            "metricId": "e79bfcc3-2fc6-408c-a168-4e31cec3d457",
+            "metricId": "8bd176a8-c475-4d59-a32d-3e2d16490ae8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:45Z",
+        "createdTime": "2021-02-01T13:13:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +112,17 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "660",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-0dfd8aedd90912419aca7fde6dc3b3a4-7bf0184dbc809c4a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-e23ad2d441c17745bb44b2f9f97fc96b-9c72718707f76f4c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f7c7aaf5c0acb03d10262fd519d1f4c8",
+        "x-ms-client-request-id": "d52f2610d119c8f45c530690f036c21a",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +131,10 @@
           "query": "query"
         },
         "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeeddo7sgZHb",
+        "dataFeedName": "dataFeedCfLcmpX8",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +155,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a1f375eb-fe3f-4ffb-84fe-7070df072087",
+        "apim-request-id": "803ecbbb-da38-4ef0-9c31-0a3ef17a5532",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:46 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "523",
-        "x-request-id": "a1f375eb-fe3f-4ffb-84fe-7070df072087"
+        "x-envoy-upstream-service-time": "724",
+        "x-request-id": "803ecbbb-da38-4ef0-9c31-0a3ef17a5532"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a22780ae59d1d043a43fe113e4127a64-74774e88c989474c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-9e1016fffdf0244b97bcac25fd351446-b77a22484a2f624c-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "9006535c36f01ac20fb71bb09e93cd6a",
+        "x-ms-client-request-id": "b01bb70f939e6acd59f2ec11b3d27771",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "fc640722-7d0c-46d9-9bf5-30d561e9c140",
+        "apim-request-id": "cb9560da-2d47-4c07-a979-4be0fe65dfc0",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:46 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "168",
-        "x-request-id": "fc640722-7d0c-46d9-9bf5-30d561e9c140"
+        "x-envoy-upstream-service-time": "181",
+        "x-request-id": "cb9560da-2d47-4c07-a979-4be0fe65dfc0"
       },
       "ResponseBody": {
-        "dataFeedId": "2bb9edf9-25be-4161-bdf7-194454ec7277",
-        "dataFeedName": "dataFeeddo7sgZHb",
+        "dataFeedId": "a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
+        "dataFeedName": "dataFeedCfLcmpX8",
         "metrics": [
           {
-            "metricId": "e79bfcc3-2fc6-408c-a168-4e31cec3d457",
+            "metricId": "8bd176a8-c475-4d59-a32d-3e2d16490ae8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "SqlServer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +227,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:45Z",
+        "createdTime": "2021-02-01T13:13:10Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +237,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/2bb9edf9-25be-4161-bdf7-194454ec7277",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/a78a88a9-ce22-4dbd-8f6b-f4b6cb7a27c2",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b58a4a75edac504b8605e831c7634b68-951ed2ef1db4254c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d7b24ebd791be747a09331b4822c0263-202b8264a4e9884a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "11ecf259d2b37177c6afc57e9cd21d47",
+        "x-ms-client-request-id": "7ec5afc6d29c471dbf14892e4ea70cbe",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1a605b95-46ec-47a7-af50-43133c658d55",
+        "apim-request-id": "1f9940f2-84c5-48d6-a2ab-c583b929354a",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:46 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:11 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "328",
-        "x-request-id": "1a605b95-46ec-47a7-af50-43133c658d55"
+        "x-envoy-upstream-service-time": "322",
+        "x-request-id": "1f9940f2-84c5-48d6-a2ab-c583b929354a"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:46.6491767-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:13:11.8772441-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d784292afc5d8a4886cbba06f6c1c638-fe2aaa35019aff4f-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-d38e6a83b22aab4292f06b2e19b81dc2-32ebff81ce73c641-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "7dc4f0e1f5e6ae3b308120f93192ca5c",
         "x-ms-return-client-request-id": "true"
@@ -34,28 +31,25 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "682f844f-988a-4d0a-a9a4-b3df7678f0fe",
+        "apim-request-id": "daac2917-3fe7-4fd3-bd3e-12b2ec1c3374",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:18 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
+        "Date": "Mon, 01 Feb 2021 15:41:33 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f7abf3f-6965-4dfd-897b-1c906f7ea660",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "759",
-        "X-Request-ID": "682f844f-988a-4d0a-a9a4-b3df7678f0fe"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "427",
+        "x-request-id": "daac2917-3fe7-4fd3-bd3e-12b2ec1c3374"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f7abf3f-6965-4dfd-897b-1c906f7ea660",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3c8665636445cf46a66229dc21bf405a-f7e8df522293894b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-604762b2ad3087439730fd93011fbab8-5264acabfb778f4a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "f065a3cbc82db6783faf6af214e9396b",
         "x-ms-return-client-request-id": "true"
@@ -63,21 +57,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "6bd29e63-5f6d-4799-a95e-ca555d9141a5",
+        "apim-request-id": "c769cd27-fa8c-4c78-9953-6be2eeccf4ea",
         "Content-Length": "946",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:18 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:33 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "198",
-        "X-Request-ID": "6bd29e63-5f6d-4799-a95e-ca555d9141a5"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "175",
+        "x-request-id": "c769cd27-fa8c-4c78-9953-6be2eeccf4ea"
       },
       "ResponseBody": {
-        "dataFeedId": "7b11b665-4a30-4710-aa59-7c1568b83561",
+        "dataFeedId": "7f7abf3f-6965-4dfd-897b-1c906f7ea660",
         "dataFeedName": "dataFeedYc3bmMvk",
         "metrics": [
           {
-            "metricId": "9a138a8d-3455-4076-91c9-7c524c4732a2",
+            "metricId": "bcc766a5-1d84-4c30-a62d-1088fb16f8d6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -108,7 +102,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:18Z",
+        "createdTime": "2021-02-01T15:41:34Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -118,18 +112,15 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f7abf3f-6965-4dfd-897b-1c906f7ea660",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "660",
+        "Content-Length": "677",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-8169b578befe9c4db5356daf101a035d-7bf7fb231653ac43-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-c11ee1e9d4edb54a8b2681c871ca83c6-c4d9c28ad9a2584e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "311f94256adaa39d1f3b0d24582a207f",
         "x-ms-return-client-request-id": "true"
@@ -154,7 +145,8 @@
         "fillMissingPointType": "NoFilling",
         "viewMode": "Public",
         "admins": [
-          "foo@contoso.com"
+          "foo@contoso.com",
+          "fake@admin.com"
         ],
         "viewers": [
           "fake@viewer.com"
@@ -164,27 +156,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "83272b15-2427-4fd5-b177-a99bad8d8f1f",
+        "apim-request-id": "731ce777-9a3d-4401-8715-14899827fa09",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:19 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "846",
-        "X-Request-ID": "83272b15-2427-4fd5-b177-a99bad8d8f1f"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "450",
+        "x-request-id": "731ce777-9a3d-4401-8715-14899827fa09"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f7abf3f-6965-4dfd-897b-1c906f7ea660",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4d4446da2b1a5d4a87c43ea5ff25c1e0-7fce700414649b44-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-add04ce694e04345b0b9e959e2b0dda5-a492f047121ae546-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "6328f2116c5719b4770e3e378b499a46",
         "x-ms-return-client-request-id": "true"
@@ -192,21 +181,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "1330519c-8301-4858-8b8a-43aa185a464a",
-        "Content-Length": "1072",
+        "apim-request-id": "f051065e-689f-449a-bc36-25eb50862749",
+        "Content-Length": "1089",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:19 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "204",
-        "X-Request-ID": "1330519c-8301-4858-8b8a-43aa185a464a"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "155",
+        "x-request-id": "f051065e-689f-449a-bc36-25eb50862749"
       },
       "ResponseBody": {
-        "dataFeedId": "7b11b665-4a30-4710-aa59-7c1568b83561",
+        "dataFeedId": "7f7abf3f-6965-4dfd-897b-1c906f7ea660",
         "dataFeedName": "dataFeedxwec9cgU",
         "metrics": [
           {
-            "metricId": "9a138a8d-3455-4076-91c9-7c524c4732a2",
+            "metricId": "bcc766a5-1d84-4c30-a62d-1088fb16f8d6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -232,6 +221,7 @@
         "maxConcurrency": 6,
         "viewMode": "Public",
         "admins": [
+          "fake@admin.com",
           "foo@contoso.com"
         ],
         "viewers": [
@@ -239,7 +229,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:18Z",
+        "createdTime": "2021-02-01T15:41:34Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -249,16 +239,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f7abf3f-6965-4dfd-897b-1c906f7ea660",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-3f26d1125a0af84cb8fe108b0d5ee011-cc0d6a744e08b740-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-713aa178b6adea4c92ac5f91b7ec777a-76c941952082b344-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9cd4b5489872608106c2d0f2ba545d14",
         "x-ms-return-client-request-id": "true"
@@ -266,19 +253,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "54625f36-670e-4e69-8534-fef9e0f4b4e0",
+        "apim-request-id": "c2082d2d-4335-4c25-a063-00bcefa2df03",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:19 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:34 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "369",
-        "X-Request-ID": "54625f36-670e-4e69-8534-fef9e0f4b4e0"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "341",
+        "x-request-id": "c2082d2d-4335-4c25-a063-00bcefa2df03"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:19.6740790-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:35.2930779-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndGetInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-44e48d991897a14690b749c29f62578d-5c9933e7628d3940-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d784292afc5d8a4886cbba06f6c1c638-fe2aaa35019aff4f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f44edb11bd06e15ce1f0c47de6f53bae",
+        "x-ms-client-request-id": "7dc4f0e1f5e6ae3b308120f93192ca5c",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,47 +34,50 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3a665559-9360-4224-a5d2-e482bc1c2b0c",
+        "apim-request-id": "682f844f-988a-4d0a-a9a4-b3df7678f0fe",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:25 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+        "Date": "Mon, 01 Feb 2021 13:43:18 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "414",
-        "x-request-id": "3a665559-9360-4224-a5d2-e482bc1c2b0c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "759",
+        "X-Request-ID": "682f844f-988a-4d0a-a9a4-b3df7678f0fe"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-279015fd33dee743b7f75c267ba0f2f1-676c33c4ea7e774c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3c8665636445cf46a66229dc21bf405a-f7e8df522293894b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f920813092315ccacba365f02dc878b6",
+        "x-ms-client-request-id": "f065a3cbc82db6783faf6af214e9396b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "3712eeb6-a906-467f-8871-953a1ebf2660",
+        "apim-request-id": "6bd29e63-5f6d-4799-a95e-ca555d9141a5",
         "Content-Length": "946",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:25 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:18 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "176",
-        "x-request-id": "3712eeb6-a906-467f-8871-953a1ebf2660"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "198",
+        "X-Request-ID": "6bd29e63-5f6d-4799-a95e-ca555d9141a5"
       },
       "ResponseBody": {
-        "dataFeedId": "b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+        "dataFeedId": "7b11b665-4a30-4710-aa59-7c1568b83561",
         "dataFeedName": "dataFeedYc3bmMvk",
         "metrics": [
           {
-            "metricId": "dd28f6cd-aaae-4d5f-96c1-f37225021cd6",
+            "metricId": "9a138a8d-3455-4076-91c9-7c524c4732a2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -102,7 +108,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:25Z",
+        "createdTime": "2021-02-01T13:43:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -112,17 +118,20 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "660",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-f8979225cd3d3a40979753802a3599d5-f391e1580c99eb41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8169b578befe9c4db5356daf101a035d-7bf7fb231653ac43-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "f26aaf3fe9146b3925941f31da6a9da3",
+        "x-ms-client-request-id": "311f94256adaa39d1f3b0d24582a207f",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -131,10 +140,10 @@
           "query": "query"
         },
         "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeedYc3bmMvk",
+        "dataFeedName": "dataFeedxwec9cgU",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -155,53 +164,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2b2d3959-7f0c-4095-a28a-1654d775355c",
+        "apim-request-id": "83272b15-2427-4fd5-b177-a99bad8d8f1f",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:26 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "606",
-        "x-request-id": "2b2d3959-7f0c-4095-a28a-1654d775355c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "846",
+        "X-Request-ID": "83272b15-2427-4fd5-b177-a99bad8d8f1f"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-35c1a326cab389499cc947a87d113ce1-9ed09e57db03a147-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-4d4446da2b1a5d4a87c43ea5ff25c1e0-7fce700414649b44-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "240d3b1f2a587f2011f22863576cb419",
+        "x-ms-client-request-id": "6328f2116c5719b4770e3e378b499a46",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "54cbd674-39c4-4c9a-b102-47764ec8458b",
+        "apim-request-id": "1330519c-8301-4858-8b8a-43aa185a464a",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:26 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "182",
-        "x-request-id": "54cbd674-39c4-4c9a-b102-47764ec8458b"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "204",
+        "X-Request-ID": "1330519c-8301-4858-8b8a-43aa185a464a"
       },
       "ResponseBody": {
-        "dataFeedId": "b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
-        "dataFeedName": "dataFeedYc3bmMvk",
+        "dataFeedId": "7b11b665-4a30-4710-aa59-7c1568b83561",
+        "dataFeedName": "dataFeedxwec9cgU",
         "metrics": [
           {
-            "metricId": "dd28f6cd-aaae-4d5f-96c1-f37225021cd6",
+            "metricId": "9a138a8d-3455-4076-91c9-7c524c4732a2",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "SqlServer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -227,7 +239,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:25Z",
+        "createdTime": "2021-02-01T13:43:18Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -237,33 +249,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/b2d0cf8f-ed57-4b89-ac2a-27ff2f609c34",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7b11b665-4a30-4710-aa59-7c1568b83561",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6e96cf90d60e82458a66b331a5a46065-a666bb7b9ebb9a44-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-3f26d1125a0af84cb8fe108b0d5ee011-cc0d6a744e08b740-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "373e0e77498b469a48b5d49c72988160",
+        "x-ms-client-request-id": "9cd4b5489872608106c2d0f2ba545d14",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fe40e1e2-3f73-489c-9464-2bd1fadaebfd",
+        "apim-request-id": "54625f36-670e-4e69-8534-fef9e0f4b4e0",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:27 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:19 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "386",
-        "x-request-id": "fe40e1e2-3f73-489c-9464-2bd1fadaebfd"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "369",
+        "X-Request-ID": "54625f36-670e-4e69-8534-fef9e0f4b4e0"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:26.8109530-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:19.6740790-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e6b72e8c6f995a4eb48300714b814136-da22bd87fdd62d4c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-122d75633556d44194fc3927866dc6e5-6297b86d5a525e49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "2be5ffdc3e0ef1aff109ae7d0dca60bb",
+        "x-ms-client-request-id": "7dae09f1ca0dbb60260764495f814f77",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +31,29 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "d2ee4abc-e45d-498d-a872-baa71f3ae95c",
+        "apim-request-id": "3aade665-5cfc-446c-9a6f-e22f38e16e0c",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:47 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+        "Date": "Mon, 01 Feb 2021 13:13:12 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "338",
-        "x-request-id": "d2ee4abc-e45d-498d-a872-baa71f3ae95c"
+        "x-envoy-upstream-service-time": "547",
+        "x-request-id": "3aade665-5cfc-446c-9a6f-e22f38e16e0c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "548",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d761d65928105241a5d967eeff361708-96b61be47dab554d-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-11bf493745ad9d4b9ced80b37a2b5a01-eec00cc360d4004d-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "49640726815f774fc728b7e332625672",
+        "x-ms-client-request-id": "e3b728c76232725626edc7c96f1d55ef",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +62,10 @@
           "query": "query"
         },
         "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeedCE4QcpDi",
+        "dataFeedName": "dataFeedk5t1Qd3l",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +79,53 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "e4015276-0438-4be1-be16-5c9647fae007",
+        "apim-request-id": "d524d88c-36fa-4abb-8baf-43c5929f5ac1",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:47 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:12 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "644",
-        "x-request-id": "e4015276-0438-4be1-be16-5c9647fae007"
+        "x-envoy-upstream-service-time": "723",
+        "x-request-id": "d524d88c-36fa-4abb-8baf-43c5929f5ac1"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c1a7afbb687b2f439602145d3ddf30c0-26df3896c4a1fd4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-28a3d5bc30ae8846a511b21ead893e60-e5967fa8031d2c48-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "c9c7ed261d6fef5549be90e899e0ad59",
+        "x-ms-client-request-id": "e890be49e09959adb2cad9cbf79e1e5b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "df7e1563-215c-42df-bca4-a0ee5c4cddc4",
+        "apim-request-id": "9ddba1dc-c3eb-41c1-a08e-0e796d8923b5",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:50:48 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "150",
-        "x-request-id": "df7e1563-215c-42df-bca4-a0ee5c4cddc4"
+        "x-envoy-upstream-service-time": "185",
+        "x-request-id": "9ddba1dc-c3eb-41c1-a08e-0e796d8923b5"
       },
       "ResponseBody": {
-        "dataFeedId": "0a0f5dff-945c-420e-80db-e6f1217ae828",
-        "dataFeedName": "dataFeedCE4QcpDi",
+        "dataFeedId": "14c4b87e-5134-4e88-a7dc-035fe3f7587f",
+        "dataFeedName": "dataFeedk5t1Qd3l",
         "metrics": [
           {
-            "metricId": "36cc92e6-0717-4a79-89c6-0aa67cdd82e3",
+            "metricId": "e719987d-2dcd-4311-9ae5-90fc335684b8",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "SqlServer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +151,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:50:47Z",
+        "createdTime": "2021-02-01T13:13:12Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +161,33 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/0a0f5dff-945c-420e-80db-e6f1217ae828",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-eda69a37bec1fd4a898360c30ae5acfc-034672d7e7e7b349-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b8e4966b63bcf34c86f0897de11ccd13-eedb9d3cc6752f42-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "cbd9cab29ef75b1eb06e64e586ccbf8f",
+        "x-ms-client-request-id": "e5646eb0cc868fbfb23b561f02974c09",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2a9e87cf-0989-407a-b6ff-ffcda9b7105b",
+        "apim-request-id": "1a6afed6-2fdb-4d57-bc9d-118917e701a9",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:50:48 GMT",
+        "Date": "Mon, 01 Feb 2021 13:13:13 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "290",
-        "x-request-id": "2a9e87cf-0989-407a-b6ff-ffcda9b7105b"
+        "x-envoy-upstream-service-time": "364",
+        "x-request-id": "1a6afed6-2fdb-4d57-bc9d-118917e701a9"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:50:48.3329712-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:13:13.7857251-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
@@ -8,10 +8,10 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-122d75633556d44194fc3927866dc6e5-6297b86d5a525e49-00",
+        "traceparent": "00-02d8a520b464d7499db59243397d04db-19a0ee40bb98a84a-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "7dae09f1ca0dbb60260764495f814f77",
+        "x-ms-client-request-id": "2a34b85e97d7ca22c14bdee40f9b5f05",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -20,7 +20,7 @@
           "query": "query"
         },
         "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeedCE4QcpDi",
+        "dataFeedName": "dataFeedRl9VouPL",
         "granularityName": "Daily",
         "metrics": [
           {
@@ -31,38 +31,34 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "3aade665-5cfc-446c-9a6f-e22f38e16e0c",
+        "apim-request-id": "6de1067f-e6be-4ba2-a280-1f9278cf9811",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:12 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
+        "Date": "Mon, 01 Feb 2021 15:45:43 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "547",
-        "x-request-id": "3aade665-5cfc-446c-9a6f-e22f38e16e0c"
+        "x-envoy-upstream-service-time": "377",
+        "x-request-id": "6de1067f-e6be-4ba2-a280-1f9278cf9811"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "548",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-11bf493745ad9d4b9ced80b37a2b5a01-eec00cc360d4004d-00",
+        "traceparent": "00-cc5f65748741e847aba26655bf591ce6-057c74140ee0f84f-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e3b728c76232725626edc7c96f1d55ef",
+        "x-ms-client-request-id": "4bbe67ea2cef35234728037df7cc4854",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeedk5t1Qd3l",
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedName": "dataFeedwYO3ctIS",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
         "dataStartFrom": "2020-09-21T00:00:00Z",
@@ -79,46 +75,46 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d524d88c-36fa-4abb-8baf-43c5929f5ac1",
+        "apim-request-id": "6db586a8-8e3e-4fc5-906a-b92b1b877115",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:12 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "723",
-        "x-request-id": "d524d88c-36fa-4abb-8baf-43c5929f5ac1"
+        "x-envoy-upstream-service-time": "208",
+        "x-request-id": "6db586a8-8e3e-4fc5-906a-b92b1b877115"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-28a3d5bc30ae8846a511b21ead893e60-e5967fa8031d2c48-00",
+        "traceparent": "00-7491fb91d97fd949b18c05b3779a7746-7b3d4c913e4ac044-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e890be49e09959adb2cad9cbf79e1e5b",
+        "x-ms-client-request-id": "87355cae680fbc8aa1fe0f6e970c0bbf",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9ddba1dc-c3eb-41c1-a08e-0e796d8923b5",
+        "apim-request-id": "04856f94-fe5c-4675-8c37-50185532f773",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:13:13 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:43 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "185",
-        "x-request-id": "9ddba1dc-c3eb-41c1-a08e-0e796d8923b5"
+        "x-envoy-upstream-service-time": "171",
+        "x-request-id": "04856f94-fe5c-4675-8c37-50185532f773"
       },
       "ResponseBody": {
-        "dataFeedId": "14c4b87e-5134-4e88-a7dc-035fe3f7587f",
-        "dataFeedName": "dataFeedk5t1Qd3l",
+        "dataFeedId": "f3ffae73-a13f-4c0c-b41c-64e23e028706",
+        "dataFeedName": "dataFeedwYO3ctIS",
         "metrics": [
           {
-            "metricId": "e719987d-2dcd-4311-9ae5-90fc335684b8",
+            "metricId": "4c7174b6-5082-4655-ad01-f0fec7bc1df9",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -151,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:13:12Z",
+        "createdTime": "2021-02-01T15:45:43Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,37 +157,37 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/14c4b87e-5134-4e88-a7dc-035fe3f7587f",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b8e4966b63bcf34c86f0897de11ccd13-eedb9d3cc6752f42-00",
+        "traceparent": "00-9b93f092fe795743a178d399b6918d59-8eeb83070f618c41-00",
         "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "e5646eb0cc868fbfb23b561f02974c09",
+        "x-ms-client-request-id": "341e63892c8f318195fee2af93a4d2f5",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1a6afed6-2fdb-4d57-bc9d-118917e701a9",
+        "apim-request-id": "a47f67a4-e217-4d0a-af33-2976a727f177",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:13:13 GMT",
+        "Date": "Mon, 01 Feb 2021 15:45:44 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "364",
-        "x-request-id": "1a6afed6-2fdb-4d57-bc9d-118917e701a9"
+        "x-envoy-upstream-service-time": "357",
+        "x-request-id": "a47f67a4-e217-4d0a-af33-2976a727f177"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:13:13.7857251-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:45:43.8198294-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",
     "METRICSADVISOR_SUBSCRIPTION_KEY": "Sanitized",
-    "RandomSeed": "1169437676"
+    "RandomSeed": "781180273"
   }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-02d8a520b464d7499db59243397d04db-19a0ee40bb98a84a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-087b0c8cbad20247b3a44ed052077c93-d109ee50685fb542-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2a34b85e97d7ca22c14bdee40f9b5f05",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "6de1067f-e6be-4ba2-a280-1f9278cf9811",
+        "apim-request-id": "bcb2e58c-e445-43c3-82c3-2951b309bfe9",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:43 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
+        "Date": "Mon, 01 Feb 2021 15:52:49 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f64aed8-d76d-4128-b379-b05dea2b8d66",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "377",
-        "x-request-id": "6de1067f-e6be-4ba2-a280-1f9278cf9811"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "382",
+        "X-Request-ID": "bcb2e58c-e445-43c3-82c3-2951b309bfe9"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f64aed8-d76d-4128-b379-b05dea2b8d66",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cc5f65748741e847aba26655bf591ce6-057c74140ee0f84f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7945d03b117e1c40a7681529e87489a5-b86e55dffdaabf4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "4bbe67ea2cef35234728037df7cc4854",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeedwYO3ctIS",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "6db586a8-8e3e-4fc5-906a-b92b1b877115",
+        "apim-request-id": "3459e424-8068-4f51-ab59-ca41c7771671",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:43 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "208",
-        "x-request-id": "6db586a8-8e3e-4fc5-906a-b92b1b877115"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "160",
+        "X-Request-ID": "3459e424-8068-4f51-ab59-ca41c7771671"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f64aed8-d76d-4128-b379-b05dea2b8d66",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7491fb91d97fd949b18c05b3779a7746-7b3d4c913e4ac044-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a765796748a8c44ab3c17ac8f1358893-f67ea6341936a445-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "87355cae680fbc8aa1fe0f6e970c0bbf",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "04856f94-fe5c-4675-8c37-50185532f773",
+        "apim-request-id": "70facb2e-f338-49a3-8366-387aa1aa9129",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:45:43 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "171",
-        "x-request-id": "04856f94-fe5c-4675-8c37-50185532f773"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "142",
+        "X-Request-ID": "70facb2e-f338-49a3-8366-387aa1aa9129"
       },
       "ResponseBody": {
-        "dataFeedId": "f3ffae73-a13f-4c0c-b41c-64e23e028706",
+        "dataFeedId": "7f64aed8-d76d-4128-b379-b05dea2b8d66",
         "dataFeedName": "dataFeedwYO3ctIS",
         "metrics": [
           {
-            "metricId": "4c7174b6-5082-4655-ad01-f0fec7bc1df9",
+            "metricId": "f7f2a683-48c1-4d05-b1cd-cfc49fd86f7a",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:45:43Z",
+        "createdTime": "2021-02-01T15:52:49Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/f3ffae73-a13f-4c0c-b41c-64e23e028706",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/7f64aed8-d76d-4128-b379-b05dea2b8d66",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-9b93f092fe795743a178d399b6918d59-8eeb83070f618c41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-29ac39dc8586364e963255d65750797e-471b2b24f6a6974b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "341e63892c8f318195fee2af93a4d2f5",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "a47f67a4-e217-4d0a-af33-2976a727f177",
+        "apim-request-id": "70552b5e-9181-4efa-a00f-70cdf8ee62c1",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:45:44 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:49 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "357",
-        "x-request-id": "a47f67a4-e217-4d0a-af33-2976a727f177"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "286",
+        "X-Request-ID": "70552b5e-9181-4efa-a00f-70cdf8ee62c1"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:45:43.8198294-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:50.0454167-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,10 +8,13 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-c9a2a8d60a68a24588a0ea2569778564-ae919a4dcb03e049-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d6840ac81797f44b81c8948a98f27433-7696ae3ee3ce2446-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "8db3021b53adb493bbbbbc48877f519f",
+        "x-ms-client-request-id": "48bcbbbb7f879f515f56fda8d380ff86",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -31,29 +34,32 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "0d57bcd4-8a4d-456f-a2ef-52e9d3d9bf90",
+        "apim-request-id": "b1d0200b-2fdf-4a15-aab4-d7068718ba78",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:27 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+        "Date": "Mon, 01 Feb 2021 13:43:20 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "556",
-        "x-request-id": "0d57bcd4-8a4d-456f-a2ef-52e9d3d9bf90"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "706",
+        "X-Request-ID": "b1d0200b-2fdf-4a15-aab4-d7068718ba78"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
         "Content-Length": "548",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-e20dee2399d4d646924da70b90da0e13-98cf45f5ce8a9d4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-a833572b6805664fac29ebfa314f5e38-e1199386f2988444-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "a8fd565f80d386ffcfb1bc96988ed0ec",
+        "x-ms-client-request-id": "96bcb1cf8e98ecd0bc51543b68a98c26",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
@@ -62,10 +68,10 @@
           "query": "query"
         },
         "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeedhxzk8laj",
+        "dataFeedName": "dataFeed8LKfUkkF",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "startOffsetInSeconds": 2400,
         "maxConcurrency": 6,
         "minRetryIntervalInSeconds": 90,
@@ -79,53 +85,56 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "951332ff-ad39-4a94-a815-3b9811f60459",
+        "apim-request-id": "ee1b354a-5ab0-4cef-a44c-23881ad8db93",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:28 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "527",
-        "x-request-id": "951332ff-ad39-4a94-a815-3b9811f60459"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "609",
+        "X-Request-ID": "ee1b354a-5ab0-4cef-a44c-23881ad8db93"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-205b151900861c4195787b26ae6e503a-5540eed207b9fe42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-42af84727615e3488e65e0832b328b3b-b7c0500e091e684b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "3b5451bca968268c814f9065a9183ce2",
+        "x-ms-client-request-id": "65904f8118a9e23c34b8a6db4e88869b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "5edabdd9-5308-445c-9ab3-4983f26752ef",
+        "apim-request-id": "9fe49392-ca4b-45ec-ba14-b94d7de516ba",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 05 Jan 2021 04:51:28 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:20 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "191",
-        "x-request-id": "5edabdd9-5308-445c-9ab3-4983f26752ef"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "200",
+        "X-Request-ID": "9fe49392-ca4b-45ec-ba14-b94d7de516ba"
       },
       "ResponseBody": {
-        "dataFeedId": "39b0f538-24d7-4609-9bad-61a05713eb22",
-        "dataFeedName": "dataFeedhxzk8laj",
+        "dataFeedId": "1be5afa2-dd90-41bc-9362-c5af4d8b221b",
+        "dataFeedName": "dataFeed8LKfUkkF",
         "metrics": [
           {
-            "metricId": "a7e2417d-3443-4928-8114-ad6d228d3dd2",
+            "metricId": "8374a707-3c8b-4bea-b157-ad314c08e61f",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
           }
         ],
         "dimension": [],
-        "dataStartFrom": "2020-08-01T00:00:00Z",
+        "dataStartFrom": "2020-09-21T00:00:00Z",
         "dataSourceType": "SqlServer",
         "timestampColumn": "updatedTimestampColumn",
         "startOffsetInSeconds": 2400,
@@ -151,7 +160,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-01-05T04:51:27Z",
+        "createdTime": "2021-02-01T13:43:20Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -161,33 +170,36 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/39b0f538-24d7-4609-9bad-61a05713eb22",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-4f5907a130ef8947ba36a12101c6af3e-396296ebd824d34a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210104.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-5f1186784db6c34c952edd914eacc0e4-813e1bf61714a54d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
-        "x-ms-client-request-id": "dba6b834884e9b86022cbefb97fd1b2d",
+        "x-ms-client-request-id": "fbbe2c02fd972d1bebd08b362b1636b6",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "1a5f89f6-eb0a-409d-bc54-d2d8d51f5512",
+        "apim-request-id": "3c17c3a6-c033-4916-bee1-14fb61895936",
         "Content-Length": "0",
-        "Date": "Tue, 05 Jan 2021 04:51:28 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "360",
-        "x-request-id": "1a5f89f6-eb0a-409d-bc54-d2d8d51f5512"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "373",
+        "X-Request-ID": "3c17c3a6-c033-4916-bee1-14fb61895936"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-01-04T20:51:28.6385236-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:21.7223561-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-6ea822852c9a944caa65b9242e048b21-88f7eb61e2978a49-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ef9895eeb4ebd542a694894845e79235-06e6503c7eadf94b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "48bcbbbb7f879f515f56fda8d380ff86",
         "x-ms-return-client-request-id": "true"
@@ -31,33 +34,36 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "4263ca87-0f3f-488b-a0aa-c3804e7d564c",
+        "apim-request-id": "d2cba59d-ac41-456e-a87f-11583355c600",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:35 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
+        "Date": "Mon, 01 Feb 2021 15:53:20 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/da8eb64e-2471-4196-83f8-6d35e308d58d",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "415",
-        "x-request-id": "4263ca87-0f3f-488b-a0aa-c3804e7d564c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "366",
+        "X-Request-ID": "d2cba59d-ac41-456e-a87f-11583355c600"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/da8eb64e-2471-4196-83f8-6d35e308d58d",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "492",
+        "Content-Length": "470",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-02ad197c432252429aa09c2999222c18-63af781f6452754f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-228ded15c2c8334391c1192bdf4d58a8-1e25f0b468e4e348-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "96bcb1cf8e98ecd0bc51543b68a98c26",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedName": "dataFeed8LKfUkkF",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -75,24 +81,27 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "21fe73da-485b-42de-a98e-9bdceca25833",
+        "apim-request-id": "35b845f1-2d34-43d4-9a75-1f97e65b4189",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "192",
-        "x-request-id": "21fe73da-485b-42de-a98e-9bdceca25833"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "180",
+        "X-Request-ID": "35b845f1-2d34-43d4-9a75-1f97e65b4189"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/da8eb64e-2471-4196-83f8-6d35e308d58d",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-819c8ef7c854054693f82e45aed994dd-d3903a625d917848-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7737deb74f7e3d4c89fc25dfc9838019-16fadd885a940b4a-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "65904f8118a9e23c34b8a6db4e88869b",
         "x-ms-return-client-request-id": "true"
@@ -100,21 +109,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "84836936-2f1e-4380-9a44-52df128187ac",
+        "apim-request-id": "39b4c82b-3b92-4ee1-ab66-b1f856865791",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 15:41:35 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "193",
-        "x-request-id": "84836936-2f1e-4380-9a44-52df128187ac"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "146",
+        "X-Request-ID": "39b4c82b-3b92-4ee1-ab66-b1f856865791"
       },
       "ResponseBody": {
-        "dataFeedId": "34c373dc-4406-4b9f-a0e0-407744f8c570",
+        "dataFeedId": "da8eb64e-2471-4196-83f8-6d35e308d58d",
         "dataFeedName": "dataFeed8LKfUkkF",
         "metrics": [
           {
-            "metricId": "e3770d1a-576e-4454-b3be-0a6a3b19dac6",
+            "metricId": "9c5cec28-87a3-40ab-9746-25c8516578cb",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -147,7 +156,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T15:41:36Z",
+        "createdTime": "2021-02-01T15:53:21Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -157,13 +166,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/da8eb64e-2471-4196-83f8-6d35e308d58d",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cef2469c2d185644b48faf0f045c485a-07d17753ba60204a-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-b955a487dedcfa4d8b61d4858d83b65d-345cbbbe495fa549-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fbbe2c02fd972d1bebd08b362b1636b6",
         "x-ms-return-client-request-id": "true"
@@ -171,19 +183,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2b9bfafc-5202-4e3e-8e05-2c467725adf3",
+        "apim-request-id": "fbf54776-4a40-4c2b-be57-2b80ff1e8b7b",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 15:41:36 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "328",
-        "x-request-id": "2b9bfafc-5202-4e3e-8e05-2c467725adf3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "283",
+        "X-Request-ID": "fbf54776-4a40-4c2b-be57-2b80ff1e8b7b"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T07:41:36.6496664-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:22.4960101-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithEveryMemberAndNewInstanceAsync.json
@@ -8,11 +8,8 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d6840ac81797f44b81c8948a98f27433-7696ae3ee3ce2446-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-6ea822852c9a944caa65b9242e048b21-88f7eb61e2978a49-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "48bcbbbb7f879f515f56fda8d380ff86",
         "x-ms-return-client-request-id": "true"
@@ -34,40 +31,33 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "b1d0200b-2fdf-4a15-aab4-d7068718ba78",
+        "apim-request-id": "4263ca87-0f3f-488b-a0aa-c3804e7d564c",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:20 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
+        "Date": "Mon, 01 Feb 2021 15:41:35 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "706",
-        "X-Request-ID": "b1d0200b-2fdf-4a15-aab4-d7068718ba78"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "415",
+        "x-request-id": "4263ca87-0f3f-488b-a0aa-c3804e7d564c"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "548",
+        "Content-Length": "492",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-a833572b6805664fac29ebfa314f5e38-e1199386f2988444-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-02ad197c432252429aa09c2999222c18-63af781f6452754f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "96bcb1cf8e98ecd0bc51543b68a98c26",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "SqlServer",
+        "dataSourceType": "AzureApplicationInsights",
         "dataFeedName": "dataFeed8LKfUkkF",
         "dataFeedDescription": "This data feed was updated to test the .NET client.",
         "timestampColumn": "updatedTimestampColumn",
@@ -85,27 +75,24 @@
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "ee1b354a-5ab0-4cef-a44c-23881ad8db93",
+        "apim-request-id": "21fe73da-485b-42de-a98e-9bdceca25833",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "609",
-        "X-Request-ID": "ee1b354a-5ab0-4cef-a44c-23881ad8db93"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "192",
+        "x-request-id": "21fe73da-485b-42de-a98e-9bdceca25833"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-42af84727615e3488e65e0832b328b3b-b7c0500e091e684b-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-819c8ef7c854054693f82e45aed994dd-d3903a625d917848-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "65904f8118a9e23c34b8a6db4e88869b",
         "x-ms-return-client-request-id": "true"
@@ -113,21 +100,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "9fe49392-ca4b-45ec-ba14-b94d7de516ba",
+        "apim-request-id": "84836936-2f1e-4380-9a44-52df128187ac",
         "Content-Length": "1072",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:20 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:35 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "200",
-        "X-Request-ID": "9fe49392-ca4b-45ec-ba14-b94d7de516ba"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "193",
+        "x-request-id": "84836936-2f1e-4380-9a44-52df128187ac"
       },
       "ResponseBody": {
-        "dataFeedId": "1be5afa2-dd90-41bc-9362-c5af4d8b221b",
+        "dataFeedId": "34c373dc-4406-4b9f-a0e0-407744f8c570",
         "dataFeedName": "dataFeed8LKfUkkF",
         "metrics": [
           {
-            "metricId": "8374a707-3c8b-4bea-b157-ad314c08e61f",
+            "metricId": "e3770d1a-576e-4454-b3be-0a6a3b19dac6",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -160,7 +147,7 @@
         ],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:20Z",
+        "createdTime": "2021-02-01T15:41:36Z",
         "isAdmin": true,
         "actionLinkTemplate": "https://fakeurl.com/%datafeed/%metric",
         "dataSourceParameter": {
@@ -170,16 +157,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/1be5afa2-dd90-41bc-9362-c5af4d8b221b",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/34c373dc-4406-4b9f-a0e0-407744f8c570",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-5f1186784db6c34c952edd914eacc0e4-813e1bf61714a54d-00",
-        "User-Agent": [
-          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
-          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-cef2469c2d185644b48faf0f045c485a-07d17753ba60204a-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "fbbe2c02fd972d1bebd08b362b1636b6",
         "x-ms-return-client-request-id": "true"
@@ -187,19 +171,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "3c17c3a6-c033-4916-bee1-14fb61895936",
+        "apim-request-id": "2b9bfafc-5202-4e3e-8e05-2c467725adf3",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:21 GMT",
+        "Date": "Mon, 01 Feb 2021 15:41:36 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "373",
-        "X-Request-ID": "3c17c3a6-c033-4916-bee1-14fb61895936"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "328",
+        "x-request-id": "2b9bfafc-5202-4e3e-8e05-2c467725adf3"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:21.7223561-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:41:36.6496664-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,8 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-181c15acfd4fa140871a98c852d7c070-56d51982058a6048-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-befcaafe0bffb84bbe5ec5183fd2606f-59c642b247d8004e-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2b0366fc49807c1d06fd44f1d59e1e21",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +31,55 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "192c9b09-63d1-453a-a084-276cd186e60d",
+        "apim-request-id": "21d53558-b7bc-4328-8d6d-68ec0a71e830",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:45 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d353e874-5cd8-4232-af3f-78341c0798b2",
+        "Date": "Mon, 01 Feb 2021 12:46:41 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "347",
-        "x-request-id": "192c9b09-63d1-453a-a084-276cd186e60d"
+        "x-envoy-upstream-service-time": "383",
+        "x-request-id": "21d53558-b7bc-4328-8d6d-68ec0a71e830"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d353e874-5cd8-4232-af3f-78341c0798b2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "250",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-56d6e6b982bb2c4dbe42be3fdcaccd11-e78b753aae531b41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-39dc77405a5826488fdddf88a4700162-05c563859ad73646-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "11ab45cf59510cfc8283e65f11af43ce",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeedpZPdVNQe",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "2ba4da75-cc84-400d-b01d-c7d6b1dcb4c4",
+        "apim-request-id": "10c351d5-3e20-4084-9a75-924858b9a3b3",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:46 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:41 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "447",
-        "x-request-id": "2ba4da75-cc84-400d-b01d-c7d6b1dcb4c4"
+        "x-envoy-upstream-service-time": "177",
+        "x-request-id": "10c351d5-3e20-4084-9a75-924858b9a3b3"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d353e874-5cd8-4232-af3f-78341c0798b2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-cca88ea51be6c14aaf15fc353e95fcef-1f334f139da40c4b-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ee452df914248b4bb63847db965144e3-3c58b80513f9ee4f-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ee5bfb41d0119ff0abc0abdfd5177acb",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +87,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "13b005f7-3acf-4000-bb0e-0680bc7a0629",
+        "apim-request-id": "411a049b-387c-4d26-940a-d76c80ec9834",
         "Content-Length": "997",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Thu, 31 Dec 2020 18:09:46 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "168",
-        "x-request-id": "13b005f7-3acf-4000-bb0e-0680bc7a0629"
+        "x-envoy-upstream-service-time": "162",
+        "x-request-id": "411a049b-387c-4d26-940a-d76c80ec9834"
       },
       "ResponseBody": {
-        "dataFeedId": "d353e874-5cd8-4232-af3f-78341c0798b2",
+        "dataFeedId": "4e9029bb-98fc-4bc0-bd88-2d38728dca80",
         "dataFeedName": "dataFeedpZPdVNQe",
         "metrics": [
           {
-            "metricId": "76b7fac0-d5ff-488d-85fe-bdb1e18dd10c",
+            "metricId": "70716c68-8138-4bc3-8766-92569faf3298",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +132,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-31T18:09:45Z",
+        "createdTime": "2021-02-01T12:46:42Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +142,13 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/d353e874-5cd8-4232-af3f-78341c0798b2",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-52acc1c309cb4e438c09a522e824066c-4f9e40822a9d534c-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-7b3fd9e9147e2843973432127fbb0850-4c89c17d3a182640-00",
+        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "da6453e4081ba2d969f6a8fc63be6a56",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +156,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "59940022-9805-4e8e-962a-8b90fc841640",
+        "apim-request-id": "fc38a369-6427-4550-add8-c3596a9dea58",
         "Content-Length": "0",
-        "Date": "Thu, 31 Dec 2020 18:09:46 GMT",
+        "Date": "Mon, 01 Feb 2021 12:46:42 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "276",
-        "x-request-id": "59940022-9805-4e8e-962a-8b90fc841640"
+        "x-envoy-upstream-service-time": "382",
+        "x-request-id": "fc38a369-6427-4550-add8-c3596a9dea58"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-31T10:09:46.8031210-08:00",
+    "DateTimeOffsetNow": "2021-02-01T04:46:42.8775122-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstance.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstance.json
@@ -8,8 +8,11 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-befcaafe0bffb84bbe5ec5183fd2606f-59c642b247d8004e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-203974853266424ca0a97e7afdbc1413-26cf9c5d4a780646-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "2b0366fc49807c1d06fd44f1d59e1e21",
         "x-ms-return-client-request-id": "true"
@@ -31,55 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "21d53558-b7bc-4328-8d6d-68ec0a71e830",
+        "apim-request-id": "c52c117d-7126-457c-b6a1-e828d2e6eea7",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:41 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
+        "Date": "Mon, 01 Feb 2021 15:52:50 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fd46c8e-4f47-4556-af4f-ce646ece31c6",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "383",
-        "x-request-id": "21d53558-b7bc-4328-8d6d-68ec0a71e830"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "389",
+        "X-Request-ID": "c52c117d-7126-457c-b6a1-e828d2e6eea7"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fd46c8e-4f47-4556-af4f-ce646ece31c6",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-39dc77405a5826488fdddf88a4700162-05c563859ad73646-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-ff1b160ca57de14babf610b191e708a2-085a1f09c27f584c-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "11ab45cf59510cfc8283e65f11af43ce",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "10c351d5-3e20-4084-9a75-924858b9a3b3",
+        "apim-request-id": "7939572e-4d48-481b-83ac-b2a0c4254922",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:41 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "177",
-        "x-request-id": "10c351d5-3e20-4084-9a75-924858b9a3b3"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "150",
+        "X-Request-ID": "7939572e-4d48-481b-83ac-b2a0c4254922"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fd46c8e-4f47-4556-af4f-ce646ece31c6",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-ee452df914248b4bb63847db965144e3-3c58b80513f9ee4f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-61350e1d9b19504fbd2f9f70be946f4f-c1f208ede8dda64f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "ee5bfb41d0119ff0abc0abdfd5177acb",
         "x-ms-return-client-request-id": "true"
@@ -87,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "411a049b-387c-4d26-940a-d76c80ec9834",
+        "apim-request-id": "a7da9e40-cb04-4aec-b97b-20957e8c1e96",
         "Content-Length": "997",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 12:46:42 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:50 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
+        "X-Content-Type-Options": "nosniff",
         "x-envoy-upstream-service-time": "162",
-        "x-request-id": "411a049b-387c-4d26-940a-d76c80ec9834"
+        "X-Request-ID": "a7da9e40-cb04-4aec-b97b-20957e8c1e96"
       },
       "ResponseBody": {
-        "dataFeedId": "4e9029bb-98fc-4bc0-bd88-2d38728dca80",
+        "dataFeedId": "4fd46c8e-4f47-4556-af4f-ce646ece31c6",
         "dataFeedName": "dataFeedpZPdVNQe",
         "metrics": [
           {
-            "metricId": "70716c68-8138-4bc3-8766-92569faf3298",
+            "metricId": "4e534b2d-ed1c-4999-a8b3-91ddcb9b2f63",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -132,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T12:46:42Z",
+        "createdTime": "2021-02-01T15:52:50Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -142,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4e9029bb-98fc-4bc0-bd88-2d38728dca80",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/4fd46c8e-4f47-4556-af4f-ce646ece31c6",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7b3fd9e9147e2843973432127fbb0850-4c89c17d3a182640-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-c79890da9b15024f8cdfa3c36743e179-9da89aa022eaef45-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "da6453e4081ba2d969f6a8fc63be6a56",
         "x-ms-return-client-request-id": "true"
@@ -156,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "fc38a369-6427-4550-add8-c3596a9dea58",
+        "apim-request-id": "c6b918e2-ab2d-4c88-9b00-8687594d11ac",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 12:46:42 GMT",
+        "Date": "Mon, 01 Feb 2021 15:52:51 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "382",
-        "x-request-id": "fc38a369-6427-4550-add8-c3596a9dea58"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "293",
+        "X-Request-ID": "c6b918e2-ab2d-4c88-9b00-8687594d11ac"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T04:46:42.8775122-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:52:51.1570437-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,7 +8,7 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-58ebefbc7f006c48bdcda68a58676ecd-530a4f596829c742-00",
+        "traceparent": "00-69179ad9b223f143b55bb1f2b37cac1c-66e75f836df54e4f-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -34,26 +34,26 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "1965f4ee-bd94-4c9c-a827-ea92aeea046a",
+        "apim-request-id": "d7c554bd-3234-43c1-91e5-52cda78d4dcf",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:21 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
+        "Date": "Mon, 01 Feb 2021 15:53:22 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0df7375-7308-4417-b87c-0f4005df50fb",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "528",
-        "X-Request-ID": "1965f4ee-bd94-4c9c-a827-ea92aeea046a"
+        "x-envoy-upstream-service-time": "399",
+        "X-Request-ID": "d7c554bd-3234-43c1-91e5-52cda78d4dcf"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0df7375-7308-4417-b87c-0f4005df50fb",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "121",
+        "Content-Length": "99",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-d47a312d8cc4e24c88b6b4ab4d5d60cf-35c284cec8996d4b-00",
+        "traceparent": "00-7f0c2d356ee1e147b6153dc6f2b19e4d-a75d98f4694c7f42-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -63,28 +63,28 @@
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceType": "AzureApplicationInsights",
+        "dataSourceType": null,
         "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "f5526505-21aa-406b-8eb6-ebfc070963be",
+        "apim-request-id": "bbdd56af-3cf4-455d-93b2-679ae50b728d",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:21 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "224",
-        "X-Request-ID": "f5526505-21aa-406b-8eb6-ebfc070963be"
+        "x-envoy-upstream-service-time": "170",
+        "X-Request-ID": "bbdd56af-3cf4-455d-93b2-679ae50b728d"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0df7375-7308-4417-b87c-0f4005df50fb",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-534d6385c0934b4fb00ca4f3425b4c6b-5bfcd5d1bdee2549-00",
+        "traceparent": "00-f09097c700dfc44282c870eb63150597-91b684b9c65f0247-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -96,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "41caae58-ec83-4c0f-afb7-2e0015e42cea",
+        "apim-request-id": "10186c80-8461-47d3-9e6a-d179d2bbbf67",
         "Content-Length": "997",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Mon, 01 Feb 2021 13:43:22 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "230",
-        "X-Request-ID": "41caae58-ec83-4c0f-afb7-2e0015e42cea"
+        "x-envoy-upstream-service-time": "158",
+        "X-Request-ID": "10186c80-8461-47d3-9e6a-d179d2bbbf67"
       },
       "ResponseBody": {
-        "dataFeedId": "88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
+        "dataFeedId": "e0df7375-7308-4417-b87c-0f4005df50fb",
         "dataFeedName": "dataFeedUDnNGcwm",
         "metrics": [
           {
-            "metricId": "e041ad28-8da2-481a-92ec-c0a20d0a68de",
+            "metricId": "c5af831a-ef36-4cb8-bd9b-9ab26104ec4c",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -141,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2021-02-01T13:43:22Z",
+        "createdTime": "2021-02-01T15:53:23Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -151,12 +151,12 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/e0df7375-7308-4417-b87c-0f4005df50fb",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-834198d12e0813489d5dd6d81aba5080-1a6f2c1727e7c44d-00",
+        "traceparent": "00-f74b5484c5d85a40a37a21e5e3869885-034e03f9f4f45a49-00",
         "User-Agent": [
           "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
           "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
@@ -168,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "af399dc5-a3eb-4eaa-aa86-7ad8892b2e17",
+        "apim-request-id": "f977ae63-0863-4b5f-add1-2dd3ff1ad79a",
         "Content-Length": "0",
-        "Date": "Mon, 01 Feb 2021 13:43:22 GMT",
+        "Date": "Mon, 01 Feb 2021 15:53:23 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "429",
-        "X-Request-ID": "af399dc5-a3eb-4eaa-aa86-7ad8892b2e17"
+        "x-envoy-upstream-service-time": "333",
+        "X-Request-ID": "f977ae63-0863-4b5f-add1-2dd3ff1ad79a"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2021-02-01T05:43:23.1948753-08:00",
+    "DateTimeOffsetNow": "2021-02-01T07:53:23.6113771-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstanceAsync.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/DataFeedLiveTests/UpdateSqlServerDataFeedWithMinimumSetupAndNewInstanceAsync.json
@@ -8,8 +8,11 @@
         "Content-Length": "234",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-b00f945b00bde241b36b593015e469cc-e5372ae5f90bfe4e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-58ebefbc7f006c48bdcda68a58676ecd-530a4f596829c742-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "03f2e5fd10fe955a5ae5f01c7627ce0e",
         "x-ms-return-client-request-id": "true"
@@ -31,61 +34,61 @@
       },
       "StatusCode": 201,
       "ResponseHeaders": {
-        "apim-request-id": "913446f0-ba30-436f-b0dc-1c43b28c5e9c",
+        "apim-request-id": "1965f4ee-bd94-4c9c-a827-ea92aeea046a",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:22:59 GMT",
-        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b7ff90e-b451-4399-b83a-a28abf9e1631",
+        "Date": "Mon, 01 Feb 2021 13:43:21 GMT",
+        "Location": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "627",
-        "x-request-id": "913446f0-ba30-436f-b0dc-1c43b28c5e9c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "528",
+        "X-Request-ID": "1965f4ee-bd94-4c9c-a827-ea92aeea046a"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b7ff90e-b451-4399-b83a-a28abf9e1631",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
       "RequestMethod": "PATCH",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "250",
+        "Content-Length": "121",
         "Content-Type": "application/merge-patch\u002Bjson",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-1262cbbd700fb640a91641a3cae423cf-15154e966755b549-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-d47a312d8cc4e24c88b6b4ab4d5d60cf-35c284cec8996d4b-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "9698fc16a4def208afc017e02eee2cf2",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
-        "dataSourceParameter": {
-          "connectionString": "Sanitized",
-          "query": "query"
-        },
-        "dataSourceType": "SqlServer",
-        "dataFeedName": "dataFeedUDnNGcwm",
-        "dataFeedDescription": "This data feed was created to test the .NET client.",
-        "dataStartFrom": "2020-08-01T00:00:00Z"
+        "dataSourceType": "AzureApplicationInsights",
+        "dataFeedDescription": "This data feed was created to test the .NET client."
       },
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "121ac514-552d-41c8-9531-4a40ac0962cd",
+        "apim-request-id": "f5526505-21aa-406b-8eb6-ebfc070963be",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:23:00 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:21 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "587",
-        "x-request-id": "121ac514-552d-41c8-9531-4a40ac0962cd"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "224",
+        "X-Request-ID": "f5526505-21aa-406b-8eb6-ebfc070963be"
       },
       "ResponseBody": []
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b7ff90e-b451-4399-b83a-a28abf9e1631",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
       "RequestMethod": "GET",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-35690ed04d95534d83f72430f5cb8574-0eb2fcdb4f9cec41-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-534d6385c0934b4fb00ca4f3425b4c6b-5bfcd5d1bdee2549-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "00bb799bcf08c8b948abb2aa8a9f4319",
         "x-ms-return-client-request-id": "true"
@@ -93,21 +96,21 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "c40a5f62-961b-470a-9100-b2af9ca32f94",
+        "apim-request-id": "41caae58-ec83-4c0f-afb7-2e0015e42cea",
         "Content-Length": "997",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 30 Dec 2020 23:23:00 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "160",
-        "x-request-id": "c40a5f62-961b-470a-9100-b2af9ca32f94"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "230",
+        "X-Request-ID": "41caae58-ec83-4c0f-afb7-2e0015e42cea"
       },
       "ResponseBody": {
-        "dataFeedId": "3b7ff90e-b451-4399-b83a-a28abf9e1631",
+        "dataFeedId": "88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
         "dataFeedName": "dataFeedUDnNGcwm",
         "metrics": [
           {
-            "metricId": "cf04e742-5071-438c-a5e1-8164ce62622a",
+            "metricId": "e041ad28-8da2-481a-92ec-c0a20d0a68de",
             "metricName": "cost",
             "metricDisplayName": "cost",
             "metricDescription": ""
@@ -138,7 +141,7 @@
         "viewers": [],
         "creator": "foo@contoso.com",
         "status": "Active",
-        "createdTime": "2020-12-30T23:23:00Z",
+        "createdTime": "2021-02-01T13:43:22Z",
         "isAdmin": true,
         "actionLinkTemplate": "",
         "dataSourceParameter": {
@@ -148,13 +151,16 @@
       }
     },
     {
-      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/3b7ff90e-b451-4399-b83a-a28abf9e1631",
+      "RequestUri": "https://js-metrics-advisor.cognitiveservices.azure.com/metricsadvisor/v1.0/dataFeeds/88b350ac-75ff-4e48-8fbb-fe9f249d10ec",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-7a339e59ba10964ea0f29ccbd3b186f0-9e4f74bf35d32841-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20201223.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-834198d12e0813489d5dd6d81aba5080-1a6f2c1727e7c44d-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210201.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "8f99237d3d8958dfdc00543df979666c",
         "x-ms-return-client-request-id": "true"
@@ -162,19 +168,19 @@
       "RequestBody": null,
       "StatusCode": 204,
       "ResponseHeaders": {
-        "apim-request-id": "d5119524-32e2-4c7f-abf6-be9cd96b9165",
+        "apim-request-id": "af399dc5-a3eb-4eaa-aa86-7ad8892b2e17",
         "Content-Length": "0",
-        "Date": "Wed, 30 Dec 2020 23:23:00 GMT",
+        "Date": "Mon, 01 Feb 2021 13:43:22 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "276",
-        "x-request-id": "d5119524-32e2-4c7f-abf6-be9cd96b9165"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "429",
+        "X-Request-ID": "af399dc5-a3eb-4eaa-aa86-7ad8892b2e17"
       },
       "ResponseBody": []
     }
   ],
   "Variables": {
-    "DateTimeOffsetNow": "2020-12-30T15:23:01.5406645-08:00",
+    "DateTimeOffsetNow": "2021-02-01T05:43:23.1948753-08:00",
     "METRICSADVISOR_ACCOUNT_NAME": "js-metrics-advisor",
     "METRICSADVISOR_ENDPOINT_SUFFIX": null,
     "METRICSADVISOR_PRIMARY_API_KEY": "Sanitized",


### PR DESCRIPTION
Changes:
- DataFeed constructor is now parameterless. Properties required during a Create operation are now set via property setters. They may be left as `null` during an Update operation.
- DataFeed-related models have been updated to remove setters from collections. Collection will be set in the constructor only, and should be populated via their getters only.
- Tests updated accordingly. Live tests update may seem large, but they're very repetitive.

Part of https://github.com/azure/azure-sdk-for-net/issues/16321.
Part of https://github.com/Azure/azure-sdk-for-net/issues/18318.
Fixes https://github.com/Azure/azure-sdk-for-net/issues/17719 by accident.