### PR TITLE
Fix Key Vault tests that are completing too soon

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientLiveTests.cs
@@ -27,6 +27,8 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 {
     public partial class CertificateClientLiveTests : CertificatesTestBase
     {
+        private static readonly TimeSpan CancelWait = TimeSpan.FromSeconds(10);
+
         public CertificateClientLiveTests(bool isAsync, CertificateClientOptions.ServiceVersion serviceVersion)
             : base(isAsync, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
@@ -60,7 +62,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 },
             };
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(() => Client.StartCreateCertificateAsync(certName, certificatePolicy));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await Client.StartCreateCertificateAsync(certName, certificatePolicy));
             Assert.AreEqual(400, ex.Status);
         }
 
@@ -107,7 +109,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
 
             OperationCanceledException ex = Assert.ThrowsAsync<OperationCanceledException>(
-                () => WaitForCompletion(operation),
+                async () => await WaitForCompletion(operation),
                 $"Expected exception {nameof(OperationCanceledException)} not thrown. Operation status: {operation?.Properties?.Status}, error: {operation?.Properties?.Error?.Message}");
 
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
@@ -139,7 +141,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             }
 
             OperationCanceledException ex = Assert.ThrowsAsync<OperationCanceledException>(
-                () => WaitForCompletion(operation),
+                async () => await WaitForCompletion(operation),
                 $"Expected exception {nameof(OperationCanceledException)} not thrown. Operation status: {operation?.Properties?.Status}, error: {operation?.Properties?.Error?.Message}");
             Assert.AreEqual("The operation was canceled so no value is available.", ex.Message);
 
@@ -162,7 +164,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
 
             await operation.DeleteAsync();
 
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(() => WaitForCompletion(operation));
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForCompletion(operation));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
 
             Assert.IsTrue(operation.HasCompleted);
@@ -192,7 +194,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
                 Assert.Inconclusive("The create operation completed before it could be canceled.");
             }
 
-            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(() => WaitForCompletion(operation));
+            InvalidOperationException ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await WaitForCompletion(operation));
             Assert.AreEqual("The operation was deleted so no value is available.", ex.Message);
 
             Assert.IsTrue(operation.HasCompleted);

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificateClientTests.cs
@@ -26,16 +26,16 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void CreateIssuerArgumentValidation()
         {
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateIssuerAsync(null));
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.CreateIssuerAsync(null));
             Assert.AreEqual("issuer", ex.ParamName);
 
             CertificateIssuer issuer = new CertificateIssuer();
-            ex = Assert.ThrowsAsync<ArgumentException>(() => Client.CreateIssuerAsync(issuer));
+            ex = Assert.ThrowsAsync<ArgumentException>(async () => await Client.CreateIssuerAsync(issuer));
             Assert.AreEqual("issuer", ex.ParamName);
             StringAssert.StartsWith("issuer.Name cannot be null or an empty string.", ex.Message);
 
             issuer = new CertificateIssuer("test");
-            ex = Assert.ThrowsAsync<ArgumentException>(() => Client.CreateIssuerAsync(issuer));
+            ex = Assert.ThrowsAsync<ArgumentException>(async () => await Client.CreateIssuerAsync(issuer));
             Assert.AreEqual("issuer", ex.ParamName);
             StringAssert.StartsWith("issuer.Provider cannot be null or an empty string.", ex.Message);
         }
@@ -43,10 +43,10 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void GetIssuerArgumentValidation()
         {
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(() => Client.GetIssuerAsync(null));
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.GetIssuerAsync(null));
             Assert.AreEqual("issuerName", ex.ParamName);
 
-            ex = Assert.ThrowsAsync<ArgumentException>(() => Client.GetIssuerAsync(string.Empty));
+            ex = Assert.ThrowsAsync<ArgumentException>(async () => await Client.GetIssuerAsync(string.Empty));
             Assert.AreEqual("issuerName", ex.ParamName);
             StringAssert.StartsWith("Value cannot be an empty string.", ex.Message);
         }
