### PR TITLE
[Event Hubs Client] Move Blob Checkpoint Store to Shared

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobsCheckpointStore.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/src/Diagnostics/BlobsCheckpointStore.Diagnostics.cs
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Processor.Diagnostics;
+
+namespace Azure.Messaging.EventHubs.Processor
+{
+    /// <summary>
+    ///   A storage blob service that keeps track of checkpoints and ownership.
+    /// </summary>
+    ///
+    internal sealed partial class BlobsCheckpointStore
+    {
+        /// <summary>
+        /// Initializes the <see cref="BlobsCheckpointStore"/> type.
+        /// </summary>
+#pragma warning disable CA1810 // Initialize static fields inline
+        static BlobsCheckpointStore()
+        {
+            BlobsResourceDoesNotExist = Resources.BlobsResourceDoesNotExist;
+        }
+#pragma warning restore CA1810
+
+        /// <summary>
+        ///   The instance of <see cref="BlobEventStoreEventSource" /> which can be mocked for testing.
+        /// </summary>
+        ///
+        internal BlobEventStoreEventSource Logger { get; set; } = BlobEventStoreEventSource.Log;
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of ownership has completed.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="ownershipCount">The amount of ownership received from the storage service.</param>
+        ///
+        partial void ListOwnershipComplete(string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           int ownershipCount) =>
+            Logger.ListOwnershipComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, ownershipCount);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while retrieving a list of ownership.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void ListOwnershipError(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup,
+                                        Exception exception) =>
+            Logger.ListOwnershipError(fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of ownership has started.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        ///
+        partial void ListOwnershipStart(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup) =>
+            Logger.ListOwnershipStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of checkpoints has completed.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoints are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
+        /// <param name="checkpointCount">The amount of checkpoints received from the storage service.</param>
+        ///
+        partial void ListCheckpointsComplete(string fullyQualifiedNamespace,
+                                             string eventHubName,
+                                             string consumerGroup,
+                                             int checkpointCount) =>
+            Logger.ListCheckpointsComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, checkpointCount);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while retrieving a list of checkpoints.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoints are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void ListCheckpointsError(string fullyQualifiedNamespace,
+                                          string eventHubName,
+                                          string consumerGroup,
+                                          Exception exception) =>
+            Logger.ListCheckpointsError(fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+
+        /// <summary>
+        ///   Indicates that invalid checkpoint data was found during an attempt to retrieve a list of checkpoints.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition the data is associated with.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the data is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the data is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the data is associated with.</param>
+        ///
+        partial void InvalidCheckpointFound(string partitionId,
+                                            string fullyQualifiedNamespace,
+                                            string eventHubName,
+                                            string consumerGroup) =>
+            Logger.InvalidCheckpointFound(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of checkpoints has started.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoints are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
+        ///
+        partial void ListCheckpointsStart(string fullyQualifiedNamespace,
+                                          string eventHubName,
+                                          string consumerGroup) =>
+            Logger.ListCheckpointsStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while updating a checkpoint.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void UpdateCheckpointError(string partitionId,
+                                           string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           Exception exception) =>
+            Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+
+        /// <summary>
+        ///   Indicates that an attempt to update a checkpoint has completed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        ///
+        partial void UpdateCheckpointComplete(string partitionId,
+                                              string fullyQualifiedNamespace,
+                                              string eventHubName,
+                                              string consumerGroup) =>
+            Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to create/update a checkpoint has started.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        ///
+        partial void UpdateCheckpointStart(string partitionId,
+                                           string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup) =>
+            Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve claim partition ownership has completed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        ///
+        partial void ClaimOwnershipComplete(string partitionId,
+                                            string fullyQualifiedNamespace,
+                                            string eventHubName,
+                                            string consumerGroup,
+                                            string ownerIdentifier) =>
+            Logger.ClaimOwnershipComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while attempting to retrieve claim partition ownership.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void ClaimOwnershipError(string partitionId,
+                                         string fullyQualifiedNamespace,
+                                         string eventHubName,
+                                         string consumerGroup,
+                                         string ownerIdentifier,
+                                         Exception exception) =>
+            Logger.ClaimOwnershipError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier, exception.Message);
+
+        /// <summary>
+        ///   Indicates that ownership was unable to be claimed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        /// <param name="message">The message for the failure.</param>
+        ///
+        partial void OwnershipNotClaimable(string partitionId,
+                                           string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           string ownerIdentifier,
+                                           string message) =>
+            Logger.OwnershipNotClaimable(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier, message);
+
+        /// <summary>
+        ///   Indicates that ownership was successfully claimed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        ///
+        partial void OwnershipClaimed(string partitionId,
+                                      string fullyQualifiedNamespace,
+                                      string eventHubName,
+                                      string consumerGroup,
+                                      string ownerIdentifier) =>
+            Logger.OwnershipClaimed(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+
+        /// <summary>
+        ///   Indicates that an attempt to claim a partition ownership has started.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        ///
+        partial void ClaimOwnershipStart(string partitionId,
+                                         string fullyQualifiedNamespace,
+                                         string eventHubName,
+                                         string consumerGroup,
+                                         string ownerIdentifier) =>
+            Logger.ClaimOwnershipStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+
+        /// <summary>
+        ///   Indicates that a <see cref="BlobsCheckpointStore" /> was created.
+        /// </summary>
+        ///
+        /// <param name="typeName">The type name for the checkpoint store.</param>
+        /// <param name="accountName">The Storage account name corresponding to the associated container client.</param>
+        /// <param name="containerName">The name of the associated container client.</param>
+        ///
+        partial void BlobsCheckpointStoreCreated(string typeName,
+                                                 string accountName,
+                                                 string containerName) =>
+            Logger.BlobsCheckpointStoreCreated(typeName, accountName, containerName);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a checkpoint has started.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
+        ///
+        partial void GetCheckpointStart(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup,
+                                        string partitionId) =>
+            Logger.GetCheckpointStart(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a checkpoint has completed.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
+        ///
+        partial void GetCheckpointComplete(string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           string partitionId) =>
+            Logger.GetCheckpointComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while retrieving a checkpoint.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
+        /// <param name="exception">The message for the exception that occurred.</param>
+        ///
+        partial void GetCheckpointError(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup,
+                                        string partitionId,
+                                        Exception exception) =>
+            Logger.GetCheckpointError(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, exception.Message);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Azure.Messaging.EventHubs.Processor.Tests.csproj
@@ -17,12 +17,10 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Polly" />
+    <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="System.ValueTuple" />
-
-    <!-- This package will be removed when v5.3.0 is released for GA as the dependency will be available from Core -->
-    <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,10 +28,7 @@
     <ProjectReference Include="..\src\Azure.Messaging.EventHubs.Processor.csproj" />
   </ItemGroup>
 
-  <!-- TEMP: Use a project reference to Data; remove when published"-->
-  <!-- END TEMP-->
-
   <!-- Import Event Hubs shared source -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Testing.projitems" Label="Testing" />
-
+  <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.BlobStorageTesting.projitems" Label="BlobStorageTesting" />
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobsCheckpointStoreDiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/tests/Diagnostics/BlobsCheckpointStoreDiagnosticsTests.cs
@@ -1,0 +1,771 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Primitives;
+using Azure.Messaging.EventHubs.Processor.Diagnostics;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Processor.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="BlobsCheckpointStore" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class BlobsCheckpointStoreDiagnosticsTests
+    {
+        private const string FullyQualifiedNamespace = "fqns";
+        private const string EventHubName = "name";
+        private const string ConsumerGroup = "group";
+        private const string MatchingEtag = "etag";
+        private const string WrongEtag = "wrongEtag";
+        private const string PartitionId = "1";
+
+        private readonly EventHubsRetryPolicy DefaultRetryPolicy = new BasicRetryPolicy(new EventHubsRetryOptions());
+        private readonly string OwnershipIdentifier = Guid.NewGuid().ToString();
+
+        /// <summary>
+        ///   Verifies basic functionality of ListOwnershipAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ListOwnershipLogsStartAndComplete()
+        {
+            var blobList = new List<BlobItem>
+            {
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/{Guid.NewGuid().ToString()}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string> {{BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()}})
+            };
+
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            await target.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, CancellationToken.None);
+
+            mockLog.Verify(m => m.ListOwnershipStart(FullyQualifiedNamespace, EventHubName, ConsumerGroup));
+            mockLog.Verify(m => m.ListOwnershipComplete(FullyQualifiedNamespace, EventHubName, ConsumerGroup, blobList.Count));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListOwnershipAsync and ensures the appropriate events are emitted on failure.
+        /// </summary>
+        ///
+        [Test]
+        public void ListOwnershipLogsErrorOnException()
+        {
+            var ex = new RequestFailedException(0, "foo", BlobErrorCode.ContainerNotFound.ToString(), null);
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient(getBlobsAsyncException: ex),
+                                                  DefaultRetryPolicy);
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.ListOwnershipAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
+            mockLog.Verify(m => m.ListOwnershipError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, ex.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate logging.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClaimOwnershipLogsStartAndComplete()
+        {
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow
+                }
+            };
+
+            var mockBlobContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/1", _ => { });
+            var target = new BlobsCheckpointStore(mockBlobContainerClient, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            var result = await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None);
+            mockLog.Verify(m => m.ClaimOwnershipStart(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
+            mockLog.Verify(m => m.ClaimOwnershipComplete(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate logging.
+        /// </summary>
+        ///
+        [Test]
+        public void ClaimOwnershipLogsErrors()
+        {
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow
+                }
+            };
+
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            var mockContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/1", client => client.UploadBlobException = expectedException);
+
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(m => m.ClaimOwnershipError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier, expectedException.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClaimOwnershipForNewPartitionLogsOwnershipClaimed()
+        {
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow
+                }
+            };
+
+            var mockBlobContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/1", _ => { });
+            var target = new BlobsCheckpointStore(mockBlobContainerClient, DefaultRetryPolicy);
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            var result = await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None);
+            mockLog.Verify(m => m.OwnershipClaimed(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClaimOwnershipForExistingPartitionLogsOwnershipClaimed()
+        {
+            var blobInfo = BlobsModelFactory.BlobInfo(new ETag($@"""{MatchingEtag}"""), DateTime.UtcNow);
+
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow,
+                    Version = MatchingEtag
+                }
+            };
+
+            var mockContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/1", client => client.BlobInfo = blobInfo);
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            var result = await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None);
+            mockLog.Verify(m => m.OwnershipClaimed(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClaimOwnershipForExistingPartitionWithWrongEtagLogsOwnershipNotClaimable()
+        {
+            var blobInfo = BlobsModelFactory.BlobInfo(new ETag($@"""{WrongEtag}"""), DateTime.UtcNow);
+
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow,
+                    Version = MatchingEtag
+                }
+            };
+
+            var mockContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/1", client => client.BlobInfo = blobInfo);
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            var result = await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None);
+            mockLog.Verify(m => m.OwnershipNotClaimable(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier, It.Is<string>(e => e.Contains(BlobErrorCode.ConditionNotMet.ToString()))));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ClaimOwnershipAsync and ensures the appropriate events are emitted on failure.
+        /// </summary>
+        ///
+        [Test]
+        public void ClaimOwnershipForMissingPartitionLogsClaimOwnershipError()
+        {
+            var partitionOwnership = new List<EventProcessorPartitionOwnership>
+            {
+                new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = FullyQualifiedNamespace,
+                    EventHubName = EventHubName,
+                    ConsumerGroup = ConsumerGroup,
+                    OwnerIdentifier = OwnershipIdentifier,
+                    PartitionId = PartitionId,
+                    LastModifiedTime = DateTime.UtcNow,
+                    Version = MatchingEtag
+                }
+            };
+
+            var mockBlobContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/1", _ => { });
+            var target = new BlobsCheckpointStore(mockBlobContainerClient, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.ClaimOwnershipAsync(partitionOwnership, CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
+            mockLog.Verify(m => m.ClaimOwnershipError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, OwnershipIdentifier, It.Is<string>(e => e.Contains(BlobErrorCode.BlobNotFound.ToString()))));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ListCheckpointsLogsStartAndComplete()
+        {
+            var blobList = new List<BlobItem>
+            {
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{Guid.NewGuid().ToString()}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string>
+                                           {
+                                               {BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()},
+                                               {BlobMetadataKey.Offset, "0"}
+                                           })
+            };
+
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, CancellationToken.None);
+
+            mockLog.Verify(m => m.ListCheckpointsStart(FullyQualifiedNamespace, EventHubName, ConsumerGroup));
+            mockLog.Verify(m => m.ListCheckpointsComplete(FullyQualifiedNamespace, EventHubName, ConsumerGroup, blobList.Count));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the appropriate events are emitted when errors occur.
+        /// </summary>
+        ///
+        [Test]
+        public void ListCheckpointsLogsErrors()
+        {
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            var mockContainerClient = new MockBlobContainerClient() { GetBlobsAsyncException = expectedException };
+
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, CancellationToken.None), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(m => m.ListCheckpointsError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, expectedException.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ListCheckpointsLogsInvalidCheckpoint()
+        {
+            var partitionId = Guid.NewGuid().ToString();
+
+            var blobList = new List<BlobItem>
+            {
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/{partitionId}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string> {{BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()}})
+            };
+
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, CancellationToken.None);
+            mockLog.Verify(m => m.InvalidCheckpointFound(partitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of ListCheckpointsAsync and ensures the appropriate events are emitted on failure.
+        /// </summary>
+        ///
+        [Test]
+        public void ListCheckpointsForMissingPartitionLogsListCheckpointsError()
+        {
+            var ex = new RequestFailedException(0, "foo", BlobErrorCode.ContainerNotFound.ToString(), null);
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient(getBlobsAsyncException: ex), DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
+            mockLog.Verify(m => m.ListCheckpointsError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, ex.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of UpdateCheckpointAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task UpdateCheckpointLogsStartAndCompleteWhenTheBlobExists()
+        {
+            var checkpoint = new EventProcessorCheckpoint
+            {
+                FullyQualifiedNamespace = FullyQualifiedNamespace,
+                EventHubName = EventHubName,
+                ConsumerGroup = ConsumerGroup,
+                PartitionId = PartitionId,
+            };
+
+            var blobInfo = BlobsModelFactory.BlobInfo(new ETag($@"""{MatchingEtag}"""), DateTime.UtcNow);
+
+            var blobList = new List<BlobItem>
+            {
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/{Guid.NewGuid().ToString()}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string> {{BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()}})
+            };
+
+            var mockContainerClient = new MockBlobContainerClient() { Blobs = blobList };
+
+            mockContainerClient.AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/1", client =>
+            {
+                client.BlobInfo = blobInfo;
+                client.UploadBlobException = new Exception("Upload should not be called");
+            });
+
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), CancellationToken.None);
+            mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of UpdateCheckpointAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task UpdateCheckpointLogsStartAndCompleteWhenTheBlobDoesNotExist()
+        {
+            var checkpoint = new EventProcessorCheckpoint
+            {
+                FullyQualifiedNamespace = FullyQualifiedNamespace,
+                EventHubName = EventHubName,
+                ConsumerGroup = ConsumerGroup,
+                PartitionId = PartitionId,
+            };
+
+            var blobList = new List<BlobItem>
+            {
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/ownership/{Guid.NewGuid().ToString()}",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string> {{BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()}})
+            };
+            var mockBlobContainerClient = new MockBlobContainerClient() { Blobs = blobList };
+            mockBlobContainerClient.AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/1", _ => { });
+
+            var target = new BlobsCheckpointStore(mockBlobContainerClient, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), CancellationToken.None);
+            mockLog.Verify(log => log.UpdateCheckpointStart(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup));
+            mockLog.Verify(log => log.UpdateCheckpointComplete(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of UpdateCheckpointAsync and ensures the appropriate logs are written
+        ///   when exceptions occur.
+        /// </summary>
+        ///
+        [Test]
+        public void UpdateCheckpointLogsErrorsWhenTheBlobExists()
+        {
+            var checkpoint = new EventProcessorCheckpoint
+            {
+                FullyQualifiedNamespace = FullyQualifiedNamespace,
+                EventHubName = EventHubName,
+                ConsumerGroup = ConsumerGroup,
+                PartitionId = PartitionId,
+            };
+
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+
+            var mockContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/1", client =>
+            {
+                client.BlobClientSetMetadataException = expectedException;
+                client.UploadBlobException = new Exception("Upload should not be called");
+            });
+
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, expectedException.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of UpdateCheckpointAsync and ensures the appropriate logs are written
+        ///   when exceptions occur.
+        /// </summary>
+        ///
+        [Test]
+        public void UpdateCheckpointLogsErrorsWhenTheBlobDoesNotExist()
+        {
+            var checkpoint = new EventProcessorCheckpoint
+            {
+                FullyQualifiedNamespace = FullyQualifiedNamespace,
+                EventHubName = EventHubName,
+                ConsumerGroup = ConsumerGroup,
+                PartitionId = PartitionId,
+            };
+
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+
+            var mockContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/1", client =>
+            {
+                client.UploadBlobException = expectedException;
+            });
+
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), CancellationToken.None), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(log => log.UpdateCheckpointError(checkpoint.PartitionId, checkpoint.FullyQualifiedNamespace, checkpoint.EventHubName, checkpoint.ConsumerGroup, expectedException.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of UpdateCheckpointAsync and ensures the appropriate events are emitted on failure.
+        /// </summary>
+        ///
+        [Test]
+        public void UpdateCheckpointForMissingContainerLogsCheckpointUpdateError()
+        {
+            var checkpoint = new EventProcessorCheckpoint
+            {
+                FullyQualifiedNamespace = FullyQualifiedNamespace,
+                EventHubName = EventHubName,
+                ConsumerGroup = ConsumerGroup,
+                PartitionId = PartitionId
+            };
+
+            var ex = new RequestFailedException(404, BlobErrorCode.ContainerNotFound.ToString(), BlobErrorCode.ContainerNotFound.ToString(), null);
+            var mockBlobContainerClient = new MockBlobContainerClient().AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/1", client => client.UploadBlobException = ex);
+            var target = new BlobsCheckpointStore(mockBlobContainerClient, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.UpdateCheckpointAsync(checkpoint, new EventData(Array.Empty<byte>()), CancellationToken.None), Throws.InstanceOf<RequestFailedException>());
+            mockLog.Verify(m => m.UpdateCheckpointError(PartitionId, FullyQualifiedNamespace, EventHubName, ConsumerGroup, ex.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of GetCheckpointAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetCheckpointLogsStartAndComplete()
+        {
+            var blobList = new List<BlobItem>
+            {
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/0",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string>
+                                           {
+                                               {BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()},
+                                               {BlobMetadataKey.Offset, "0"}
+                                           })
+            };
+
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            await target.GetCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, "0", CancellationToken.None);
+
+            mockLog.Verify(m => m.GetCheckpointStart(FullyQualifiedNamespace, EventHubName, ConsumerGroup, "0"));
+            mockLog.Verify(m => m.GetCheckpointComplete(FullyQualifiedNamespace, EventHubName, ConsumerGroup, "0"));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of GetCheckpointAsync and ensures the appropriate events are emitted when errors occur.
+        /// </summary>
+        ///
+        [Test]
+        public void GetCheckpointLogsErrors()
+        {
+            var expectedException = new DllNotFoundException("BOOM!");
+            var mockContainerClient = new MockBlobContainerClient() { GetBlobsAsyncException = expectedException };
+            var target = new BlobsCheckpointStore(mockContainerClient, DefaultRetryPolicy);
+
+            mockContainerClient.AddBlobClient($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/0", client =>
+            {
+                client.GetPropertiesException = expectedException;
+            });
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            Assert.That(async () => await target.GetCheckpointAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, "0", CancellationToken.None), Throws.Exception.EqualTo(expectedException));
+            mockLog.Verify(m => m.GetCheckpointError(FullyQualifiedNamespace, EventHubName, ConsumerGroup, "0", expectedException.Message));
+        }
+
+        /// <summary>
+        ///   Verifies basic functionality of GetCheckpointAsync and ensures the appropriate events are emitted on success.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetCheckpointLogsInvalidCheckpoint()
+        {
+            var blobList = new List<BlobItem>
+            {
+                BlobsModelFactory.BlobItem($"{FullyQualifiedNamespace}/{EventHubName}/{ConsumerGroup}/checkpoint/0",
+                                           false,
+                                           BlobsModelFactory.BlobItemProperties(true, lastModified: DateTime.UtcNow, eTag: new ETag(MatchingEtag)),
+                                           "snapshot",
+                                           new Dictionary<string, string> {{BlobMetadataKey.OwnerIdentifier, Guid.NewGuid().ToString()}})
+            };
+            var target = new BlobsCheckpointStore(new MockBlobContainerClient() { Blobs = blobList }, DefaultRetryPolicy);
+
+            var mockLog = new Mock<BlobEventStoreEventSource>();
+            target.Logger = mockLog.Object;
+
+            await target.ListCheckpointsAsync(FullyQualifiedNamespace, EventHubName, ConsumerGroup, CancellationToken.None);
+            mockLog.Verify(m => m.InvalidCheckpointFound("0", FullyQualifiedNamespace, EventHubName, ConsumerGroup));
+        }
+
+        private class MockBlobContainerClient : BlobContainerClient
+        {
+            public override Uri Uri { get; }
+            public override string AccountName { get; }
+            public override string Name { get; }
+            internal IEnumerable<BlobItem> Blobs;
+            internal Exception GetBlobsAsyncException;
+            internal Dictionary<string, MockBlobClient> BlobClients = new ();
+
+            public MockBlobContainerClient(string accountName = "blobAccount",
+                                           string containerName = "container",
+                                           Exception getBlobsAsyncException = null)
+            {
+                GetBlobsAsyncException = getBlobsAsyncException;
+                Blobs = Enumerable.Empty<BlobItem>();
+                AccountName = accountName;
+                Name = containerName;
+                Uri = new Uri("https://foo");
+            }
+            public override AsyncPageable<BlobItem> GetBlobsAsync(BlobTraits traits = BlobTraits.None, BlobStates states = BlobStates.None, string prefix = null, CancellationToken cancellationToken = default)
+            {
+                if (GetBlobsAsyncException != null)
+                {
+                    throw GetBlobsAsyncException;
+                }
+
+                return new MockAsyncPageable<BlobItem>(Blobs.Where(b => prefix == null || b.Name.StartsWith(prefix, StringComparison.Ordinal)));
+            }
+
+            public override BlobClient GetBlobClient(string blobName)
+            {
+                if (BlobClients.TryGetValue(blobName, out var client))
+                {
+                    return client;
+                }
+
+                var blob = Blobs.SingleOrDefault(c => c.Name == blobName);
+                if (blob != null)
+                {
+                    return new MockBlobClient(blobName)
+                    {
+                        Properties = BlobsModelFactory.BlobProperties(metadata: blob.Metadata)
+                    };
+                }
+
+                return new MockBlobClient(blobName);
+            }
+
+            internal MockBlobContainerClient AddBlobClient(string name, Action<MockBlobClient> configure)
+            {
+                var client = new MockBlobClient(name);
+                configure(client);
+                BlobClients[name] = client;
+                return this;
+            }
+        }
+
+        private class MockBlobClient : BlobClient
+        {
+            public override string Name { get; }
+
+            internal BlobInfo BlobInfo;
+            internal BlobProperties Properties;
+            internal Exception UploadBlobException;
+            internal Exception BlobClientSetMetadataException;
+            internal DllNotFoundException GetPropertiesException;
+            public MockBlobClient(string blobName)
+            {
+                Name = blobName;
+            }
+
+            public override Task<Response<BlobInfo>> SetMetadataAsync(IDictionary<string, string> metadata, BlobRequestConditions conditions = null, CancellationToken cancellationToken = default)
+            {
+                if (BlobClientSetMetadataException != null)
+                {
+                    throw BlobClientSetMetadataException;
+                }
+
+                if (BlobInfo == null)
+                {
+                    throw new RequestFailedException(404, BlobErrorCode.BlobNotFound.ToString(), BlobErrorCode.BlobNotFound.ToString(), default);
+                }
+
+                if ((conditions == null) || (BlobInfo.ETag.Equals($@"""{conditions.IfMatch}""")))
+                {
+                    return Task.FromResult(Response.FromValue(BlobInfo, Mock.Of<Response>()));
+                }
+
+                throw new RequestFailedException(412, BlobErrorCode.ConditionNotMet.ToString(), BlobErrorCode.ConditionNotMet.ToString(), default);
+            }
+
+            public override Task<Response<BlobContentInfo>> UploadAsync(Stream content, BlobHttpHeaders httpHeaders = null, IDictionary<string, string> metadata = null, BlobRequestConditions conditions = null, IProgress<long> progressHandler = null, AccessTier? accessTier = null, StorageTransferOptions transferOptions = default, CancellationToken cancellationToken = default)
+            {
+                if (UploadBlobException != null)
+                {
+                    throw UploadBlobException;
+                }
+
+                if (BlobInfo != null)
+                {
+                    throw new RequestFailedException(409, BlobErrorCode.BlobAlreadyExists.ToString(), BlobErrorCode.BlobAlreadyExists.ToString(), default);
+                }
+
+                return Task.FromResult(
+                    Response.FromValue(
+                        BlobsModelFactory.BlobContentInfo(new ETag("etag"), DateTime.UtcNow, new byte[] { }, string.Empty, 0L),
+                        Mock.Of<Response>()));
+            }
+
+            public override Task<Response> DownloadToAsync(Stream destination, CancellationToken cancellationToken) => Task.FromResult(Mock.Of<Response>());
+
+            public override Task<Response<BlobProperties>> GetPropertiesAsync(BlobRequestConditions conditions = null, CancellationToken cancellationToken = default)
+            {
+                if (GetPropertiesException != null)
+                {
+                    throw GetPropertiesException;
+                }
+
+                if (Properties == null)
+                {
+                    throw new RequestFailedException(404, BlobErrorCode.BlobNotFound.ToString(), BlobErrorCode.BlobNotFound.ToString(), default);
+                }
+
+                return Task.FromResult(Response.FromValue(Properties, Mock.Of<Response>()));
+            }
+        }
+
+        private class MockAsyncPageable<T> : AsyncPageable<T>
+        {
+            private readonly IEnumerable<T> Items;
+
+            internal MockAsyncPageable(IEnumerable<T> items)
+            {
+                Items = items;
+            }
+            public override IAsyncEnumerable<Page<T>> AsPages(string continuationToken = null, int? pageSizeHint = null)
+            {
+                return CratePageResponse(Items);
+            }
+
+            internal async IAsyncEnumerable<Page<P>> CratePageResponse<P>(IEnumerable<P> value)
+            {
+                await Task.Delay(0);
+                yield return new MockPage<P>(value);
+            }
+        }
+
+        private class MockPage<T> : Page<T>
+        {
+            private readonly IReadOnlyList<T> InnerValues;
+            public override IReadOnlyList<T> Values => InnerValues;
+
+            public override string ContinuationToken => throw new NotImplementedException();
+
+            public override Response GetRawResponse() => throw new NotImplementedException();
+
+            public MockPage(IEnumerable<T> items)
+            {
+                InnerValues = items.ToList().AsReadOnly();
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.BlobStorageTesting.projitems
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.BlobStorageTesting.projitems
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>b9a2bfb3-5636-45b8-9e94-f429ebf3fc1d</SharedGUID>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Import_RootNamespace>Azure.Messaging.EventHubs.Tests</Import_RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisfileDirectory)BlobStorageTesting\*.cs" Link="SharedSource\Testing\%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.shproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.shproj
@@ -11,9 +11,11 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
 
   <!-- Import shared source groups -->
+  <Import Project="Azure.Messaging.EventHubs.Shared.Authorization.projitems" Label="Authorization" />
+  <Import Project="Azure.Messaging.EventHubs.Shared.BlobCheckpointStore.projitems" Label="BlobCheckpointStore" />
+  <Import Project="Azure.Messaging.EventHubs.Shared.BlobStorageTesting.projitems" Label="BlobStorageTesting" />
   <Import Project="Azure.Messaging.EventHubs.Shared.Core.projitems" Label="Core" />
   <Import Project="Azure.Messaging.EventHubs.Shared.Diagnostics.projitems" Label="Diagnostics" />
-  <Import Project="Azure.Messaging.EventHubs.Shared.Authorization.projitems" Label="Authorization" />
   <Import Project="Azure.Messaging.EventHubs.Shared.Processor.projitems" Label="Processor" />
   <Import Project="Azure.Messaging.EventHubs.Shared.Testing.projitems" Label="Testing" />
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobStorageTesting/StorageScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobStorageTesting/StorageScope.cs
@@ -5,13 +5,12 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs.Tests;
 using Microsoft.Azure.Management.ResourceManager;
 using Microsoft.Azure.Management.Storage;
 using Microsoft.Azure.Management.Storage.Models;
 using Microsoft.Rest;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///  Provides a dynamically created Azure blob container instance which exists only in the context
@@ -32,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         private static readonly Uri AzureResourceManagerUri = new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl);
 
         /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
-        private bool _disposed = false;
+        private volatile bool _disposed = false;
 
         /// <summary>
         ///  The name of the blob storage container that was created.
@@ -64,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var storageAccount = StorageTestEnvironment.Instance.StorageAccountName;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
             var client = new StorageManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
@@ -103,7 +102,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var storageAccount = StorageTestEnvironment.Instance.StorageAccountName;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 
@@ -125,7 +124,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         {
             var subscription = EventHubsTestEnvironment.Instance.SubscriptionId;
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
 
             static string CreateName() => $"neteventhubs{ Guid.NewGuid().ToString("N").Substring(0, 12) }";
 
@@ -152,7 +151,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
         {
             var subscription = EventHubsTestEnvironment.Instance.SubscriptionId;
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
 
             using (var client = new StorageManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = subscription })
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobStorageTesting/StorageTestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/BlobStorageTesting/StorageTestEnvironment.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   Represents the ambient environment for Azure storage resource in which the test suite is

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventHubScope.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private static readonly Uri AzureResourceManagerUri = new Uri(EventHubsTestEnvironment.Instance.ResourceManagerUrl);
 
         /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
-        private bool _disposed = false;
+        private volatile bool _disposed = false;
 
         /// <summary>
         ///   The name of the Event Hub that was created.
@@ -88,7 +88,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var eventHubNamespace = EventHubsTestEnvironment.Instance.EventHubsNamespace;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
             var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId };
 
             try
@@ -147,7 +147,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var subscription = EventHubsTestEnvironment.Instance.SubscriptionId;
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
 
             string CreateName() => $"net-eventhubs-{ Guid.NewGuid().ToString("D") }";
 
@@ -174,7 +174,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var subscription = EventHubsTestEnvironment.Instance.SubscriptionId;
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
 
             using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = subscription })
             {
@@ -218,7 +218,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private static async Task<EventHubScope> BuildScopeFromExistingEventHub()
         {
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
 
             using (var client = new EventHubManagementClient(AzureResourceManagerUri, new TokenCredentials(token)) { SubscriptionId = EventHubsTestEnvironment.Instance.SubscriptionId })
             {
@@ -253,7 +253,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var groups = (consumerGroups ?? Enumerable.Empty<string>()).ToList();
             var resourceGroup = EventHubsTestEnvironment.Instance.ResourceGroup;
             var eventHubNamespace = EventHubsTestEnvironment.Instance.EventHubsNamespace;
-            var token = await ResourceManager.AquireManagementTokenAsync().ConfigureAwait(false);
+            var token = await ResourceManager.AcquireManagementTokenAsync().ConfigureAwait(false);
 
             string CreateName() => $"{ Guid.NewGuid().ToString("D").Substring(0, 13) }-{ caller }";
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/LiveResourceManager.cs
@@ -75,7 +75,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <returns>The token to use for management operations against the Event Hubs Live test namespace.</returns>
         ///
-        public async Task<string> AquireManagementTokenAsync()
+        public async Task<string> AcquireManagementTokenAsync()
         {
             var token = s_managementToken;
             var authority = new Uri(new Uri(EventHubsTestEnvironment.Instance.AuthorityHostUrl), EventHubsTestEnvironment.Instance.TenantId).ToString();

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Azure.Messaging.EventHubs.Shared.Tests.csproj
@@ -12,10 +12,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
+    <PackageReference Include="Microsoft.Azure.Management.Storage" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="Polly" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,17 +35,13 @@
   </ItemGroup>
 
   <!-- Import Event Hubs shared source -->
+  <Import Project="..\src\Azure.Messaging.EventHubs.Shared.Authorization.projitems" Label="Authorization" />
+  <Import Project="..\src\Azure.Messaging.EventHubs.Shared.BlobCheckpointStore.projitems" Label="CheckpointStore" />
   <Import Project="..\src\Azure.Messaging.EventHubs.Shared.Core.projitems" Label="Core" />
   <Import Project="..\src\Azure.Messaging.EventHubs.Shared.Diagnostics.projitems" Label="Diagnostics" />
-  <Import Project="..\src\Azure.Messaging.EventHubs.Shared.Authorization.projitems" Label="Authorization" />
   <Import Project="..\src\Azure.Messaging.EventHubs.Shared.Processor.projitems" Label="Processor" />
-
-  <ItemGroup>
-    <Compile Include="..\src\Testing\EventDataExtensions.cs" Link="SharedSource\Testing\EventDataExtensions.cs" />
-    <Compile Include="..\src\Testing\InMemoryStorageManager.cs" Link="SharedSource\Testing\InMemoryStorageManager.cs" />
-    <Compile Include="..\src\Testing\MockEventData.cs" Link="SharedSource\Testing\MockEventData.cs" />
-    <Compile Include="..\src\Testing\TaskExtensions.cs" Link="SharedSource\Testing\TaskExtensions.cs" />
-  </ItemGroup>
+  <Import Project="..\src\Azure.Messaging.EventHubs.Shared.Testing.projitems" Label="Testing" />
+  <Import Project="..\src\Azure.Messaging.EventHubs.Shared.BlobStorageTesting.projitems" Label="BlobStorageTesting" />
 
   <!--Embed the shared resources -->
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/BlobCheckpointStore/BlobsCheckpointStoreLiveTests.cs
@@ -9,11 +9,11 @@ using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Primitives;
-using Azure.Messaging.EventHubs.Tests;
+using Azure.Messaging.EventHubs.Processor;
 using Azure.Storage.Blobs;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of live tests for the <see cref="BlobsCheckpointStore" />
@@ -30,7 +30,10 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
     [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
     public class BlobsCheckpointStoreLiveTests
     {
-        /// <summary>The default retry policy to use for the test cases in this class.</summary>
+        /// <summary>
+        ///   The default retry policy to use for the test cases in this class.
+        /// </summary>
+        ///
         private EventHubsRetryPolicy DefaultRetryPolicy { get; } = new BasicRetryPolicy(new EventHubsRetryOptions());
 
         /// <summary>
@@ -45,7 +48,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default), Throws.Nothing);
@@ -64,7 +66,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default), Throws.Nothing);
@@ -85,8 +86,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
+
                 var ownershipList = new List<EventProcessorPartitionOwnership>
                 {
                     // Null version and non-null version hit different paths of the code, calling different methods that connect
@@ -119,8 +120,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
+
                 var ownershipList = new List<EventProcessorPartitionOwnership>
                 {
                     // Make sure the ownership exists beforehand so we hit all storage SDK calls in the checkpoint store.
@@ -166,9 +167,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                IEnumerable<EventProcessorPartitionOwnership> ownership = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
+                var ownership = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(ownership, Is.Not.Null.And.Empty);
             }
@@ -186,9 +186,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                IEnumerable<EventProcessorCheckpoint> checkpoints = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
+                var checkpoints = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(checkpoints, Is.Not.Null.And.Empty);
             }
@@ -206,24 +205,22 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var ownership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
+
+                var ownership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
                 ownershipList.Add(ownership);
-
                 await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -245,24 +242,22 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
 
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var ownership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
+
+                var ownership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
                 ownershipList.Add(ownership);
 
-                IEnumerable<EventProcessorPartitionOwnership> claimedOwnership = await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
-
+                var claimedOwnership = await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
                 var claimedOwnershipMatch = s_doubleQuotesExpression.Match(claimedOwnership.First().Version);
                 var storedOwnershipListMatch = s_doubleQuotesExpression.Match(storedOwnershipList.First().Version);
 
@@ -283,26 +278,23 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var ownership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
+
+                var ownership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
                 ownershipList.Add(ownership);
-
                 await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
 
                 Assert.That(ownership.LastModifiedTime, Is.Not.EqualTo(default(DateTimeOffset)));
                 Assert.That(ownership.LastModifiedTime, Is.GreaterThan(DateTimeOffset.UtcNow.Subtract(TimeSpan.FromSeconds(5))));
-
                 Assert.That(ownership.Version, Is.Not.Null);
             }
         }
@@ -321,41 +313,31 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var firstOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
 
-                ownershipList.Add(firstOwnership);
+                var firstOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { firstOwnership }, default);
 
-                ownershipList.Clear();
+                var secondOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId",
+                    Version = version
+                };
 
-                var secondOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId",
-                        Version = version
-                    };
-
-                ownershipList.Add(secondOwnership);
-
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
-
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default);
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -375,26 +357,20 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                var ownershipList = new List<EventProcessorPartitionOwnership>();
 
-                var eTaggyOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId",
-                        Version = "ETag"
-                    };
+                var eTaggyOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId",
+                    Version = "ETag"
+                };
 
-                ownershipList.Add(eTaggyOwnership);
-
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
-
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { eTaggyOwnership }, default);
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null.And.Empty);
             }
