### PR TITLE
Azure Monitor Exporter: Upgrade OpenTelemetry to v1.0.1

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -193,9 +193,10 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="0.8.0-beta.1" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="0.8.0-beta.1" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="0.8.0-beta.1" />
+    <PackageReference Update="OpenTelemetry" Version="1.0.0-rc3" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc3" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -194,9 +194,9 @@
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Update="OpenTelemetry" Version="1.0.0-rc3" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" />
-    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc3" />
+    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
+    <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Update="PublicApiGenerator" Version="10.0.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -86,16 +86,16 @@
     <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="2.16.8" />
     <!-- TODO: Make sure this package is arch-board approved -->
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
+
+    <PackageReference Update="OpenTelemetry" Version="1.0.1"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 
   <!-- 
     Dependency versions for Track 2, Microsoft.* libraries.
     These are dependencies for Track 2 integration packages
   -->
-
   <ItemGroup Condition="'$(IsClientLibrary)' == 'true' and $(MSBuildProjectName.StartsWith('Microsoft.'))">
     <PackageReference Update="CloudNative.CloudEvents" Version="2.0.0-beta.1" />
-    <PackageReference Update="OpenTelemetry" Version="0.8.0-beta.1" />
     <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.25" />
     <PackageReference Update="Microsoft.Spatial" Version="7.5.3" />
     <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
@@ -193,7 +193,6 @@
     <PackageReference Update="NSubstitute" Version="3.1.0" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Update="OpenTelemetry" Version="1.0.0-rc3" />
     <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc2" />
     <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc2" />
     <PackageReference Update="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc2" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -87,6 +87,7 @@
     <!-- TODO: Make sure this package is arch-board approved -->
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
 
+    <!-- OpenTelemetry dependency approved for Azure.Monitor.OpenTelemetry.Exporter package only -->
     <PackageReference Update="OpenTelemetry" Version="1.0.1"  Condition="'$(MSBuildProjectName)' == 'Azure.Monitor.OpenTelemetry.Exporter'" />
   </ItemGroup>
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="OpenTelemetry" VersionOverride="0.8.0-beta.1"/>
+    <PackageReference Include="OpenTelemetry" VersionOverride="1.0.0-rc3"/>
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="OpenTelemetry" VersionOverride="1.0.0-rc3"/>
+    <PackageReference Include="OpenTelemetry" />
   </ItemGroup>
 
   <!-- Shared source from Azure.Core -->

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorConverter.cs
@@ -8,6 +8,7 @@ using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
 using OpenTelemetry;
 using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter
 {
@@ -25,7 +26,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             [TelemetryType.Event] = "EventData",
         };
 
-        internal static List<TelemetryItem> Convert(Batch<Activity> batchActivity, string instrumentationKey)
+        internal static List<TelemetryItem> Convert(Batch<Activity> batchActivity, Resource resource, string instrumentationKey)
         {
             List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
             TelemetryItem telemetryItem;
@@ -33,7 +34,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             foreach (var activity in batchActivity)
             {
                 MonitorBase telemetryData = new MonitorBase();
-                telemetryItem = TelemetryPartA.GetTelemetryItem(activity, instrumentationKey);
+                telemetryItem = TelemetryPartA.GetTelemetryItem(activity, resource, instrumentationKey);
 
                 switch (activity.GetTelemetryType())
                 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterHelperExtensions.cs
@@ -30,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             configure?.Invoke(options);
 
             // TODO: Pick Simple vs Batching based on AzureMonitorExporterOptions
-            return builder.AddProcessor(new BatchExportProcessor<Activity>(new AzureMonitorTraceExporter(options)));
+            return builder.AddProcessor(new BatchActivityExportProcessor(new AzureMonitorTraceExporter(options)));
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterLoggingExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging
             var options = new AzureMonitorExporterOptions();
             configure?.Invoke(options);
 
-            return loggerOptions.AddProcessor(new BatchExportProcessor<LogRecord>(new AzureMonitorLogExporter(options)));
+            return loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(options)));
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorTraceExporter.cs
@@ -38,7 +38,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             try
             {
-                var telemetryItems = AzureMonitorConverter.Convert(batch, this.instrumentationKey);
+                var resource = this.ParentProvider.GetResource();
+
+                var telemetryItems = AzureMonitorConverter.Convert(batch, resource, this.instrumentationKey);
 
                 // TODO: Handle return value, it can be converted as metrics.
                 // TODO: Validate CancellationToken and async pattern here.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartA.cs
@@ -30,14 +30,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
         internal static string RoleInstance { get; set; }
 
-        internal static TelemetryItem GetTelemetryItem(Activity activity, string instrumentationKey)
+        internal static TelemetryItem GetTelemetryItem(Activity activity, Resource resource, string instrumentationKey)
         {
             TelemetryItem telemetryItem = new TelemetryItem(PartA_Name_Mapping[activity.GetTelemetryType()], activity.StartTimeUtc.ToString(CultureInfo.InvariantCulture))
             {
                 InstrumentationKey = instrumentationKey
             };
 
-            InitRoleInfo(activity);
+            InitRoleInfo(resource);
             telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()] = RoleName;
             telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = RoleInstance;
             telemetryItem.Tags[ContextTagKeys.AiOperationId.ToString()] = activity.TraceId.ToHexString();
@@ -82,14 +82,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             return telemetryItem;
         }
 
