### PR TITLE
Print assembly informational version

### DIFF
--- a/common/Perf/Azure.Test.Perf/PerfProgram.cs
+++ b/common/Perf/Azure.Test.Perf/PerfProgram.cs
@@ -74,7 +74,8 @@ namespace Azure.Test.Perf
                 .OrderBy(a => a.Name);
             foreach (var a in azureAssemblies)
             {
-                Console.WriteLine($"{a.Name}: {a.Version}");
+                var informationalVersion = FileVersionInfo.GetVersionInfo(Assembly.Load(a).Location).ProductVersion;
+                Console.WriteLine($"{a.Name}: {a.Version} ({informationalVersion})");
             }
             Console.WriteLine();
 


### PR DESCRIPTION
Before:
```
=== Versions ===
Runtime: 4.0.30319.42000
Azure.Core: 1.9.0.0
Azure.Core.TestFramework: 1.0.0.0
Azure.Storage.Blobs: 12.9.0.0
Azure.Storage.Common: 12.8.0.0
```

After:
```
=== Versions ===
Runtime: 4.0.30319.42000
Azure.Core: 1.9.0.0 (1.9.0-alpha.20210204.1+c1fa3d1db439f20c2fae95f2cf0830584c80be1f)
Azure.Core.TestFramework: 1.0.0.0 (1.0.0-alpha.20210205.1+773dc1be340faf5a07bde2bcdd7282b328b00a06)
Azure.Storage.Blobs: 12.9.0.0 (12.9.0-alpha.20210204.1+3861b9d4ef376d74512c700f30892bc1d48e2b43)
Azure.Storage.Common: 12.8.0.0 (12.8.0-alpha.20210204.1+3861b9d4ef376d74512c700f30892bc1d48e2b43)
```