### PR TITLE
Azure Monitor Exporter: support for Api Version

### DIFF
--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/ApplicationInsightsRestClient.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/ApplicationInsightsRestClient.cs
@@ -10,8 +10,13 @@ using Microsoft.OpenTelemetry.Exporter.AzureMonitor.Models;
 
 namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
 {
+    /// <summary>
+    /// This is the custom class. The other partial is the Swagger auto-generated class.
+    /// </summary>
     internal partial class ApplicationInsightsRestClient
     {
+        internal string ApiVersion { get; set; } = "2";
+
         /// <summary>
         /// This operation sends a sequence of telemetry events that will be monitored by Azure Monitor.
         /// </summary>
@@ -46,16 +51,23 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
             return message.TryGetProperty("ItemsAccepted", out var objItemsAccepted) && objItemsAccepted is int itemsAccepted ? itemsAccepted : 0;
         }
 
+        /// <summary>
+        /// Builds the ingestion Uri. (Example: https://dc.services.visualstudio.com/v2/track).
+        /// </summary>
+        internal RequestUriBuilder GetIngestionUri()
+        {
+            var uri = new RawRequestUriBuilder();
+            uri.AppendRaw(this.host, false);
+            uri.AppendPath($"/v{this.ApiVersion}/track", false);
+            return uri;
+        }
+
         internal HttpMessage CreateTrackRequest(IEnumerable<TelemetryItem> body)
         {
             var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(host, false);
-            uri.AppendRaw("/v2", false);
-            uri.AppendPath("/track", false);
-            request.Uri = uri;
+            request.Uri = GetIngestionUri();
             request.Headers.Add("Content-Type", "application/json");
             request.Headers.Add("Accept", "application/json");
             using var content = new NDJsonWriter();
@@ -74,11 +86,7 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
             var message = _pipeline.CreateMessage();
             var request = message.Request;
             request.Method = RequestMethod.Post;
-            var uri = new RawRequestUriBuilder();
-            uri.AppendRaw(host, false);
-            uri.AppendRaw("/v2", false);
-            uri.AppendPath("/track", false);
-            request.Uri = uri;
+            request.Uri = GetIngestionUri();
             request.Headers.Add("Content-Type", "application/json");
             request.Headers.Add("Accept", "application/json");
             using var content = new NDJsonWriter();

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/AzureMonitorExporterOptions.cs
@@ -3,10 +3,15 @@
 
 using Azure.Core;
 
+using System.ComponentModel;
+
 namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
 {
     public class AzureMonitorExporterOptions : ClientOptions
     {
         public string ConnectionString { get; set; }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string ApiVersion { get; set; }
     }
 }

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/AzureMonitorTransmitter.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/src/AzureMonitorTransmitter.cs
@@ -28,6 +28,10 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
             options.AddPolicy(new IngestionResponsePolicy(), HttpPipelinePosition.PerCall);
 
             applicationInsightsRestClient = new ApplicationInsightsRestClient(new ClientDiagnostics(options), HttpPipelineBuilder.Build(options), host: ingestionEndpoint);
+            if (!string.IsNullOrWhiteSpace(options.ApiVersion))
+            {
+                applicationInsightsRestClient.ApiVersion = options.ApiVersion;
+            }
         }
 
         public async ValueTask<int> TrackAsync(IEnumerable<TelemetryItem> telemetryItems, bool async, CancellationToken cancellationToken)
@@ -62,5 +66,10 @@ namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
 
             return itemsAccepted;
         }
+
+        /// <summary>
+        /// This method is provided to inspect the Ingestion Uri in unit tests.
+        /// </summary>
+        internal string GetIngestionUri() => this.applicationInsightsRestClient.GetIngestionUri().ToUri().ToString();
     }
 }

--- a/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Tests/ApplicationInsightsRestClientTests.cs
+++ b/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/tests/Microsoft.OpenTelemetry.Exporter.AzureMonitor.Tests/ApplicationInsightsRestClientTests.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.OpenTelemetry.Exporter.AzureMonitor
+{
+    using Xunit;
+
+    public class ApplicationInsightsRestClientTests
+    {
+        [Theory]
+        [InlineData(null)] // default case
+        [InlineData("2")]
+        public void VerifyGetIngestionUri(string version)
+        {
+            var testHost = "https://dc.services.visualstudio.com";
+
+            var options = new AzureMonitorExporterOptions
+            {
+                ConnectionString = $"InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint={testHost}",
+                ApiVersion = version,
+            };
+
+            var transmitter = new AzureMonitorTransmitter(options);
+            var testUri = transmitter.GetIngestionUri();
+
+            Assert.Equal(expected: "https://dc.services.visualstudio.com/v2/track", actual: testUri);
+        }
+    }
+}


### PR DESCRIPTION
Addressing #18081 
- Adds `AzureMonitorExporterOptions.ApiVersion`.
This gives users a way to specify the ingestion api version (default: /v2/track)