-        internal static void InitRoleInfo(Activity activity)
+        internal static void InitRoleInfo(Resource resource)
         {
             if (RoleName != null || RoleInstance != null)
             {
                 return;
             }
-
-            var resource = activity.GetResource();
 
             if (resource == null)
             {
@@ -101,15 +99,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
 
             foreach (var attribute in resource.Attributes)
             {
-                if (attribute.Key == Resource.ServiceNameKey && attribute.Value is string)
+                if (attribute.Key == SemanticConventions.AttributeServiceName && attribute.Value is string)
                 {
                     serviceName = attribute.Value.ToString();
                 }
-                else if (attribute.Key == Resource.ServiceNamespaceKey && attribute.Value is string)
+                else if (attribute.Key == SemanticConventions.AttributeServiceNamespace && attribute.Value is string)
                 {
                     serviceNamespace = attribute.Value.ToString();
                 }
-                else if (attribute.Key == Resource.ServiceInstanceIdKey && attribute.Value is string)
+                else if (attribute.Key == SemanticConventions.AttributeServiceInstance && attribute.Value is string)
                 {
                     RoleInstance = attribute.Value.ToString();
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/TelemetryPartB.cs
@@ -109,7 +109,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                 PartCTags = AzMonList.Initialize()
             };
 
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
             return monitorTags;
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsBenchmarks.cs
@@ -86,30 +86,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         }
 
         [Benchmark]
-        public void Enumerate_AzMonList_NoItem()
-        {
-            NoItemActivity.EnumerateTags(ref monitorTags);
-        }
-
-        [Benchmark]
-        public void Enumerate_AzMonList_Part_B()
-        {
-            PartBActivity.EnumerateTags(ref monitorTags);
-        }
-
-        [Benchmark]
-        public void Enumerate_AzMonList_Part_C()
-        {
-            PartCActivity.EnumerateTags(ref monitorTags);
-        }
-
-        [Benchmark]
-        public void Enumerate_AzMonList_PartB_And_C()
-        {
-            PartBAndCActivity.EnumerateTags(ref monitorTags);
-        }
-
-        [Benchmark]
         public void Enumerate_TagObjects_NoItem()
         {
             _ = tagObjects.ToAzureMonitorTags(out var _, out var _);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Benchmarks/TagObjectsGetValuesBenchmarks.cs
@@ -100,17 +100,5 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Benchmarks
         {
             object _ = AzMonList.GetTagValue(ref AzMonList_Items, SemanticConventions.AttributeHttpHost);
         }
-
-        [Benchmark]
-        public void GetTagValueEmptyActivityTags()
-        {
-            object _ = this.EmptyActivity.GetTagValue(SemanticConventions.AttributeHttpHost);
-        }
-
-        [Benchmark]
-        public void GetTagValueNonemptyActivityTags()
-        {
-            object _ = this.ItemActivity.GetTagValue(SemanticConventions.AttributeHttpHost);
-        }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing/DemoTrace.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing/DemoTrace.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using global::OpenTelemetry;
 using global::OpenTelemetry.Resources;
+
+using OpenTelemetry.Trace;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 {
@@ -13,9 +16,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
 
         public static void Main()
         {
-            var resource = Resources.CreateServiceResource("my-service", "roleinstance1", "my-namespace");
+            var resourceAttributes = new Dictionary<string, object> { { "service.name", "my-service" }, { "service.namespace", "my-namespace" }, { "service.instance.id", "my-instance" } };
+            var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .SetResource(resource)
+                .SetResourceBuilder(resourceBuilder)
                 .AddSource("Demo.DemoServer")
                 .AddSource("Demo.DemoClient")
                 .AddAzureMonitorTraceExporter(o => {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TagsTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity();
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -51,7 +51,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(new Dictionary<string, object>());
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -75,7 +75,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -96,7 +96,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             IEnumerable<KeyValuePair<string, object>> tagObjects = new Dictionary<string, object> { ["somekey"] = "value" }; ;
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -122,7 +122,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Http, monitorTags.activityType);
             Assert.Equal(4, monitorTags.PartBTags.Length);
@@ -152,7 +152,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Http, monitorTags.activityType);
             Assert.Equal(3, monitorTags.PartBTags.Length);
@@ -180,7 +180,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -204,7 +204,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -228,7 +228,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -252,7 +252,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -276,7 +276,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);
@@ -305,7 +305,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             };
 
             using var activity = CreateTestActivity(tagObjects);
-            activity.EnumerateTags(ref monitorTags);
+            monitorTags.ForEach(activity.TagObjects);
 
             Assert.Equal(PartBType.Unknown, monitorTags.activityType);
             Assert.Empty(monitorTags.PartBTags);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryPartATests.cs
@@ -150,7 +150,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
         /// <remarks>
         /// An alternative way to get an instance of a Resource is as follows:
         /// <code>
-        /// var tracerProvider = Sdk.CreateTracerProviderBuilder().Build();
+        /// var resourceAttributes = new Dictionary<string, object> { { "service.name", "my-service" }, { "service.namespace", "my-namespace" }, { "service.instance.id", "my-instance" } };
+        /// var resourceBuilder = ResourceBuilder.CreateDefault().AddAttributes(resourceAttributes);
+        /// var tracerProvider = Sdk.CreateTracerProviderBuilder().SetResourceBuilder(resourceBuilder).Build();
         /// var resource = tracerProvider.GetResource();
         /// </code>
         /// </remarks>
@@ -158,22 +160,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Demo.Tracing
         {
             var testAttributes = new Dictionary<string, object>();
 
-            if (serviceName != null)
-            {
-                testAttributes.Add("service.name", serviceName);
-            }
+            if (serviceName != null) testAttributes.Add("service.name", serviceName);
+            if (serviceNamespace != null) testAttributes.Add("service.namespace", serviceNamespace);
+            if (serviceInstance != null) testAttributes.Add("service.instance.id", serviceInstance);
 
-            if (serviceNamespace != null)
-            {
-                testAttributes.Add("service.namespace", serviceNamespace);
-            }
-
-            if (serviceInstance != null)
-            {
-                testAttributes.Add("service.instance.id", serviceInstance);
-            }
-
-            //var testAttributes = new Dictionary<string, object> { { "service.name", "my-service" }, { "service.instance.id", "my-instance" } };
             return ResourceBuilder.CreateDefault().AddAttributes(testAttributes).Build();
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TelemetryItemTests.cs
@@ -98,7 +98,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
             using var activitySource = new ActivitySource(ActivitySourceName);
 
             var mockTransmitter = new MockTransmitter();
-            var processor = new BatchExportProcessor<Activity>(new AzureMonitorTraceExporter(
+            var processor = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(
                 options: new AzureMonitorExporterOptions
                 {
                     ConnectionString = EmptyConnectionString,
@@ -125,7 +125,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
         {
             // SETUP
             var mockTransmitter = new MockTransmitter();
-            var processor = new BatchExportProcessor<LogRecord>(new AzureMonitorLogExporter(
+            var processor = new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(
                 options: new AzureMonitorExporterOptions
                 {
                     ConnectionString = EmptyConnectionString,
@@ -171,11 +171,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
                 ConnectionString = EmptyConnectionString,
             };
 
-            var processor1 = new BatchExportProcessor<Activity>(new AzureMonitorTraceExporter(
+            var processor1 = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(
                 options: azureMonitorExporterOptions,
                 transmitter: mockTransmitter));
 
-            var processor2 = new BatchExportProcessor<LogRecord>(new AzureMonitorLogExporter(
+            var processor2 = new BatchLogRecordExportProcessor(new AzureMonitorLogExporter(
                 options: azureMonitorExporterOptions,
                 transmitter: mockTransmitter));
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TestFramework/OpenTelemetryWebApplicationFactory.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/TestFramework/OpenTelemetryWebApplicationFactory.cs
@@ -30,7 +30,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.TestFramework
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            this.ActivityProcessor = new BatchExportProcessor<Activity>(new AzureMonitorTraceExporter(
+            this.ActivityProcessor = new BatchActivityExportProcessor(new AzureMonitorTraceExporter(
                 options: new AzureMonitorExporterOptions
                 {
                     ConnectionString = EmptyConnectionString,


### PR DESCRIPTION
- Update OpenTelemetry version from v0.8.0 to v1.0.1.
- Update other OTel SDKs to their highest available version.
- `BatchExportProcessor<T>` was changed to `BatchActivityExportProcessor` and `BatchLogRecordExportProcessor`
- `Resource` was removed from `Activity` and moved to `Exporter.ParentProvider.GetResource()`
- `Activity.EnumerateTags` was removed and is instead `Activity.TagObjects`
- unit tests have been updated to support these changes