### PR TITLE
Add variable setting warning level to warn

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,5 +1,8 @@
 trigger: none
 
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 extends:
   template: /eng/common/pipelines/templates/steps/prepare-pipelines.yml
   parameters:


### PR DESCRIPTION
The ```prepare-pipelines``` pipeline is failing because of the new NuGet security policy. Even though our standard pipelines suppress the error, this pipeline doesn't contain that suppression.