@@ -412,45 +388,33 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var firstOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
 
-                ownershipList.Add(firstOwnership);
+                var firstOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { firstOwnership }, default);
 
-                // Version must have been set by the checkpoint store.
+                // The first ownership's version should have been set by the checkpoint store.
 
-                var version = firstOwnership.Version;
+                var secondOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId",
+                    Version = firstOwnership.Version
+                };
 
-                ownershipList.Clear();
-
-                var secondOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId",
-                        Version = version
-                    };
-
-                ownershipList.Add(secondOwnership);
-
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
-
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default);
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -470,12 +434,11 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<EventProcessorPartitionOwnership>();
                 var ownershipCount = 5;
 
-                for (int i = 0; i < ownershipCount; i++)
+                for (var i = 0; i < ownershipCount; i++)
                 {
                     ownershipList.Add(
                         new EventProcessorPartitionOwnership
@@ -489,8 +452,7 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 }
 
                 await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
-
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(ownershipCount));
@@ -517,7 +479,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
                 var ownershipList = new List<EventProcessorPartitionOwnership>();
                 var ownershipCount = 5;
@@ -540,7 +501,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                 // The versions must have been set by the checkpoint store.
 
                 var versions = ownershipList.Select(ownership => ownership.Version).ToList();
-
                 ownershipList.Clear();
 
                 // Use a valid eTag when 'i' is odd.  This way, we can expect 'ownershipCount / 2' successful
