### PR TITLE
Add import and non-sparse parameter functionality to job matrix generation

### DIFF
--- a/eng/scripts/job-matrix/Create-JobMatrix.ps1
+++ b/eng/scripts/job-matrix/Create-JobMatrix.ps1
@@ -12,14 +12,23 @@ param (
     [Parameter(Mandatory=$True)][string] $ConfigPath,
     [Parameter(Mandatory=$True)][string] $Selection,
     [Parameter(Mandatory=$False)][string] $DisplayNameFilter,
-    [Parameter(Mandatory=$False)][array] $Filters
+    [Parameter(Mandatory=$False)][array] $Filters,
+    [Parameter(Mandatory=$False)][array] $NonSparseParameters
 )
 
 . $PSScriptRoot/job-matrix-functions.ps1
 
 $config = GetMatrixConfigFromJson (Get-Content $ConfigPath)
+# Strip empty string filters in order to be able to use azure pipelines yaml join()
+$Filters = $Filters | Where-Object { $_ }
 
-[array]$matrix = GenerateMatrix $config $Selection $DisplayNameFilter $Filters
+[array]$matrix = GenerateMatrix `
+    -config $config `
+    -selectFromMatrixType $Selection `
+    -displayNameFilter $DisplayNameFilter `
+    -filters $Filters `
+    -nonSparseParameters $NonSparseParameters
+
 $serialized = SerializePipelineMatrix $matrix
 
 Write-Output $serialized.pretty

--- a/eng/scripts/job-matrix/job-matrix-functions.modification.tests.ps1
+++ b/eng/scripts/job-matrix/job-matrix-functions.modification.tests.ps1
@@ -1,0 +1,219 @@
+Import-Module Pester
+
+
+BeforeAll {
+    . ./job-matrix-functions.ps1
+
+    function CompareMatrices([Array]$matrix, [Array]$expected) {
+        $matrix.Length | Should -Be $expected.Length
+
+        for ($i = 0; $i -lt $matrix.Length; $i++) {
+            foreach ($entry in $matrix[$i]) {
+                $expected[$i].name | Should -Be $entry.name
+                foreach ($param in $entry.parameters.GetEnumerator()) {
+                    $expected[$i].parameters[$param.Name] | Should -Be $param.Value
+                }
+            }
+        }
+    }
+}
+
+Describe "Platform Matrix nonSparse" -Tag "nonsparse" {
+    BeforeEach {
+        $matrixJson = @'
+{
+    "matrix": {
+        "testField1": [ 1, 2 ],
+        "testField2": [ 1, 2, 3 ],
+        "testField3": [ 1, 2, 3, 4 ],
+    }
+}
+'@
+        $config = GetMatrixConfigFromJson $matrixJson
+    }
+
+    It "Should process nonSparse parameters" {
+        $parameters, $nonSparse = ProcessNonSparseParameters $config.orderedMatrix "testField1","testField3"
+        $parameters.Count | Should -Be 1
+        $parameters["testField2"] | Should -Be 1,2,3
+        $nonSparse.Count | Should -Be 2
+        $nonSparse["testField1"] | Should -Be 1,2
+        $nonSparse["testField3"] | Should -Be 1,2,3,4
+
+        $parameters, $nonSparse = ProcessNonSparseParameters $config.orderedMatrix "testField3"
+        $parameters.Count | Should -Be 2
+        $parameters.Contains("testField3") | Should -Be $false
+        $nonSparse.Count | Should -Be 1
+        $nonSparse["testField3"] | Should -Be 1,2,3,4
+    }
+
+    It "Should ignore nonSparse with all selection" {
+        $matrix = GenerateMatrix $config "all" -nonSparseParameters "testField3"
+        $matrix.Length | Should -Be 24
+    }
+
+    It "Should combine sparse matrix with nonSparse parameters" {
+        $matrix = GenerateMatrix $config "sparse" -nonSparseParameters "testField3"
+        $matrix.Length | Should -Be 12
+    }
+
+    It "Should combine with multiple nonSparse fields" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "testField1": [ 1, 2 ],
+        "testField2": [ 1, 2 ],
+        "testField3": [ 31, 32 ],
+        "testField4": [ 41, 42 ]
+    }
+}
+'@
+        $config = GetMatrixConfigFromJson $matrixJson
+
+        $matrix = GenerateMatrix $config "all" -nonSparseParameters "testField3","testField4"
+        $matrix.Length | Should -Be 16
+
+        $matrix = GenerateMatrix $config "sparse" -nonSparseParameters "testField3","testField4"
+        $matrix.Length | Should -Be 8
+    }
+}
+
+Describe "Platform Matrix Import" -Tag "import" {
+    It "Should generate a matrix with nonSparseParameters and an imported sparse matrix" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "testField": [ "test1", "test2" ]
+    }
+}
+'@
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse" -nonSparseParameters "testField"
+
+        $matrix.Length | Should -Be 6
+
+        $matrix[0].name | Should -Be test1_foo1_bar1
+        $matrix[0].parameters.testField | Should -Be "test1"
+        $matrix[0].parameters.Foo | Should -Be "foo1"
+        $matrix[2].name | Should -Be test1_importedBaz
+        $matrix[2].parameters.testField | Should -Be "test1"
+        $matrix[2].parameters.Baz | Should -Be "importedBaz"
+        $matrix[4].name | Should -Be test2_foo2_bar2
+        $matrix[4].parameters.testField | Should -Be "test2"
+        $matrix[4].parameters.Foo | Should -Be "foo2"
+    }
+
+    It "Should generate a sparse matrix with an imported a sparse matrix" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "testField1": [ "test11", "test12" ],
+        "testField2": [ "test21", "test22" ]
+    }
+}
+'@
+
+        $expectedMatrix = @'
+[
+  {
+    "parameters": { "testField1": "test11", "testField2": "test21", "Foo": "foo1", "Bar": "bar1" },
+    "name": "test11_test21_foo1_bar1"
+  },
+  {
+    "parameters": { "testField1": "test11", "testField2": "test21", "Foo": "foo2", "Bar": "bar2" },
+    "name": "test11_test21_foo2_bar2"
+  },
+  {
+    "parameters": { "testField1": "test11", "testField2": "test21", "Baz": "importedBaz" },
+    "name": "test11_test21_importedBaz"
+  },
+  {
+    "parameters": { "testField1": "test12", "testField2": "test22", "Foo": "foo1", "Bar": "bar1" },
+    "name": "test12_test22_foo1_bar1"
+  },
+  {
+    "parameters": { "testField1": "test12", "testField2": "test22", "Foo": "foo2", "Bar": "bar2" },
+    "name": "test12_test22_foo2_bar2"
+  },
+  {
+    "parameters": { "testField1": "test12", "testField2": "test22", "Baz": "importedBaz" },
+    "name": "test12_test22_importedBaz"
+  }
+]
+'@
+
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse"
+        $expected = $expectedMatrix | ConvertFrom-Json -AsHashtable
+
+        $matrix.Length | Should -Be 6
+        CompareMatrices $matrix $expected
+    }
+
+    It "Should import a sparse matrix with import, include, and exclude" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "testField": [ "test1", "test2", "test3" ],
+    },
+    "include": [
+      {
+        "testImportIncludeName": [ "testInclude1", "testInclude2" ]
+      }
+    ],
+    "exclude": [
+      {
+        "testField": "test1"
+      },
+      {
+        "testField": "test3",
+        "Baz": "importedBaz"
+      }
+    ]
+}
+'@
+
+        $expectedMatrix = @'
+[
+  {
+    "parameters": { "testField": "test2", "Foo": "foo1", "Bar": "bar1" },
+    "name": "test2_foo1_bar1"
+  },
+  {
+    "parameters": { "testField": "test2", "Foo": "foo2", "Bar": "bar2" },
+    "name": "test2_foo2_bar2"
+  },
+  {
+    "parameters": { "testField": "test2", "Baz": "importedBaz" },
+    "name": "test2_importedBaz"
+  },
+  {
+    "parameters": { "testField": "test3", "Foo": "foo1", "Bar": "bar1" },
+    "name": "test3_foo1_bar1"
+  },
+  {
+    "parameters": { "testField": "test3", "Foo": "foo2", "Bar": "bar2" },
+    "name": "test3_foo2_bar2"
+  },
+  {
+    "parameters": { "testImportIncludeName": "testInclude1" },
+    "name": "testInclude1"
+  },
+  {
+    "parameters": { "testImportIncludeName": "testInclude2" },
+    "name": "testInclude2"
+  }
+]
+'@
+
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse"
+        $expected = $expectedMatrix | ConvertFrom-Json -AsHashtable
+
+        $matrix.Length | Should -Be 7
+        CompareMatrices $matrix $expected
+    }
+}

--- a/eng/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/scripts/job-matrix/job-matrix-functions.ps1
@@ -9,6 +9,8 @@ class MatrixConfig {
     [Array]$exclude
 }
 
+$IMPORT_KEYWORD = '$IMPORT'
+
 function CreateDisplayName([string]$parameter, [Hashtable]$displayNamesLookup)
 {
     $name = $parameter.ToString()
@@ -25,28 +27,58 @@ function CreateDisplayName([string]$parameter, [Hashtable]$displayNamesLookup)
 
 function GenerateMatrix(
     [MatrixConfig]$config,
-    [string]$selectFromMatrixType,
-    [string]$displayNameFilter = ".*",
-    [array]$filters = @()
+    [String]$selectFromMatrixType,
+    [String]$displayNameFilter = ".*",
+    [Array]$filters = @(),
+    [Array]$nonSparseParameters = @()
 ) {
+    $orderedMatrix, $importedMatrix = ProcessImport $config.orderedMatrix $selectFromMatrixType
     if ($selectFromMatrixType -eq "sparse") {
-        [Array]$matrix = GenerateSparseMatrix $config.orderedMatrix $config.displayNamesLookup
+        [Array]$matrix = GenerateSparseMatrix $orderedMatrix $config.displayNamesLookup $nonSparseParameters
     } elseif ($selectFromMatrixType -eq "all") {
-        [Array]$matrix = GenerateFullMatrix $config.orderedMatrix $config.displayNamesLookup
+        [Array]$matrix = GenerateFullMatrix $orderedMatrix $config.displayNamesLookup
     } else {
         throw "Matrix generator not implemented for selectFromMatrixType: $($platform.selectFromMatrixType)"
+    }
+
+    # Combine with imported after matrix generation, since a sparse selection should result in a full combination of the
+    # top level and imported sparse matrices (as opposed to a sparse selection of both matrices).
+    if ($importedMatrix) {
+        [Array]$matrix = CombineMatrices $matrix $importedMatrix
     }
 
     if ($config.exclude) {
         [Array]$matrix = ProcessExcludes $matrix $config.exclude
     }
     if ($config.include) {
-        [Array]$matrix = ProcessIncludes $matrix $config.include $config.displayNamesLookup
+        [Array]$matrix = ProcessIncludes $config $matrix $selectFromMatrixType
     }
 
     [Array]$matrix = FilterMatrixDisplayName $matrix $displayNameFilter
     [Array]$matrix = FilterMatrix $matrix $filters
     return $matrix
+}
+
+function ProcessNonSparseParameters(
+    [System.Collections.Specialized.OrderedDictionary]$parameters,
+    [Array]$nonSparseParameters
+) {
+    if (!$nonSparseParameters) {
+        return $parameters, $null
+    }
+
+    $sparse = [ordered]@{}
+    $nonSparse = [ordered]@{}
+
+    foreach ($param in $parameters.GetEnumerator()) {
+        if ($param.Name -in $nonSparseParameters) {
+            $nonSparse[$param.Name] = $param.Value
+        } else {
+            $sparse[$param.Name] = $param.Value
+        }
+    }
+
+    return $sparse, $nonSparse
 }
 
 function FilterMatrixDisplayName([array]$matrix, [string]$filter) {
@@ -97,7 +129,7 @@ function ParseFilter([string]$filter) {
 
 # Importing the JSON as PSCustomObject preserves key ordering,
 # whereas ConvertFrom-Json -AsHashtable does not
-function GetMatrixConfigFromJson($jsonConfig)
+function GetMatrixConfigFromJson([String]$jsonConfig)
 {
     [MatrixConfig]$config = $jsonConfig | ConvertFrom-Json
     $config.orderedMatrix = [ordered]@{}
@@ -137,8 +169,7 @@ function ProcessExcludes([Array]$matrix, [Array]$excludes)
     $exclusionMatrix = @()
 
     foreach ($exclusion in $excludes) {
-        $converted = ConvertToMatrixArrayFormat $exclusion
-        $full = GenerateFullMatrix $converted
+        $full = GenerateFullMatrix $exclusion
         $exclusionMatrix += $full
     }
 
@@ -154,15 +185,68 @@ function ProcessExcludes([Array]$matrix, [Array]$excludes)
     return $matrix | Where-Object { !$_.parameters.Contains($deleteKey) }
 }
 
-function ProcessIncludes([Array]$matrix, [Array]$includes, [Hashtable]$displayNamesLookup)
+function ProcessIncludes([MatrixConfig]$config, [Array]$matrix)
 {
-    foreach ($inclusion in $includes) {
-        $converted = ConvertToMatrixArrayFormat $inclusion
-        $full = GenerateFullMatrix $converted $displayNamesLookup
-        $matrix += $full
+    $inclusionMatrix = @()
+    foreach ($inclusion in $config.include) {
+        $full = GenerateFullMatrix $inclusion $config.displayNamesLookup
+        $inclusionMatrix += $full
     }
 
-    return $matrix
+    return $matrix + $inclusionMatrix
+}
+
+function ProcessImport([System.Collections.Specialized.OrderedDictionary]$matrix, [String]$selection)
+{
+    if (!$matrix -or !$matrix.Contains($IMPORT_KEYWORD)) {
+        return $matrix
+    }
+
+    $importPath = $matrix[$IMPORT_KEYWORD]
+    $matrix.Remove($IMPORT_KEYWORD)
+
+    $matrixConfig = GetMatrixConfigFromJson (Get-Content $importPath)
+    $importedMatrix = GenerateMatrix $matrixConfig $selection
+
+    return $matrix, $importedMatrix
+}
+
+function CombineMatrices([Array]$matrix1, [Array]$matrix2)
+{
+    $combined = @()
+    if (!$matrix1) {
+        return $matrix2
+    }
+    if (!$matrix2) {
+        return $matrix1
+    }
+
+    foreach ($entry1 in $matrix1) {
+        foreach ($entry2 in $matrix2) {
+            $newEntry = @{
+                name = $entry1.name
+                parameters = CloneOrderedDictionary $entry1.parameters
+            }
+            foreach($param in $entry2.parameters.GetEnumerator()) {
+                if (!$newEntry.Contains($param.Name)) {
+                    $newEntry.parameters[$param.Name] = $param.Value
+                } else {
+                    Write-Warning "Skipping duplicate parameter `"$($param.Name)`" when combining matrix."
+                }
+            }
+
+            # The maximum allowed matrix name length is 100 characters
+            $entry2.name = $entry2.name.TrimStart("job_")
+            $newEntry.name = $newEntry.name, $entry2.name -join "_"
+            if ($newEntry.name.Length -gt 100) {
+                $newEntry.name = $newEntry.name[0..99] -join ""
+            }
+
+            $combined += $newEntry
+        }
+    }
+
+    return $combined
 }
 
 function MatrixElementMatch([System.Collections.Specialized.OrderedDictionary]$source, [System.Collections.Specialized.OrderedDictionary]$target)
