### PR TITLE
[Event Hubs Client] Producer Dead Code Removal

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -492,64 +492,6 @@ namespace Azure.Messaging.EventHubs.Producer
         }
 
         /// <summary>
-        ///   Sends the <see cref="EventData" /> to the associated Event Hub.  To avoid the
-        ///   overhead associated with measuring and validating the size in the client, validation will
-        ///   be delegated to the Event Hubs service and is deferred until the operation is invoked.
-        ///   The call will fail if the size of the specified <paramref name="eventData"/> exceeds the
-        ///   maximum allowable size of a single event.
-        /// </summary>
-        ///
-        /// <param name="eventData">The event data to send.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
-        ///
-        /// <returns>
-        ///   A task to be resolved on when the operation has completed; if no exception is thrown when awaited, the
-        ///   Event Hubs service has acknowledge receipt and assumed responsibility for delivery of the event.
-        /// </returns>
-        ///
-        /// <seealso cref="SendAsync(EventData, SendEventOptions, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
-        /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
-        ///
-        internal virtual async Task SendAsync(EventData eventData,
-                                              CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(eventData, nameof(eventData));
-            await SendAsync(new[] { eventData }, null, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        ///   Sends the <see cref="EventData" /> to the associated Event Hub.  To avoid the
-        ///   overhead associated with measuring and validating the size in the client, validation will
-        ///   be delegated to the Event Hubs service and is deferred until the operation is invoked.
-        ///   The call will fail if the size of the specified <paramref name="eventData"/> exceeds the
-        ///   maximum allowable size of a single event.
-        /// </summary>
-        ///
-        /// <param name="eventData">The event data to send.</param>
-        /// <param name="options">The set of options to consider when sending this batch.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
-        ///
-        /// <returns>
-        ///   A task to be resolved on when the operation has completed; if no exception is thrown when awaited, the
-        ///   Event Hubs service has acknowledge receipt and assumed responsibility for delivery of the event.
-        /// </returns>
-        ///
-        /// <seealso cref="SendAsync(EventData, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, CancellationToken)" />
-        /// <seealso cref="SendAsync(IEnumerable{EventData}, SendEventOptions, CancellationToken)" />
-        /// <seealso cref="SendAsync(EventDataBatch, CancellationToken)" />
-        ///
-        internal virtual async Task SendAsync(EventData eventData,
-                                              SendEventOptions options,
-                                              CancellationToken cancellationToken = default)
-        {
-            Argument.AssertNotNull(eventData, nameof(eventData));
-            await SendAsync(new[] { eventData }, options, cancellationToken).ConfigureAwait(false);
-        }
-
-        /// <summary>
         ///   Sends a set of events to the associated Event Hub as a single operation.  To avoid the
         ///   overhead associated with measuring and validating the size in the client, validation will
         ///   be delegated to the Event Hubs service and is deferred until the operation is invoked.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var producer = new EventHubProducerClient(fakeConnection, transportMock.Object);
 
             var eventData = new EventData(ReadOnlyMemory<byte>.Empty);
-            await producer.SendAsync(eventData);
+            await producer.SendAsync(new[] { eventData });
 
             activity.Stop();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubProducerClientTests.cs
@@ -520,68 +520,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void SendSingleWithoutOptionsRequiresAnEvent()
-        {
-            var producer = new EventHubProducerClient(new MockConnection());
-            Assert.That(async () => await producer.SendAsync(default(EventData)), Throws.ArgumentNullException);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public void SendSingleRequiresAnEvent()
-        {
-            var producer = new EventHubProducerClient(new MockConnection());
-            Assert.That(async () => await producer.SendAsync(default(EventData), new SendEventOptions()), Throws.ArgumentNullException);
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public async Task SendSingleWithoutOptionsDelegatesToBatchSend()
-        {
-            var transportProducer = new ObservableTransportProducerMock();
-            var producer = new Mock<EventHubProducerClient> { CallBase = true };
-
-            producer
-                .Setup(instance => instance.SendAsync(It.Is<IEnumerable<EventData>>(value => value.Count() == 1), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask)
-                .Verifiable("The single send should delegate to the batch send.");
-
-            await producer.Object.SendAsync(new EventData(new byte[] { 0x22 }));
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
-        public async Task SendSingleWitOptionsDelegatesToBatchSend()
-        {
-            var transportProducer = new ObservableTransportProducerMock();
-            var producer = new Mock<EventHubProducerClient> { CallBase = true };
-
-            producer
-                .Setup(instance => instance.SendAsync(It.Is<IEnumerable<EventData>>(value => value.Count() == 1), It.IsAny<SendEventOptions>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask)
-                .Verifiable("The single send should delegate to the batch send.");
-
-            await producer.Object.SendAsync(new EventData(new byte[] { 0x22 }), new SendEventOptions());
-        }
-
-        /// <summary>
-        ///   Verifies functionality of the <see cref="EventHubProducerClient.SendAsync" />
-        ///   method.
-        /// </summary>
-        ///
-        [Test]
         public void SendWithoutOptionsRequiresEvents()
         {
             var transportProducer = new ObservableTransportProducerMock();


### PR DESCRIPTION
# Summary

The focus of these changes is to trim the dead code paths for publishing a single event from the producer client and associated tests.  This overload existed in early pre-GA betas but has been determined to be unlikely to return to the public API in the future.

# Last Upstream Rebase

Thursday, February 4, 2021, 9:45am (EST)