### PR TITLE
Disable OS verification

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-mgmt.yml
@@ -55,7 +55,7 @@ jobs:
     pool:
       vmImage: "$(OSVmImage)"
     steps:
-      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+#      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
       - script: "echo $(system.pullrequest.pullrequestnumber), http://github.com/$(build.repository.id), http://github.com/$(build.repository.ID)"
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
       - script: "dotnet msbuild mgmt.proj /v:n /t:RunTests /p:Scope=${{parameters.Scope}} /p:ForPublishing=$(ShouldPublish) /clp:ShowtimeStamp $(RPScopeArgs)"

--- a/eng/pipelines/templates/jobs/smoke-tests.yml
+++ b/eng/pipelines/templates/jobs/smoke-tests.yml
@@ -104,7 +104,7 @@ jobs:
       vmImage: $(OSVmImage)
 
     steps:
-      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+#      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
 
       - ${{ if eq(parameters.Daily, true) }}:
         - task: PowerShell@2


### PR DESCRIPTION
This PR disables OS verification in the smoke test pipelines and management plane pipeline whilst the following PR is being merged:

https://github.com/Azure/azure-sdk-tools/pull/1371

We need to do this because the OS verification script is now going to explicitly take the Pool and VM image as arguments to cross check whether the OS on the allocated VM is correct. But in order to avoid disruption I first need to disable this check anywhere it is used.