### PR TITLE
[Smoke Tests] Refactor Test Resources ARM

### DIFF
--- a/common/SmokeTests/SmokeTest/EventHubsTest.cs
+++ b/common/SmokeTests/SmokeTest/EventHubsTest.cs
@@ -36,12 +36,13 @@ namespace SmokeTest
             Console.WriteLine("1.- Send an Event batch");
             Console.WriteLine("2.- Receive those events\n");
 
-            var connectionString = Environment.GetEnvironmentVariable("EVENT_HUBS_CONNECTION_STRING");
+            var connectionString = Environment.GetEnvironmentVariable("EVENT_HUBS_NAMESPACE_CONNECTION_STRING");
+            var eventHubName = Environment.GetEnvironmentVariable("EVENT_HUBS_TESTHUB_NAME");
             var storageConnectionString = Environment.GetEnvironmentVariable("BLOB_CONNECTION_STRING");
 
             try
             {
-                CreateSenderAndReceiver(connectionString, storageConnectionString);
+                CreateSenderAndReceiver(connectionString, eventHubName, storageConnectionString);
                 await SendAndReceiveEvents();
             }
             finally
@@ -52,13 +53,13 @@ namespace SmokeTest
 
         public static Task Cleanup() => sender.CloseAsync();
 
-        private static void CreateSenderAndReceiver(string connectionString, string storageConnectionString)
+        private static void CreateSenderAndReceiver(string connectionString, string eventHubName, string storageConnectionString)
         {
             Console.Write("Creating the Sender and Receivers... ");
 
-            sender = new EventHubProducerClient(connectionString);
+            sender = new EventHubProducerClient(connectionString, eventHubName);
             storageClient = new BlobContainerClient(storageConnectionString, "mycontainer");
-            processor = new EventProcessorClient(storageClient, EventHubConsumerClient.DefaultConsumerGroupName, connectionString);
+            processor = new EventProcessorClient(storageClient, EventHubConsumerClient.DefaultConsumerGroupName, connectionString, eventHubName);
             Console.WriteLine("\tdone");
         }
 
@@ -97,7 +98,7 @@ namespace SmokeTest
                 {
                     var bodyReader = new StreamReader(eventArgs.Data.BodyAsStream);
                     var bodyContents = bodyReader.ReadToEnd();
-                    Console.WriteLine("Recieved Event: {0}", bodyContents);
+                    Console.WriteLine("Received Event: {0}", bodyContents);
                 }
 
                 return Task.CompletedTask;

--- a/common/SmokeTests/SmokeTest/test-resources.json
+++ b/common/SmokeTests/SmokeTest/test-resources.json
@@ -32,26 +32,22 @@
         "keyVaultName": "[format('kv-smk-{0}', parameters('baseName'))]",
         "iotHubName": "[format('iot-smoke-{0}', parameters('baseName'))]",
         "eventHubNamespaceName": "[format('eh-smoke-{0}', parameters('baseName'))]",
-        "eventHubName": "myeventhub",
-        "eventHubAuthorizationRuleName": "RootManageSharedAccessKey",
+        "eventHubName": "smoketest",
+        "eventHubsKeyName": "RootManageSharedAccessKey",
+        "eventHubsAuthRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', variables('eventHubNamespaceName'), variables('eventHubsKeyName'))]",
         "storageAccountName": "[format('stsmoke{0}', parameters('baseName'))]"
     },
     "resources": [
         {
-            "type": "Microsoft.EventHub/namespaces",
-            "apiVersion": "2018-01-01-preview",
+            "apiVersion": "2015-08-01",
             "name": "[variables('eventHubNamespaceName')]",
+            "type": "Microsoft.EventHub/Namespaces",
             "location": "[parameters('location')]",
             "sku": {
-                "name": "Basic",
-                "tier": "Basic",
-                "capacity": 1
+              "name": "Standard",
+              "tier": "Standard"
             },
             "properties": {
-                "zoneRedundant": false,
-                "isAutoInflateEnabled": false,
-                "maximumThroughputUnits": 0,
-                "kafkaEnabled": false
             }
         },
         {
@@ -159,22 +155,6 @@
             }
         },
         {
-            "type": "Microsoft.EventHub/namespaces/AuthorizationRules",
-            "apiVersion": "2017-04-01",
-            "name": "[format('{0}/{1}', variables('eventHubNamespaceName'), variables('eventHubAuthorizationRuleName'))]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]"
-            ],
-            "properties": {
-                "rights": [
-                    "Listen",
-                    "Manage",
-                    "Send"
-                ]
-            }
-        },
-        {
             "type": "Microsoft.EventHub/namespaces/eventhubs",
             "apiVersion": "2017-04-01",
             "name": "[format('{0}/{1}', variables('eventHubNamespaceName'), variables('eventHubName'))]",
@@ -205,23 +185,6 @@
                 "deleteRetentionPolicy": {
                     "enabled": false
                 }
-            }
-        },
-        {
-            "type": "Microsoft.EventHub/namespaces/eventhubs/authorizationRules",
-            "apiVersion": "2017-04-01",
-            "name": "[concat(variables('eventHubNamespaceName'), '/myeventhub/Test')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', variables('eventHubNamespaceName'), 'myeventhub')]",
-                "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]"
-            ],
-            "properties": {
-                "rights": [
-                    "Manage",
-                    "Listen",
-                    "Send"
-                ]
             }
         },
         {
@@ -277,9 +240,13 @@
             "type": "string",
             "value": "[reference(variables('keyVaultName')).vaultUri]"
         },
-        "EVENT_HUBS_CONNECTION_STRING": {
+        "EVENT_HUBS_NAMESPACE_CONNECTION_STRING": {
             "type": "string",
-            "value": "[listKeys(resourceId('Microsoft.EventHub/namespaces/eventhubs/authorizationRules', variables('eventHubNamespaceName'),  variables('eventHubName'), 'Test'), '2017-04-01').primaryConnectionString]"
+            "value": "[listkeys(variables('eventHubsAuthRuleResourceId'), '2015-08-01').primaryConnectionString]"
+        },
+        "EVENT_HUBS_TESTHUB_NAME": {
+            "type": "string",
+            "value": "[variables('eventHubName')]"
         },
         "BLOB_CONNECTION_STRING": {
             "type": "string",


### PR DESCRIPTION
# Summary

The focus of these changes is to refactor the test resources ARM template to shift to using the namespace-level connection strings for the Event Hubs resource to allow for a new sample to be added without the need to create additional namespaces or auth rules.  This pattern is also more closely aligned with the majority of customer scenarios in real-world use.

# Last Upstream Rebase

Tuesday, February 16, 2021, 4:00pm (EST)

# References and Related

- [Add AzureEventSourceListener Sample with Event Hubs logging (#15971 )](https://github.com/Azure/azure-sdk-for-net/issues/15971)