### PR TITLE
Add net5.0 to smoke tests. Fix dependency issues.

### DIFF
--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461;net5.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <StartupObject>SmokeTest.Program</StartupObject>
   </PropertyGroup>

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -10,13 +10,13 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.8.0" />
+    <PackageReference Include="Azure.Core" Version="1.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.4.0-beta.1" />
     <!-- The OverrideDailyVersion attribute prevents the Update-Dependencies script from overwriting it with a daily build version -->
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0-beta.4" OverrideDailyVersion="" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.0-beta.4" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0" OverrideDailyVersion="" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.0" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.2.0-beta.3" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0-beta.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.9" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.20.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.0" />

--- a/common/SmokeTests/SmokeTest/SmokeTest.csproj
+++ b/common/SmokeTests/SmokeTest/SmokeTest.csproj
@@ -10,10 +10,10 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Add an OverrideDailyVersion attribute to prevent the Update-Dependencies script from overwriting it with a daily build version -->
     <PackageReference Include="Azure.Core" Version="1.9.0" />
     <PackageReference Include="Azure.Identity" Version="1.4.0-beta.1" />
-    <!-- The OverrideDailyVersion attribute prevents the Update-Dependencies script from overwriting it with a daily build version -->
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0" OverrideDailyVersion="" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.3.0" />
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.3.0" />
     <PackageReference Include="Azure.Security.Keyvault.Secrets" Version="4.2.0-beta.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />


### PR DESCRIPTION
This PR adds net5.0 as a target framework to the smoke test project. It also fixes some dependency evaluation issues with the new release of the eventhubs package.