### PR TITLE
Update xml documentation for TokenRequestContext.Claims

### DIFF
--- a/sdk/core/Azure.Core/src/TokenRequestContext.cs
+++ b/sdk/core/Azure.Core/src/TokenRequestContext.cs
@@ -44,7 +44,7 @@ namespace Azure.Core
         public string? ParentRequestId { get; }
 
         /// <summary>
-        /// Additional claims to be included in the token.
+        /// Additional claims to be included in the token. See <see cref="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</see> for more information on format and content.
         /// </summary>
         public string? Claims { get; }
     }

--- a/sdk/core/Azure.Core/src/TokenRequestContext.cs
+++ b/sdk/core/Azure.Core/src/TokenRequestContext.cs
@@ -44,7 +44,7 @@ namespace Azure.Core
         public string? ParentRequestId { get; }
 
         /// <summary>
-        /// Additional claims to be included in the token. See <see cref="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</see> for more information on format and content.
+        /// Additional claims to be included in the token. See <see href="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</see> for more information on format and content.
         /// </summary>
         public string? Claims { get; }
     }


### PR DESCRIPTION
Missed updating the XML docs for the `Claims` property on `TokenReqeustContext` per discussion [here](https://github.com/Azure/azure-sdk-for-net/pull/18236#discussion_r565593250).