@@ -54,11 +54,11 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void UpdateIssuerArgumentValidation()
         {
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(() => Client.UpdateIssuerAsync(null));
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.UpdateIssuerAsync(null));
             Assert.AreEqual("issuer", ex.ParamName);
 
             CertificateIssuer issuer = new CertificateIssuer();
-            ex = Assert.ThrowsAsync<ArgumentException>(() => Client.UpdateIssuerAsync(issuer));
+            ex = Assert.ThrowsAsync<ArgumentException>(async () => await Client.UpdateIssuerAsync(issuer));
             Assert.AreEqual("issuer", ex.ParamName);
             StringAssert.StartsWith("issuer.Name cannot be null or an empty string.", ex.Message);
         }
@@ -66,27 +66,27 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         [Test]
         public void DeleteIssuerArgumentValidation()
         {
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(() => Client.DeleteIssuerAsync(null));
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.DeleteIssuerAsync(null));
             Assert.AreEqual("issuerName", ex.ParamName);
 
-            ex = Assert.ThrowsAsync<ArgumentException>(() => Client.DeleteIssuerAsync(string.Empty));
+            ex = Assert.ThrowsAsync<ArgumentException>(async () => await Client.DeleteIssuerAsync(string.Empty));
             Assert.AreEqual("issuerName", ex.ParamName);
         }
 
         [Test]
         public void SetContactsArgumentValidation()
         {
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(() => Client.SetContactsAsync(null));
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.SetContactsAsync(null));
             Assert.AreEqual("contacts", ex.ParamName);
         }
 
         [Test]
         public void GetCertificatePolicyArgumentValidation()
         {
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(() => Client.GetCertificatePolicyAsync(null));
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.GetCertificatePolicyAsync(null));
             Assert.AreEqual("certificateName", ex.ParamName);
 
-            ex = Assert.ThrowsAsync<ArgumentException>(() => Client.GetCertificatePolicyAsync(string.Empty));
+            ex = Assert.ThrowsAsync<ArgumentException>(async () => await Client.GetCertificatePolicyAsync(string.Empty));
             Assert.AreEqual("certificateName", ex.ParamName);
             StringAssert.StartsWith("Value cannot be an empty string.", ex.Message);
         }
@@ -96,10 +96,10 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         {
             CertificatePolicy policy = new CertificatePolicy(WellKnownIssuerNames.Self, "CN=Azure SDK");
 
-            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(() => Client.UpdateCertificatePolicyAsync(null, policy));
+            ArgumentException ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.UpdateCertificatePolicyAsync(null, policy));
             Assert.AreEqual("certificateName", ex.ParamName);
 
-            ex = Assert.ThrowsAsync<ArgumentException>(() => Client.UpdateCertificatePolicyAsync(string.Empty, policy));
+            ex = Assert.ThrowsAsync<ArgumentException>(async () => await Client.UpdateCertificatePolicyAsync(string.Empty, policy));
             Assert.AreEqual("certificateName", ex.ParamName);
             StringAssert.StartsWith("Value cannot be an empty string.", ex.Message);
         }
@@ -108,7 +108,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
         public void ChallengeBasedAuthenticationRequiresHttps()
         {
             // After passing parameter validation, ChallengeBasedAuthenticationPolicy should throw for "http" requests.
-            Assert.ThrowsAsync<InvalidOperationException>(() => Client.GetCertificateAsync("test"));
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await Client.GetCertificateAsync("test"));
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/CryptographyClientTests.cs
@@ -30,15 +30,15 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void SignDataAsyncArugmentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.SignDataAsync(SignatureAlgorithm.ES256Value, (byte[])null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.SignDataAsync(SignatureAlgorithm.ES256Value, (Stream)null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.SignDataAsync(SignatureAlgorithm.ES256Value, (byte[])null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.SignDataAsync(SignatureAlgorithm.ES256Value, (Stream)null));
         }
 
         [Test]
         public void VerifyDataAsyncArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (byte[])null, new byte[0]));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (Stream)null, new byte[0]));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (byte[])null, new byte[0]));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.VerifyDataAsync(SignatureAlgorithm.ES256Value, (Stream)null, new byte[0]));
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
@@ -551,7 +551,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void GetKeyNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -583,7 +583,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.NotNull(deletedKey.ScheduledPurgeDate);
             AssertKeyVaultKeysEqual(key, deletedKey);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(keyName));
         }
 
         [Test]
