### PR TITLE
Revert "[TestFramework] Downgrade Azure.Identity for maximum compat (#18153)"

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
+++ b/sdk/core/Azure.Core.TestFramework/src/Azure.Core.TestFramework.csproj
@@ -4,11 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-      Test framework should depend on lowest version of Azure.Identity for maximum compatibility, allowing test
-      projects to choose a higher version if desired.
-    -->
-    <PackageReference Include="Azure.Identity" VersionOverride="1.0.0" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />


### PR DESCRIPTION
- Azure.Identity 1.0.0 does not work on sovereign cloud which is required for our functional tests
- Reverting until we can find a better solution for both perf and functional tests
