### PR TITLE
Add sovereign cloud opt-in to tests weekly

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -5,6 +5,9 @@ parameters:
 - name: Clouds
   type: string
   default: 'Public'
+- name: SupportedClouds
+  type: string
+  default: 'Public,Canary'
 - name: UnsupportedClouds
   type: string
   default: ''
@@ -93,7 +96,7 @@ stages:
   # TODO: re-enable tests-weekly allow filter once sovereign cloud live tests are stable: https://github.com/Azure/azure-sdk/issues/2074
   # Run all clouds by default for weekly test pipeline, except for clouds specifically unsupported by the calling pipeline
   # - ${{ if or(contains(parameters.Clouds, cloud.key), contains(variables['Build.DefinitionName'], 'tests-weekly')) }}:
-  - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'tests-weekly'), eq(cloud.key, 'Canary'))) }}:
+  - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'tests-weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
     - ${{ if not(contains(parameters.UnsupportedClouds, cloud.key)) }}:
       - stage: ${{ cloud.key }}
         dependsOn: []

--- a/sdk/extensions/tests.yml
+++ b/sdk/extensions/tests.yml
@@ -4,4 +4,4 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: extensions
-    Clouds: 'Public,Preview,UsGov,China'
+    SupportedClouds: 'Public,Canary,UsGov,China'

--- a/sdk/search/tests.yml
+++ b/sdk/search/tests.yml
@@ -6,7 +6,7 @@ extends:
     ServiceDirectory: search
     TimeoutInMinutes: 240
     MaxParallel: 2
-    UnsupportedClouds: Canary
-    Clouds: 'Public,Preview,UsGov,China'
+    UnsupportedClouds: 'Canary'
+    SupportedClouds: 'Public,UsGov,China'
     EnvVars:
       AZURE_SEARCH_TEST_MODE: Live


### PR DESCRIPTION
Currently the tests-weekly pipelines, which are eventually meant for running sovereign cloud tests, exclude sovereign clouds on an opt-out basis. This adds support for opt-in, as we add support one by one for services.

This also opts in extensions and search, which will be working for sovereign clouds after https://github.com/Azure/azure-sdk-for-net/pull/18162 goes in.