### PR TITLE
[Storage] Base64 encoding remarks in Webjobs docs.

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueAttribute.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -25,6 +26,17 @@ namespace Microsoft.Azure.WebJobs
     /// <item><description><see cref="ICollector{T}"/> of these types (to enqueue multiple messages via <see cref="ICollector{T}.Add"/></description></item>
     /// <item><description><see cref="IAsyncCollector{T}"/> of these types (to enqueue multiple messages via <see cref="IAsyncCollector{T}.AddAsync(T, System.Threading.CancellationToken)"/></description></item>
     /// </list>
+    ///
+    /// By default the extension Base64-encodes outgoing messages.
+    /// This behavior can be changed by setting <see cref="QueuesOptions.MessageEncoding"/>.
+    /// For example, to configure Azure Functions to perform no base64 encoding/decoding, specify the following in host.json.
+    /// <code>
+    /// "extensions": {
+    ///   "queues": {
+    ///     "messageEncoding": "none"
+    ///   }
+    /// }
+    /// </code>
     /// </remarks>
 #pragma warning restore CA1200 // Avoid using cref tags with a prefix
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1813:AvoidUnsealedAttributes")]

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueTriggerAttribute.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/src/QueueTriggerAttribute.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -22,6 +23,17 @@ namespace Microsoft.Azure.WebJobs
     /// <item><description><see cref="BinaryData"/></description></item>
     /// <item><description>A user-defined type (serialized as JSON)</description></item>
     /// </list>
+    ///
+    /// By default messages received from the queue are expected to be Base64-encoded and are decoded before calling the function.
+    /// This behavior can be changed by setting <see cref="QueuesOptions.MessageEncoding"/>.
+    /// For example, to configure Azure Functions to perform no base64 encoding/decoding, specify the following in host.json.
+    /// <code>
+    /// "extensions": {
+    ///   "queues": {
+    ///     "messageEncoding": "none"
+    ///   }
+    /// }
+    /// </code>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
 #pragma warning restore CA1200 // Avoid using cref tags with a prefix


### PR DESCRIPTION
2nd part of https://github.com/Azure/azure-sdk-for-net/issues/17404