### PR TITLE
[Communication] - Ensure RestClients are created based on ClientOptions.ApiVersion

### DIFF
--- a/sdk/communication/Azure.Communication.Identity/src/CommunicationIdentityClient.cs
+++ b/sdk/communication/Azure.Communication.Identity/src/CommunicationIdentityClient.cs
@@ -20,23 +20,14 @@ namespace Azure.Communication.Identity
         private readonly ClientDiagnostics _clientDiagnostics;
         internal CommunicationIdentityRestClient RestClient { get; }
 
-        /// <summary> Initializes a new instance of <see cref="CommunicationIdentityClient"/>.</summary>
-        /// <param name="endpoint">The URI of the Azure Communication Services resource.</param>
-        /// <param name="keyCredential">The <see cref="AzureKeyCredential"/> used to authenticate requests.</param>
-        /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
-        public CommunicationIdentityClient(Uri endpoint, AzureKeyCredential keyCredential, CommunicationIdentityClientOptions options = default)
-            : this(
-                AssertNotNull(endpoint, nameof(endpoint)),
-                options ?? new CommunicationIdentityClientOptions(),
-                AssertNotNull(keyCredential, nameof(keyCredential)))
-        { }
+        #region public constructors - all argument need null check
 
         /// <summary> Initializes a new instance of <see cref="CommunicationIdentityClient"/>.</summary>
         /// <param name="connectionString">Connection string acquired from the Azure Communication Services resource.</param>
         public CommunicationIdentityClient(string connectionString)
             : this(
-                  new CommunicationIdentityClientOptions(),
-                  ConnectionString.Parse(AssertNotNull(connectionString, nameof(connectionString))))
+                ConnectionString.Parse(AssertNotNullOrEmpty(connectionString, nameof(connectionString))),
+                new CommunicationIdentityClientOptions())
         { }
 
         /// <summary> Initializes a new instance of <see cref="CommunicationIdentityClient"/>.</summary>
@@ -44,8 +35,19 @@ namespace Azure.Communication.Identity
         /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
         public CommunicationIdentityClient(string connectionString, CommunicationIdentityClientOptions options)
             : this(
-                  options ?? new CommunicationIdentityClientOptions(),
-                  ConnectionString.Parse(AssertNotNull(connectionString, nameof(connectionString))))
+                ConnectionString.Parse(AssertNotNullOrEmpty(connectionString, nameof(connectionString))),
+                options ?? new CommunicationIdentityClientOptions())
+        { }
+
+        /// <summary> Initializes a new instance of <see cref="CommunicationIdentityClient"/>.</summary>
+        /// <param name="endpoint">The URI of the Azure Communication Services resource.</param>
+        /// <param name="keyCredential">The <see cref="AzureKeyCredential"/> used to authenticate requests.</param>
+        /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
+        public CommunicationIdentityClient(Uri endpoint, AzureKeyCredential keyCredential, CommunicationIdentityClientOptions options = default)
+            : this(
+                AssertNotNull(endpoint, nameof(endpoint)).AbsoluteUri,
+                AssertNotNull(keyCredential, nameof(keyCredential)),
+                options ?? new CommunicationIdentityClientOptions())
         { }
 
         /// <summary> Initializes a new instance of <see cref="CommunicationIdentityClient"/>.</summary>
@@ -54,43 +56,40 @@ namespace Azure.Communication.Identity
         /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
         public CommunicationIdentityClient(Uri endpoint, TokenCredential tokenCredential, CommunicationIdentityClientOptions options = default)
             : this(
-                AssertNotNull(endpoint, nameof(endpoint)),
-                options ?? new CommunicationIdentityClientOptions(),
-                AssertNotNull(tokenCredential, nameof(tokenCredential)))
+                AssertNotNull(endpoint, nameof(endpoint)).AbsoluteUri,
+                AssertNotNull(tokenCredential, nameof(tokenCredential)),
+                options ?? new CommunicationIdentityClientOptions())
         { }
 