@@ -605,7 +605,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.NotNull(deletedKey.ScheduledPurgeDate);
             AssertKeyVaultKeysEqual(ecHsmKey, deletedKey);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(keyName));
         }
 
         [Test]
@@ -627,13 +627,13 @@ namespace Azure.Security.KeyVault.Keys.Tests
             Assert.NotNull(deletedKey.ScheduledPurgeDate);
             AssertKeyVaultKeysEqual(rsaHsmKey, deletedKey);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(keyName));
         }
 
         [Test]
         public void DeleteKeyNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.StartDeleteKeyAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.StartDeleteKeyAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -715,7 +715,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void GetDeletedKeyNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetDeletedKeyAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetDeletedKeyAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -730,7 +730,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             await WaitForDeletedKey(keyName);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(keyName));
 
             RecoverDeletedKeyOperation recoverOperation = await Client.StartRecoverDeletedKeyAsync(keyName);
             KeyVaultKey recoverKeyResult = recoverOperation.Value;
@@ -761,7 +761,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             await WaitForDeletedKey(keyName);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(keyName));
 
             RecoverDeletedKeyOperation recoverOperation = await Client.StartRecoverDeletedKeyAsync(keyName);
 
@@ -793,7 +793,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             await WaitForDeletedKey(keyName);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(keyName));
 
             RecoverDeletedKeyOperation recoverOperation = await Client.StartRecoverDeletedKeyAsync(keyName);
 
@@ -813,7 +813,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void RecoverDeletedKeyNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.StartRecoverDeletedKeyAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.StartRecoverDeletedKeyAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -833,7 +833,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void BackupKeyNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.BackupKeyAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.BackupKeyAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -852,7 +852,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             await Client.PurgeDeletedKeyAsync(keyName);
             await WaitForPurgedKey(keyName);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetKeyAsync(keyName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetKeyAsync(keyName));
 
             KeyVaultKey restoredResult = await Client.RestoreKeyBackupAsync(backup);
             RegisterForCleanup(restoredResult.Name);
@@ -864,7 +864,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         public void RestoreKeyNonExisting()
         {
             byte[] backupMalformed = Encoding.ASCII.GetBytes("non-existing");
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.RestoreKeyBackupAsync(backupMalformed));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.RestoreKeyBackupAsync(backupMalformed));
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientTests.cs
@@ -26,12 +26,12 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void CreateKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateKeyAsync(null, KeyType.Ec));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.CreateKeyAsync("name", default));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.CreateKeyAsync(string.Empty, KeyType.Ec));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateEcKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateRsaKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.CreateOctKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.CreateKeyAsync(null, KeyType.Ec));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.CreateKeyAsync("name", default));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.CreateKeyAsync(string.Empty, KeyType.Ec));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.CreateEcKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.CreateRsaKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.CreateOctKeyAsync(null));
         }
 
         [Test]
