### PR TITLE
[TA] Specify model version for subcategories

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeEntitiesTests.cs
@@ -81,11 +81,14 @@ namespace Azure.AI.TextAnalytics.Tests
             TextAnalyticsClient client = GetClient();
             string document = "I had a wonderful trip to Seattle last week.";
 
-            CategorizedEntityCollection entities = await client.RecognizeEntitiesAsync(document);
+            RecognizeEntitiesResultCollection result = await client.RecognizeEntitiesBatchAsync(new List<string>() { document }, options: new TextAnalyticsRequestOptions() { ModelVersion = "2020-04-01" } );
 
-            Assert.GreaterOrEqual(entities.Count, 3);
+            var documentResult = result.FirstOrDefault();
+            Assert.IsFalse(documentResult.HasError);
 
-            foreach (CategorizedEntity entity in entities)
+            Assert.GreaterOrEqual(documentResult.Entities.Count, 3);
+
+            foreach (CategorizedEntity entity in documentResult.Entities)
             {
                 if (entity.Text == "last week")
                     Assert.AreEqual("DateRange", entity.SubCategory);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTest.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTest.json
@@ -1,21 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://textanalytics-westeurope.ppe.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/recognition/general?model-version=2020-04-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
+        "Accept": "application/json, text/json",
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-930df0868380e14694697971335fa9bf-dfbcac296a20954b-00",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20201116.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-3a4aa4f516676643bd772a780f6ccbf6-eb57c886c0d35d41-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "c580665e455e125e80a821d61e9c3c18",
         "x-ms-return-client-request-id": "true"
       },
@@ -30,14 +24,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a45ceae5-b02a-46bd-9314-3449bca409bb",
+        "apim-request-id": "46d030fb-5883-4367-803c-7eb27dfc2e73",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
-        "Date": "Tue, 17 Nov 2020 20:17:16 GMT",
+        "Date": "Mon, 01 Feb 2021 19:20:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "81"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "76"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +73,6 @@
   "Variables": {
     "RandomSeed": "1531566714",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://textanalytics-westeurope.ppe.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com/"
   }
 }

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTestAsync.json
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/SessionRecords/RecognizeEntitiesTests/RecognizeEntitiesWithSubCategoryTestAsync.json
@@ -1,21 +1,15 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://textanalytics-westeurope.ppe.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/recognition/general?stringIndexType=Utf16CodeUnit",
+      "RequestUri": "https://mariari-westus2-s.cognitiveservices.azure.com/text/analytics/v3.1-preview.3/entities/recognition/general?model-version=2020-04-01\u0026showStats=false\u0026stringIndexType=Utf16CodeUnit",
       "RequestMethod": "POST",
       "RequestHeaders": {
-        "Accept": [
-          "application/json",
-          "text/json"
-        ],
+        "Accept": "application/json, text/json",
         "Content-Length": "96",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-2228b702566fa34ba8f263a8dbd716f5-e691e31e80ef1a4e-00",
-        "User-Agent": [
-          "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20201116.1",
-          "(.NET Core 4.6.29321.03; Microsoft Windows 10.0.19042 )"
-        ],
+        "traceparent": "00-e2d6e4927918e0448ceee4388fd87b02-82a45b0dda646b4b-00",
+        "User-Agent": "azsdk-net-AI.TextAnalytics/5.1.0-alpha.20210201.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
         "x-ms-client-request-id": "3b4b745166e69035ddd947884a09aa87",
         "x-ms-return-client-request-id": "true"
       },
@@ -30,14 +24,14 @@
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "a6121784-0c63-4892-a22d-00b3173dc6b9",
+        "apim-request-id": "a526d509-a667-4524-80cd-e0f0c14ad98a",
         "Content-Type": "application/json; charset=utf-8",
         "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
-        "Date": "Tue, 17 Nov 2020 20:17:19 GMT",
+        "Date": "Mon, 01 Feb 2021 19:20:45 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
         "Transfer-Encoding": "chunked",
-        "X-Content-Type-Options": "nosniff",
-        "x-envoy-upstream-service-time": "69"
+        "x-content-type-options": "nosniff",
+        "x-envoy-upstream-service-time": "78"
       },
       "ResponseBody": {
         "documents": [
@@ -79,6 +73,6 @@
   "Variables": {
     "RandomSeed": "1094081853",
     "TEXT_ANALYTICS_API_KEY": "Sanitized",
-    "TEXT_ANALYTICS_ENDPOINT": "https://textanalytics-westeurope.ppe.cognitiveservices.azure.com"
+    "TEXT_ANALYTICS_ENDPOINT": "https://mariari-westus2-s.cognitiveservices.azure.com/"
   }
 }


### PR DESCRIPTION
Latest model version (2021-01-15) is returning less entities than the one our test depend on (2020-04-01).
To fix our tests, I am specifying the version. Meanwhile, I opened a thread with the service team to understand more their model-version behavior.