### PR TITLE
[Communication] - Update the changelog to reflect the changes in the identifiers

### DIFF
--- a/sdk/communication/Azure.Communication.Common/CHANGELOG.md
+++ b/sdk/communication/Azure.Communication.Common/CHANGELOG.md
@@ -6,12 +6,13 @@
 - Added `MicrosoftTeamsUserIdentifier`.
 
 ### Breaking Changes
+- Removed `CallingApplication`.
 - Renamed `CommunicationUserCredential` to `CommunicationTokenCredential`.
 - Replace `CommunicationTokenCredential(bool refreshProactively, Func<CancellationToken, string> tokenRefresher,Func<CancellationToken, ValueTask<string>>? asyncTokenRefresher = null, string? initialToken = null)` 
-with `CommunicationTokenCredential(CommunicationTokenRefreshOptions tokenRefreshOptions)`.
+constructor with `CommunicationTokenCredential(CommunicationTokenRefreshOptions tokenRefreshOptions)`.
 - Renamed `PhoneNumber` to `PhoneNumberIdentifier`
 - Renamed `CommunicationUser` to `CommunicationUserIdentifier `
-- Renamed `CallingApplication` to `CallingApplicationIdentifier`
+- Renamed `Id` to `RawId` in `PhoneNumberIdentifier`.
 
 ## 1.0.0-beta.3 (2020-11-16)
 Updated `Azure.Communication.Common` version.


### PR DESCRIPTION
The code change was in https://github.com/Azure/azure-sdk-for-net/pull/18389, but I had forgotten to update the change log.