### PR TITLE
Add support for MSI credential in configuration

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.1.0-beta.2 (Unreleased)
 
+### Added
+
+- The ability to use `ManagedIdentityCredential` from the configuration using the `"credential": "managedidentity"`
 
 ## 1.1.0-beta.1 (2020-11-10)
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Internal/ClientFactory.cs
@@ -85,12 +85,18 @@ namespace Microsoft.Extensions.Azure
 
         internal static TokenCredential CreateCredential(IConfiguration configuration, TokenCredentialOptions identityClientOptions = null)
         {
+            var credentialType = configuration["credential"];
             var clientId = configuration["clientId"];
             var tenantId = configuration["tenantId"];
             var clientSecret = configuration["clientSecret"];
             var certificate = configuration["clientCertificate"];
             var certificateStoreName = configuration["clientCertificateStoreName"];
             var certificateStoreLocation = configuration["clientCertificateStoreLocation"];
+
+            if (string.Equals(credentialType, "managedidentity", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ManagedIdentityCredential(clientId);
+            }
 
             if (!string.IsNullOrWhiteSpace(tenantId) &&
                 !string.IsNullOrWhiteSpace(clientId) &&

--- a/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
+++ b/sdk/extensions/Microsoft.Extensions.Azure/tests/ClientFactoryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Azure.Identity;
 using Microsoft.Extensions.Azure;
@@ -153,6 +154,43 @@ namespace Azure.Core.Extensions.Tests
             Assert.AreEqual("ConfigurationClientId", clientSecretCredential.ClientId);
             Assert.AreEqual("ConfigurationClientSecret", clientSecretCredential.ClientSecret);
             Assert.AreEqual("ConfigurationTenantId", clientSecretCredential.TenantId);
+        }
+
+        [Test]
+        public void CreatesManagedServiceIdentityCredentialsWithClientId()
+        {
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("clientId", "ConfigurationClientId"),
+                new KeyValuePair<string, string>("credential", "managedidentity")
+            );
+
+            var credential = ClientFactory.CreateCredential(configuration);
+
+            Assert.IsInstanceOf<ManagedIdentityCredential>(credential);
+            var managedIdentityCredential = (ManagedIdentityCredential)credential;
+
+            var client = (ManagedIdentityClient)typeof(ManagedIdentityCredential).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(managedIdentityCredential);
+            var clientId = typeof(ManagedIdentityClient).GetProperty("ClientId", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(client);
+
+            Assert.AreEqual("ConfigurationClientId", clientId);
+        }
+
+        [Test]
+        public void CreatesManagedServiceIdentityCredentials()
+        {
+            IConfiguration configuration = GetConfiguration(
+                new KeyValuePair<string, string>("credential", "managedidentity")
+            );
+
+            var credential = ClientFactory.CreateCredential(configuration);
+
+            Assert.IsInstanceOf<ManagedIdentityCredential>(credential);
+            var managedIdentityCredential = (ManagedIdentityCredential)credential;
+
+            var client = (ManagedIdentityClient)typeof(ManagedIdentityCredential).GetField("_client", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(managedIdentityCredential);
+            var clientId = typeof(ManagedIdentityClient).GetProperty("ClientId", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(client);
+
+            Assert.Null(clientId);
         }
 
         [Test]


### PR DESCRIPTION
now you can write

```
"connection": {
	"endpoint": ...,
	"credential": "managedidentity",
	"clientId": "1231232-12312312312-12312312"
}
```

The `clientId` is optional.

cc @mattchenderson