@@ -562,8 +522,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                         });
                 }
 
-                IEnumerable<EventProcessorPartitionOwnership> claimedOwnershipList = await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
-                IEnumerable<EventProcessorPartitionOwnership> expectedOwnership = ownershipList.Where(ownership => int.Parse(ownership.PartitionId) % 2 == 1);
+                var claimedOwnershipList = await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                var expectedOwnership = ownershipList.Where(ownership => int.Parse(ownership.PartitionId) % 2 == 1);
 
                 Assert.That(claimedOwnershipList, Is.Not.Null);
                 Assert.That(claimedOwnershipList.Count, Is.EqualTo(expectedClaimedCount));
@@ -590,45 +550,33 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var firstOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup1",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
 
-                ownershipList.Add(firstOwnership);
+                var firstOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup1",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { firstOwnership }, default);
 
-                // Version must have been set by the checkpoint store.
+                // The first ownership's version should have been set by the checkpoint store.
 
-                var version = firstOwnership.Version;
+                var secondOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup2",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId",
+                    Version = firstOwnership.Version
+                };
 
-                ownershipList.Clear();
-
-                var secondOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup2",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId",
-                        Version = version
-                    };
-
-                ownershipList.Add(secondOwnership);
-
-                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList, default), Throws.InstanceOf<RequestFailedException>());
-
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup1", default);
+                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default), Throws.InstanceOf<RequestFailedException>());
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup1", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -648,45 +596,33 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var firstOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName1",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
 
