### PR TITLE
Use Utf8JsonWriter to write JsonElement to stream instead of using th…

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/QueryRestClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/QueryRestClient.cs
@@ -16,7 +16,6 @@ namespace Azure.DigitalTwins.Core
             QuerySpecification querySpecification,
             QueryOptions queryTwinsOptions = null,
             ObjectSerializer objectSerializer = null,
-            ObjectSerializer defaultObjectSerializer = null,
             CancellationToken cancellationToken = default)
         {
             if (querySpecification == null)
@@ -37,7 +36,7 @@ namespace Azure.DigitalTwins.Core
                 case 200:
                     {
                         using JsonDocument document = await JsonDocument.ParseAsync(message.Response.ContentStream, default, cancellationToken).ConfigureAwait(false);
-                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer, defaultObjectSerializer);
+                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:
@@ -49,7 +48,6 @@ namespace Azure.DigitalTwins.Core
             QuerySpecification querySpecification,
             QueryOptions queryTwinsOptions = null,
             ObjectSerializer objectSerializer = null,
-            ObjectSerializer defaultObjectSerializer = null,
             CancellationToken cancellationToken = default)
         {
             if (querySpecification == null)
@@ -70,7 +68,7 @@ namespace Azure.DigitalTwins.Core
                 case 200:
                     {
                         using var document = JsonDocument.Parse(message.Response.ContentStream);
-                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer, defaultObjectSerializer);
+                        QueryResult<T> value = QueryResult<T>.DeserializeQueryResult(document.RootElement, objectSerializer);
                         return ResponseWithHeaders.FromValue(value, headers, message.Response);
                     }
                 default:

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/DigitalTwinsClient.cs
@@ -33,12 +33,6 @@ namespace Azure.DigitalTwins.Core
 
         private readonly ObjectSerializer _objectSerializer;
 
-        /// <summary>
-        /// In order to serialize/deserialize JsonElements into and out of a stream, we have to use the out of the box ObjectSerializer (JsonObjectSerializer).
-        /// If the user specifies a different type of serializer to instantiate the client than the default one, the SDK will instantiate a new JsonObjectSerializer of its own.
-        /// </summary>
-        private readonly ObjectSerializer _defaultObjectSerializer;
-
         private readonly DigitalTwinsRestClient _dtRestClient;
         private readonly DigitalTwinModelsRestClient _dtModelsRestClient;
         private readonly EventRoutesRestClient _eventRoutesRestClient;
@@ -98,13 +92,6 @@ namespace Azure.DigitalTwins.Core
             _clientDiagnostics = new ClientDiagnostics(options);
 
             _objectSerializer = options.Serializer ?? new JsonObjectSerializer();
-
-            // If the objectSerializer is of type JsonObjectSerializer, we will re-use the same object and set it as the defaultObjectSerializer.
-            // Otherwise, we will instantiate it and re-use it in the future.
-            _defaultObjectSerializer =
-                (_objectSerializer is JsonObjectSerializer)
-                    ? _objectSerializer
-                    : new JsonObjectSerializer();
 
             options.AddPolicy(new BearerTokenAuthenticationPolicy(credential, GetAuthorizationScopes()), HttpPipelinePosition.PerCall);
             _httpPipeline = HttpPipelineBuilder.Build(options);
@@ -2058,7 +2045,6 @@ namespace Azure.DigitalTwins.Core
                                 querySpecification,
                                 options,
                                 _objectSerializer,
-                                _defaultObjectSerializer,
                                 cancellationToken)
                             .ConfigureAwait(false);
 
@@ -2093,7 +2079,6 @@ namespace Azure.DigitalTwins.Core
                                 querySpecification,
                                 options,
                                 _objectSerializer,
-                                _defaultObjectSerializer,
                                 cancellationToken)
                             .ConfigureAwait(false);
 
@@ -2169,7 +2154,6 @@ namespace Azure.DigitalTwins.Core
                                 querySpecification,
                                 options,
                                 _objectSerializer,
-                                _defaultObjectSerializer,
                                 cancellationToken);
 
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());
@@ -2203,7 +2187,6 @@ namespace Azure.DigitalTwins.Core
                                 querySpecification,
                                 options,
                                 _objectSerializer,
-                                _defaultObjectSerializer,
                                 cancellationToken);
 
                         return Page.FromValues(response.Value.Value, response.Value.ContinuationToken, response.GetRawResponse());

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
@@ -40,9 +40,8 @@ namespace Azure.DigitalTwins.Core
         /// </summary>
         /// <param name="element">The JSON element to be deserialized into a QueryResult.</param>
         /// <param name="objectSerializer">The object serializer instance used to deserialize the items in the collection.</param>
-        /// <param name="defaultObjectSerializer">The out of the box object serializer to interact with the JsonElement (serialize/deserialize into and out of streams).</param>
         /// <returns>A collection of query results deserialized into type <typeparamref name="T"/>.</returns>
-        internal static QueryResult<T> DeserializeQueryResult(JsonElement element, ObjectSerializer objectSerializer, ObjectSerializer defaultObjectSerializer)
+        internal static QueryResult<T> DeserializeQueryResult(JsonElement element, ObjectSerializer objectSerializer)
         {
             IReadOnlyList<T> items = default;
             string continuationToken = default;
@@ -63,7 +62,7 @@ namespace Azure.DigitalTwins.Core
                         // defaultObjectSerializer of type JsonObjectSerializer needs to be used to serialize the JsonElement into a stream.
                         // Using any other ObjectSerializer (e.g. NewtonsoftJsonObjectSerializer) won't be able to deserialize the JsonElement into
                         // a MemoryStream correctly.
-                        using MemoryStream streamedObject = StreamHelper.WriteToStream(item, defaultObjectSerializer, default);
+                        using MemoryStream streamedObject = StreamHelper.WriteJsonElementToStream(item);
 
                         // To deserialize the stream object into the generic type of T, the provided ObjectSerializer will be used.
                         T obj = (T)objectSerializer.Deserialize(streamedObject, typeof(T), default);

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/QueryResult.cs
@@ -59,9 +59,6 @@ namespace Azure.DigitalTwins.Core
 
                     foreach (JsonElement item in property.Value.EnumerateArray())
                     {
-                        // defaultObjectSerializer of type JsonObjectSerializer needs to be used to serialize the JsonElement into a stream.
-                        // Using any other ObjectSerializer (e.g. NewtonsoftJsonObjectSerializer) won't be able to deserialize the JsonElement into
-                        // a MemoryStream correctly.
                         using MemoryStream streamedObject = StreamHelper.WriteJsonElementToStream(item);
 
                         // To deserialize the stream object into the generic type of T, the provided ObjectSerializer will be used.

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/StreamHelper.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/StreamHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Serialization;
@@ -42,6 +43,23 @@ namespace Azure.DigitalTwins.Core
             var memoryStream = new MemoryStream();
 
             objectSerializer.Serialize(memoryStream, obj, typeof(T), cancellationToken);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            return memoryStream;
+        }
+
+        /// <summary>
+        /// Serializes a JsonElement and writes it into a memory stream.
+        /// </summary>
+        /// <param name="item">JsonElement to be deserialized into a stream.</param>
+        /// <returns>A binary representation of the object written to a stream.</returns>
+        internal static MemoryStream WriteJsonElementToStream(JsonElement item)
+        {
+            var memoryStream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(memoryStream);
+
+            item.WriteTo(writer);
+            writer.Flush();
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             return memoryStream;


### PR DESCRIPTION
Thanks to Pavel and his suggestion, we can use Utf8JsonWriter to deserialize JsonElements to streams instead of using the default object serializer.