-        private CommunicationIdentityClient(CommunicationIdentityClientOptions options, ConnectionString connectionString)
+        #endregion
+
+        #region private constructors
+
+        private CommunicationIdentityClient(ConnectionString connectionString, CommunicationIdentityClientOptions options)
+            : this(connectionString.GetRequired("endpoint"), options.BuildHttpPipeline(connectionString), options)
+        { }
+
+        private CommunicationIdentityClient(string endpoint, AzureKeyCredential keyCredential, CommunicationIdentityClientOptions options)
+            : this(endpoint, options.BuildHttpPipeline(keyCredential), options)
+        { }
+
+        private CommunicationIdentityClient(string endpoint, TokenCredential tokenCredential, CommunicationIdentityClientOptions options)
+            : this(endpoint, options.BuildHttpPipeline(tokenCredential), options)
+        { }
+
+        private CommunicationIdentityClient(string endpoint, HttpPipeline httpPipeline, CommunicationIdentityClientOptions options)
         {
             _clientDiagnostics = new ClientDiagnostics(options);
-            RestClient = new CommunicationIdentityRestClient(
-                _clientDiagnostics,
-                options.BuildHttpPipeline(connectionString),
-                connectionString.GetRequired("endpoint"));
+            RestClient = new CommunicationIdentityRestClient(_clientDiagnostics, httpPipeline, endpoint, options.ApiVersion);
         }
 
-        private CommunicationIdentityClient(Uri endpoint, CommunicationIdentityClientOptions options, AzureKeyCredential credential)
-        {
-            _clientDiagnostics = new ClientDiagnostics(options);
-            RestClient = new CommunicationIdentityRestClient(
-                _clientDiagnostics,
-                options.BuildHttpPipeline(credential),
-                endpoint.AbsoluteUri);
-        }
-
-        private CommunicationIdentityClient(Uri endpoint, CommunicationIdentityClientOptions options, TokenCredential tokenCredential)
-        {
-            _clientDiagnostics = new ClientDiagnostics(options);
-            RestClient = new CommunicationIdentityRestClient(
-                _clientDiagnostics,
-                options.BuildHttpPipeline(tokenCredential),
-                endpoint.AbsoluteUri);
-        }
+        #endregion
 
         /// <summary>Initializes a new instance of <see cref="CommunicationIdentityClient"/> for mocking.</summary>
         protected CommunicationIdentityClient()
         {
-            _clientDiagnostics = null!;
-            RestClient = null!;
+            _clientDiagnostics = null;
+            RestClient = null;
         }
 
         /// <summary>Creates a new <see cref="CommunicationUserIdentifier"/>.</summary>
@@ -294,6 +293,12 @@ namespace Azure.Communication.Identity
             where T : class
         {
             Argument.AssertNotNull(argument, argumentName);
+            return argument;
+        }
+
+        private static string AssertNotNullOrEmpty(string argument, string argumentName)
+        {
+            Argument.AssertNotNullOrEmpty(argument, argumentName);
             return argument;
         }
     }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/api/Azure.Communication.PhoneNumbers.netstandard2.0.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/api/Azure.Communication.PhoneNumbers.netstandard2.0.cs