@@ -40,67 +40,67 @@ namespace Azure.Security.KeyVault.Keys.Tests
             var keyOperations = new List<KeyOperation>() { KeyOperation.Sign };
             var key = new KeyProperties("name");
 
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.UpdateKeyPropertiesAsync(null, null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.UpdateKeyPropertiesAsync(null, keyOperations));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.UpdateKeyPropertiesAsync(key, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.UpdateKeyPropertiesAsync(null, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.UpdateKeyPropertiesAsync(null, keyOperations));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.UpdateKeyPropertiesAsync(key, null));
         }
 
         [Test]
         public void RestoreKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.RestoreKeyBackupAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.RestoreKeyBackupAsync(null));
         }
 
         [Test]
         public void PurgeDeletedKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.PurgeDeletedKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.PurgeDeletedKeyAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.PurgeDeletedKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.PurgeDeletedKeyAsync(string.Empty));
         }
 
         [Test]
         public void GetKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.GetKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.GetKeyAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.GetKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.GetKeyAsync(string.Empty));
         }
 
         [Test]
         public void DeleteKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.StartDeleteKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.StartDeleteKeyAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.StartDeleteKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.StartDeleteKeyAsync(string.Empty));
         }
 
         [Test]
         public void GetDeletedKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.GetDeletedKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.GetDeletedKeyAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.GetDeletedKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.GetDeletedKeyAsync(string.Empty));
         }
 
         [Test]
         public void RecoverDeletedKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.StartRecoverDeletedKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.StartRecoverDeletedKeyAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.StartRecoverDeletedKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.StartRecoverDeletedKeyAsync(string.Empty));
         }
 
         [Test]
         public void BackupKeyArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.BackupKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.BackupKeyAsync(string.Empty));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.BackupKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.BackupKeyAsync(string.Empty));
         }
 
         [Test]
         public void ImportKeyArgumentValidation()
         {
             var jwk = new JsonWebKey();
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.ImportKeyAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.ImportKeyAsync(string.Empty, jwk));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.ImportKeyAsync(null, jwk));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.ImportKeyAsync(null, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.ImportKeyAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.ImportKeyAsync(string.Empty, jwk));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.ImportKeyAsync(null, jwk));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.ImportKeyAsync(null, null));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         public void ChallengeBasedAuthenticationRequiresHttps()
         {
             // After passing parameter validation, ChallengeBasedAuthenticationPolicy should throw for "http" requests.
-            Assert.ThrowsAsync<InvalidOperationException>(() => Client.GetKeyAsync("test"));
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await Client.GetKeyAsync("test"));
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverLiveTests.cs
@@ -48,7 +48,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             uriBuilder.AppendPath(Recording.GenerateId());
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Resolver.ResolveAsync(uriBuilder.ToUri()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Resolver.ResolveAsync(uriBuilder.ToUri()));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             uriBuilder.AppendPath(Recording.GenerateId());
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Resolver.ResolveAsync(uriBuilder.ToUri()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Resolver.ResolveAsync(uriBuilder.ToUri()));
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverMockTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverMockTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             KeyResolver resolver = GetResolver(transport);
             CryptographyClient client = await resolver.ResolveAsync(new Uri("https://mock.vault.azure.net/keys/mock-key"));
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(() => client.UnwrapKeyAsync(KeyWrapAlgorithm.A256KW, new byte[] { 0, 1, 2, 3 }));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await client.UnwrapKeyAsync(KeyWrapAlgorithm.A256KW, new byte[] { 0, 1, 2, 3 }));
             Assert.AreEqual((int)HttpStatusCode.Forbidden, ex.Status);
         }
 
@@ -39,7 +39,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             KeyResolver resolver = GetResolver(transport);
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(() => resolver.ResolveAsync(new Uri("https://mock.vault.azure.net/secrets/mock-secret")));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await resolver.ResolveAsync(new Uri("https://mock.vault.azure.net/secrets/mock-secret")));
             Assert.AreEqual((int)HttpStatusCode.Forbidden, ex.Status);
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyResolverTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public void ResolveAsyncArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => new KeyResolver(new DefaultAzureCredential()).ResolveAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await new KeyResolver(new DefaultAzureCredential()).ResolveAsync(null));
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
@@ -128,7 +128,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
 
             AssertSecretPropertiesEqual(secret.Properties, updateResult);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetSecretAsync(secretName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetSecretAsync(secretName));
 
             secret.Properties.Enabled = true;
 
@@ -259,7 +259,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         [Test]
         public void BackupSecretNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.BackupSecretAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.BackupSecretAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -280,8 +280,8 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             await Client.PurgeDeletedSecretAsync(secretName);
             await WaitForPurgedSecret(secretName);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetSecretAsync(secretName));
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetDeletedSecretAsync(secretName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetSecretAsync(secretName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetDeletedSecretAsync(secretName));
 
             SecretProperties restoreResult = await Client.RestoreSecretBackupAsync(backup);
 
@@ -292,7 +292,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         public void RestoreMalformedBackup()
         {
             byte[] backupMalformed = Encoding.ASCII.GetBytes("non-existing");
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.RestoreSecretBackupAsync(backupMalformed));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.RestoreSecretBackupAsync(backupMalformed));
         }
 
         [Test]
