### PR TITLE
Log Key Vault Certificates content for live tests

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/CertificatesTestBase.cs
@@ -46,7 +46,7 @@ namespace Azure.Security.KeyVault.Certificates.Tests
             {
                 Diagnostics =
                 {
-                    IsLoggingContentEnabled = Debugger.IsAttached,
+                    IsLoggingContentEnabled = Debugger.IsAttached || Mode == RecordedTestMode.Live,
                     LoggedHeaderNames =
                     {
                         "x-ms-request-id",


### PR DESCRIPTION
Needed to diagnose a test failure where the operation is completed, but the status is still "inProgress".
