### PR TITLE
ADT: Remove <inheritdoc> from customized models to fix project warnings

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateModelsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateModelsOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsAddOptions")]
     internal partial class CreateModelsOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceDigitalTwinOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsAddOptions")]
     internal partial class CreateOrReplaceDigitalTwinOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceEventRouteOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("EventRoutesAddOptions")]
     internal partial class CreateOrReplaceEventRouteOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/CreateOrReplaceRelationshipOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsAddRelationshipOptions")]
     internal partial class CreateOrReplaceRelationshipOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DecommissionModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DecommissionModelOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsUpdateOptions")]
     internal partial class DecommissionModelOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteDigitalTwinOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsDeleteOptions")]
     internal partial class DeleteDigitalTwinOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteEventRouteOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("EventRoutesDeleteOptions")]
     internal partial class DeleteEventRouteOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteModelOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsDeleteOptions")]
     internal partial class DeleteModelOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DeleteRelationshipOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsDeleteRelationshipOptions")]
     internal partial class DeleteRelationshipOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsEventRoute.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsEventRoute.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("EventRoute")]
     public partial class DigitalTwinsEventRoute
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/DigitalTwinsModelData.cs
@@ -7,7 +7,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsModelData")]
     public partial class DigitalTwinsModelData
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetComponentOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetComponentOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsGetComponentOptions")]
     internal partial class GetComponentOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsGetByIdOptions")]
     internal partial class GetDigitalTwinOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRouteOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRouteOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("EventRoutesGetByIdOptions")]
     internal partial class GetDigitalTwinsEventRouteOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetDigitalTwinsEventRoutesOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("EventRoutesListOptions")]
     internal partial class GetDigitalTwinsEventRoutesOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetIncomingRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetIncomingRelationshipsOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsListIncomingRelationshipsOptions")]
     internal partial class GetIncomingRelationshipsOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetModelOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinModelsGetByIdOptions")]
     internal partial class GetModelOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsGetRelationshipByIdOptions")]
     internal partial class GetRelationshipOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipsOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/GetRelationshipsOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsListRelationshipsOptions")]
     internal partial class GetRelationshipsOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/IncomingRelationship.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/IncomingRelationship.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("IncomingRelationship")]
     public partial class IncomingRelationship
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishComponentTelemetryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishComponentTelemetryOptions.cs
@@ -6,7 +6,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsSendComponentTelemetryOptions")]
     internal partial class PublishComponentTelemetryOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishTelemetryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/PublishTelemetryOptions.cs
@@ -6,7 +6,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsSendTelemetryOptions")]
     internal partial class PublishTelemetryOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/QueryOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/QueryOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("QueryTwinsOptions")]
     internal partial class QueryOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateComponentOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateComponentOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsUpdateComponentOptions")]
     internal partial class UpdateComponentOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateDigitalTwinOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateDigitalTwinOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsUpdateOptions")]
     internal partial class UpdateDigitalTwinOptions
     {

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateRelationshipOptions.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Customized/Models/UpdateRelationshipOptions.cs
@@ -5,7 +5,6 @@ using Azure.Core;
 
 namespace Azure.DigitalTwins.Core
 {
-    /// <inheritdoc />
     [CodeGenModel("DigitalTwinsUpdateRelationshipOptions")]
     internal partial class UpdateRelationshipOptions
     {


### PR DESCRIPTION
We have many <inheritdoc> attributes on customized code where there is no inheritance and no docs to inherit. 
This will bring project warnings to 0. 