### PR TITLE
ADT: Fix the issue with non-default object serializers in Query APIs

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -153,6 +153,7 @@
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Update="Microsoft.AspNetCore.Server.WebListener" Version="1.0.2" />
     <PackageReference Update="Microsoft.Azure.Core.Spatial" Version="1.0.0" />
+    <PackageReference Update="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
     <PackageReference Update="Microsoft.Azure.Devices" Version="1.19.0" />
     <PackageReference Update="Microsoft.Azure.Devices.Client" Version="1.27.0" />
     <PackageReference Update="Microsoft.Azure.Graph.RBAC" Version="2.2.2-preview" />

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/Program.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/Program.cs
@@ -16,7 +16,7 @@ namespace Azure.DigitalTwins.Core.Samples
         /// </summary>
         public static async Task Main(string[] args)
         {
-            // Parse and validate paramters
+            // Parse and validate parameters
             Options options = null;
             ParserResult<Options> result = Parser.Default.ParseArguments<Options>(args)
                 .WithParsed(parsedOptions =>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/QueryRestClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/QueryRestClient.cs
@@ -16,6 +16,7 @@ namespace Azure.DigitalTwins.Core
             QuerySpecification querySpecification,
             QueryOptions queryTwinsOptions = null,
             ObjectSerializer objectSerializer = null,
+            ObjectSerializer defaultObjectSerializer = null,
             CancellationToken cancellationToken = default)
         {
             if (querySpecification == null)
@@ -36,7 +37,7 @@ namespace Azure.DigitalTwins.Core
                 case 200:
                     {
                         using JsonDocument document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer);
+                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer, defaultObjectSerializer);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -48,6 +49,7 @@ namespace Azure.DigitalTwins.Core
             QuerySpecification querySpecification,
             QueryOptions queryTwinsOptions = null,
             ObjectSerializer objectSerializer = null,
+            ObjectSerializer defaultObjectSerializer = null,
             CancellationToken cancellationToken = default)
         {
             if (querySpecification == null)
@@ -68,7 +70,7 @@ namespace Azure.DigitalTwins.Core
                 case 200:
                     {
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer);
+                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer, defaultObjectSerializer);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -33,6 +33,12 @@ namespace Azure.DigitalTwins.Core
 
         private readonly ObjectSerializer _objectSerializer;
 
+        /// <summary>
+        /// In order to serialize/deserialize JsonElements into and out of a stream, we have to use the out of the box ObjectSerializer (JsonObjectSerializer).
+        /// If the user specifies a different type of serializer to instantiate the client than the default one, the SDK will instantiate a new JsonObjectSerializer of its own.
+        /// </summary>
+        private readonly ObjectSerializer _defaultObjectSerializer;
+
         private readonly DigitalTwinsRestClient _dtRestClient;
         private readonly DigitalTwinModelsRestClient _dtModelsRestClient;
         private readonly EventRoutesRestClient _eventRoutesRestClient;
@@ -92,6 +98,17 @@ namespace Azure.DigitalTwins.Core
             _clientDiagnostics = new ClientDiagnostics(options);
 
             _objectSerializer = options.Serializer ?? new JsonObjectSerializer();
+
+            // If the objectSerializer is of type JsonObjectSerializer, we will re-use the same object and set it as the defaultObjectSerializer.
+            if (_objectSerializer is JsonObjectSerializer)
+            {
+                _defaultObjectSerializer = _objectSerializer;
+            }
+            // Otherwise, we will instantiate it and re-use it in the future.
+            else
+            {
+                _defaultObjectSerializer = new JsonObjectSerializer();
+            }
 
             options.AddPolicy(new BearerTokenAuthenticationPolicy(credential, GetAuthorizationScopes()), HttpPipelinePosition.PerCall);
             _httpPipeline = HttpPipelineBuilder.Build(options);
@@ -2040,7 +2057,7 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(querySpecification, options, _objectSerializer, cancellationToken).ConfigureAwait(false);
+                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken).ConfigureAwait(false);
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)
@@ -2067,7 +2084,7 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(querySpecification, options, _objectSerializer, cancellationToken).ConfigureAwait(false);
+                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken).ConfigureAwait(false);
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)
@@ -2135,7 +2152,7 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(querySpecification, options, _objectSerializer, cancellationToken);
+                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken);
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)
@@ -2162,7 +2179,7 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(querySpecification, options, _objectSerializer, cancellationToken);
+                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken);
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1739,7 +1739,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// catch (RequestFailedException ex)
         /// {
-        ///     FatalError($&quot;Failed to decommision model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
+        ///     FatalError($&quot;Failed to decommission model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
         /// }
         /// </code>
         /// </example>
@@ -2057,7 +2057,13 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken).ConfigureAwait(false);
+                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(
+                            querySpecification,
+                            options,
+                            _objectSerializer,
+                            _defaultObjectSerializer,
+                            cancellationToken).ConfigureAwait(false);
+
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)
@@ -2084,7 +2090,13 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken).ConfigureAwait(false);
+                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(
+                            querySpecification,
+                            options,
+                            _objectSerializer,
+                            _defaultObjectSerializer,
+                            cancellationToken).ConfigureAwait(false);
+
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)
@@ -2152,7 +2164,13 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken);
+                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(
+                            querySpecification,
+                            options,
+                            _objectSerializer,
+                            _defaultObjectSerializer,
+                            cancellationToken);
+
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)
@@ -2179,7 +2197,12 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(querySpecification, options, _objectSerializer, _defaultObjectSerializer, cancellationToken);
+                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(
+                            querySpecification,
+                            options,
+                            _objectSerializer,
+                            _defaultObjectSerializer,
+                            cancellationToken);
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -1735,7 +1735,7 @@ namespace Azure.DigitalTwins.Core
         /// }
         /// catch (RequestFailedException ex)
         /// {
-        ///     FatalError($&quot;Failed to decommission model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
+        ///     FatalError($&quot;Failed to decommision model &apos;{sampleModelId}&apos; due to:\n{ex}&quot;);
         /// }
         /// </code>
         /// </example>
@@ -2086,12 +2086,14 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(
-                            querySpecification,
-                            options,
-                            _objectSerializer,
-                            _defaultObjectSerializer,
-                            cancellationToken).ConfigureAwait(false);
+                        Response<QueryResult<T>> response = await _queryClient
+                            .QueryTwinsAsync<T>(
+                                querySpecification,
+                                options,
+                                _objectSerializer,
+                                _defaultObjectSerializer,
+                                cancellationToken)
+                            .ConfigureAwait(false);
 
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -2053,12 +2053,14 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = await _queryClient.QueryTwinsAsync<T>(
-                            querySpecification,
-                            options,
-                            _objectSerializer,
-                            _defaultObjectSerializer,
-                            cancellationToken).ConfigureAwait(false);
+                        Response<QueryResult<T>> response = await _queryClient
+                            .QueryTwinsAsync<T>(
+                                querySpecification,
+                                options,
+                                _objectSerializer,
+                                _defaultObjectSerializer,
+                                cancellationToken)
+                            .ConfigureAwait(false);
 
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
@@ -2162,12 +2164,13 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(
-                            querySpecification,
-                            options,
-                            _objectSerializer,
-                            _defaultObjectSerializer,
-                            cancellationToken);
+                        Response<QueryResult<T>> response = _queryClient
+                            .QueryTwins<T>(
+                                querySpecification,
+                                options,
+                                _objectSerializer,
+                                _defaultObjectSerializer,
+                                cancellationToken);
 
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
@@ -2195,12 +2198,14 @@ namespace Azure.DigitalTwins.Core
                             MaxItemsPerPage = pageSizeHint
                         };
 
-                        Response<QueryResult<T>> response = _queryClient.QueryTwins<T>(
-                            querySpecification,
-                            options,
-                            _objectSerializer,
-                            _defaultObjectSerializer,
-                            cancellationToken);
+                        Response<QueryResult<T>> response = _queryClient
+                            .QueryTwins<T>(
+                                querySpecification,
+                                options,
+                                _objectSerializer,
+                                _defaultObjectSerializer,
+                                cancellationToken);
+
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
                     }
                     catch (Exception ex)

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -100,15 +100,11 @@ namespace Azure.DigitalTwins.Core
             _objectSerializer = options.Serializer ?? new JsonObjectSerializer();
 
             // If the objectSerializer is of type JsonObjectSerializer, we will re-use the same object and set it as the defaultObjectSerializer.
-            if (_objectSerializer is JsonObjectSerializer)
-            {
-                _defaultObjectSerializer = _objectSerializer;
-            }
             // Otherwise, we will instantiate it and re-use it in the future.