-                ownershipList.Add(firstOwnership);
+                var firstOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName1",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { firstOwnership }, default);
 
-                // Version must have been set by the checkpoint store.
+                // The first ownership's version should have been set by the checkpoint store.
 
-                var version = firstOwnership.Version;
+                var secondOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace",
+                    EventHubName = "eventHubName2",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId",
+                    Version = firstOwnership.Version
+                };
 
-                ownershipList.Clear();
-
-                var secondOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace",
-                        EventHubName = "eventHubName2",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId",
-                        Version = version
-                    };
-
-                ownershipList.Add(secondOwnership);
-
-                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList, default), Throws.InstanceOf<RequestFailedException>());
-
-                IEnumerable<EventProcessorPartitionOwnership> storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName1", "consumerGroup", default);
+                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default), Throws.InstanceOf<RequestFailedException>());
+                var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace", "eventHubName1", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
                 Assert.That(storedOwnershipList.Count, Is.EqualTo(1));
@@ -706,44 +642,32 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, storageScope.ContainerName);
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
-                var ownershipList = new List<EventProcessorPartitionOwnership>();
-                var firstOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace1",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId"
-                    };
 
-                ownershipList.Add(firstOwnership);
+                var firstOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace1",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId"
+                };
 
