### PR TITLE
[MetricsAdvisor] Removed setters from collections

### DIFF
--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/CHANGELOG.md
@@ -28,6 +28,9 @@
 - In `DataFeedRollupSettings`, removed the setter of the property `AutoRollupGroupByColumnNames`.
 - In `AnomalyDetectionConfiguration`, removed the setters of the properties `SeriesDetectionConditions` and `SeriesGroupDetectionConditions`.
 - In `WebNotificationHook`, removed the setter of the property `Headers`.
+- In `GetAnomaliesForDetectionConfigurationFilter`, removed the setter of the property `SeriesGroupKeys`. Keys can be added directly to the property.
+- In `GetMetricSeriesDefinitionsOptions`, removed the setter of the property `DimensionCombinationsToFilter`. Keys combinations can be added directly to the property.
+- In `GetValuesOfDimensionWithAnomaliesOptions`, removed the setter of the property `DimensionToFilter`. Dimension columns can be added directly to the property.
 - `DataFeed.SourceType` is now nullable. It will be null whenever `DataFeed.DataSource` is null.
 - `DataFeed.IngestionStartTime` is now nullable.
 - `MetricsAdvisorAdministrationClient.CreateDataFeed` sync and async methods now throw an `ArgumentException` if required properties are not set properly.
@@ -35,6 +38,8 @@
 - `MetricsAdvisorAdministrationClient.CreateAlertConfiguration` sync and async methods now throw an `ArgumentException` if required properties are not set properly.
 - In `MetricsAdvisorKeyCredential`, renamed the parameter `key` to `subscriptionKey` in the method `UpdateSubscriptionKey`.
 - In `MetricsAdvisorKeyCredential`, renamed the parameter `key` to `apiKey` in the method `UpdateApiKey`.
+- In `GetMetricSeriesDataOptions`, removed the parameter `seriesToFilter` from the constructor. Keys can be added directly to `SeriesToFilter`.
+- In `FeedbackDimensionFilter`, removed the parameter `dimensionFilter` from the constructor. Dimension columns can be added directly to `DimensionFilter`.
 
 ### Key Bug Fixes
 - Fixed a bug in which setting `WebNotificationHook.CertificatePassword` would actually set the property `Username` instead.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/api/Azure.AI.MetricsAdvisor.netstandard2.0.cs
@@ -69,7 +69,7 @@ namespace Azure.AI.MetricsAdvisor
         public GetAnomaliesForDetectionConfigurationFilter(Azure.AI.MetricsAdvisor.Models.AnomalySeverity minimumSeverity, Azure.AI.MetricsAdvisor.Models.AnomalySeverity maximumSeverity) { }
         public Azure.AI.MetricsAdvisor.Models.AnomalySeverity? MaximumSeverity { get { throw null; } }
         public Azure.AI.MetricsAdvisor.Models.AnomalySeverity? MinimumSeverity { get { throw null; } }