@@ -3,7 +3,8 @@ namespace Azure.Communication.PhoneNumbers
     public partial class PhoneNumberAdministrationClient
     {
         protected PhoneNumberAdministrationClient() { }
-        public PhoneNumberAdministrationClient(string connectionString, Azure.Communication.PhoneNumbers.PhoneNumberAdministrationClientOptions? options = null) { }
+        public PhoneNumberAdministrationClient(string connectionString) { }
+        public PhoneNumberAdministrationClient(string connectionString, Azure.Communication.PhoneNumbers.PhoneNumberAdministrationClientOptions options) { }
         public PhoneNumberAdministrationClient(System.Uri endpoint, Azure.AzureKeyCredential keyCredential, Azure.Communication.PhoneNumbers.PhoneNumberAdministrationClientOptions? options = null) { }
         public PhoneNumberAdministrationClient(System.Uri endpoint, Azure.Core.TokenCredential tokenCredential, Azure.Communication.PhoneNumbers.PhoneNumberAdministrationClientOptions? options = null) { }
         public virtual Azure.Response CancelReservation(string reservationId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/communication/Azure.Communication.Sms/src/SmsClient.cs
+++ b/sdk/communication/Azure.Communication.Sms/src/SmsClient.cs
@@ -20,23 +20,14 @@ namespace Azure.Communication.Sms
         private readonly ClientDiagnostics _clientDiagnostics;
         internal SmsRestClient RestClient { get; }
 
-        /// <summary> Initializes a new instance of <see cref="SmsClient"/>.</summary>
-        /// <param name="endpoint">The URI of the Azure Communication Services resource.</param>
-        /// <param name="keyCredential">The <see cref="AzureKeyCredential"/> used to authenticate requests.</param>
-        /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
-        public SmsClient(Uri endpoint, AzureKeyCredential keyCredential, SmsClientOptions options = default)
-            : this(
-                AssertNotNull(endpoint, nameof(endpoint)),
-                options ?? new SmsClientOptions(),
-                AssertNotNull(keyCredential, nameof(keyCredential)))
-        { }
+        #region public constructors - all arguments need null check
 
         /// <summary> Initializes a new instance of <see cref="SmsClient"/>.</summary>
         /// <param name="connectionString">Connection string acquired from the Azure Communication Services resource.</param>
         public SmsClient(string connectionString)
             : this(
-                  new SmsClientOptions(),
-                  ConnectionString.Parse(AssertNotNullOrEmpty(connectionString, nameof(connectionString))))
+                ConnectionString.Parse(AssertNotNullOrEmpty(connectionString, nameof(connectionString))),
+                new SmsClientOptions())
         { }
 
         /// <summary> Initializes a new instance of <see cref="SmsClient"/>.</summary>
@@ -44,8 +35,19 @@ namespace Azure.Communication.Sms
         /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
         public SmsClient(string connectionString, SmsClientOptions options)
             : this(
-                  options ?? new SmsClientOptions(),
-                  ConnectionString.Parse(AssertNotNullOrEmpty(connectionString, nameof(connectionString))))
+                ConnectionString.Parse(AssertNotNullOrEmpty(connectionString, nameof(connectionString))),
+                options ?? new SmsClientOptions())
+        { }
+
+        /// <summary> Initializes a new instance of <see cref="SmsClient"/>.</summary>
+        /// <param name="endpoint">The URI of the Azure Communication Services resource.</param>
+        /// <param name="keyCredential">The <see cref="AzureKeyCredential"/> used to authenticate requests.</param>
+        /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
+        public SmsClient(Uri endpoint, AzureKeyCredential keyCredential, SmsClientOptions options = default)
+            : this(
+                AssertNotNull(endpoint, nameof(endpoint)).AbsoluteUri,
+                AssertNotNull(keyCredential, nameof(keyCredential)),
+                options ?? new SmsClientOptions())
         { }
 
         /// <summary> Initializes a new instance of <see cref="SmsClient"/>.</summary>
@@ -54,50 +56,40 @@ namespace Azure.Communication.Sms
         /// <param name="options">Client option exposing <see cref="ClientOptions.Diagnostics"/>, <see cref="ClientOptions.Retry"/>, <see cref="ClientOptions.Transport"/>, etc.</param>
         public SmsClient(Uri endpoint, TokenCredential tokenCredential, SmsClientOptions options = default)
             : this(
-                  endpoint,
-                  options ?? new SmsClientOptions(),
-                  tokenCredential)
+                AssertNotNull(endpoint, nameof(endpoint)).AbsoluteUri,
+                AssertNotNull(tokenCredential, nameof(tokenCredential)),
+                options ?? new SmsClientOptions())
         { }