-                await checkpointStore.ClaimOwnershipAsync(ownershipList, default);
+                await checkpointStore.ClaimOwnershipAsync(new[] { firstOwnership }, default);
 
-                // Version must have been set by the checkpoint store.
+                // The first ownership's version should have been set by the checkpoint store.
 
-                var version = firstOwnership.Version;
+                var secondOwnership = new EventProcessorPartitionOwnership
+                {
+                    FullyQualifiedNamespace = "namespace2",
+                    EventHubName = "eventHubName",
+                    ConsumerGroup = "consumerGroup",
+                    OwnerIdentifier = "ownerIdentifier",
+                    PartitionId = "partitionId",
+                    Version = firstOwnership.Version
+                };
 
-                ownershipList.Clear();
-
-                var secondOwnership =
-                    new EventProcessorPartitionOwnership
-                    {
-                        FullyQualifiedNamespace = "namespace2",
-                        EventHubName = "eventHubName",
-                        ConsumerGroup = "consumerGroup",
-                        OwnerIdentifier = "ownerIdentifier",
-                        PartitionId = "partitionId",
-                        Version = version
-                    };
-
-                ownershipList.Add(secondOwnership);
-
-                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(ownershipList, default), Throws.InstanceOf<RequestFailedException>());
-
+                Assert.That(async () => await checkpointStore.ClaimOwnershipAsync(new[] { secondOwnership }, default), Throws.InstanceOf<RequestFailedException>());
                 var storedOwnershipList = await checkpointStore.ListOwnershipAsync("namespace1", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedOwnershipList, Is.Not.Null);