-            else
-            {
-                _defaultObjectSerializer = new JsonObjectSerializer();
-            }
+            _defaultObjectSerializer =
+                (_objectSerializer is JsonObjectSerializer)
+                    ? _objectSerializer
+                    : new JsonObjectSerializer();
 
             options.AddPolicy(new BearerTokenAuthenticationPolicy(credential, GetAuthorizationScopes()), HttpPipelinePosition.PerCall);
             _httpPipeline = HttpPipelineBuilder.Build(options);

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
@@ -61,7 +61,7 @@ namespace Azure.DigitalTwins.Core
                     foreach (JsonElement item in property.Value.EnumerateArray())
                     {
                         // defaultObjectSerializer of type JsonObjectSerializer needs to be used to serialize the JsonElement into a stream.
-                        // Using any other ObjectSerializer (ex: NewtonsoftJsonObjectSerializer) won't be able to deserialize the JsonElement into
+                        // Using any other ObjectSerializer (e.g. NewtonsoftJsonObjectSerializer) won't be able to deserialize the JsonElement into
                         // a MemoryStream correctly.
                         using MemoryStream streamedObject = StreamHelper.WriteToStream(item, defaultObjectSerializer, default);
 

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
@@ -25,13 +25,6 @@ namespace Azure.DigitalTwins.Core
         internal string ContinuationToken { get; }
 
         /// <summary>
-        /// In order to serialize/deserialize JsonElements into and out of a stream, we have to use the out of the box ObjectSerializer (JsonObjectSerializer).
-        /// This static property is instantiated whenever it is used so we can efficiently re-use the same object serializer that is provided by default
-        /// If the user specifies a different type of serializer to instantiate the client, the SDK will instantiate a new JsonObjectSerializer of its own.
-        /// </summary>
-        internal static ObjectSerializer defaultObjectSerializer { get; private set; }
-
-        /// <summary>
         /// Initializes a new instance of QueryResult.
         /// </summary>
         /// <param name="value">The query results.</param>
@@ -47,25 +40,12 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="element">The JSON element to be deserialized into a QueryResult.</param>
         /// <param name="objectSerializer">The object serializer instance used to deserialize the items in the collection.</param>
+        /// <param name="defaultObjectSerializer">The out of the box object serializer to interact with the JsonElement (serialize/deserialize into and out of streams).</param>
         /// <returns>A collection of query results deserialized into type <typeparamref name="T"/>.</returns>
-        internal static QueryResult<T> DeserializeQueryResult(JsonElement element, ObjectSerializer objectSerializer)
+        internal static QueryResult<T> DeserializeQueryResult(JsonElement element, ObjectSerializer objectSerializer, ObjectSerializer defaultObjectSerializer)
         {
             IReadOnlyList<T> items = default;
             string continuationToken = default;
-
-            // If the provided objectSerializer is of type JsonObjectSerializer, we will re-use the same object and set it as the defaultObjectSerializer.
-            if (objectSerializer is JsonObjectSerializer)
-            {
-                defaultObjectSerializer = objectSerializer;
-            }
-            // Otherwise, if the defaultObjectSerializer is null, we will statically instantiate it and re-use it in the future.
-            else
-            {
-                if (defaultObjectSerializer == null)
-                {
-                    defaultObjectSerializer = new JsonObjectSerializer();
-                }
-            }
 
             foreach (JsonProperty property in element.EnumerateObject())
             {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/StreamHelper.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/StreamHelper.cs
@@ -42,7 +42,6 @@ namespace Azure.DigitalTwins.Core
             var memoryStream = new MemoryStream();
 
             objectSerializer.Serialize(memoryStream, obj, typeof(T), cancellationToken);
-
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             return memoryStream;

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/Azure.DigitalTwins.Core.Tests.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/Azure.DigitalTwins.Core.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson"/>
+    <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/Azure.DigitalTwins.Core.Tests.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/Azure.DigitalTwins.Core.Tests.csproj
@@ -6,11 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Update="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/NewtonsoftObjectSerializerTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/NewtonsoftObjectSerializerTests.cs
@@ -14,6 +14,8 @@ namespace Azure.DigitalTwins.Core.Tests
     /// Tests for custom ObjectSerializer.
     /// Users can specify their own serializer/deserializer and not go with the default JsonObjectSerializer.
     /// SDK needs to make sure it can properly use different serializers and the behavior is seamless.
+    /// Specifically, we have a work around in the query code which requires use of a System.Text.Json serializer because it works on a JsonElement.
+    /// When the user initializes with a non-default serializer, we must not use that to do this work.
     /// </summary>
     public class NewtonsoftObjectSerializerTests : E2eTestBase
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/NewtonsoftObjectSerializerTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/NewtonsoftObjectSerializerTests.cs
@@ -5,12 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace Azure.DigitalTwins.Core.Tests
 {
     /// <summary>
     /// Tests for custom ObjectSerializer.
+    /// Users can specify their own serializer/deserializer and not go with the default JsonObjectSerializer.
+    /// SDK needs to make sure it can properly use different serializers and the behavior is seamless.
     /// </summary>
     public class NewtonsoftObjectSerializerTests : E2eTestBase
     {
@@ -52,19 +55,15 @@ namespace Azure.DigitalTwins.Core.Tests
                 // Get digital twin using the simple DigitalTwin model annotated with Newtonsoft attributes
                 SimpleNewtonsoftDtModel getResponse = await testClient.GetDigitalTwinAsync<SimpleNewtonsoftDtModel>(roomTwinId).ConfigureAwait(false);
 
-                Assert.IsNotNull(getResponse.Id, "Digital twin Id should not be null or empty");
+                getResponse.Id.Should().NotBeNullOrEmpty("Digital twin ID should not be null or empty");
 
                 // Query DigitalTwins using the simple DigitalTwin model annotated with Newtonsoft attributes
                 AsyncPageable<SimpleNewtonsoftDtModel> queryResponse = testClient.QueryAsync<SimpleNewtonsoftDtModel>("SELECT * FROM DIGITALTWINS");
 
                 await foreach (SimpleNewtonsoftDtModel twin in queryResponse)
                 {
-                    Assert.IsNotNull(twin.Id, "Digital twin Id should not be null or empty");
+                    twin.Id.Should().NotBeNullOrEmpty("Digital twin Id should not be null or empty");
                 }
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail($"Failure in executing a step in the test case: {ex.Message}.");
             }
             finally
             {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/NewtonsoftObjectSerializerTests.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/NewtonsoftObjectSerializerTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.Core.Serialization;
+using NUnit.Framework;
+
+namespace Azure.DigitalTwins.Core.Tests
+{
+    /// <summary>
+    /// Tests for custom ObjectSerializer.
+    /// </summary>
+    public class NewtonsoftObjectSerializerTests : E2eTestBase
+    {
+        public NewtonsoftObjectSerializerTests(bool isAsync)
+            : base(isAsync)
+        {
+        }
+
+        [Test]
+        public async Task TestNewtonsoftObjectSerializerWithDigitalTwins()
+        {
+            DigitalTwinsClient defaultClient = GetClient();
+
+            string roomTwinId = await GetUniqueTwinIdAsync(defaultClient, TestAssetDefaults.RoomTwinIdPrefix).ConfigureAwait(false);
+            string floorModelId = await GetUniqueModelIdAsync(defaultClient, TestAssetDefaults.FloorModelIdPrefix).ConfigureAwait(false);
+            string roomModelId = await GetUniqueModelIdAsync(defaultClient, TestAssetDefaults.RoomModelIdPrefix).ConfigureAwait(false);
+
+            try
+            {
+                // arrange
+
+                // create room model
+                string roomModel = TestAssetsHelper.GetRoomModelPayload(roomModelId, floorModelId);
+                await CreateAndListModelsAsync(defaultClient, new List<string> { roomModel }).ConfigureAwait(false);
+
+                // act
+
+                // create room twin
+                BasicDigitalTwin roomTwin = TestAssetsHelper.GetRoomTwinPayload(roomModelId);
+                await defaultClient.CreateOrReplaceDigitalTwinAsync<BasicDigitalTwin>(roomTwinId, roomTwin).ConfigureAwait(false);
+
+                // Create a client with NewtonsoftJsonObjectSerializer configured as the serializer.
+                DigitalTwinsClient testClient = GetClient(
+                    new DigitalTwinsClientOptions
+                    {
+                        Serializer = new NewtonsoftJsonObjectSerializer()
+                    });
+
+                // Get digital twin using the simple DigitalTwin model annotated with Newtonsoft attributes
+                SimpleNewtonsoftDtModel getResponse = await testClient.GetDigitalTwinAsync<SimpleNewtonsoftDtModel>(roomTwinId).ConfigureAwait(false);
+
+                Assert.IsNotNull(getResponse.Id, "Digital twin Id should not be null or empty");
+
+                // Query DigitalTwins using the simple DigitalTwin model annotated with Newtonsoft attributes
+                AsyncPageable<SimpleNewtonsoftDtModel> queryResponse = testClient.QueryAsync<SimpleNewtonsoftDtModel>("SELECT * FROM DIGITALTWINS");
+
+                await foreach (SimpleNewtonsoftDtModel twin in queryResponse)
+                {
+                    Assert.IsNotNull(twin.Id, "Digital twin Id should not be null or empty");
+                }
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Failure in executing a step in the test case: {ex.Message}.");
+            }
+            finally
+            {
+                // cleanup
+                try
+                {
+                    // delete twin
+                    if (!string.IsNullOrWhiteSpace(roomTwinId))
+                    {
+                        await defaultClient.DeleteDigitalTwinAsync(roomTwinId).ConfigureAwait(false);
+                    }
+
+                    // delete models
+                    if (!string.IsNullOrWhiteSpace(roomModelId))
+                    {
+                        await defaultClient.DeleteModelAsync(roomModelId).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail($"Test clean up failed: {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwins.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwins.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-00a2e702d268814b8394504d6cc3ac8e-cb1a034aeb282d4f-00",
+        "traceparent": "00-94268e797b46484ba32ad82cb8f32b1a-8530dc8f38b1f64c-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "ee670b1f86883f706b9cc45a7502e2cd",
@@ -19,9 +19,9 @@
       "ResponseHeaders": {
         "Content-Length": "271",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-00a2e702d268814b8394504d6cc3ac8e-17566bbae91d924d-01"
+        "traceresponse": "00-94268e797b46484ba32ad82cb8f32b1a-6eb08bdcacaf964b-01"
       },
       "ResponseBody": {
         "error": {
@@ -36,9 +36,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-eff1384104ee764993b26c76428a7a2c-6b9323e991313941-00",
+        "traceparent": "00-fb0e3f2b93957b4187fe043186a66103-64705bfe5b796e4a-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "28d270be2fa2004e00b47d1c56db47c9",
@@ -49,9 +49,9 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-eff1384104ee764993b26c76428a7a2c-9dea6a771789e14b-01"
+        "traceresponse": "00-fb0e3f2b93957b4187fe043186a66103-11c15fbe57b35c4e-01"
       },
       "ResponseBody": {
         "error": {
@@ -66,9 +66,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-7242e1b3cd293c4d8a535094941c334a-8ea1ff96f0cf2747-00",
+        "traceparent": "00-b3d2f15649adef438844141ed973eb2c-35f11ce18040174f-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "b96248db1a536e3e7e415f38a7a438a1",
@@ -79,9 +79,9 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-7242e1b3cd293c4d8a535094941c334a-1148b5240c7a304d-01"
+        "traceresponse": "00-b3d2f15649adef438844141ed973eb2c-c691a052d2bdba48-01"
       },
       "ResponseBody": {
         "error": {
@@ -98,9 +98,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "804",
         "Content-Type": "application/json",
-        "traceparent": "00-10351cf0ee51a74b854f40c9243dcfc9-bb7e8477507d3b44-00",
+        "traceparent": "00-185e14d10fa0ec4fab2b984e2825d508-0c0dea7ec14f264f-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "ca8f95927d5c19dbee88d1f22214c17d",
@@ -111,11 +111,11 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-10351cf0ee51a74b854f40c9243dcfc9-d458faae2889044c-01"
+        "traceresponse": "00-185e14d10fa0ec4fab2b984e2825d508-cc3f7dbc3a09d646-01"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;149813251\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222021-02-03T03:30:29.0829572\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;149813251\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222021-02-03T17:46:19.7890657\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
@@ -123,9 +123,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-42b9d024a341da4496634ac4e0e07c89-3e6e933485f5b74d-00",
+        "traceparent": "00-78f4b792a7c9dd43947cf7ecb4355d14-37cebd78cebb5d4c-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "99265191cd6a556a93b923eeeec7590f",
@@ -134,11 +134,11 @@
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
-        "Content-Length": "12343",
+        "Content-Length": "12535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-42b9d024a341da4496634ac4e0e07c89-6ff38c81758a2f4c-01"
+        "traceresponse": "00-78f4b792a7c9dd43947cf7ecb4355d14-185f012138a6264f-01"
       },
       "ResponseBody": {
         "value": [
@@ -810,7 +810,18 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2021-02-03T03:30:29.0829572\u002B00:00"
+            "uploadTime": "2021-02-03T17:46:19.7890657\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;176638439",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T17:46:19.8291397\u002B00:00"
           }
         ],
         "nextLink": null
@@ -824,9 +835,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "traceparent": "00-ecd9719b3d717a44a08dce20a58d0302-7487480344c77e44-00",
+        "traceparent": "00-f20bbfa2fe375b4eb05576904ca5da4f-c80bbb911f20e24d-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "45c47b44feb75ec76d49cbcb494c4c69",
@@ -847,14 +858,14 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
-        "ETag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
+        "ETag": "W/\u00222aa47b84-fbfa-4c41-aac0-d2e0d6bfb309\u0022",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-ecd9719b3d717a44a08dce20a58d0302-c1085a9c8deed443-01"
+        "traceresponse": "00-f20bbfa2fe375b4eb05576904ca5da4f-ac199edd5727d54b-01"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1430706564",
-        "$etag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "$etag": "W/\u00222aa47b84-fbfa-4c41-aac0-d2e0d6bfb309\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -862,16 +873,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;149813251",
           "Temperature": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           }
         }
       }
@@ -882,9 +893,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-86cfe5a557791545974d0609a83ddb5a-db9c7d9675adc447-00",
+        "traceparent": "00-ac1cdf807a2e544b876064da2789f5d7-9b0777a3fe93054e-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "55a7e27f9e7ec4362b3936a359ed2b26",
@@ -895,14 +906,14 @@
       "ResponseHeaders": {
         "Content-Length": "461",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
-        "ETag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
+        "ETag": "W/\u00222aa47b84-fbfa-4c41-aac0-d2e0d6bfb309\u0022",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-86cfe5a557791545974d0609a83ddb5a-38e802f1e7325943-01"
+        "traceresponse": "00-ac1cdf807a2e544b876064da2789f5d7-ce676d855b759140-01"
       },
       "ResponseBody": {
         "$dtId": "roomTwin1430706564",
-        "$etag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "$etag": "W/\u00222aa47b84-fbfa-4c41-aac0-d2e0d6bfb309\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -910,16 +921,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;149813251",
           "Temperature": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9201685Z"
           }
         }
       }
@@ -932,9 +943,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "38",
         "Content-Type": "application/json",
-        "traceparent": "00-595cad1e970dc64c9ff9c7034c5bb0cf-ba4af52cf7b08546-00",
+        "traceparent": "00-b1c736c840cd484ca9b8ae50b25bae7c-dc1d9c7619e06e40-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "a6adc12f7c5092c58ac82c21019f0c47",
@@ -946,10 +957,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "query-charge": "10.12",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-595cad1e970dc64c9ff9c7034c5bb0cf-a4f6df7057bcf540-01",
+        "traceresponse": "00-b1c736c840cd484ca9b8ae50b25bae7c-2246eb90c5600f46-01",
         "Transfer-Encoding": "chunked"
       },
       "ResponseBody": {
@@ -2082,9 +2093,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-647b7f63c1ecb245929b45407d9876f2-19b26a03a0aa354b-00",
+        "traceparent": "00-9c090f676f27464085556c162093c8f2-3a49aa414caaa24d-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "0c6eb96d0320a59144ff1a7ec7240480",
@@ -2094,9 +2105,9 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-647b7f63c1ecb245929b45407d9876f2-5da16df206a6b946-01"
+        "traceresponse": "00-9c090f676f27464085556c162093c8f2-48d9bb3f6a0f3648-01"
       },
       "ResponseBody": []
     },
@@ -2106,9 +2117,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-fb79969a502d734ea49c536a63051cdd-cba6a1adc9148646-00",
+        "traceparent": "00-ca3a08b494dde248a5494aaeb89d9ad4-ef833cd75317ba4d-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "879ca51ea59e03191c15cbb57215c38c",
@@ -2118,9 +2129,9 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-fb79969a502d734ea49c536a63051cdd-266abf403e20be4a-01"
+        "traceresponse": "00-ca3a08b494dde248a5494aaeb89d9ad4-e0a59c9c9cff3d4e-01"
       },
       "ResponseBody": []
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwins.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwins.json
@@ -1,0 +1,2132 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1430706564?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-00a2e702d268814b8394504d6cc3ac8e-cb1a034aeb282d4f-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "ee670b1f86883f706b9cc45a7502e2cd",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "271",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-00a2e702d268814b8394504d6cc3ac8e-17566bbae91d924d-01"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin1430706564. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Afloor%3B11267207?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-eff1384104ee764993b26c76428a7a2c-6b9323e991313941-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "28d270be2fa2004e00b47d1c56db47c9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-eff1384104ee764993b26c76428a7a2c-9dea6a771789e14b-01"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:floor;11267207. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B149813251?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-7242e1b3cd293c4d8a535094941c334a-8ea1ff96f0cf2747-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "b96248db1a536e3e7e415f38a7a438a1",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-7242e1b3cd293c4d8a535094941c334a-1148b5240c7a304d-01"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:room;149813251. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "804",
+        "Content-Type": "application/json",
+        "traceparent": "00-10351cf0ee51a74b854f40c9243dcfc9-bb7e8477507d3b44-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "ca8f95927d5c19dbee88d1f22214c17d",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;149813251\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;11267207\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "193",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-10351cf0ee51a74b854f40c9243dcfc9-d458faae2889044c-01"
+      },
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;149813251\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222021-02-03T03:30:29.0829572\u002B00:00\u0022}]"
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-42b9d024a341da4496634ac4e0e07c89-3e6e933485f5b74d-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "99265191cd6a556a93b923eeeec7590f",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "12343",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-42b9d024a341da4496634ac4e0e07c89-6ff38c81758a2f4c-01"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "dtmi:example:Ward;154155931",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:00.6914759\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;145613168",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:00.6923131\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;133999852",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:00.8468548\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;111892730",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:01.4893239\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;181053342",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:01.8055239\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;118112199",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:01.9458203\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1734752",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.544589\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1455457",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.5446266\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1475050",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.5446476\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1190300",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.9320071\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1986367",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.9320364\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1888485",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.932053\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1548262",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:07.6974692\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1066046",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:16.3332236\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1634334",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:16.3332519\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1089118",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:16.3332689\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1882161",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:17.0853142\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1822742",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:23.0141874\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1180692",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:23.0142213\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1527130",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:23.0142444\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1781699",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:24.1119772\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1617621",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:33.5352077\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1134858",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:33.5352424\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1712969",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:33.5352652\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1474799",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:34.7165797\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1350530",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:20.2901271\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1762171",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:20.2902086\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1615597",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:20.290229\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1830135",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:21.1974929\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1957271",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:28.1822238\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1544799",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:28.1822593\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1158158",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:28.1822814\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1890267",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:29.1430355\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1497822",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:43.1253465\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1951340",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:43.1253771\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1756932",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:43.1253961\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1398142",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:44.5335538\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1603592",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:54.8008172\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1384592",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:54.8008622\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1731623",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:54.8008805\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1532010",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:58.3645375\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;1506729",
+            "description": {
+              "en": "Anenclosureinsideabuilding."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:54:08.4752622\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;1312262",
+            "description": {
+              "en": "Anenclosureinsideabuilding."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:59:27.9783165\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;1867454",
+            "description": {
+              "en": "Anenclosureinsideabuilding."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:00:45.1707261\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1413132",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:37.8242053\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1008415",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:37.824234\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1009686",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:37.8242498\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1277563",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:39.2372893\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1014437",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:46.8489933\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1295996",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:46.8490202\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1191474",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:46.8490373\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1499878",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:48.0720751\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:ComponentModel;6174",
+            "description": {},
+            "displayName": {
+              "en": "Component1"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-29T23:30:03.3607167\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Building;1",
+            "description": {},
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0704576\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Floor;1",
+            "description": {},
+            "displayName": {
+              "en": "Floor"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0704794\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:HVAC;1",
+            "description": {},
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0705227\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Room;1",
+            "description": {},
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0705463\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Wifi;1",
+            "description": {},
+            "displayName": {
+              "en": "Wifi"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0705686\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;116029261",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:13:35.4814974\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;195438086",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:21:36.3092503\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;19885524",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:25:50.3518595\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;149813251",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:30:29.0829572\u002B00:00"
+          }
+        ],
+        "nextLink": null
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1430706564?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "traceparent": "00-ecd9719b3d717a44a08dce20a58d0302-7487480344c77e44-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "45c47b44feb75ec76d49cbcb494c4c69",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;149813251"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "ETag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-ecd9719b3d717a44a08dce20a58d0302-c1085a9c8deed443-01"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1430706564",
+        "$etag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;149813251",
+          "Temperature": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1430706564?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-86cfe5a557791545974d0609a83ddb5a-db9c7d9675adc447-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "55a7e27f9e7ec4362b3936a359ed2b26",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "461",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "ETag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-86cfe5a557791545974d0609a83ddb5a-38e802f1e7325943-01"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin1430706564",
+        "$etag": "W/\u002287f61116-c7bf-4ab3-8b7b-c127c6cf1c4c\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;149813251",
+          "Temperature": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2135940Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "38",
+        "Content-Type": "application/json",
+        "traceparent": "00-595cad1e970dc64c9ff9c7034c5bb0cf-ba4af52cf7b08546-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "a6adc12f7c5092c58ac82c21019f0c47",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "query": "SELECT * FROM DIGITALTWINS"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "query-charge": "10.12",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-595cad1e970dc64c9ff9c7034c5bb0cf-a4f6df7057bcf540-01",
+        "Transfer-Encoding": "chunked"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin460152108",
+            "$etag": "W/\u0022c14258f3-f518-4569-94b7-5b6a7009bd4b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;111892730",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1420781814",
+            "$etag": "W/\u002215823347-e6e5-4250-a774-a3735d9303e1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;133999852",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1320328829",
+            "$etag": "W/\u0022dee956ef-7343-4a8e-b5aa-94d64f1b468d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;116845994",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1171852527",
+            "$etag": "W/\u0022c7f421ee-7902-4289-8868-38ff79815e3f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;163554513",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1019252643",
+            "$etag": "W/\u002285191640-cb26-4c66-a264-8f08e1e63485\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;118127707",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin898922460",
+            "$etag": "W/\u0022e069c97b-c9bd-4c01-804e-9a62c1598ebc\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;170118024",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8712463Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8712463Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.7880790Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin958754835",
+            "$etag": "W/\u00229a25e697-7c99-4372-a1d1-73a3584dd0ce\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;196301502",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1474340914",
+            "$etag": "W/\u0022de67105c-b008-4468-a455-66f455271827\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;160194944",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin788116830",
+            "$etag": "W/\u00226c936a90-ffd1-48e3-81c3-b40ac3a3b65d\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;139380843",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:03.3817391Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:03.3817391Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:03.2854024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2114072427",
+            "$etag": "W/\u0022977e9abd-8343-476b-a5e1-cbd5fa5c955d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;114297411",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1701250104",
+            "$etag": "W/\u0022a69fafd6-d74a-4f88-89f6-01f69605a005\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;121095457",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:04.8505962Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:04.8505962Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:04.7716505Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1500965769",
+            "$etag": "W/\u0022bf630b74-c175-4fb8-a83d-45e3baab71fb\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;154962552",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:05.0732015Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:05.0732015Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:04.9949133Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin869533390",
+            "$etag": "W/\u002289e13884-7481-4fc5-b803-3931c746fe42\u0022",
+            "Temperature": 70,
+            "Humidity": 80,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;110330782",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:05.3490298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:05.4214756Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:05.2988498Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin298405819",
+            "$etag": "W/\u0022ecc3c21b-e6dd-45eb-9aa6-02ae422e5b53\u0022",
+            "Temperature": 70,
+            "Humidity": 80,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;117174263",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:05.5359604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:05.6061579Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:05.4861448Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1043399473",
+            "$etag": "W/\u0022109b2419-637c-4ce0-901e-12ff446a47e2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1755945808",
+            "$etag": "W/\u0022f4f88b1a-f016-4bdd-8ff7-28e548165d3a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin394889929",
+            "$etag": "W/\u00222694a5ef-8bfe-481b-b279-268e29183c65\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin222731943",
+            "$etag": "W/\u0022049808dc-629e-4a2c-8d87-26e4d798c020\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin406365159",
+            "$etag": "W/\u00229b710bc4-44bd-420e-b799-4bcbf9f7a000\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin261798201",
+            "$etag": "W/\u0022825684fb-5321-43aa-87cb-c22b2dc4e5b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2103656111",
+            "$etag": "W/\u0022ad688175-f6f3-48d7-aa2a-68c427974f58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin517701651",
+            "$etag": "W/\u0022bb4caafd-aced-4f87-8022-b7d13a08188b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin419605825",
+            "$etag": "W/\u00222d290fc3-d225-49a6-86a9-128c7df273ab\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1973949077",
+            "$etag": "W/\u002275340c9f-b967-46b8-b394-318dccfeae7c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin858105055",
+            "$etag": "W/\u002212bad670-c7a8-4599-a9c6-28416afe7145\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin428015386",
+            "$etag": "W/\u00225cc173c7-38ee-4b6a-953f-518936f90b1f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2103316411",
+            "$etag": "W/\u0022d55e6abe-9221-4a2a-875d-958c2b9ea127\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin159399716",
+            "$etag": "W/\u002250be124e-acb3-47f4-a981-d4e08601e876\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2115596528",
+            "$etag": "W/\u00229c1c216c-0f8c-4b67-aecc-aea37f9c12f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin979747018",
+            "$etag": "W/\u002238f7995f-f224-4d1e-b48d-fd3d2572284f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin747583795",
+            "$etag": "W/\u0022c41c71c4-2227-4ed3-bb04-6d69a7e46a88\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1234052869",
+            "$etag": "W/\u0022cd915e94-4d74-4644-8667-e5d0341b954d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin416498780",
+            "$etag": "W/\u0022c717cdb8-9cae-44c9-bc0b-770c66de6f7d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin952596496",
+            "$etag": "W/\u0022ed52c3eb-24d3-4c58-8ad8-7b0616b3324a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin798293087",
+            "$etag": "W/\u0022a8018f03-6a52-4e02-83f2-c3a72fa982dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;131459891",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1346838400",
+            "$etag": "W/\u002275e9b3e0-2d8e-443c-9b3c-76c6bf3f56d5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;153942695",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin844044",
+            "$etag": "W/\u0022341bd569-8d62-475c-a368-85c814877df0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin070857",
+            "$etag": "W/\u0022fb6537b8-c035-480e-b8f4-7fd5d9571783\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin381161",
+            "$etag": "W/\u0022fb20bb6b-923c-42e0-82c2-c878adebec14\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin246198",
+            "$etag": "W/\u0022cd5b90ba-d932-4d39-8aad-d36355a1fe1e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin766189",
+            "$etag": "W/\u00221fac2335-a558-403b-96d3-a79dc2d202dd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin739702",
+            "$etag": "W/\u00226a280d75-5537-4fef-a671-e3b58194830a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin544952",
+            "$etag": "W/\u002248429892-9afa-4ce7-a5f8-a5ed0da53da7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin830667",
+            "$etag": "W/\u002243e7a0ad-60b7-4daa-afaf-b81088d49f9d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin372470",
+            "$etag": "W/\u0022b7bf5c12-9408-454d-8408-6ed2ca7f703b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin566336",
+            "$etag": "W/\u0022e3674b63-2f7e-4e7c-b1f4-3651fb5c130e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin803247",
+            "$etag": "W/\u00224e743e14-1f6b-4c0a-8950-2fda7a65b9f8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin445180",
+            "$etag": "W/\u002285ee93d1-be61-44bf-b905-63e0b0b046dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              }
+            }
+          },
+          {
+            "$dtId": "BuildingTwin",
+            "$etag": "W/\u0022d54dde15-aff7-4b0c-b898-f66804a4ca74\u0022",
+            "AverageTemperature": 68,
+            "TemperatureUnit": "Celsius",
+            "$metadata": {
+              "$model": "dtmi:com:samples:Building;1",
+              "AverageTemperature": {
+                "lastUpdateTime": "2021-02-02T23:27:56.3899645Z"
+              },
+              "TemperatureUnit": {
+                "lastUpdateTime": "2021-02-02T23:27:56.3899645Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1220449681",
+            "$etag": "W/\u00220c94367b-5077-402c-a2ca-51b4bd27fb4e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;116029261",
+              "Temperature": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": null
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin1430706564?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-647b7f63c1ecb245929b45407d9876f2-19b26a03a0aa354b-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "0c6eb96d0320a59144ff1a7ec7240480",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-647b7f63c1ecb245929b45407d9876f2-5da16df206a6b946-01"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B149813251?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-fb79969a502d734ea49c536a63051cdd-cba6a1adc9148646-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "879ca51ea59e03191c15cbb57215c38c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-fb79969a502d734ea49c536a63051cdd-266abf403e20be4a-01"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DIGITALTWINS_URL": "https://fakeHost.api.wus2.digitaltwins.azure.net",
+    "RandomSeed": "2113105330"
+  }
+}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwinsAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwinsAsync.json
@@ -6,9 +6,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-92efd01577c8084788ccf3a6591bddc7-0c6a947437d2864f-00",
+        "traceparent": "00-18a990705dec9040bd710f2a5e8311ce-378b7d74fc979c42-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "34ed8aa11b3ff9b4fa18a2195671c648",
@@ -19,9 +19,9 @@
       "ResponseHeaders": {
         "Content-Length": "270",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-92efd01577c8084788ccf3a6591bddc7-f13f50d09862ac44-01"
+        "traceresponse": "00-18a990705dec9040bd710f2a5e8311ce-899668565194d848-01"
       },
       "ResponseBody": {
         "error": {
@@ -36,9 +36,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-b19ea791cc55e94d95f533ef6718d493-9f4e02f11ca9824d-00",
+        "traceparent": "00-2da69963a3988144beee11329a6f69a2-7b3947bbb4d3a849-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "76566f9a905b2f9d1d9f1097425b6689",
@@ -49,9 +49,9 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-b19ea791cc55e94d95f533ef6718d493-df3974c1a282eb43-01"
+        "traceresponse": "00-2da69963a3988144beee11329a6f69a2-6ea7e664f8e2a34c-01"
       },
       "ResponseBody": {
         "error": {
@@ -66,9 +66,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-f48d9d0797f3d141958398a754bbebac-cd702cd01ceb224e-00",
+        "traceparent": "00-abcafc24ddfbdb4a973223a4dc3acf0c-b72a648ed5c63147-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "4c0a9eebb6d3e27a8c61c63b004e8c01",
@@ -79,9 +79,9 @@
       "ResponseHeaders": {
         "Content-Length": "212",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-f48d9d0797f3d141958398a754bbebac-86aaa5bbe4649941-01"
+        "traceresponse": "00-abcafc24ddfbdb4a973223a4dc3acf0c-a68964ac15f47542-01"
       },
       "ResponseBody": {
         "error": {
@@ -98,9 +98,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "804",
         "Content-Type": "application/json",
-        "traceparent": "00-eea52f469757b94fb7b9936c87906f78-848a518e5b925c47-00",
+        "traceparent": "00-87d364af7810244dadb0cb394bf1a865-2c5e6429506f634a-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "0496c95445ff50f904227ba362b7bd3c",
@@ -111,11 +111,11 @@
       "ResponseHeaders": {
         "Content-Length": "193",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-eea52f469757b94fb7b9936c87906f78-fe3ed714db1cb04c-01"
+        "traceresponse": "00-87d364af7810244dadb0cb394bf1a865-ab5fdc9850b61447-01"
       },
-      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;176638439\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222021-02-03T03:30:29.1761779\u002B00:00\u0022}]"
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;176638439\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222021-02-03T17:46:19.8291397\u002B00:00\u0022}]"
     },
     {
       "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?includeModelDefinition=false\u0026api-version=2020-10-31",
@@ -123,9 +123,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-bb1b8169c3422f4f8db7faf44305a28f-e4ef0f4ad205e842-00",
+        "traceparent": "00-1f0ad63d61157a42b17c03e65bdb496f-663c5f054e501d40-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "28854990d03db9c7dc94cf2fd6f41d51",
@@ -136,9 +136,9 @@
       "ResponseHeaders": {
         "Content-Length": "12535",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-bb1b8169c3422f4f8db7faf44305a28f-eb11a0ee6377be42-01"
+        "traceresponse": "00-1f0ad63d61157a42b17c03e65bdb496f-4b4c3835257d354d-01"
       },
       "ResponseBody": {
         "value": [
@@ -810,7 +810,7 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2021-02-03T03:30:29.0829572\u002B00:00"
+            "uploadTime": "2021-02-03T17:46:19.7890657\u002B00:00"
           },
           {
             "id": "dtmi:example:room;176638439",
@@ -821,7 +821,7 @@
               "en": "Room"
             },
             "decommissioned": false,
-            "uploadTime": "2021-02-03T03:30:29.1761779\u002B00:00"
+            "uploadTime": "2021-02-03T17:46:19.8291397\u002B00:00"
           }
         ],
         "nextLink": null
@@ -835,9 +835,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "154",
         "Content-Type": "application/json",
-        "traceparent": "00-4db852bfc51cce499ecf7e516edcd19d-fa2c3eaa40099145-00",
+        "traceparent": "00-89f82112102c2c43ad72b3061a1633e3-ff07712fc6708940-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "91ee958384d0a60da4ba47b03ad67fd4",
@@ -858,14 +858,14 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
-        "ETag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
+        "ETag": "W/\u0022e4f65e8a-0c2a-40bb-a745-9c129e84eb69\u0022",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-4db852bfc51cce499ecf7e516edcd19d-ee484af384dceb42-01"
+        "traceresponse": "00-89f82112102c2c43ad72b3061a1633e3-2024d8ec2eea734a-01"
       },
       "ResponseBody": {
         "$dtId": "roomTwin359524726",
-        "$etag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "$etag": "W/\u0022e4f65e8a-0c2a-40bb-a745-9c129e84eb69\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -873,16 +873,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;176638439",
           "Temperature": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           }
         }
       }
@@ -893,9 +893,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-041d9e836db2cb43bc3a8e09a314f674-5e3c59191d38ff47-00",
+        "traceparent": "00-fed3f84bf22bd3408ff775c94e5e77b9-f67011059e74504f-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "b6aa8aa464c983c402dc286b75ca7910",
@@ -906,14 +906,14 @@
       "ResponseHeaders": {
         "Content-Length": "460",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
-        "ETag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
+        "ETag": "W/\u0022e4f65e8a-0c2a-40bb-a745-9c129e84eb69\u0022",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-041d9e836db2cb43bc3a8e09a314f674-0b808af837b30744-01"
+        "traceresponse": "00-fed3f84bf22bd3408ff775c94e5e77b9-9cc042970baac945-01"
       },
       "ResponseBody": {
         "$dtId": "roomTwin359524726",
-        "$etag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "$etag": "W/\u0022e4f65e8a-0c2a-40bb-a745-9c129e84eb69\u0022",
         "Temperature": 80,
         "Humidity": 25,
         "IsOccupied": true,
@@ -921,16 +921,16 @@
         "$metadata": {
           "$model": "dtmi:example:room;176638439",
           "Temperature": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           },
           "Humidity": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           },
           "IsOccupied": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           },
           "EmployeeId": {
-            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+            "lastUpdateTime": "2021-02-03T17:46:19.9280255Z"
           }
         }
       }
@@ -943,9 +943,9 @@
         "Authorization": "Sanitized",
         "Content-Length": "38",
         "Content-Type": "application/json",
-        "traceparent": "00-4cad763ee714c84f99856495f20f7f0e-ef282d1a247ec549-00",
+        "traceparent": "00-c5ee43e2a5a3194aa1d654652e371635-509510ca81f6d54f-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "cc202a042bc80b6b3bdf838289167e06",
@@ -957,10 +957,10 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "query-charge": "10.12",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-4cad763ee714c84f99856495f20f7f0e-6752bc993078dd4e-01",
+        "traceresponse": "00-c5ee43e2a5a3194aa1d654652e371635-c158cdebb7dfc342-01",
         "Transfer-Encoding": "chunked"
       },
       "ResponseBody": {
@@ -2093,9 +2093,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-755a8c695a7bce4ab96cd1038da0fff7-115e4f7698ddc146-00",
+        "traceparent": "00-3efcaff2be382d41ab33a3a2de791b2a-b7aef5df59ce5540-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "4b8bfa1466491f88d16b8ff35ca230d9",
@@ -2105,9 +2105,9 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 03 Feb 2021 03:30:29 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-755a8c695a7bce4ab96cd1038da0fff7-9e4434f333d08b42-01"
+        "traceresponse": "00-3efcaff2be382d41ab33a3a2de791b2a-603099310a75dd4d-01"
       },
       "ResponseBody": []
     },