-        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesGroupKeys { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesGroupKeys { get { throw null; } }
     }
     public partial class GetAnomaliesForDetectionConfigurationOptions
     {
@@ -142,23 +142,23 @@ namespace Azure.AI.MetricsAdvisor
     }
     public partial class GetMetricSeriesDataOptions
     {
-        public GetMetricSeriesDataOptions(System.Collections.Generic.IEnumerable<Azure.AI.MetricsAdvisor.Models.DimensionKey> seriesToFilter, System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
+        public GetMetricSeriesDataOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
         public System.DateTimeOffset EndTime { get { throw null; } }
-        public System.Collections.Generic.IEnumerable<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesToFilter { get { throw null; } }
+        public System.Collections.Generic.ICollection<Azure.AI.MetricsAdvisor.Models.DimensionKey> SeriesToFilter { get { throw null; } }
         public System.DateTimeOffset StartTime { get { throw null; } }
     }
     public partial class GetMetricSeriesDefinitionsOptions
     {
         public GetMetricSeriesDefinitionsOptions(System.DateTimeOffset activeSince) { }
         public System.DateTimeOffset ActiveSince { get { throw null; } }
-        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>> DimensionCombinationsToFilter { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<string>> DimensionCombinationsToFilter { get { throw null; } }
         public int? SkipCount { get { throw null; } set { } }
         public int? TopCount { get { throw null; } set { } }
     }
     public partial class GetValuesOfDimensionWithAnomaliesOptions
     {
         public GetValuesOfDimensionWithAnomaliesOptions(System.DateTimeOffset startTime, System.DateTimeOffset endTime) { }
-        public Azure.AI.MetricsAdvisor.Models.DimensionKey DimensionToFilter { get { throw null; } set { } }
+        public Azure.AI.MetricsAdvisor.Models.DimensionKey DimensionToFilter { get { throw null; } }
         public System.DateTimeOffset EndTime { get { throw null; } }
         public int? SkipCount { get { throw null; } set { } }
         public System.DateTimeOffset StartTime { get { throw null; } }
@@ -811,7 +811,7 @@ namespace Azure.AI.MetricsAdvisor.Models
     }
     public partial class FeedbackDimensionFilter
     {
-        public FeedbackDimensionFilter(Azure.AI.MetricsAdvisor.Models.DimensionKey dimensionFilter) { }
+        public FeedbackDimensionFilter() { }
         public Azure.AI.MetricsAdvisor.Models.DimensionKey DimensionFilter { get { throw null; } }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomaliesForDetectionConfigurationFilter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetAnomaliesForDetectionConfigurationFilter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using Azure.AI.MetricsAdvisor.Models;
@@ -15,8 +14,6 @@ namespace Azure.AI.MetricsAdvisor
     /// </summary>
     public class GetAnomaliesForDetectionConfigurationFilter
     {
-        private IList<DimensionKey> _seriesGroupKeys;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GetAnomaliesForDetectionConfigurationFilter"/> class.
         /// </summary>
@@ -41,18 +38,7 @@ namespace Azure.AI.MetricsAdvisor
         /// Filters the result by series. Only anomalies detected in the time series groups specified will
         /// be returned.
         /// </summary>
-        /// <exception cref="ArgumentNullException">The value assigned to <see cref="SeriesGroupKeys"/> is null.</exception>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public IList<DimensionKey> SeriesGroupKeys
-        {
-            get => _seriesGroupKeys;
-            set
-            {
-                Argument.AssertNotNull(value, nameof(SeriesGroupKeys));
-                _seriesGroupKeys = value;
-            }
-        }
-#pragma warning restore CA2227 // Collection properties should be readonly
+        public IList<DimensionKey> SeriesGroupKeys { get; }
 
         /// <summary>
         /// The minimum severity level an anomaly must have to be returned.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDataOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDataOptions.cs
@@ -17,14 +17,11 @@ namespace Azure.AI.MetricsAdvisor
         /// <summary>
         /// Initializes a new instance of the <see cref="GetMetricSeriesDataOptions"/> class.
         /// </summary>
-        /// <param name="seriesToFilter">Only time series with the specified series keys will be returned. These keys uniquely identify a time series within a metric. Every dimension contained in the associated <see cref="DataFeed"/> must be assigned a value.</param>
         /// <param name="startTime">Filters the result. Only data points ingested from this point in time, in UTC, will be returned.</param>
         /// <param name="endTime">Filters the result. Only data points ingested up to this point in time, in UTC, will be returned.</param>
-        public GetMetricSeriesDataOptions(IEnumerable<DimensionKey> seriesToFilter, DateTimeOffset startTime, DateTimeOffset endTime)
+        public GetMetricSeriesDataOptions(DateTimeOffset startTime, DateTimeOffset endTime)
         {
-            Argument.AssertNotNull(seriesToFilter, nameof(seriesToFilter));
-
-            SeriesToFilter = seriesToFilter;
+            SeriesToFilter = new ChangeTrackingList<DimensionKey>();
             StartTime = startTime;
             EndTime = endTime;
         }
@@ -34,7 +31,7 @@ namespace Azure.AI.MetricsAdvisor
         /// a time series within a metric. Every dimension contained in the associated <see cref="DataFeed"/>
         /// must be assigned a value.
         /// </summary>
-        public IEnumerable<DimensionKey> SeriesToFilter { get; }
+        public ICollection<DimensionKey> SeriesToFilter { get; }
 
         /// <summary>
         /// Filters the result. Only data points ingested from this point in time, in UTC, will be returned.

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDefinitionsOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetMetricSeriesDefinitionsOptions.cs
@@ -13,8 +13,6 @@ namespace Azure.AI.MetricsAdvisor
     /// </summary>
     public class GetMetricSeriesDefinitionsOptions
     {
-        private IDictionary<string, IList<string>> _dimensionCombinationsToFilter;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GetMetricSeriesDefinitionsOptions"/> class.
         /// </summary>
@@ -34,17 +32,7 @@ namespace Azure.AI.MetricsAdvisor
         /// Filters the result, mapping a dimension's name to a list of possible values it can assume. Only time series
         /// with the specified dimension values will be returned.
         /// </summary>
-#pragma warning disable CA2227 // Collection properties should be readonly
-        public IDictionary<string, IList<string>> DimensionCombinationsToFilter
-        {
-            get => _dimensionCombinationsToFilter;
-            set
-            {
-                Argument.AssertNotNull(value, nameof(DimensionCombinationsToFilter));
-                _dimensionCombinationsToFilter = value;
-            }
-        }
-#pragma warning restore CA2227 // Collection properties should be readonly
+        public IDictionary<string, IList<string>> DimensionCombinationsToFilter { get; }
 
         /// <summary>
         /// If set, skips the first set of items returned. This property specifies the amount of items to

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetValuesOfDimensionWithAnomaliesOptions.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/GetValuesOfDimensionWithAnomaliesOptions.cs
@@ -21,6 +21,7 @@ namespace Azure.AI.MetricsAdvisor
         {
             StartTime = startTime;
             EndTime = endTime;
+            DimensionToFilter = new DimensionKey();
         }
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace Azure.AI.MetricsAdvisor
         /// Filters the result by series. Only anomalies detected in the time series group specified will
         /// be returned.
         /// </summary>
-        public DimensionKey DimensionToFilter { get; set; }
+        public DimensionKey DimensionToFilter { get; }
 
         /// <summary>
         /// If set, skips the first set of items returned. This property specifies the amount of items to

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/FeedbackDimensionFilter.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/src/Models/MetricFeedback/FeedbackDimensionFilter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Azure.Core;
 
 namespace Azure.AI.MetricsAdvisor.Models
 {
@@ -15,13 +14,9 @@ namespace Azure.AI.MetricsAdvisor.Models
         /// <summary>
         /// Initializes a new instance of the <see cref="FeedbackDimensionFilter"/> class.
         /// </summary>
-        /// <param name="dimensionFilter">Filters the result by series. Only feedbacks for the series in the time series group specified will be returned.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="dimensionFilter"/> is null.</exception>
-        public FeedbackDimensionFilter(DimensionKey dimensionFilter)
+        public FeedbackDimensionFilter()
         {
-            Argument.AssertNotNull(dimensionFilter, nameof(dimensionFilter));
-
-            DimensionFilter = dimensionFilter;
+            DimensionFilter = new DimensionKey();
         }
 
         /// <summary> Initializes a new instance of FeedbackDimensionFilter. </summary>

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/AnomalyDetectionLiveTests.cs
@@ -324,10 +324,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var options = new GetValuesOfDimensionWithAnomaliesOptions(SamplingStartTime, SamplingEndTime)
-            {
-                DimensionToFilter = new DimensionKey()
-            };
+            var options = new GetValuesOfDimensionWithAnomaliesOptions(SamplingStartTime, SamplingEndTime);
 
             options.DimensionToFilter.AddDimensionColumn("category", "Handmade");
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackLiveTests.cs
@@ -12,6 +12,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
 {
     public class MetricFeedbackLiveTests : MetricsAdvisorLiveTestBase
     {
+        private const string ExpectedCity = "Delhi";
+
+        private const string ExpectedCategory = "Handmade";
+
         public MetricFeedbackLiveTests(bool isAsync) : base(isAsync)
         {
         }
@@ -27,11 +31,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient(useTokenCredential);
 
-            var dimensionKey = new DimensionKey();
-            dimensionKey.AddDimensionColumn("city", "Delhi");
-            dimensionKey.AddDimensionColumn("category", "Handmade");
+            var filter = new FeedbackDimensionFilter();
 
-            var filter = new FeedbackDimensionFilter(dimensionKey);
+            filter.DimensionFilter.AddDimensionColumn("city", ExpectedCity);
+            filter.DimensionFilter.AddDimensionColumn("category", ExpectedCategory);
 
             var feedbackToAdd = new MetricAnomalyFeedback(MetricId, filter, CreatedFeedbackStartTime, CreatedFeedbackEndTime, AnomalyValue.AutoDetect);
 
@@ -41,7 +44,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricFeedback addedFeedback = await client.GetFeedbackAsync(feedbackId);
 
-            ValidateMetricFeedback(addedFeedback, feedbackId, dimensionKey);
+            ValidateMetricFeedback(addedFeedback, feedbackId);
 
             Assert.That(addedFeedback.Type, Is.EqualTo(FeedbackType.Anomaly));
 
@@ -60,11 +63,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var dimensionKey = new DimensionKey();
-            dimensionKey.AddDimensionColumn("city", "Delhi");
-            dimensionKey.AddDimensionColumn("category", "Handmade");
+            var filter = new FeedbackDimensionFilter();
 
-            var filter = new FeedbackDimensionFilter(dimensionKey);
+            filter.DimensionFilter.AddDimensionColumn("city", ExpectedCity);
+            filter.DimensionFilter.AddDimensionColumn("category", ExpectedCategory);
 
             var feedbackToAdd = new MetricAnomalyFeedback(MetricId, filter, CreatedFeedbackStartTime, CreatedFeedbackEndTime, AnomalyValue.AutoDetect)
             {
@@ -77,7 +79,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricFeedback addedFeedback = await client.GetFeedbackAsync(feedbackId);
 
-            ValidateMetricFeedback(addedFeedback, feedbackId, dimensionKey);
+            ValidateMetricFeedback(addedFeedback, feedbackId);
 
             Assert.That(addedFeedback.Type, Is.EqualTo(FeedbackType.Anomaly));
 
@@ -96,11 +98,10 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var dimensionKey = new DimensionKey();
-            dimensionKey.AddDimensionColumn("city", "Delhi");
-            dimensionKey.AddDimensionColumn("category", "Handmade");
+            var filter = new FeedbackDimensionFilter();
 
-            var filter = new FeedbackDimensionFilter(dimensionKey);
+            filter.DimensionFilter.AddDimensionColumn("city", ExpectedCity);
+            filter.DimensionFilter.AddDimensionColumn("category", ExpectedCategory);
 
             var feedbackToAdd = new MetricChangePointFeedback(MetricId, filter, CreatedFeedbackStartTime, CreatedFeedbackEndTime, ChangePointValue.AutoDetect);
 
@@ -110,7 +111,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricFeedback addedFeedback = await client.GetFeedbackAsync(feedbackId);
 
-            ValidateMetricFeedback(addedFeedback, feedbackId, dimensionKey);
+            ValidateMetricFeedback(addedFeedback, feedbackId);
 
             Assert.That(addedFeedback.Type, Is.EqualTo(FeedbackType.ChangePoint));
 
@@ -132,11 +133,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var dimensionKey = new DimensionKey();
-            dimensionKey.AddDimensionColumn("city", "Delhi");
-            dimensionKey.AddDimensionColumn("category", "Handmade");
+            var filter = new FeedbackDimensionFilter();
 
-            var filter = new FeedbackDimensionFilter(dimensionKey);
+            filter.DimensionFilter.AddDimensionColumn("city", ExpectedCity);
+            filter.DimensionFilter.AddDimensionColumn("category", ExpectedCategory);
+
             var comment = "Feedback created in a .NET test.";
 
             var feedbackToAdd = new MetricCommentFeedback(MetricId, filter, comment);
@@ -147,7 +148,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricFeedback addedFeedback = await client.GetFeedbackAsync(feedbackId);
 
-            ValidateMetricFeedback(addedFeedback, feedbackId, dimensionKey);
+            ValidateMetricFeedback(addedFeedback, feedbackId);
 
             Assert.That(addedFeedback.Type, Is.EqualTo(FeedbackType.Comment));
 
@@ -164,11 +165,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var dimensionKey = new DimensionKey();
-            dimensionKey.AddDimensionColumn("city", "Delhi");
-            dimensionKey.AddDimensionColumn("category", "Handmade");
+            var filter = new FeedbackDimensionFilter();
 
-            var filter = new FeedbackDimensionFilter(dimensionKey);
+            filter.DimensionFilter.AddDimensionColumn("city", ExpectedCity);
+            filter.DimensionFilter.AddDimensionColumn("category", ExpectedCategory);
+
             var comment = "Feedback created in a .NET test.";
 
             var feedbackToAdd = new MetricCommentFeedback(MetricId, filter, comment)
@@ -183,7 +184,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricFeedback addedFeedback = await client.GetFeedbackAsync(feedbackId);
 
-            ValidateMetricFeedback(addedFeedback, feedbackId, dimensionKey);
+            ValidateMetricFeedback(addedFeedback, feedbackId);
 
             Assert.That(addedFeedback.Type, Is.EqualTo(FeedbackType.Comment));
 
@@ -200,11 +201,11 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var dimensionKey = new DimensionKey();
-            dimensionKey.AddDimensionColumn("city", "Delhi");
-            dimensionKey.AddDimensionColumn("category", "Handmade");
+            var filter = new FeedbackDimensionFilter();
 
-            var filter = new FeedbackDimensionFilter(dimensionKey);
+            filter.DimensionFilter.AddDimensionColumn("city", ExpectedCity);
+            filter.DimensionFilter.AddDimensionColumn("category", ExpectedCategory);
+
             var periodValue = 10;
 
             var feedbackToAdd = new MetricPeriodFeedback(MetricId, filter, PeriodType.AutoDetect, periodValue);
@@ -215,7 +216,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
 
             MetricFeedback addedFeedback = await client.GetFeedbackAsync(feedbackId);
 
-            ValidateMetricFeedback(addedFeedback, feedbackId, dimensionKey);
+            ValidateMetricFeedback(addedFeedback, feedbackId);
 
             Assert.That(addedFeedback.Type, Is.EqualTo(FeedbackType.Period));
 
@@ -352,7 +353,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(feedbackCount, Is.GreaterThan(0));
         }
 
-        private void ValidateMetricFeedback(MetricFeedback feedback, string expectedFeedbackId, DimensionKey expectedDimensionKey)
+        private void ValidateMetricFeedback(MetricFeedback feedback, string expectedFeedbackId)
         {
             Assert.That(feedback, Is.Not.Null);
             Assert.That(feedback.Id, Is.EqualTo(expectedFeedbackId));
@@ -363,7 +364,15 @@ namespace Azure.AI.MetricsAdvisor.Tests
             Assert.That(feedback.CreatedTime, Is.GreaterThan(justNow));
 
             Assert.That(feedback.DimensionFilter, Is.Not.Null);
-            Assert.That(feedback.DimensionFilter.DimensionFilter, Is.EqualTo(expectedDimensionKey));
+            Assert.That(feedback.DimensionFilter.DimensionFilter, Is.Not.Null);
+
+            var dimensionColumns = feedback.DimensionFilter.DimensionFilter.AsDictionary();
+
+            Assert.That(dimensionColumns.Count, Is.EqualTo(2));
+            Assert.That(dimensionColumns.ContainsKey("city"));
+            Assert.That(dimensionColumns.ContainsKey("category"));
+            Assert.That(dimensionColumns["city"], Is.EqualTo(ExpectedCity));
+            Assert.That(dimensionColumns["category"], Is.EqualTo(ExpectedCategory));
         }
     }
 }

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/MetricFeedbackTests.cs
@@ -33,8 +33,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var filter = new FeedbackDimensionFilter(new DimensionKey());
-            var feedback = new MetricCommentFeedback(FakeGuid, filter, "comment");
+            var feedback = new MetricCommentFeedback(FakeGuid, new (), "comment");
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesLiveTests.cs
@@ -150,10 +150,12 @@ namespace Azure.AI.MetricsAdvisor.Tests
             seriesKey2.AddDimensionColumn("city", "Koltaka");
             seriesKey2.AddDimensionColumn("category", "__SUM__");
 
-            var seriesKeys = new List<DimensionKey>() { seriesKey1, seriesKey2 };
             var returnedKeys = new List<DimensionKey>();
 
-            var options = new GetMetricSeriesDataOptions(seriesKeys, SamplingStartTime, SamplingEndTime);
+            var options = new GetMetricSeriesDataOptions(SamplingStartTime, SamplingEndTime)
+            {
+                SeriesToFilter = { seriesKey1, seriesKey2 }
+            };
 
             await foreach (MetricSeriesData seriesData in client.GetMetricSeriesDataAsync(MetricId, options))
             {
@@ -175,7 +177,9 @@ namespace Azure.AI.MetricsAdvisor.Tests
                 returnedKeys.Add(seriesData.Definition.SeriesKey);
             }
 
-            Assert.That(seriesKeys, Is.EquivalentTo(returnedKeys));
+            Assert.That(returnedKeys.Count, Is.EqualTo(2));
+            Assert.That(returnedKeys.Contains(seriesKey1));
+            Assert.That(returnedKeys.Contains(seriesKey2));
         }
 
         [RecordedTest]

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesTests.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/MetricsAdvisorClient/TimeSeriesTests.cs
@@ -91,8 +91,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var seriesToFilter = new List<DimensionKey>();
-            var options = new GetMetricSeriesDataOptions(seriesToFilter, default, default);
+            var options = new GetMetricSeriesDataOptions(default, default);
 
             Assert.That(() => client.GetMetricSeriesDataAsync(null, options), Throws.InstanceOf<ArgumentNullException>());
             Assert.That(() => client.GetMetricSeriesDataAsync("", options), Throws.InstanceOf<ArgumentException>());
@@ -110,8 +109,7 @@ namespace Azure.AI.MetricsAdvisor.Tests
         {
             MetricsAdvisorClient client = GetMetricsAdvisorClient();
 
-            var seriesToFilter = new List<DimensionKey>();
-            var options = new GetMetricSeriesDataOptions(seriesToFilter, default, default);
+            var options = new GetMetricSeriesDataOptions(default, default);
 
             using var cancellationSource = new CancellationTokenSource();
             cancellationSource.Cancel();

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample09_QueryTimeSeriesInformation.cs
@@ -161,6 +161,10 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string metricId = MetricId;
 
+            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
+            var endTime = DateTimeOffset.UtcNow;
+            var options = new GetMetricSeriesDataOptions(startTime, endTime);
+
             // Only the two time series with the keys specified below will be returned.
 
             var seriesKey1 = new DimensionKey();
@@ -171,11 +175,8 @@ namespace Azure.AI.MetricsAdvisor.Samples
             seriesKey2.AddDimensionColumn("city", "Hong Kong");
             seriesKey2.AddDimensionColumn("category", "Industrial & Scientific");
 
-            var filter = new List<DimensionKey>() { seriesKey1, seriesKey2 };
-
-            var startTime = DateTimeOffset.Parse("2020-01-01T00:00:00Z");
-            var endTime = DateTimeOffset.UtcNow;
-            var options = new GetMetricSeriesDataOptions(filter, startTime, endTime);
+            options.SeriesToFilter.Add(seriesKey1);
+            options.SeriesToFilter.Add(seriesKey2);
 
             await foreach (MetricSeriesData seriesData in client.GetMetricSeriesDataAsync(metricId, options))
             {

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample10_FeedbackCrudOperations.cs
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/Samples/Sample10_FeedbackCrudOperations.cs
@@ -23,10 +23,10 @@ namespace Azure.AI.MetricsAdvisor.Samples
 
             string metricId = MetricId;
 
-            DimensionKey groupKey = new DimensionKey();
-            groupKey.AddDimensionColumn("city", "Belo Horizonte");
+            FeedbackDimensionFilter filter = new FeedbackDimensionFilter();
 
-            FeedbackDimensionFilter filter = new FeedbackDimensionFilter(groupKey);
+            filter.DimensionFilter.AddDimensionColumn("city", "Belo Horizonte");
+
             var startTime = DateTimeOffset.Parse("2020-02-01T00:00:00Z");
             var endTime = DateTimeOffset.Parse("2020-02-03T00:00:00Z");
 

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(False).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(False).json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "92",
+        "Content-Length": "127",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-990c595a8f4482408877099108ea7ffb-8fd475cfc2c4d24e-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210119.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-8105df66bc7ece4b8be80f8b9f1d30ca-46c8a8fe024d504f-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "38a83e304094ff90ceb319601b84e4de",
         "x-ms-return-client-request-id": "true"
@@ -17,18 +20,21 @@
       "RequestBody": {
         "startTime": "2020-10-01T00:00:00Z",
         "endTime": "2020-10-31T00:00:00Z",
-        "dimensionName": "city"
+        "dimensionName": "city",
+        "dimensionFilter": {
+          "dimension": {}
+        }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "01b73c96-c7de-4ac1-ba05-9ec2e0b2adb6",
+        "apim-request-id": "affad8fd-527d-48d0-9de5-68421cbe37d8",
         "Content-Length": "692",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 19 Jan 2021 17:42:35 GMT",
+        "Date": "Fri, 05 Feb 2021 20:34:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "249",
-        "x-request-id": "01b73c96-c7de-4ac1-ba05-9ec2e0b2adb6"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "354",
+        "X-Request-ID": "affad8fd-527d-48d0-9de5-68421cbe37d8"
       },
       "ResponseBody": {
         "value": [

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(False)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(False)Async.json
@@ -5,11 +5,14 @@
       "RequestMethod": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
-        "Content-Length": "92",
+        "Content-Length": "127",
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": "Sanitized",
-        "traceparent": "00-23b198edadc7104e8c2f60b908bf5820-d47ebe046a904c42-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210119.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-1102fd37931e0d4ca625dc2321c3b18a-ca51cb2dce162f47-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-api-key": "Sanitized",
         "x-ms-client-request-id": "1b3201153b6a0425b654c9297dbf44bb",
         "x-ms-return-client-request-id": "true"
@@ -17,18 +20,21 @@
       "RequestBody": {
         "startTime": "2020-10-01T00:00:00Z",
         "endTime": "2020-10-31T00:00:00Z",
-        "dimensionName": "city"
+        "dimensionName": "city",
+        "dimensionFilter": {
+          "dimension": {}
+        }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "990bff87-ed6d-44b8-bd1e-8829877f1443",
+        "apim-request-id": "a30235cc-1ebb-48f9-b527-7b2f75076e95",
         "Content-Length": "692",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 19 Jan 2021 17:42:42 GMT",
+        "Date": "Fri, 05 Feb 2021 20:34:55 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "234",
-        "x-request-id": "990bff87-ed6d-44b8-bd1e-8829877f1443"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "277",
+        "X-Request-ID": "a30235cc-1ebb-48f9-b527-7b2f75076e95"
       },
       "ResponseBody": {
         "value": [

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(True).json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(True).json
@@ -6,28 +6,34 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "92",
+        "Content-Length": "127",
         "Content-Type": "application/json",
-        "traceparent": "00-e857918d38fe174897869ff74acce0ef-cceea62baf733d45-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210119.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-118671b155a8c04bafaee42d0e72e96e-18fa7e1d0aef6249-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-ms-client-request-id": "11b15dd584359f3249c01600a8fedb99",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "startTime": "2020-10-01T00:00:00Z",
         "endTime": "2020-10-31T00:00:00Z",
-        "dimensionName": "city"
+        "dimensionName": "city",
+        "dimensionFilter": {
+          "dimension": {}
+        }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4972faa8-c0fb-4408-83d8-7cda437890dc",
+        "apim-request-id": "45af4db0-8981-4cab-969a-2e4d8ca66ad0",
         "Content-Length": "692",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 19 Jan 2021 17:42:35 GMT",
+        "Date": "Fri, 05 Feb 2021 20:34:48 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "124",
-        "x-request-id": "4972faa8-c0fb-4408-83d8-7cda437890dc"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "1084",
+        "X-Request-ID": "45af4db0-8981-4cab-969a-2e4d8ca66ad0"
       },
       "ResponseBody": {
         "value": [

--- a/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(True)Async.json
+++ b/sdk/metricsadvisor/Azure.AI.MetricsAdvisor/tests/SessionRecords/AnomalyDetectionLiveTests/GetValuesOfDimensionWithAnomaliesWithMinimumSetup(True)Async.json
@@ -6,28 +6,34 @@
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "Sanitized",
-        "Content-Length": "92",
+        "Content-Length": "127",
         "Content-Type": "application/json",
-        "traceparent": "00-c8900e218d9f6045b95cd1f8217b3bc1-0d2cfce97a3e144f-00",
-        "User-Agent": "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210119.1 (.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 )",
+        "traceparent": "00-128d06e8cf6bb041ad6073e6093ebc5f-a9739ffacdeb524e-00",
+        "User-Agent": [
+          "azsdk-net-AI.MetricsAdvisor/1.0.0-alpha.20210205.1",
+          "(.NET Core 4.6.29518.01; Microsoft Windows 10.0.19042 )"
+        ],
         "x-ms-client-request-id": "e57fbf5659278075d2a85f55bd2c8a16",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": {
         "startTime": "2020-10-01T00:00:00Z",
         "endTime": "2020-10-31T00:00:00Z",
-        "dimensionName": "city"
+        "dimensionName": "city",
+        "dimensionFilter": {
+          "dimension": {}
+        }
       },
       "StatusCode": 200,
       "ResponseHeaders": {
-        "apim-request-id": "4c4f2457-e9c9-4a75-b1b3-bc24571fc90c",
+        "apim-request-id": "a3eef0d6-8a48-46c0-b262-aaf6065d522d",
         "Content-Length": "692",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Tue, 19 Jan 2021 17:42:42 GMT",
+        "Date": "Fri, 05 Feb 2021 20:34:54 GMT",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-        "x-content-type-options": "nosniff",
-        "x-envoy-upstream-service-time": "153",
-        "x-request-id": "4c4f2457-e9c9-4a75-b1b3-bc24571fc90c"
+        "X-Content-Type-Options": "nosniff",
+        "x-envoy-upstream-service-time": "4353",
+        "X-Request-ID": "a3eef0d6-8a48-46c0-b262-aaf6065d522d"
       },
       "ResponseBody": {
         "value": [


### PR DESCRIPTION
Fixes https://github.com/azure/azure-sdk-for-net/issues/18318.

Most of the work has been done in other PRs. This PR removes the setters of the remaining collection properties.