@@ -764,7 +688,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListOwnershipAsync("namespace", "eventHubName", "consumerGroup", default), Throws.InstanceOf<RequestFailedException>());
@@ -783,7 +706,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 Assert.That(async () => await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default), Throws.InstanceOf<RequestFailedException>());
@@ -802,7 +724,6 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
             {
                 var storageConnectionString = StorageTestEnvironment.Instance.StorageConnectionString;
                 var containerClient = new BlobContainerClient(storageConnectionString, $"test-container-{Guid.NewGuid()}");
-
                 var checkpointStore = new BlobsCheckpointStore(containerClient, DefaultRetryPolicy);
 
                 var checkpoint = new EventProcessorCheckpoint
@@ -1004,8 +925,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     PartitionId = "partitionId"
                 }, mockEvent, default);
 
-                IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup1", default);
-                IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup2", default);
+                var storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup1", default);
+                var storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup2", default);
 
                 Assert.That(storedCheckpointsList1, Is.Not.Null);
                 Assert.That(storedCheckpointsList1.Count, Is.EqualTo(1));
@@ -1050,8 +971,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     PartitionId = "partitionId"
                 }, mockEvent, default);
 
-                IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName1", "consumerGroup", default);
-                IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName2", "consumerGroup", default);
+                var storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName1", "consumerGroup", default);
+                var storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName2", "consumerGroup", default);
 
                 Assert.That(storedCheckpointsList1, Is.Not.Null);
                 Assert.That(storedCheckpointsList1.Count, Is.EqualTo(1));
@@ -1096,8 +1017,8 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     PartitionId = "partitionId"
                 }, mockEvent, default);
 
-                IEnumerable<EventProcessorCheckpoint> storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace1", "eventHubName", "consumerGroup", default);
-                IEnumerable<EventProcessorCheckpoint> storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace2", "eventHubName", "consumerGroup", default);
+                var storedCheckpointsList1 = await checkpointStore.ListCheckpointsAsync("namespace1", "eventHubName", "consumerGroup", default);
+                var storedCheckpointsList2 = await checkpointStore.ListCheckpointsAsync("namespace2", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedCheckpointsList1, Is.Not.Null);
                 Assert.That(storedCheckpointsList1.Count, Is.EqualTo(1));
@@ -1142,13 +1063,13 @@ namespace Azure.Messaging.EventHubs.Processor.Tests
                     PartitionId = "partitionId2"
                 }, mockEvent, default);
 
-                IEnumerable<EventProcessorCheckpoint> storedCheckpointsList = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
+                var storedCheckpointsList = await checkpointStore.ListCheckpointsAsync("namespace", "eventHubName", "consumerGroup", default);
 
                 Assert.That(storedCheckpointsList, Is.Not.Null);
                 Assert.That(storedCheckpointsList.Count, Is.EqualTo(2));
 
