### PR TITLE
[Service Bus Client] Doc Comment Reformatting Test

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Primitives/ServiceBusMessage.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.ServiceBus
         /// Creates a new message from the specified <see cref="BinaryData"/> instance.
         /// </summary>
         /// <param name="body">The payload of the message.</param>
-        public ServiceBusMessage(BinaryData body) : this (body?.ToMemory() ?? default)
+        public ServiceBusMessage(BinaryData body) : this(body?.ToMemory() ?? default)
         {
         }
 
@@ -148,12 +148,12 @@ namespace Azure.Messaging.ServiceBus
         /// Gets or sets the MessageId to identify the message.
         /// </summary>
         /// <remarks>
-        ///    The message identifier is an application-defined value that uniquely identifies the
-        ///    message and its payload. The identifier is a free-form string and can reflect a GUID
-        ///    or an identifier derived from the application context. If enabled, the
-        ///    <see href="https://docs.microsoft.com/azure/service-bus-messaging/duplicate-detection">duplicate detection</see>
-        ///    feature identifies and removes second and further submissions of messages with the
-        ///    same MessageId.
+        /// The message identifier is an application-defined value that uniquely identifies the
+        /// message and its payload. The identifier is a free-form string and can reflect a GUID
+        /// or an identifier derived from the application context. If enabled, the
+        /// <see href="https://docs.microsoft.com/azure/service-bus-messaging/duplicate-detection">duplicate detection</see>
+        /// feature identifies and removes second and further submissions of messages with the
+        /// same MessageId.
         /// </remarks>
         public string MessageId
         {
@@ -170,10 +170,10 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets a partition key for sending a message to a partitioned entity.</summary>
         /// <value>The partition key. Maximum length is 128 characters.</value>
         /// <remarks>
-        ///    For <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning">partitioned entities</see>,
-        ///    setting this value enables assigning related messages to the same internal partition, so that submission sequence
-        ///    order is correctly recorded. The partition is chosen by a hash function over this value and cannot be chosen
-        ///    directly. For session-aware entities, the <see cref="SessionId"/> property overrides this value.
+        /// For <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning">partitioned entities</see>,
+        /// setting this value enables assigning related messages to the same internal partition, so that submission sequence
+        /// order is correctly recorded. The partition is chosen by a hash function over this value and cannot be chosen
+        /// directly. For session-aware entities, the <see cref="SessionId"/> property overrides this value.
         /// </remarks>
         public string PartitionKey
         {
@@ -195,10 +195,10 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets a partition key for sending a message into an entity via a partitioned transfer queue.</summary>
         /// <value>The partition key. Maximum length is 128 characters. </value>
         /// <remarks>
-        ///    If a message is sent via a transfer queue in the scope of a transaction, this value selects the
-        ///    transfer queue partition: This is functionally equivalent to <see cref="PartitionKey"/> and ensures that
-        ///    messages are kept together and in order as they are transferred.
-        ///    See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-transactions#transfers-and-send-via">Transfers and Send Via</see>.
+        /// If a message is sent via a transfer queue in the scope of a transaction, this value selects the
+        /// transfer queue partition: This is functionally equivalent to <see cref="PartitionKey"/> and ensures that
+        /// messages are kept together and in order as they are transferred.
+        /// See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-transactions#transfers-and-send-via">Transfers and Send Via</see>.
         /// </remarks>
         internal string TransactionPartitionKey
         {
@@ -216,11 +216,11 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets the session identifier for a session-aware entity.</summary>
         /// <value>The session identifier. Maximum length is 128 characters.</value>
         /// <remarks>
-        ///    For session-aware entities, this application-defined value specifies the session
-        ///    affiliation of the message. Messages with the same session identifier are subject
-        ///    to summary locking and enable exact in-order processing and demultiplexing.
-        ///    For session-unaware entities, this value is ignored.
-        ///    See <see href="https://docs.microsoft.com/azure/service-bus-messaging/message-sessions">Message Sessions</see>.
+        /// For session-aware entities, this application-defined value specifies the session
+        /// affiliation of the message. Messages with the same session identifier are subject
+        /// to summary locking and enable exact in-order processing and demultiplexing.
+        /// For session-unaware entities, this value is ignored.
+        /// See <see href="https://docs.microsoft.com/azure/service-bus-messaging/message-sessions">Message Sessions</see>.
         /// </remarks>
         public string SessionId
         {
@@ -240,9 +240,9 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets a session identifier augmenting the <see cref="ReplyTo"/> address.</summary>
         /// <value>Session identifier. Maximum length is 128 characters.</value>
         /// <remarks>
-        ///    This value augments the ReplyTo information and specifies which SessionId should be set
-        ///    for the reply when sent to the reply entity.
-        ///    See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation">Message Routing and Correlation</see>
+        /// This value augments the ReplyTo information and specifies which SessionId should be set
+        /// for the reply when sent to the reply entity.
+        /// See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation">Message Routing and Correlation</see>
         /// </remarks>
         public string ReplyToSessionId
         {
@@ -260,11 +260,11 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <value>The message’s time to live value.</value>
         /// <remarks>
-        ///     This value is the relative duration after which the message expires.
-        ///      When not set explicitly, the assumed value is the DefaultTimeToLive for the respective queue or topic.
-        ///      A message-level <see cref="TimeToLive"/> value cannot be longer than the entity's DefaultTimeToLive
-        ///      setting and it is silently adjusted if it does.
-        ///      See <see href="https://docs.microsoft.com/azure/service-bus-messaging/message-expiration">Expiration</see>.
+        /// This value is the relative duration after which the message expires.
+        /// When not set explicitly, the assumed value is the DefaultTimeToLive for the respective queue or topic.
+        /// A message-level <see cref="TimeToLive"/> value cannot be longer than the entity's DefaultTimeToLive
+        /// setting and it is silently adjusted if it does.
+        /// See <see href="https://docs.microsoft.com/azure/service-bus-messaging/message-expiration">Expiration</see>.
         /// </remarks>
         public TimeSpan TimeToLive
         {
@@ -282,9 +282,9 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets the a correlation identifier.</summary>
         /// <value>Correlation identifier.</value>
         /// <remarks>
-        ///    Allows an application to specify a context for the message for the purposes of correlation,
-        ///    for example reflecting the MessageId of a message that is being replied to.
-        ///    See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation">Message Routing and Correlation</see>.
+        /// Allows an application to specify a context for the message for the purposes of correlation,
+        /// for example reflecting the MessageId of a message that is being replied to.
+        /// See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation">Message Routing and Correlation</see>.
         /// </remarks>
         public string CorrelationId
         {
@@ -301,8 +301,8 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets an application specific subject.</summary>
         /// <value>The application specific subject.</value>
         /// <remarks>
-        ///   This property enables the application to indicate the purpose of the message to the receiver in a standardized
-        ///   fashion, similar to an email subject line. The mapped AMQP property is "subject".
+        /// This property enables the application to indicate the purpose of the message to the receiver in a standardized
+        /// fashion, similar to an email subject line. The mapped AMQP property is "subject".
         /// </remarks>
         public string Subject
         {
@@ -319,10 +319,10 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets the "to" address.</summary>
         /// <value>The "to" address.</value>
         /// <remarks>
-        ///    This property is reserved for future use in routing scenarios and presently ignored by the broker itself.
-        ///     Applications can use this value in rule-driven
-        ///     <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-auto-forwarding">auto-forward chaining</see> scenarios to indicate the
-        ///     intended logical destination of the message.
+        /// This property is reserved for future use in routing scenarios and presently ignored by the broker itself.
+        /// Applications can use this value in rule-driven
+        /// <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-auto-forwarding">auto-forward chaining</see> scenarios to indicate the
+        /// intended logical destination of the message.
         /// </remarks>
         public string To
         {
@@ -339,8 +339,8 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets the content type descriptor.</summary>
         /// <value>RFC2045 Content-Type descriptor.</value>
         /// <remarks>
-        ///   Optionally describes the payload of the message, with a descriptor following the format of
-        ///   RFC2045, Section 5, for example "application/json".
+        /// Optionally describes the payload of the message, with a descriptor following the format of
+        /// RFC2045, Section 5, for example "application/json".
         /// </remarks>
         public string ContentType
         {
@@ -357,10 +357,10 @@ namespace Azure.Messaging.ServiceBus
         /// <summary>Gets or sets the address of an entity to send replies to.</summary>
         /// <value>The reply entity address.</value>
         /// <remarks>
-        ///    This optional and application-defined value is a standard way to express a reply path
-        ///    to the receiver of the message. When a sender expects a reply, it sets the value to the
-        ///    absolute or relative path of the queue or topic it expects the reply to be sent to.
-        ///    See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation">Message Routing and Correlation</see>.
+        /// This optional and application-defined value is a standard way to express a reply path
+        /// to the receiver of the message. When a sender expects a reply, it sets the value to the
+        /// absolute or relative path of the queue or topic it expects the reply to be sent to.
+        /// See <see href="https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation">Message Routing and Correlation</see>.
         /// </remarks>
         public string ReplyTo
         {
@@ -375,16 +375,16 @@ namespace Azure.Messaging.ServiceBus
         }
 
         /// <summary>
-        ///   Gets or sets the date and time in UTC at which the message will be enqueued. This
-        ///   property returns the time in UTC; when setting the property, the supplied DateTime value must also be in UTC.
+        /// Gets or sets the date and time in UTC at which the message will be enqueued. This
+        /// property returns the time in UTC; when setting the property, the supplied DateTime value must also be in UTC.
         /// </summary>
         /// <value>
-        ///   The scheduled enqueue time in UTC. This value is for delayed message sending.
-        ///   It is utilized to delay messages sending to a specific time in the future.
+        /// The scheduled enqueue time in UTC. This value is for delayed message sending.
+        /// It is utilized to delay messages sending to a specific time in the future.
         /// </value>
         /// <remarks>
-        ///   Message enqueuing time does not mean that the message will be sent at the same time. It will get enqueued, but the actual sending time
-        ///   depends on the queue's workload and its state.
+        /// Message enqueuing time does not mean that the message will be sent at the same time. It will get enqueued, but the actual sending time
+        /// depends on the queue's workload and its state.
         /// </remarks>
         public DateTimeOffset ScheduledEnqueueTime
         {


### PR DESCRIPTION
# Summary

The focus of these changes is to reformat the doc comments in a file that has been rendering incorrectly for the MS Docs site to test the theory that the indentation of the XML is influencing MS Docs formatting.