### PR TITLE
Prepare MR Authentication for pre-release

### DIFF
--- a/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.0.0-beta.1 (2021-02-09)
+
+- Removed nullable annotations per guidance.
+
 ## 1.0.0-preview.3 (2021-01-15)
 
 - Updated to latest version of spec file which changes the account identifier to be a `Guid` rather than a `string`.

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/api/Azure.MixedReality.Authentication.netstandard2.0.cs
@@ -3,10 +3,10 @@ namespace Azure.MixedReality.Authentication
     public partial class MixedRealityStsClient
     {
         protected MixedRealityStsClient() { }
-        public MixedRealityStsClient(System.Guid accountId, string accountDomain, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
-        public MixedRealityStsClient(System.Guid accountId, string accountDomain, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
-        public MixedRealityStsClient(System.Guid accountId, System.Uri endpoint, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
-        public MixedRealityStsClient(System.Guid accountId, System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions? options = null) { }
+        public MixedRealityStsClient(System.Guid accountId, string accountDomain, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions options = null) { }
+        public MixedRealityStsClient(System.Guid accountId, string accountDomain, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions options = null) { }
+        public MixedRealityStsClient(System.Guid accountId, System.Uri endpoint, Azure.AzureKeyCredential keyCredential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions options = null) { }
+        public MixedRealityStsClient(System.Guid accountId, System.Uri endpoint, Azure.Core.TokenCredential credential, Azure.MixedReality.Authentication.MixedRealityStsClientOptions options = null) { }
         public System.Guid AccountId { get { throw null; } }
         public System.Uri Endpoint { get { throw null; } }
         public virtual Azure.Response<Azure.Core.AccessToken> GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure Mixed Reality STS Client</AssemblyTitle>
-    <Version>1.0.0-preview.2</Version>
+    <Version>1.0.0-beta.1</Version>
     <PackageTags>Azure MixedReality</PackageTags>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/Azure.MixedReality.Authentication.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure Mixed Reality STS Client</AssemblyTitle>
     <Version>1.0.0-preview.2</Version>
@@ -7,8 +7,6 @@
     <Authors>Microsoft</Authors>
     <PackageProjectUrl>https://azure.microsoft.com/topic/mixed-reality/</PackageProjectUrl>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <Nullable>enable</Nullable>
-    <DefineConstants>$(DefineConstants);AZURE_NULLABLE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClient.cs
+++ b/sdk/mixedreality/Azure.MixedReality.Authentication/src/MixedRealityStsClient.cs
@@ -37,7 +37,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="accountDomain">The Mixed Reality service account domain.</param>
         /// <param name="keyCredential">The Mixed Reality service account primary or secondary key credential.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(Guid accountId, string accountDomain, AzureKeyCredential keyCredential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, string accountDomain, AzureKeyCredential keyCredential, MixedRealityStsClientOptions options = null)
             : this(accountId, AuthenticationEndpoint.ConstructFromDomain(accountDomain), new MixedRealityAccountKeyCredential(accountId, keyCredential), options) { }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="endpoint">The Mixed Reality STS service endpoint.</param>
         /// <param name="keyCredential">The Mixed Reality service account primary or secondary key credential.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(Guid accountId, Uri endpoint, AzureKeyCredential keyCredential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, Uri endpoint, AzureKeyCredential keyCredential, MixedRealityStsClientOptions options = null)
             : this(accountId, endpoint, new MixedRealityAccountKeyCredential(accountId, keyCredential), options) { }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="accountDomain">The Mixed Reality service account domain.</param>
         /// <param name="credential">The credential used to access the Mixed Reality service.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(Guid accountId, string accountDomain, TokenCredential credential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, string accountDomain, TokenCredential credential, MixedRealityStsClientOptions options = null)
             : this(accountId, AuthenticationEndpoint.ConstructFromDomain(accountDomain), credential, options) { }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Azure.MixedReality.Authentication
         /// <param name="endpoint">The Mixed Reality STS service endpoint.</param>
         /// <param name="credential">The credential used to access the Mixed Reality service.</param>
         /// <param name="options">The options.</param>
-        public MixedRealityStsClient(Guid accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions? options = null)
+        public MixedRealityStsClient(Guid accountId, Uri endpoint, TokenCredential credential, MixedRealityStsClientOptions options = null)
         {
             Argument.AssertNotDefault(ref accountId, nameof(accountId));
             Argument.AssertNotNull(endpoint, nameof(endpoint));


### PR DESCRIPTION
This change removes the nullable awareness since that is the current guidance. I've also changed the prerelase tag to match current guidance.