### PR TITLE
[Azure.Core.Experimental] Package Ref to Core

### DIFF
--- a/sdk/core/Azure.Core.Experimental/CHANGELOG.md
+++ b/sdk/core/Azure.Core.Experimental/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Release History
 
-## 0.1.0-preview.9 (Unreleased)
+## 0.1.0-preview.9 (2021-02-09)
 
+### Key Bug Fixes
+- Fixed a dependency issue with `Azure.Core`, rebinding the reference to the latest released package.
 
 ## 0.1.0-preview.8 (2021-02-09)
 

--- a/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
+++ b/sdk/core/Azure.Core.Experimental/src/Azure.Core.Experimental.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../Azure.Core/src/Azure.Core.csproj" />
+    <PackageReference Include="Azure.Core" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Summary

The focus of these changes is to shift to a package reference to `Azure.Core`, allowing the dependency to bind to the latest GA release.

# Last Upstream Rebase

Tuesday, February 9, 2021, 3:00pm (EST)