@@ -172,27 +256,12 @@ function MatrixElementMatch([System.Collections.Specialized.OrderedDictionary]$s
     }
 
     foreach ($key in $target.Keys) {
-        if (-not $source.Contains($key) -or $source[$key] -ne $target[$key]) {
+        if (!$source.Contains($key) -or $source[$key] -ne $target[$key]) {
             return $false
         }
     }
 
     return $true
-}
-
-function ConvertToMatrixArrayFormat([System.Collections.Specialized.OrderedDictionary]$matrix)
-{
-    $converted = [Ordered]@{}
-
-    foreach ($key in $matrix.Keys) {
-        if ($matrix[$key] -isnot [Array]) {
-            $converted[$key] = ,$matrix[$key]
-        } else {
-            $converted[$key] = $matrix[$key]
-        }
-    }
-
-    return $converted
 }
 
 function CloneOrderedDictionary([System.Collections.Specialized.OrderedDictionary]$dictionary) {
@@ -219,13 +288,33 @@ function SerializePipelineMatrix([Array]$matrix)
     }
 }
 
-function GenerateSparseMatrix([System.Collections.Specialized.OrderedDictionary]$parameters, [Hashtable]$displayNamesLookup)
-{
+function GenerateSparseMatrix(
+    [System.Collections.Specialized.OrderedDictionary]$parameters,
+    [Hashtable]$displayNamesLookup,
+    [Array]$nonSparseParameters = @()
+) {
+    $parameters, $nonSparse = ProcessNonSparseParameters $parameters $nonSparseParameters
     [Array]$dimensions = GetMatrixDimensions $parameters
-    $size = ($dimensions | Measure-Object -Maximum).Maximum
-
     [Array]$matrix = GenerateFullMatrix $parameters $displayNamesLookup
+
     $sparseMatrix = @()
+    $indexes = GetSparseMatrixIndexes $dimensions
+    foreach ($idx in $indexes) {
+        $sparseMatrix += GetNdMatrixElement $idx $matrix $dimensions
+    }
+
+    if ($nonSparse) {
+        [Array]$allOfMatrix = GenerateFullMatrix $nonSparse $displayNamesLookup
+        return CombineMatrices $allOfMatrix $sparseMatrix
+    }
+
+    return $sparseMatrix
+}
+
+function GetSparseMatrixIndexes([Array]$dimensions)
+{
+    $size = ($dimensions | Measure-Object -Maximum).Maximum
+    $indexes = @()
 
     # With full matrix, retrieve items by doing diagonal lookups across the matrix N times.
     # For example, given a matrix with dimensions 3, 2, 2:
@@ -238,14 +327,16 @@ function GenerateSparseMatrix([System.Collections.Specialized.OrderedDictionary]
         for ($j = 0; $j -lt $dimensions.Length; $j++) {
             $idx += $i % $dimensions[$j]
         }
-        $sparseMatrix += GetNdMatrixElement $idx $matrix $dimensions
+        $indexes += ,$idx
     }
 
-    return $sparseMatrix
+    return $indexes
 }
 
-function GenerateFullMatrix([System.Collections.Specialized.OrderedDictionary] $parameters, [Hashtable]$displayNamesLookup = @{})
-{
+function GenerateFullMatrix(
+    [System.Collections.Specialized.OrderedDictionary] $parameters,
+    [Hashtable]$displayNamesLookup = @{}
+) {
     # Handle when the config does not have a matrix specified (e.g. only the include field is specified)
     if ($parameters.Count -eq 0) {
         return @()
@@ -256,7 +347,7 @@ function GenerateFullMatrix([System.Collections.Specialized.OrderedDictionary] $
     $matrix = [System.Collections.ArrayList]::new()
     InitializeMatrix $parameterArray $displayNamesLookup $matrix
 
-    return $matrix.ToArray()
+    return $matrix
 }
 
 function CreateMatrixEntry([System.Collections.Specialized.OrderedDictionary]$permutation, [Hashtable]$displayNamesLookup = @{})
@@ -308,19 +399,20 @@ function InitializeMatrix
         [System.Collections.ArrayList]$permutations,
         $permutation = [Ordered]@{}
     )
+    $head, $tail = $parameters
 
-    if (-not $parameters) {
+    if (!$head) {
         $entry = CreateMatrixEntry $permutation $displayNamesLookup
         $permutations.Add($entry) | Out-Null
         return
     }
 
-    $head, $tail = $parameters
-    foreach ($value in $head.value) {
-        $newPermutation = CloneOrderedDictionary($permutation)
+    # This behavior implicitly treats non-array values as single elements
+    foreach ($value in $head.Value) {
+        $newPermutation = CloneOrderedDictionary $permutation
         if ($value -is [PSCustomObject]) {
             foreach ($nestedParameter in $value.PSObject.Properties) {
-                $nestedPermutation = CloneOrderedDictionary($newPermutation)
+                $nestedPermutation = CloneOrderedDictionary $newPermutation
                 $nestedPermutation[$nestedParameter.Name] = $nestedParameter.Value
                 InitializeMatrix $tail $displayNamesLookup $permutations $nestedPermutation
             }
@@ -334,11 +426,11 @@ function InitializeMatrix
 function GetMatrixDimensions([System.Collections.Specialized.OrderedDictionary]$parameters)
 {
     $dimensions = @()
-    foreach ($val in $parameters.Values) {
-        if ($val -is [PSCustomObject]) {
-            $dimensions += ($val.PSObject.Properties | Measure-Object).Count
-        } elseif ($val -is [Array]) {
-            $dimensions += $val.Length
+    foreach ($param in $parameters.GetEnumerator()) {
+        if ($param.Value -is [PSCustomObject]) {
+            $dimensions += ($param.Value.PSObject.Properties | Measure-Object).Count
+        } elseif ($param.Value -is [Array]) {
+            $dimensions += $param.Value.Length
         } else {
             $dimensions += 1
         }

--- a/eng/scripts/job-matrix/test-import-matrix.json
+++ b/eng/scripts/job-matrix/test-import-matrix.json
@@ -1,0 +1,11 @@
+{
+  "matrix": {
+    "Foo": [ "foo1", "foo2" ],
+    "Bar": [ "bar1", "bar2" ]
+  },
+  "include": [
+    {
+      "Baz": "importedBaz"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for config import and non-sparse parameters to job matrix generation. This code is being synced from the latest changes in azure-sdk-for-python.

The import feature allows a matrix configuration to depend on another matrix configuration, for example if a live test wanted to run our base platform matrix, but add a set of additional test arguments to it. There are multiple places in the python sdk tests.yml files where we duplicate the platform matrix in order to make some minor modifications to it.

The non-sparse parameter feature allows us to generate sparse matrices while making sure that we still include all combinations of one or more parameters. This is also useful in conjunction with the import feature in order to enable some platform configurations that need to add multiple parameters to the base, but only need the full set of one parameter, otherwise the test matrix would be very large.

See the README changes for more in-depth details.

Example that will import a common sparse matrix and combine it with another sparse matrix, and then combine that with all values of `testFieldC`:
```
{
    "matrix": {
        "$IMPORT": "./test-import-matrix.json",
        "testFieldA": [ "test1A", "test2A" ],
        "testFieldB": [ "test1B", "test2B" ],
        "testFieldC": [ "test1C", "test2C", "test3C" ]
    }
}

Create-JobMatrix ./matrix.json -selection sparse -nonSparseParameters testFieldC
```