@@ -2117,9 +2117,9 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "traceparent": "00-0c12b80188852d41be6064d1d5414b4c-0445f1fbd081064b-00",
+        "traceparent": "00-13e958bfd4a4404683e59d0cf4ffe06d-b729d8db65b99147-00",
         "User-Agent": [
-          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210203.1",
           "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
         ],
         "x-ms-client-request-id": "0fab3740b3b5780c1f9f7beae041faec",
@@ -2129,9 +2129,9 @@
       "StatusCode": 204,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 03 Feb 2021 03:30:29 GMT",
+        "Date": "Wed, 03 Feb 2021 17:46:19 GMT",
         "Strict-Transport-Security": "max-age=2592000",
-        "traceresponse": "00-0c12b80188852d41be6064d1d5414b4c-a981e6d215f60d49-01"
+        "traceresponse": "00-13e958bfd4a4404683e59d0cf4ffe06d-3a3cd96907615249-01"
       },
       "ResponseBody": []
     }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwinsAsync.json
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SessionRecords/NewtonsoftObjectSerializerTests/TestNewtonsoftObjectSerializerWithDigitalTwinsAsync.json
@@ -1,0 +1,2143 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin359524726?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-92efd01577c8084788ccf3a6591bddc7-0c6a947437d2864f-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "34ed8aa11b3ff9b4fa18a2195671c648",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "270",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-92efd01577c8084788ccf3a6591bddc7-f13f50d09862ac44-01"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "DigitalTwinNotFound",
+          "message": "There is no digital twin instance that exists with the ID roomTwin359524726. Please verify that the twin id is valid and ensure that the twin is not deleted. See section on querying the twins http://aka.ms/adtv2query."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Afloor%3B11464619?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-b19ea791cc55e94d95f533ef6718d493-9f4e02f11ca9824d-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "76566f9a905b2f9d1d9f1097425b6689",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-b19ea791cc55e94d95f533ef6718d493-df3974c1a282eb43-01"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:floor;11464619. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B176638439?includeModelDefinition=true\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-f48d9d0797f3d141958398a754bbebac-cd702cd01ceb224e-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "4c0a9eebb6d3e27a8c61c63b004e8c01",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 404,
+      "ResponseHeaders": {
+        "Content-Length": "212",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-f48d9d0797f3d141958398a754bbebac-86aaa5bbe4649941-01"
+      },
+      "ResponseBody": {
+        "error": {
+          "code": "ModelNotFound",
+          "message": "There is no Model(s) available that matches the provided id(s) dtmi:example:room;176638439. Check that the Model ID provided is valid by doing a Model_List API call."
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "804",
+        "Content-Type": "application/json",
+        "traceparent": "00-eea52f469757b94fb7b9936c87906f78-848a518e5b925c47-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "0496c95445ff50f904227ba362b7bd3c",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": "[{    \u0022@id\u0022: \u0022dtmi:example:room;176638439\u0022,    \u0022@type\u0022: \u0022Interface\u0022,    \u0022displayName\u0022: \u0022Room\u0022,    \u0022description\u0022: \u0022An enclosure inside a building.\u0022,    \u0022contents\u0022: [        {            \u0022@type\u0022: \u0022Relationship\u0022,            \u0022name\u0022: \u0022containedIn\u0022,            \u0022target\u0022: \u0022dtmi:example:floor;11464619\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Temperature\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022Humidity\u0022,            \u0022schema\u0022: \u0022double\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022IsOccupied\u0022,            \u0022schema\u0022: \u0022boolean\u0022        },        {            \u0022@type\u0022: \u0022Property\u0022,            \u0022name\u0022: \u0022EmployeeId\u0022,            \u0022schema\u0022: \u0022string\u0022        }    ],    \u0022@context\u0022: \u0022dtmi:dtdl:context;2\u0022}]",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "193",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-eea52f469757b94fb7b9936c87906f78-fe3ed714db1cb04c-01"
+      },
+      "ResponseBody": "[{\u0022id\u0022:\u0022dtmi:example:room;176638439\u0022,\u0022description\u0022:{\u0022en\u0022:\u0022An enclosure inside a building.\u0022},\u0022displayName\u0022:{\u0022en\u0022:\u0022Room\u0022},\u0022decommissioned\u0022:false,\u0022uploadTime\u0022:\u00222021-02-03T03:30:29.1761779\u002B00:00\u0022}]"
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models?includeModelDefinition=false\u0026api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-bb1b8169c3422f4f8db7faf44305a28f-e4ef0f4ad205e842-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "28854990d03db9c7dc94cf2fd6f41d51",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "12535",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-bb1b8169c3422f4f8db7faf44305a28f-eb11a0ee6377be42-01"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "id": "dtmi:example:Ward;154155931",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:00.6914759\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;145613168",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:00.6923131\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;133999852",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:00.8468548\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;111892730",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:01.4893239\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;181053342",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:01.8055239\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;118112199",
+            "description": {
+              "en": "A separate partition in a building, made of rooms and hallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-12T23:39:01.9458203\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1734752",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.544589\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1455457",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.5446266\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1475050",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.5446476\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1190300",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.9320071\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1986367",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.9320364\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1888485",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:06.932053\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1548262",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:07.6974692\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1066046",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:16.3332236\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1634334",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:16.3332519\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1089118",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:16.3332689\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1882161",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:22:17.0853142\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1822742",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:23.0141874\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1180692",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:23.0142213\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1527130",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:23.0142444\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1781699",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:24.1119772\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1617621",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:33.5352077\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1134858",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:33.5352424\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1712969",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:33.5352652\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1474799",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:24:34.7165797\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1350530",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:20.2901271\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1762171",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:20.2902086\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1615597",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:20.290229\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1830135",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:21.1974929\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1957271",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:28.1822238\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1544799",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:28.1822593\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1158158",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:28.1822814\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1890267",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:26:29.1430355\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1497822",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:43.1253465\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1951340",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:43.1253771\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1756932",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:43.1253961\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1398142",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:44.5335538\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1603592",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:54.8008172\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1384592",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:54.8008622\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1731623",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:54.8008805\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1532010",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:28:58.3645375\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;1506729",
+            "description": {
+              "en": "Anenclosureinsideabuilding."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:54:08.4752622\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;1312262",
+            "description": {
+              "en": "Anenclosureinsideabuilding."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T19:59:27.9783165\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;1867454",
+            "description": {
+              "en": "Anenclosureinsideabuilding."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:00:45.1707261\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1413132",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:37.8242053\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1008415",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:37.824234\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1009686",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:37.8242498\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1277563",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:39.2372893\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Building;1014437",
+            "description": {
+              "en": "Afree-standingstructure."
+            },
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:46.8489933\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Hvac;1295996",
+            "description": {
+              "en": "Aheating,ventilation,andairconditioningunit."
+            },
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:46.8490202\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1191474",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:46.8490373\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:Ward;1499878",
+            "description": {
+              "en": "Aseparatepartitioninabuilding,madeofroomsandhallways."
+            },
+            "displayName": {
+              "en": "Ward"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-13T20:05:48.0720751\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:ComponentModel;6174",
+            "description": {},
+            "displayName": {
+              "en": "Component1"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-01-29T23:30:03.3607167\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Building;1",
+            "description": {},
+            "displayName": {
+              "en": "Building"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0704576\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Floor;1",
+            "description": {},
+            "displayName": {
+              "en": "Floor"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0704794\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:HVAC;1",
+            "description": {},
+            "displayName": {
+              "en": "HVAC"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0705227\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Room;1",
+            "description": {},
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0705463\u002B00:00"
+          },
+          {
+            "id": "dtmi:com:samples:Wifi;1",
+            "description": {},
+            "displayName": {
+              "en": "Wifi"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-02T23:27:49.0705686\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;116029261",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:13:35.4814974\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;195438086",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:21:36.3092503\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;19885524",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:25:50.3518595\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;149813251",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:30:29.0829572\u002B00:00"
+          },
+          {
+            "id": "dtmi:example:room;176638439",
+            "description": {
+              "en": "An enclosure inside a building."
+            },
+            "displayName": {
+              "en": "Room"
+            },
+            "decommissioned": false,
+            "uploadTime": "2021-02-03T03:30:29.1761779\u002B00:00"
+          }
+        ],
+        "nextLink": null
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin359524726?api-version=2020-10-31",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "154",
+        "Content-Type": "application/json",
+        "traceparent": "00-4db852bfc51cce499ecf7e516edcd19d-fa2c3eaa40099145-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "91ee958384d0a60da4ba47b03ad67fd4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "$dtId": null,
+        "$etag": null,
+        "$metadata": {
+          "$model": "dtmi:example:room;176638439"
+        },
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "ETag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-4db852bfc51cce499ecf7e516edcd19d-ee484af384dceb42-01"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin359524726",
+        "$etag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;176638439",
+          "Temperature": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin359524726?api-version=2020-10-31",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-041d9e836db2cb43bc3a8e09a314f674-5e3c59191d38ff47-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "b6aa8aa464c983c402dc286b75ca7910",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "460",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "ETag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-041d9e836db2cb43bc3a8e09a314f674-0b808af837b30744-01"
+      },
+      "ResponseBody": {
+        "$dtId": "roomTwin359524726",
+        "$etag": "W/\u00227247b80d-425c-4536-b8be-c416cd857f29\u0022",
+        "Temperature": 80,
+        "Humidity": 25,
+        "IsOccupied": true,
+        "EmployeeId": "Employee1",
+        "$metadata": {
+          "$model": "dtmi:example:room;176638439",
+          "Temperature": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          },
+          "Humidity": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          },
+          "IsOccupied": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          },
+          "EmployeeId": {
+            "lastUpdateTime": "2021-02-03T03:30:29.2700132Z"
+          }
+        }
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/query?api-version=2020-10-31",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "Content-Length": "38",
+        "Content-Type": "application/json",
+        "traceparent": "00-4cad763ee714c84f99856495f20f7f0e-ef282d1a247ec549-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "cc202a042bc80b6b3bdf838289167e06",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": {
+        "query": "SELECT * FROM DIGITALTWINS"
+      },
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Wed, 03 Feb 2021 03:30:28 GMT",
+        "query-charge": "10.12",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-4cad763ee714c84f99856495f20f7f0e-6752bc993078dd4e-01",
+        "Transfer-Encoding": "chunked"
+      },
+      "ResponseBody": {
+        "value": [
+          {
+            "$dtId": "roomTwin460152108",
+            "$etag": "W/\u0022c14258f3-f518-4569-94b7-5b6a7009bd4b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;111892730",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:01.5919399Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1420781814",
+            "$etag": "W/\u002215823347-e6e5-4250-a774-a3735d9303e1\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;133999852",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9812114Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1320328829",
+            "$etag": "W/\u0022dee956ef-7343-4a8e-b5aa-94d64f1b468d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;116845994",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:01.0108998Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1171852527",
+            "$etag": "W/\u0022c7f421ee-7902-4289-8868-38ff79815e3f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;163554513",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:02.0540624Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1019252643",
+            "$etag": "W/\u002285191640-cb26-4c66-a264-8f08e1e63485\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;118127707",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:01.7326593Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin898922460",
+            "$etag": "W/\u0022e069c97b-c9bd-4c01-804e-9a62c1598ebc\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;170118024",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8712463Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8712463Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.7880790Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin958754835",
+            "$etag": "W/\u00229a25e697-7c99-4372-a1d1-73a3584dd0ce\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;196301502",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:00.9648281Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1474340914",
+            "$etag": "W/\u0022de67105c-b008-4468-a455-66f455271827\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;160194944",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:02.8496985Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin788116830",
+            "$etag": "W/\u00226c936a90-ffd1-48e3-81c3-b40ac3a3b65d\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;139380843",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:03.3817391Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:03.3817391Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:03.2854024Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2114072427",
+            "$etag": "W/\u0022977e9abd-8343-476b-a5e1-cbd5fa5c955d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;114297411",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:02.3157643Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1701250104",
+            "$etag": "W/\u0022a69fafd6-d74a-4f88-89f6-01f69605a005\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;121095457",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:04.8505962Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:04.8505962Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:04.7716505Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1500965769",
+            "$etag": "W/\u0022bf630b74-c175-4fb8-a83d-45e3baab71fb\u0022",
+            "Temperature": 70,
+            "Humidity": 30,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;154962552",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:05.0732015Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:05.0732015Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:04.9949133Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin869533390",
+            "$etag": "W/\u002289e13884-7481-4fc5-b803-3931c746fe42\u0022",
+            "Temperature": 70,
+            "Humidity": 80,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;110330782",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:05.3490298Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:05.4214756Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:05.2988498Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin298405819",
+            "$etag": "W/\u0022ecc3c21b-e6dd-45eb-9aa6-02ae422e5b53\u0022",
+            "Temperature": 70,
+            "Humidity": 80,
+            "IsOccupied": true,
+            "$metadata": {
+              "$model": "dtmi:example:room;117174263",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:05.5359604Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:05.6061579Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:05.4861448Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1043399473",
+            "$etag": "W/\u0022109b2419-637c-4ce0-901e-12ff446a47e2\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1063553Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1755945808",
+            "$etag": "W/\u0022f4f88b1a-f016-4bdd-8ff7-28e548165d3a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.1545499Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin394889929",
+            "$etag": "W/\u00222694a5ef-8bfe-481b-b279-268e29183c65\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2239978Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin222731943",
+            "$etag": "W/\u0022049808dc-629e-4a2c-8d87-26e4d798c020\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.2706063Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin406365159",
+            "$etag": "W/\u00229b710bc4-44bd-420e-b799-4bcbf9f7a000\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.3434533Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin261798201",
+            "$etag": "W/\u0022825684fb-5321-43aa-87cb-c22b2dc4e5b8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4016374Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2103656111",
+            "$etag": "W/\u0022ad688175-f6f3-48d7-aa2a-68c427974f58\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4456522Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin517701651",
+            "$etag": "W/\u0022bb4caafd-aced-4f87-8022-b7d13a08188b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.4948790Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin419605825",
+            "$etag": "W/\u00222d290fc3-d225-49a6-86a9-128c7df273ab\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.5511476Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1973949077",
+            "$etag": "W/\u002275340c9f-b967-46b8-b394-318dccfeae7c\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6220107Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin858105055",
+            "$etag": "W/\u002212bad670-c7a8-4599-a9c6-28416afe7145\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.6512000Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin428015386",
+            "$etag": "W/\u00225cc173c7-38ee-4b6a-953f-518936f90b1f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7613366Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2103316411",
+            "$etag": "W/\u0022d55e6abe-9221-4a2a-875d-958c2b9ea127\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.7614046Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin159399716",
+            "$etag": "W/\u002250be124e-acb3-47f4-a981-d4e08601e876\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.8709030Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin2115596528",
+            "$etag": "W/\u00229c1c216c-0f8c-4b67-aecc-aea37f9c12f3\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9007131Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin979747018",
+            "$etag": "W/\u002238f7995f-f224-4d1e-b48d-fd3d2572284f\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9550226Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin747583795",
+            "$etag": "W/\u0022c41c71c4-2227-4ed3-bb04-6d69a7e46a88\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:06.9772813Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1234052869",
+            "$etag": "W/\u0022cd915e94-4d74-4644-8667-e5d0341b954d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;115780864",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0561169Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin416498780",
+            "$etag": "W/\u0022c717cdb8-9cae-44c9-bc0b-770c66de6f7d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.0760150Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin952596496",
+            "$etag": "W/\u0022ed52c3eb-24d3-4c58-8ad8-7b0616b3324a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;119708157",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.2030253Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin798293087",
+            "$etag": "W/\u0022a8018f03-6a52-4e02-83f2-c3a72fa982dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;131459891",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:07.9708016Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1346838400",
+            "$etag": "W/\u002275e9b3e0-2d8e-443c-9b3c-76c6bf3f56d5\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;153942695",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-12T23:39:08.0323481Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin844044",
+            "$etag": "W/\u0022341bd569-8d62-475c-a368-85c814877df0\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:08.7062444Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin070857",
+            "$etag": "W/\u0022fb6537b8-c035-480e-b8f4-7fd5d9571783\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:08.9898340Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin381161",
+            "$etag": "W/\u0022fb20bb6b-923c-42e0-82c2-c878adebec14\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:09.1106256Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin246198",
+            "$etag": "W/\u0022cd5b90ba-d932-4d39-8aad-d36355a1fe1e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1506729",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:54:08.8814499Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin766189",
+            "$etag": "W/\u00221fac2335-a558-403b-96d3-a79dc2d202dd\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.1474235Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin739702",
+            "$etag": "W/\u00226a280d75-5537-4fef-a671-e3b58194830a\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.3057860Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin544952",
+            "$etag": "W/\u002248429892-9afa-4ce7-a5f8-a5ed0da53da7\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.4553352Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin830667",
+            "$etag": "W/\u002243e7a0ad-60b7-4daa-afaf-b81088d49f9d\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1312262",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T19:59:28.6062951Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin372470",
+            "$etag": "W/\u0022b7bf5c12-9408-454d-8408-6ed2ca7f703b\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.6593182Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin566336",
+            "$etag": "W/\u0022e3674b63-2f7e-4e7c-b1f4-3651fb5c130e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.4717291Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin803247",
+            "$etag": "W/\u00224e743e14-1f6b-4c0a-8950-2fda7a65b9f8\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.7916041Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin445180",
+            "$etag": "W/\u002285ee93d1-be61-44bf-b905-63e0b0b046dc\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;1867454",
+              "Temperature": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-01-13T20:00:45.3327033Z"
+              }
+            }
+          },
+          {
+            "$dtId": "BuildingTwin",
+            "$etag": "W/\u0022d54dde15-aff7-4b0c-b898-f66804a4ca74\u0022",
+            "AverageTemperature": 68,
+            "TemperatureUnit": "Celsius",
+            "$metadata": {
+              "$model": "dtmi:com:samples:Building;1",
+              "AverageTemperature": {
+                "lastUpdateTime": "2021-02-02T23:27:56.3899645Z"
+              },
+              "TemperatureUnit": {
+                "lastUpdateTime": "2021-02-02T23:27:56.3899645Z"
+              }
+            }
+          },
+          {
+            "$dtId": "roomTwin1220449681",
+            "$etag": "W/\u00220c94367b-5077-402c-a2ca-51b4bd27fb4e\u0022",
+            "Temperature": 80,
+            "Humidity": 25,
+            "IsOccupied": true,
+            "EmployeeId": "Employee1",
+            "$metadata": {
+              "$model": "dtmi:example:room;116029261",
+              "Temperature": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              },
+              "Humidity": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              },
+              "IsOccupied": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              },
+              "EmployeeId": {
+                "lastUpdateTime": "2021-02-03T03:13:35.8100173Z"
+              }
+            }
+          }
+        ],
+        "continuationToken": null
+      }
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/digitaltwins/roomTwin359524726?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-755a8c695a7bce4ab96cd1038da0fff7-115e4f7698ddc146-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "4b8bfa1466491f88d16b8ff35ca230d9",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 03 Feb 2021 03:30:29 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-755a8c695a7bce4ab96cd1038da0fff7-9e4434f333d08b42-01"
+      },
+      "ResponseBody": []
+    },
+    {
+      "RequestUri": "https://fakeHost.api.wus2.digitaltwins.azure.net/models/dtmi%3Aexample%3Aroom%3B176638439?api-version=2020-10-31",
+      "RequestMethod": "DELETE",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "Sanitized",
+        "traceparent": "00-0c12b80188852d41be6064d1d5414b4c-0445f1fbd081064b-00",
+        "User-Agent": [
+          "azsdk-net-DigitalTwins.Core/1.3.0-alpha.20210202.1",
+          "(.NET 5.0.1-servicing.20575.16; Microsoft Windows 10.0.18363)"
+        ],
+        "x-ms-client-request-id": "0fab3740b3b5780c1f9f7beae041faec",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": null,
+      "StatusCode": 204,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 03 Feb 2021 03:30:29 GMT",
+        "Strict-Transport-Security": "max-age=2592000",
+        "traceresponse": "00-0c12b80188852d41be6064d1d5414b4c-a981e6d215f60d49-01"
+      },
+      "ResponseBody": []
+    }
+  ],
+  "Variables": {
+    "DIGITALTWINS_URL": "https://fakeHost.api.wus2.digitaltwins.azure.net",
+    "RandomSeed": "1695897686"
+  }
+}

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SimpleNewtonsoftDtModel.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SimpleNewtonsoftDtModel.cs
@@ -7,7 +7,7 @@ namespace Azure.DigitalTwins.Core.Tests
 {
     public class SimpleNewtonsoftDtModel
     {
-        [JsonProperty("$dtId")]
+        [JsonProperty(DigitalTwinsJsonPropertyNames.DigitalTwinId)]
         public string Id { get; set; }
     }
 }

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SimpleNewtonsoftDtModel.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/tests/SimpleNewtonsoftDtModel.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Azure.DigitalTwins.Core.Tests
+{
+    public class SimpleNewtonsoftDtModel
+    {
+        [JsonProperty("$dtId")]
+        public string Id { get; set; }
+    }
+}


### PR DESCRIPTION
We got word from a customer that they are having issues using the Query API when they  specify NewtonsoftJsonObjectSerializer as the serializer for their client. 
It turns out we are using the provided serializer to serialize the JsonElement into a stream and that wouldn't work and we have to use the default serializer to perform that action.