### PR TITLE
[Core.Experimental] Improvements for Protocol Clients

### DIFF
--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.netstandard2.0.cs
@@ -11,6 +11,7 @@ namespace Azure.Core
     }
     public partial class DynamicJson : System.Dynamic.IDynamicMetaObjectProvider
     {
+        public DynamicJson() { }
         public DynamicJson(string json) { }
         public DynamicJson(System.Text.Json.JsonElement element) { }
         public Azure.Core.DynamicJson this[int arrayIndex] { get { throw null; } set { } }
@@ -98,6 +99,10 @@ namespace Azure.Core
         protected override System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders() { throw null; }
         protected override bool TryGetHeader(string name, out string? value) { throw null; }
         protected override bool TryGetHeaderValues(string name, out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
+    }
+    public partial class ProtocolClientOptions : Azure.Core.ClientOptions
+    {
+        public ProtocolClientOptions() { }
     }
 }
 namespace Azure.Core.GeoJson

--- a/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
+++ b/sdk/core/Azure.Core.Experimental/src/DynamicJson.cs
@@ -29,6 +29,13 @@ namespace Azure.Core
         private List<DynamicJson>? _arrayRepresentation;
         private object? _value;
 
+        /// <summary>
+        /// Construcs a new DynamicJson which represents an empty JSON object.
+        /// </summary>
+        public DynamicJson() : this(System.Array.Empty<KeyValuePair<string, DynamicJson>>())
+        {
+        }
+
         public DynamicJson(string json): this(JsonDocument.Parse(json).RootElement)
         {
         }

--- a/sdk/core/Azure.Core.Experimental/src/ProtocolClientOptions.cs
+++ b/sdk/core/Azure.Core.Experimental/src/ProtocolClientOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// A concrete ClientOptions for use by client with no additonal options other than the common ones.
+    /// </summary>
+#pragma warning disable AZC0008 // ClientOptions should have a nested enum called ServiceVersion
+    public class ProtocolClientOptions : ClientOptions
+#pragma warning restore AZC0008 // ClientOptions should have a nested enum called ServiceVersion
+    {
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTest.cs
+++ b/sdk/core/Azure.Core.Experimental/tests/DynamicJsonTest.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using NUnit.Framework;
 
@@ -10,6 +10,14 @@ namespace Azure.Core.Tests
 {
     public class DynamicJsonTest
     {
+        [Test]
+        public void DefaultConstructorMakesEmptyObject()
+        {
+            var dynamicJson = new DynamicJson();
+
+            Assert.AreEqual(0, dynamicJson.EnumerateObject().Count());
+        }
+
         [Test]
         public void CanCreateFromJson()
         {


### PR DESCRIPTION
- Add a ProtocolClientOptions type for use by clients which have no
  additional options. This means we don't have to generate a type per
  client

- Add a zero argument constructor to `DynamicJson` that behaves like
  DynamicJson.Object(), since we expect that `DynamicJson` will
  appear in API signatures and users will want to be able to `new` up
  the type.