### PR TITLE
Revert "Temporarily re-enable .NET 5 SDK install step"

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,15 +1,15 @@
 # All required SDKs/runtimes are available on DevOps agents
-#steps: []
+steps: []
 # Installation steps need to be uncommented when switching to a newer SDK that's not available on DevOps agents
-steps:
- - task: UseDotNet@2
-   displayName: 'Use .NET Core SDK'
-   inputs:
-     useGlobalJson: true
-     performMultiLevelLookup: true
- - task: UseDotNet@2
-   condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
-   displayName: 'Use .NET Core 2.1 runtime'
-   inputs:
-     packageType: runtime
-     version: "2.1.x"
+#steps:
+#  - task: UseDotNet@2
+#    displayName: 'Use .NET Core SDK'
+#    inputs:
+#      useGlobalJson: true
+#      performMultiLevelLookup: true
+#  - task: UseDotNet@2
+#    condition: ne(variables['Agent.OS'], 'Windows_NT') # Windows supports MultiLevelLookup and doesn't need explicit framework installation
+#    displayName: 'Use .NET Core 2.1 runtime'
+#    inputs:
+#      packageType: runtime
+#      version: "2.1.x"


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-net#18298

The agent pools are supposed to have been fixed so undoing this change to test them. 