-                EventProcessorCheckpoint storedCheckpoint1 = storedCheckpointsList.First(checkpoint => checkpoint.PartitionId == "partitionId1");
-                EventProcessorCheckpoint storedCheckpoint2 = storedCheckpointsList.First(checkpoint => checkpoint.PartitionId == "partitionId2");
+                var storedCheckpoint1 = storedCheckpointsList.First(checkpoint => checkpoint.PartitionId == "partitionId1");
+                var storedCheckpoint2 = storedCheckpointsList.First(checkpoint => checkpoint.PartitionId == "partitionId2");
 
                 Assert.That(storedCheckpoint1, Is.Not.Null);
                 Assert.That(storedCheckpoint2, Is.Not.Null);

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStore.Diagnostics.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/BlobsCheckpointStore.Diagnostics.cs
@@ -1,0 +1,319 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Tests;
+using Moq;
+
+namespace Azure.Messaging.EventHubs.Processor
+{
+    /// <summary>
+    ///   A storage blob service that keeps track of checkpoints and ownership.
+    /// </summary>
+    ///
+    internal sealed partial class BlobsCheckpointStore
+    {
+        /// <summary>
+        ///   The instance of <see cref="BlobEventStoreEventSource" /> which can be mocked for testing.
+        /// </summary>
+        ///
+        public IBlobEventLogger Logger { get; set; } = Mock.Of<IBlobEventLogger>();
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of ownership has completed.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="ownershipCount">The amount of ownership received from the storage service.</param>
+        ///
+        partial void ListOwnershipComplete(string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           int ownershipCount) =>
+            Logger.ListOwnershipComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, ownershipCount);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while retrieving a list of ownership.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void ListOwnershipError(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup,
+                                        Exception exception) =>
+            Logger.ListOwnershipError(fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of ownership has started.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        ///
+        partial void ListOwnershipStart(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup) =>
+            Logger.ListOwnershipStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of checkpoints has completed.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoints are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
+        /// <param name="checkpointCount">The amount of checkpoints received from the storage service.</param>
+        ///
+        partial void ListCheckpointsComplete(string fullyQualifiedNamespace,
+                                             string eventHubName,
+                                             string consumerGroup,
+                                             int checkpointCount) =>
+            Logger.ListCheckpointsComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, checkpointCount);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while retrieving a list of checkpoints.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoints are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void ListCheckpointsError(string fullyQualifiedNamespace,
+                                          string eventHubName,
+                                          string consumerGroup,
+                                          Exception exception) =>
+            Logger.ListCheckpointsError(fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+
+        /// <summary>
+        ///   Indicates that invalid checkpoint data was found during an attempt to retrieve a list of checkpoints.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition the data is associated with.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the data is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the data is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the data is associated with.</param>
+        ///
+        partial void InvalidCheckpointFound(string partitionId,
+                                            string fullyQualifiedNamespace,
+                                            string eventHubName,
+                                            string consumerGroup) =>
+            Logger.InvalidCheckpointFound(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a list of checkpoints has started.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoints are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
+        ///
+        partial void ListCheckpointsStart(string fullyQualifiedNamespace,
+                                          string eventHubName,
+                                          string consumerGroup) =>
+            Logger.ListCheckpointsStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while updating a checkpoint.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void UpdateCheckpointError(string partitionId,
+                                           string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           Exception exception) =>
+            Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+
+        /// <summary>
+        ///   Indicates that an attempt to update a checkpoint has completed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        ///
+        partial void UpdateCheckpointComplete(string partitionId,
+                                              string fullyQualifiedNamespace,
+                                              string eventHubName,
+                                              string consumerGroup) =>
+            Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to create/update a checkpoint has started.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being checkpointed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        ///
+        partial void UpdateCheckpointStart(string partitionId,
+                                           string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup) =>
+            Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve claim partition ownership has completed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        ///
+        partial void ClaimOwnershipComplete(string partitionId,
+                                            string fullyQualifiedNamespace,
+                                            string eventHubName,
+                                            string consumerGroup,
+                                            string ownerIdentifier) =>
+            Logger.ClaimOwnershipComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+
+        /// <summary>
+        ///   Indicates that an exception was encountered while attempting to retrieve claim partition ownership.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        /// <param name="exception">The exception that occurred.</param>
+        ///
+        partial void ClaimOwnershipError(string partitionId,
+                                         string fullyQualifiedNamespace,
+                                         string eventHubName,
+                                         string consumerGroup,
+                                         string ownerIdentifier,
+                                         Exception exception) =>
+            Logger.ClaimOwnershipError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier, exception.Message);
+
+        /// <summary>
+        ///   Indicates that ownership was unable to be claimed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        /// <param name="message">The message for the failure.</param>
+        ///
+        partial void OwnershipNotClaimable(string partitionId,
+                                           string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           string ownerIdentifier,
+                                           string message) =>
+            Logger.OwnershipNotClaimable(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier, message);
+
+        /// <summary>
+        ///   Indicates that ownership was successfully claimed.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        ///
+        partial void OwnershipClaimed(string partitionId,
+                                      string fullyQualifiedNamespace,
+                                      string eventHubName,
+                                      string consumerGroup,
+                                      string ownerIdentifier) =>
+            Logger.OwnershipClaimed(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+
+        /// <summary>
+        ///   Indicates that an attempt to claim a partition ownership has started.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the partition being claimed.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the ownership is associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the ownership is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
+        /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
+        ///
+        partial void ClaimOwnershipStart(string partitionId,
+                                         string fullyQualifiedNamespace,
+                                         string eventHubName,
+                                         string consumerGroup,
+                                         string ownerIdentifier) =>
+            Logger.ClaimOwnershipStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+
+        /// <summary>
+        ///   Indicates that a <see cref="BlobsCheckpointStore" /> was created.
+        /// </summary>
+        ///
+        /// <param name="typeName">The type name for the checkpoint store.</param>
+        /// <param name="accountName">The Storage account name corresponding to the associated container client.</param>
+        /// <param name="containerName">The name of the associated container client.</param>
+        ///
+        partial void BlobsCheckpointStoreCreated(string typeName,
+                                                 string accountName,
+                                                 string containerName) =>
+            Logger.BlobsCheckpointStoreCreated(typeName, accountName, containerName);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a checkpoint has started.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
+        ///
+        partial void GetCheckpointStart(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup,
+                                        string partitionId) =>
+            Logger.GetCheckpointStart(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId);
+
+        /// <summary>
+        ///   Indicates that an attempt to retrieve a checkpoint has completed.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
+        ///
+        partial void GetCheckpointComplete(string fullyQualifiedNamespace,
+                                           string eventHubName,
+                                           string consumerGroup,
+                                           string partitionId) =>
+            Logger.GetCheckpointComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId);
+
+        /// <summary>
+        ///   Indicates that an unhandled exception was encountered while retrieving a checkpoint.
+        /// </summary>
+        ///
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace the checkpoint are associated with.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
+        /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
+        /// <param name="exception">The message for the exception that occurred.</param>
+        ///
+        partial void GetCheckpointError(string fullyQualifiedNamespace,
+                                        string eventHubName,
+                                        string consumerGroup,
+                                        string partitionId,
+                                        Exception exception) =>
+            Logger.GetCheckpointError(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, exception.Message);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/IBlobEventLogger.cs
@@ -1,33 +1,17 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
-using Azure.Messaging.EventHubs.Processor.Diagnostics;
 
-namespace Azure.Messaging.EventHubs.Processor
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   A storage blob service that keeps track of checkpoints and ownership.
+    ///   The contract for logging <see cref="BlobsCheckpointStore" />
+    ///   operations.
     /// </summary>
     ///
-    internal sealed partial class BlobsCheckpointStore
+    public interface IBlobEventLogger
     {
-        /// <summary>
-        /// Initializes the <see cref="BlobsCheckpointStore"/> type.
-        /// </summary>
-#pragma warning disable CA1810 // Initialize static fields inline
-        static BlobsCheckpointStore()
-        {
-            BlobsResourceDoesNotExist = Resources.BlobsResourceDoesNotExist;
-        }
-#pragma warning restore CA1810
-
-        /// <summary>
-        ///   The instance of <see cref="BlobEventStoreEventSource" /> which can be mocked for testing.
-        /// </summary>
-        ///
-        internal BlobEventStoreEventSource Logger { get; set; } = BlobEventStoreEventSource.Log;
-
         /// <summary>
         ///   Indicates that an attempt to retrieve a list of ownership has completed.
         /// </summary>
@@ -37,11 +21,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
         /// <param name="ownershipCount">The amount of ownership received from the storage service.</param>
         ///
-        partial void ListOwnershipComplete(string fullyQualifiedNamespace,
-                                           string eventHubName,
-                                           string consumerGroup,
-                                           int ownershipCount) =>
-            Logger.ListOwnershipComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, ownershipCount);
+        void ListOwnershipComplete(string fullyQualifiedNamespace,
+                                   string eventHubName,
+                                   string consumerGroup,
+                                   int ownershipCount);
 
         /// <summary>
         ///   Indicates that an unhandled exception was encountered while retrieving a list of ownership.
@@ -52,11 +35,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
-        partial void ListOwnershipError(string fullyQualifiedNamespace,
-                                        string eventHubName,
-                                        string consumerGroup,
-                                        Exception exception) =>
-            Logger.ListOwnershipError(fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+        void ListOwnershipError(string fullyQualifiedNamespace,
+                                string eventHubName,
+                                string consumerGroup,
+                                string exception);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve a list of ownership has started.
@@ -66,10 +48,9 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="eventHubName">The name of the specific Event Hub the ownership are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
         ///
-        partial void ListOwnershipStart(string fullyQualifiedNamespace,
-                                        string eventHubName,
-                                        string consumerGroup) =>
-            Logger.ListOwnershipStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
+        void ListOwnershipStart(string fullyQualifiedNamespace,
+                                string eventHubName,
+                                string consumerGroup);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve a list of checkpoints has completed.
@@ -80,11 +61,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
         /// <param name="checkpointCount">The amount of checkpoints received from the storage service.</param>
         ///
-        partial void ListCheckpointsComplete(string fullyQualifiedNamespace,
-                                             string eventHubName,
-                                             string consumerGroup,
-                                             int checkpointCount) =>
-            Logger.ListCheckpointsComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, checkpointCount);
+        void ListCheckpointsComplete(string fullyQualifiedNamespace,
+                                     string eventHubName,
+                                     string consumerGroup,
+                                     int checkpointCount);
 
         /// <summary>
         ///   Indicates that an unhandled exception was encountered while retrieving a list of checkpoints.
@@ -95,11 +75,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the ownership are associated with.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
-        partial void ListCheckpointsError(string fullyQualifiedNamespace,
-                                          string eventHubName,
-                                          string consumerGroup,
-                                          Exception exception) =>
-            Logger.ListCheckpointsError(fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+        void ListCheckpointsError(string fullyQualifiedNamespace,
+                                  string eventHubName,
+                                  string consumerGroup,
+                                  string exception);
 
         /// <summary>
         ///   Indicates that invalid checkpoint data was found during an attempt to retrieve a list of checkpoints.
@@ -110,11 +89,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="eventHubName">The name of the specific Event Hub the data is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the data is associated with.</param>
         ///
-        partial void InvalidCheckpointFound(string partitionId,
-                                            string fullyQualifiedNamespace,
-                                            string eventHubName,
-                                            string consumerGroup) =>
-            Logger.InvalidCheckpointFound(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+        void InvalidCheckpointFound(string partitionId,
+                                    string fullyQualifiedNamespace,
+                                    string eventHubName,
+                                    string consumerGroup);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve a list of checkpoints has started.
@@ -124,10 +102,9 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoints are associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoints are associated with.</param>
         ///
-        partial void ListCheckpointsStart(string fullyQualifiedNamespace,
-                                          string eventHubName,
-                                          string consumerGroup) =>
-            Logger.ListCheckpointsStart(fullyQualifiedNamespace, eventHubName, consumerGroup);
+        void ListCheckpointsStart(string fullyQualifiedNamespace,
+                                  string eventHubName,
+                                  string consumerGroup);
 
         /// <summary>
         ///   Indicates that an unhandled exception was encountered while updating a checkpoint.
@@ -139,12 +116,11 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
-        partial void UpdateCheckpointError(string partitionId,
-                                           string fullyQualifiedNamespace,
-                                           string eventHubName,
-                                           string consumerGroup,
-                                           Exception exception) =>
-            Logger.UpdateCheckpointError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, exception.Message);
+        void UpdateCheckpointError(string partitionId,
+                                   string fullyQualifiedNamespace,
+                                   string eventHubName,
+                                   string consumerGroup,
+                                   string exception);
 
         /// <summary>
         ///   Indicates that an attempt to update a checkpoint has completed.
@@ -155,11 +131,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         ///
-        partial void UpdateCheckpointComplete(string partitionId,
-                                              string fullyQualifiedNamespace,
-                                              string eventHubName,
-                                              string consumerGroup) =>
-            Logger.UpdateCheckpointComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+        void UpdateCheckpointComplete(string partitionId,
+                                      string fullyQualifiedNamespace,
+                                      string eventHubName,
+                                      string consumerGroup);
 
         /// <summary>
         ///   Indicates that an attempt to create/update a checkpoint has started.
@@ -170,11 +145,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="eventHubName">The name of the specific Event Hub the checkpoint is associated with, relative to the Event Hubs namespace that contains it.</param>
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         ///
-        partial void UpdateCheckpointStart(string partitionId,
-                                           string fullyQualifiedNamespace,
-                                           string eventHubName,
-                                           string consumerGroup) =>
-            Logger.UpdateCheckpointStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup);
+        void UpdateCheckpointStart(string partitionId,
+                                   string fullyQualifiedNamespace,
+                                   string eventHubName,
+                                   string consumerGroup);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve claim partition ownership has completed.
@@ -186,12 +160,11 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
         /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
         ///
-        partial void ClaimOwnershipComplete(string partitionId,
-                                            string fullyQualifiedNamespace,
-                                            string eventHubName,
-                                            string consumerGroup,
-                                            string ownerIdentifier) =>
-            Logger.ClaimOwnershipComplete(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+        void ClaimOwnershipComplete(string partitionId,
+                                    string fullyQualifiedNamespace,
+                                    string eventHubName,
+                                    string consumerGroup,
+                                    string ownerIdentifier);
 
         /// <summary>
         ///   Indicates that an exception was encountered while attempting to retrieve claim partition ownership.
@@ -204,13 +177,12 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
         /// <param name="exception">The exception that occurred.</param>
         ///
-        partial void ClaimOwnershipError(string partitionId,
-                                         string fullyQualifiedNamespace,
-                                         string eventHubName,
-                                         string consumerGroup,
-                                         string ownerIdentifier,
-                                         Exception exception) =>
-            Logger.ClaimOwnershipError(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier, exception.Message);
+        void ClaimOwnershipError(string partitionId,
+                                 string fullyQualifiedNamespace,
+                                 string eventHubName,
+                                 string consumerGroup,
+                                 string ownerIdentifier,
+                                 string exception);
 
         /// <summary>
         ///   Indicates that ownership was unable to be claimed.
@@ -223,13 +195,12 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
         /// <param name="message">The message for the failure.</param>
         ///
-        partial void OwnershipNotClaimable(string partitionId,
-                                           string fullyQualifiedNamespace,
-                                           string eventHubName,
-                                           string consumerGroup,
-                                           string ownerIdentifier,
-                                           string message) =>
-            Logger.OwnershipNotClaimable(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier, message);
+        void OwnershipNotClaimable(string partitionId,
+                                   string fullyQualifiedNamespace,
+                                   string eventHubName,
+                                   string consumerGroup,
+                                   string ownerIdentifier,
+                                   string message);
 
         /// <summary>
         ///   Indicates that ownership was successfully claimed.
@@ -241,8 +212,11 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
         /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
         ///
-        partial void OwnershipClaimed(string partitionId, string fullyQualifiedNamespace, string eventHubName, string consumerGroup, string ownerIdentifier) =>
-            Logger.OwnershipClaimed(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+        void OwnershipClaimed(string partitionId,
+                              string fullyQualifiedNamespace,
+                              string eventHubName,
+                              string consumerGroup,
+                              string ownerIdentifier);
 
         /// <summary>
         ///   Indicates that an attempt to claim a partition ownership has started.
@@ -254,12 +228,11 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the ownership is associated with.</param>
         /// <param name="ownerIdentifier">The identifier of the processor that attempted to claim the ownership for.</param>
         ///
-        partial void ClaimOwnershipStart(string partitionId,
-                                         string fullyQualifiedNamespace,
-                                         string eventHubName,
-                                         string consumerGroup,
-                                         string ownerIdentifier) =>
-            Logger.ClaimOwnershipStart(partitionId, fullyQualifiedNamespace, eventHubName, consumerGroup, ownerIdentifier);
+        void ClaimOwnershipStart(string partitionId,
+                                 string fullyQualifiedNamespace,
+                                 string eventHubName,
+                                 string consumerGroup,
+                                 string ownerIdentifier);
 
         /// <summary>
         ///   Indicates that a <see cref="BlobsCheckpointStore" /> was created.
@@ -269,10 +242,9 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="accountName">The Storage account name corresponding to the associated container client.</param>
         /// <param name="containerName">The name of the associated container client.</param>
         ///
-        partial void BlobsCheckpointStoreCreated(string typeName,
-                                                 string accountName,
-                                                 string containerName) =>
-            Logger.BlobsCheckpointStoreCreated(typeName, accountName, containerName);
+        void BlobsCheckpointStoreCreated(string typeName,
+                                         string accountName,
+                                         string containerName);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve a checkpoint has started.
@@ -283,11 +255,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
         ///
-        partial void GetCheckpointStart(string fullyQualifiedNamespace,
-                                        string eventHubName,
-                                        string consumerGroup,
-                                        string partitionId) =>
-            Logger.GetCheckpointStart(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId);
+        void GetCheckpointStart(string fullyQualifiedNamespace,
+                                string eventHubName,
+                                string consumerGroup,
+                                string partitionId);
 
         /// <summary>
         ///   Indicates that an attempt to retrieve a checkpoint has completed.
@@ -298,11 +269,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="consumerGroup">The name of the consumer group the checkpoint is associated with.</param>
         /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
         ///
-        partial void GetCheckpointComplete(string fullyQualifiedNamespace,
-                                           string eventHubName,
-                                           string consumerGroup,
-                                           string partitionId) =>
-            Logger.GetCheckpointComplete(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId);
+        void GetCheckpointComplete(string fullyQualifiedNamespace,
+                                   string eventHubName,
+                                   string consumerGroup,
+                                   string partitionId);
 
         /// <summary>
         ///   Indicates that an unhandled exception was encountered while retrieving a checkpoint.
@@ -314,11 +284,10 @@ namespace Azure.Messaging.EventHubs.Processor
         /// <param name="partitionId">The partition id the specific checkpoint is associated with.</param>
         /// <param name="exception">The message for the exception that occurred.</param>
         ///
-        partial void GetCheckpointError(string fullyQualifiedNamespace,
-                                        string eventHubName,
-                                        string consumerGroup,
-                                        string partitionId,
-                                        Exception exception) =>
-            Logger.GetCheckpointError(fullyQualifiedNamespace, eventHubName, consumerGroup, partitionId, exception.Message);
+        void GetCheckpointError(string fullyQualifiedNamespace,
+                                string eventHubName,
+                                string consumerGroup,
+                                string partitionId,
+                                string exception);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/PartitionOwnershipExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/PartitionOwnershipExtensions.cs
@@ -4,7 +4,7 @@
 using System;
 using Azure.Messaging.EventHubs.Primitives;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The set of extension methods for the <see cref="EventProcessorPartitionOwnership" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/PartitionOwnershipExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/PartitionOwnershipExtensionsTests.cs
@@ -5,7 +5,7 @@ using System;
 using Azure.Messaging.EventHubs.Primitives;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Processor.Tests
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="PartitionOwnershipExtensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/TestRunFixture.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/tests/Infrastructure/TestRunFixture.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   Serves as a fixture for operations that are scoped to the entire
+    ///   test run pass, rather than specific to a given test or test fixture.
+    /// </summary>
+    ///
+    [SetUpFixture]
+    public class TestRunFixture
+    {
+        /// <summary>
+        ///  Performs the tasks needed to clean up after a test run
+        ///  has completed.
+        /// </summary>
+        ///
+        [OneTimeTearDown]
+        public void Teardown()
+        {
+            // Clean-up should not be considered a critical failure that results in a test run failure.  Due
+            // to ARM being temperamental, some management operations may be rejected.  Throwing here
+            // does not help to ensure resource cleanup.
+            //
+            // Because resources may be orphaned outside of an observed exception, throwing to raise awareness
+            // is not sufficient for all scenarios; since an external process is already needed to manage
+            // orphans, there is no benefit to failing the run; allow the test results to be reported.
+
+            try
+            {
+                if (EventHubsTestEnvironment.Instance.ShouldRemoveNamespaceAfterTestRunCompletion)
+                {
+                    EventHubScope.DeleteNamespaceAsync(EventHubsTestEnvironment.Instance.EventHubsNamespace).GetAwaiter().GetResult();
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                if (StorageTestEnvironment.Instance.ShouldRemoveStorageAccountAfterTestRunCompletion)
+                {
+                    StorageScope.DeleteStorageAccountAsync(StorageTestEnvironment.Instance.StorageAccountName).GetAwaiter().GetResult();
+                }
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -16,11 +16,10 @@
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+    <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="System.Threading.Channels" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <!-- This package will be removed when v5.3.0 is released for GA as the dependency will be available from Core -->
-    <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
 
   <!-- Import the Azure.Core reference -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -33,5 +33,4 @@
 
   <!-- Import Event Hubs shared source -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Testing.projitems" Label="Testing" />
-
 </Project>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/Microsoft.Azure.WebJobs.Extensions.EventHubs.Tests.csproj
@@ -24,12 +24,11 @@
   </ItemGroup>
 
   <Import Project="../../Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.Testing.projitems" />
+  <Import Project="../../Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.BlobStorageTesting.projitems" />
 
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
     <Compile Include="..\..\..\extensions\Microsoft.Azure.WebJobs.Extensions.Clients\tests\shared\**\*.cs" />
-    <Compile Include="../../Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageScope.cs" />
-    <Compile Include="../../Azure.Messaging.EventHubs.Processor/tests/Infrastructure/StorageTestEnvironment.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/WebJobsEventHubTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs.Processor.Tests;
 using Azure.Messaging.EventHubs.Tests;
 using Microsoft.Azure.WebJobs.EventHubs;
 using Microsoft.Azure.WebJobs.Host.TestCommon;


### PR DESCRIPTION
# Summary

The focus of these changes is to complete migration of the Blobs Checkpoint Store from the `Azure.Messaging.EventHubs.Processor` project to the `Azure.Messaging.EventHubs.Shared` project.  To facilitate sharing the checkpoint store between the processor and the Functions extensions, the implementation for the store was moved into the shared project, though its tests remained in the processor.  In order to follow the pattern of keeping locality between shared code items and their tests, the checkpoint store tests, both unit and live, have been migrated to the shared testing project.

In support of this, some of the live testing infrastructure specific to managing storage resources has also been migrated into the shared project as part of the `BlobTesting` category of shared items.  

Some refactoring and reformatting of the storage tests has also been performed to improve consistency with other Event Hubs code, trim dead areas, and improve readability.

# Last Upstream Rebase

Wednesday, February 3, 2021, 2:00pm (EST)