+
+        #endregion
+
+        #region private constructors
+
+        private SmsClient(ConnectionString connectionString, SmsClientOptions options)
+            : this(connectionString.GetRequired("endpoint"), options.BuildHttpPipeline(connectionString), options)
+        { }
+
+        private SmsClient(string endpoint, TokenCredential tokenCredential, SmsClientOptions options)
+            : this(endpoint, options.BuildHttpPipeline(tokenCredential), options)
+        { }
+
+        private SmsClient(string endpoint, AzureKeyCredential keyCredential, SmsClientOptions options)
+            : this(endpoint, options.BuildHttpPipeline(keyCredential), options)
+        { }
+
+        private SmsClient(string endpoint, HttpPipeline httpPipeline, SmsClientOptions options)
+        {
+            _clientDiagnostics = new ClientDiagnostics(options);
+            RestClient = new SmsRestClient(_clientDiagnostics, httpPipeline, endpoint, options.ApiVersion);
+        }
+
+        #endregion
 
         /// <summary>Initializes a new instance of <see cref="SmsClient"/> for mocking.</summary>
         protected SmsClient()
         {
-            _clientDiagnostics = null!;
-            RestClient = null!;
-        }
-
-        private SmsClient(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, string endpointUrl)
-        {
-            RestClient = new SmsRestClient(clientDiagnostics, pipeline, endpointUrl);
-            _clientDiagnostics = clientDiagnostics;
-        }
-
-        private SmsClient(SmsClientOptions options, ConnectionString connectionString)
-            : this(
-                  clientDiagnostics: new ClientDiagnostics(options),
-                  pipeline: options.BuildHttpPipeline(connectionString),
-                  endpointUrl: connectionString.GetRequired("endpoint"))
-        { }
-
-        private SmsClient(Uri endpoint, SmsClientOptions options, TokenCredential tokenCredential)
-        {
-            Argument.AssertNotNull(endpoint, nameof(endpoint));
-            Argument.AssertNotNull(tokenCredential, nameof(tokenCredential));
-
-            _clientDiagnostics = new ClientDiagnostics(options);
-            RestClient = new SmsRestClient(
-                _clientDiagnostics,
-                options.BuildHttpPipeline(tokenCredential),
-                endpoint.AbsoluteUri);
-        }
-
-        private SmsClient(Uri endpoint, SmsClientOptions options, AzureKeyCredential credential)
-        {
-            _clientDiagnostics = new ClientDiagnostics(options);
-            RestClient = new SmsRestClient(
-                _clientDiagnostics,
-                options.BuildHttpPipeline(credential),
-                endpoint.AbsoluteUri);
+            _clientDiagnostics = null;
+            RestClient = null;
         }
 
         /// <summary>


### PR DESCRIPTION
Now we have four sets of constructors:
1. Public constructors:
```csharp
public FooClient(string connectionString) { }
public FooClient(string connectionString, FooClientOptions options) { }
public FooClient(Uri endpoint, AzureKeyCredential keyCredential, FooClientOptions options = null) { }
public FooClient(Uri endpoint, TokenCredential tokenCredential, FooClientOptions options = null) { }
```
These constructor need to do null check for input arguments and instantiate `options` if not provided/`null`. They trigger the corresponding constructor of the set below ⬇.

2. Private constructors that create `HttpPipeline`
```csharp
private FooClient(ConnectionString connectionString, FooClientOptions options) {}
private FooClient(string endpoint, AzureKeyCredential keyCredential, FooClientOptions options) {}
private FooClient(string endpoint, TokenCredential tokenCredential, FooClientOptions options) {}
```
These constructors do not need null check as the check has already happened in the public constructors. They create `HttpPipleine`s based on their method of authentication and trigger the ⬇ constructor

3. Private constructor that create the RestClient
```csharp
private FooClient(string endpoint, HttpPipeline httpPipeline, FooClientOptions options) { }
```
4. Protected constructor for Mocking purposes
```csharp
protected FooClient() { }
```
