### PR TITLE
Mixed Reality Authentication: Updated the MR STS spec file

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0-preview.3 (2021-01-15)
+
+- Updated to latest version of spec file which changes the account identifier to be a `Guid` rather than a `string`.
+
 ## 1.0.0-preview.2 (2021-01-12)
 
 - Configured with shared source.

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
@@ -3,11 +3,11 @@ namespace Azure.MixedReality.Authentication
     public partial class MixedRealityStsClient
     {
         protected MixedRealityStsClient() { }
-        public MixedRealityStsClient(string accountId, string accountDomain, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
-        public MixedRealityStsClient(string accountId, string accountDomain, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
-        public MixedRealityStsClient(string accountId, System.Uri endpoint, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
-        public MixedRealityStsClient(string accountId, System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
-        public string AccountId { get { throw null; } }
+        public MixedRealityStsClient(System.Guid accountId, string accountDomain, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
+        public MixedRealityStsClient(System.Guid accountId, string accountDomain, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
+        public MixedRealityStsClient(System.Guid accountId, System.Uri endpoint, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
+        public MixedRealityStsClient(System.Guid accountId, System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
+        public System.Guid AccountId { get { throw null; } }
         public System.Uri Endpoint { get { throw null; } }
         public virtual Azure.Response<Azure.Core.AccessToken> GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Core.AccessToken>> GetTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/shared/MixedRealityAccountKeyCredential.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/shared/MixedRealityAccountKeyCredential.cs
@@ -14,7 +14,7 @@ namespace Azure.MixedReality.Authentication
     /// <seealso cref="TokenCredential" />
     internal class MixedRealityAccountKeyCredential : TokenCredential
     {
-        private readonly string _accountId;
+        private readonly Guid _accountId;
 
         private readonly AzureKeyCredential _accountKey;
 
@@ -23,7 +23,7 @@ namespace Azure.MixedReality.Authentication
         /// </summary>
         /// <param name="accountId">The Mixed Reality service account identifier.</param>
         /// <param name="accountKey">The Mixed Reality service account primary or secondary key.</param>
-        public MixedRealityAccountKeyCredential(string accountId, string accountKey)
+        public MixedRealityAccountKeyCredential(Guid accountId, string accountKey)
             : this(accountId, new AzureKeyCredential(accountKey))
         {
         }
@@ -33,9 +33,9 @@ namespace Azure.MixedReality.Authentication
         /// </summary>
         /// <param name="accountId">The Mixed Reality service account identifier.</param>
         /// <param name="keyCredential">The Mixed Reality service account primary or secondary key credential.</param>
-        public MixedRealityAccountKeyCredential(string accountId, AzureKeyCredential keyCredential)
+        public MixedRealityAccountKeyCredential(Guid accountId, AzureKeyCredential keyCredential)
         {
-            Argument.AssertNotNullOrWhiteSpace(accountId, nameof(accountId));
+            Argument.AssertNotDefault(ref accountId, nameof(accountId));
             Argument.AssertNotNull(keyCredential, nameof(keyCredential));
 
             _accountId = accountId;

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/shared/MixedRealityTokenCredential.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/shared/MixedRealityTokenCredential.cs
@@ -24,7 +24,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="endpoint">The Mixed Reality STS service endpoint.</param>
         /// <param name="credential">The credential used to access the Mixed Reality service.</param>
         /// <param name="options">The options.</param>
-        private MixedRealityTokenCredential(string accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions? options = null)
+        private MixedRealityTokenCredential(Guid accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions? options = null)
         {
             _stsClient = new MixedRealityStsClient(accountId, endpoint, credential, options);
         }
@@ -58,7 +58,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="credential">The credential used to access the Mixed Reality service.</param>
         /// <param name="options">The options.</param>
         /// <returns><see cref="TokenCredential"/>.</returns>
-        public static TokenCredential GetMixedRealityCredential(string accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions? options = null)
+        public static TokenCredential GetMixedRealityCredential(Guid accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions? options = null)
         {
             if (credential is StaticAccessTokenCredential)
             {

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/Generated/MixedRealityStsRestClient.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/Generated/MixedRealityStsRestClient.cs
@@ -36,7 +36,7 @@ namespace Azure.MixedReality.Authentication
             _pipeline = pipeline;
         }
 
-        internal HttpMessage CreateGetTokenRequest(string accountId, MixedRealityTokenRequestOptions tokenRequestOptions)
+        internal HttpMessage CreateGetTokenRequest(Guid accountId, MixedRealityTokenRequestOptions tokenRequestOptions)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
@@ -63,14 +63,8 @@ namespace Azure.MixedReality.Authentication
         /// <param name="accountId"> The Mixed Reality account identifier. </param>
         /// <param name="tokenRequestOptions"> Parameter group. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="accountId"/> is null. </exception>
-        public async Task<ResponseWithHeaders<StsTokenResponseMessage, MixedRealityStsGetTokenHeaders>> GetTokenAsync(string accountId, MixedRealityTokenRequestOptions tokenRequestOptions = null, CancellationToken cancellationToken = default)
+        public async Task<ResponseWithHeaders<StsTokenResponseMessage, MixedRealityStsGetTokenHeaders>> GetTokenAsync(Guid accountId, MixedRealityTokenRequestOptions tokenRequestOptions = null, CancellationToken cancellationToken = default)
         {
-            if (accountId == null)
-            {
-                throw new ArgumentNullException(nameof(accountId));
-            }
-
             using var message = CreateGetTokenRequest(accountId, tokenRequestOptions);
             await _pipeline.SendAsync(message, cancellationToken).ConfigureAwait(false);
             var headers = new MixedRealityStsGetTokenHeaders(message.Response);
@@ -92,14 +86,8 @@ namespace Azure.MixedReality.Authentication
         /// <param name="accountId"> The Mixed Reality account identifier. </param>
         /// <param name="tokenRequestOptions"> Parameter group. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="accountId"/> is null. </exception>
-        public ResponseWithHeaders<StsTokenResponseMessage, MixedRealityStsGetTokenHeaders> GetToken(string accountId, MixedRealityTokenRequestOptions tokenRequestOptions = null, CancellationToken cancellationToken = default)
+        public ResponseWithHeaders<StsTokenResponseMessage, MixedRealityStsGetTokenHeaders> GetToken(Guid accountId, MixedRealityTokenRequestOptions tokenRequestOptions = null, CancellationToken cancellationToken = default)
         {
-            if (accountId == null)
-            {
-                throw new ArgumentNullException(nameof(accountId));
-            }
-
             using var message = CreateGetTokenRequest(accountId, tokenRequestOptions);
             _pipeline.Send(message, cancellationToken);
             var headers = new MixedRealityStsGetTokenHeaders(message.Response);

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClient.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClient.cs
@@ -23,7 +23,7 @@ namespace Azure.MixedReality.Authentication
         /// <summary>
         /// Gets the Mixed Reality service account identifier.
         /// </summary>
-        public string AccountId { get; }
+        public Guid AccountId { get; }
 
         /// <summary>
         /// The Mixed Reality STS service endpoint.
@@ -37,7 +37,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="accountDomain">The Mixed Reality service account domain.</param>
         /// <param name="keyCredential">The Mixed Reality service account primary or secondary key credential.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(string accountId, string accountDomain, AzureKeyCredential keyCredential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, string accountDomain, AzureKeyCredential keyCredential, MixedRealityStsClientOptions? options = null)
             : this(accountId, AuthenticationEndpoint.ConstructFromDomain(accountDomain), new MixedRealityAccountKeyCredential(accountId, keyCredential), options) { }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="endpoint">The Mixed Reality STS service endpoint.</param>
         /// <param name="keyCredential">The Mixed Reality service account primary or secondary key credential.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(string accountId, Uri endpoint, AzureKeyCredential keyCredential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, Uri endpoint, AzureKeyCredential keyCredential, MixedRealityStsClientOptions? options = null)
             : this(accountId, endpoint, new MixedRealityAccountKeyCredential(accountId, keyCredential), options) { }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="accountDomain">The Mixed Reality service account domain.</param>
         /// <param name="credential">The credential used to access the Mixed Reality service.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(string accountId, string accountDomain, TokenCredential credential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, string accountDomain, TokenCredential credential, MixedRealityStsClientOptions? options = null)
             : this(accountId, AuthenticationEndpoint.ConstructFromDomain(accountDomain), credential, options) { }
 
         /// <summary>
@@ -67,9 +67,9 @@ namespace Azure.MixedReality.Authentication
         /// <param name="endpoint">The Mixed Reality STS service endpoint.</param>
         /// <param name="credential">The credential used to access the Mixed Reality service.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(string accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions? options = null)
         {
-            Argument.AssertNotNull(accountId, nameof(accountId));
+            Argument.AssertNotDefault(ref accountId, nameof(accountId));
             Argument.AssertNotNull(endpoint, nameof(endpoint));
             Argument.AssertNotNull(credential, nameof(credential));
 

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/autorest.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/autorest.md
@@ -4,5 +4,5 @@ Run `dotnet build /t:GenerateCode` to generate code.
 
 ``` yaml
 input-file:
-    -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/e0b78897850ccbb648b3efe286b78e78c5cd8bcf/specification/mixedreality/data-plane/Microsoft.MixedReality/preview/2019-02-28-preview/mr-sts.json
+    -  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/aa19725fe79aea2a9dc580f3c66f77f89cc34563/specification/mixedreality/data-plane/Microsoft.MixedReality/preview/2019-02-28-preview/mr-sts.json
 ```

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/tests/MixedRealityStsClientLiveTests.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/tests/MixedRealityStsClientLiveTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -22,7 +23,7 @@ namespace Azure.MixedReality.Authentication.Tests
         private MixedRealityStsClient CreateClient()
         {
             string mixedRealityAccountDomain = TestEnvironment.AccountDomain;
-            string mixedRealityAccountId = TestEnvironment.AccountId;
+            Guid mixedRealityAccountId = Guid.Parse(TestEnvironment.AccountId);
             string mixedRealityAccountKey = TestEnvironment.AccountKey;
 
             return InstrumentClient(new MixedRealityStsClient(


### PR DESCRIPTION
This change updated the library to consume the latest version of spec file, which changes the account identifier to be a `Guid` rather than a `string`. The service expects a `Guid` or `UUID`, so it makes sense to be specific.