### PR TITLE
[FR] Add autorest transforms to unblock build

### DIFF
--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/KeyValueElement.Serialization.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.FormRecognizer.Models
     {
         internal static KeyValueElement DeserializeKeyValueElement(JsonElement element)
         {
-            Optional<KeyValueType> type = default;
+            Optional<KeyValueType?> type = default;
             string text = default;
             Optional<IReadOnlyList<float>> boundingBox = default;
             Optional<IReadOnlyList<string>> elements = default;
@@ -25,7 +25,7 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        type = null;
                         continue;
                     }
                     type = new KeyValueType(property.Value.GetString());

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult.Serialization.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/Generated/Models/ReadResult.Serialization.cs
@@ -80,7 +80,7 @@ namespace Azure.AI.FormRecognizer.Models
                 {
                     if (property.Value.ValueKind == JsonValueKind.Null)
                     {
-                        property.ThrowNonNullablePropertyIsNull();
+                        selectionMarks = null;
                         continue;
                     }
                     List<SelectionMark> array = new List<SelectionMark>();

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/src/autorest.md
@@ -35,6 +35,22 @@ directive:
 ``` yaml
 directive:
   from: swagger-document
+  where: $.definitions.ReadResult
+  transform: >
+    $.properties.selectionMarks["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
+  where: $.definitions.KeyValueType
+  transform: >
+    $["x-nullable"] = true;
+```
+
+``` yaml
+directive:
+  from: swagger-document
   where: $.definitions.AnalyzeOperationResult
   transform: >
     $.properties.analyzeResult["x-nullable"] = true;


### PR DESCRIPTION
FR service did a deployment to prod regions that is bringing some values as `null` and causing our [SDK to break in Debug mode](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=719000&view=results).
- `ReadResults.selectionMarks` is always present with value = null if there are no selection marks.
- `KeyValuePairs.Key.type` is always returned with value = null.   Even though the [swagger](https://github.com/Azure/azure-rest-api-specs/blob/97ae1493ff37d947cc26e00a3a5abd096982517b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.1-preview.2/FormRecognizer.json#L1761) is marked as `x-nullable=false`.  This is probably a bug so doing the transform while the service fixes it.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/18451
Issue that tracks undoing this => https://github.com/Azure/azure-sdk-for-net/issues/18422