### PR TITLE
Remove unnecessary Manage claim from sender and receiver

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
@@ -1620,7 +1620,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             amqpLinkSettings.AddProperty(AmqpClientConstants.EntityTypeName, AmqpClientConstants.EntityTypeManagement);
 
             var endpointUri = new Uri(this.ServiceBusConnection.Endpoint, entityPath);
-            string[] claims = { ClaimConstants.Manage, ClaimConstants.Listen };
+            string[] claims = { ClaimConstants.Listen };
             var amqpRequestResponseLinkCreator = new AmqpRequestResponseLinkCreator(
                 entityPath,
                 this.ServiceBusConnection,

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
@@ -747,7 +747,7 @@ namespace Microsoft.Azure.ServiceBus.Core
                 audience = new string[] { endpointUri.AbsoluteUri };
             }
 
-            string[] claims = { ClaimConstants.Manage, ClaimConstants.Send };
+            string[] claims = { ClaimConstants.Send };
             var amqpRequestResponseLinkCreator = new AmqpRequestResponseLinkCreator(
                 entityPath,
                 this.ServiceBusConnection,


### PR DESCRIPTION
Remove unnecessary Manage claim from sender and receiver. This will fix the scenario where customized `TokenProvider` is not giving `Manage` claims.

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.