@@ -311,13 +311,13 @@ namespace Azure.Security.KeyVault.Secrets.Tests
             Assert.NotNull(deletedSecret.DeletedOn);
             Assert.NotNull(deletedSecret.ScheduledPurgeDate);
 
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetSecretAsync(secretName));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetSecretAsync(secretName));
         }
 
         [Test]
         public void StartDeleteSecretNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.StartDeleteSecretAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.StartDeleteSecretAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -347,7 +347,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         [Test]
         public void GetDeletedSecretNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.GetDeletedSecretAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.GetDeletedSecretAsync(Recording.GenerateId()));
         }
 
         [Test]
@@ -379,7 +379,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         [Test]
         public void StartRecoverDeletedSecretNonExisting()
         {
-            Assert.ThrowsAsync<RequestFailedException>(() => Client.StartRecoverDeletedSecretAsync(Recording.GenerateId()));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await Client.StartRecoverDeletedSecretAsync(Recording.GenerateId()));
         }
 
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientTests.cs
@@ -25,60 +25,60 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         [Test]
         public void SetArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.SetSecretAsync(null, "value"));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.SetSecretAsync("name", null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.SetSecretAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.SetSecretAsync(null, "value"));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.SetSecretAsync("name", null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.SetSecretAsync(null));
 
-            Assert.ThrowsAsync<ArgumentException>(() => Client.SetSecretAsync("", "value"));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.SetSecretAsync("", "value"));
         }
 
         [Test]
         public void UpdatePropertiesArgumentValidation()
         {
             SecretProperties secret = new SecretProperties("secret-name");
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.UpdateSecretPropertiesAsync(null));
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.UpdateSecretPropertiesAsync(secret));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.UpdateSecretPropertiesAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.UpdateSecretPropertiesAsync(secret));
         }
 
         [Test]
         public void RestoreArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.RestoreSecretBackupAsync(null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.RestoreSecretBackupAsync(null));
         }
 
         [Test]
         public void PurgeDeletedArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.PurgeDeletedSecretAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.PurgeDeletedSecretAsync(""));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.PurgeDeletedSecretAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.PurgeDeletedSecretAsync(""));
         }
 
         [Test]
         public void GetArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.GetSecretAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.GetSecretAsync(""));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.GetSecretAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.GetSecretAsync(""));
         }
 
         [Test]
         public void DeleteArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.StartDeleteSecretAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.StartDeleteSecretAsync(""));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.StartDeleteSecretAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.StartDeleteSecretAsync(""));
         }
 
         [Test]
         public void GetDeletedArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.GetDeletedSecretAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.GetDeletedSecretAsync(""));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.GetDeletedSecretAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.GetDeletedSecretAsync(""));
         }
 
         [Test]
         public void RecoverDeletedArgumentValidation()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => Client.StartRecoverDeletedSecretAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(() => Client.StartRecoverDeletedSecretAsync(""));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await Client.StartRecoverDeletedSecretAsync(null));
+            Assert.ThrowsAsync<ArgumentException>(async () => await Client.StartRecoverDeletedSecretAsync(""));
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace Azure.Security.KeyVault.Secrets.Tests
         public void ChallengeBasedAuthenticationRequiresHttps()
         {
             // After passing parameter validation, ChallengeBasedAuthenticationPolicy should throw for "http" requests.
-            Assert.ThrowsAsync<InvalidOperationException>(() => Client.GetSecretAsync("test"));
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await Client.GetSecretAsync("test"));
         }
     }
 }


### PR DESCRIPTION
Several invocations of Assert.ThrowsAsync were incorrect which likely
lead to the issues failing nightly live tests.
