### PR TITLE
[TA] Remove extra check

### DIFF
--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/AnalyzeOperationTests.cs
@@ -380,9 +380,7 @@ namespace Azure.AI.TextAnalytics.Tests
 
             Assert.AreEqual(1, result.Count);
 
-            // TODO - Update this once the service starts returning RedactedText
-            //var redactedText = string.Empty;
-            //Assert.AreEqual(redactedText, result[0].Entities.RedactedText);
+            Assert.IsNotEmpty(result[0].Entities.RedactedText);
 
             Assert.IsFalse(result[0].HasError);
             Assert.AreEqual(2, result[0].Entities.Count);

--- a/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeHealthcareEntitiesTests.cs
+++ b/sdk/textanalytics/Azure.AI.TextAnalytics/tests/RecognizeHealthcareEntitiesTests.cs
@@ -334,7 +334,6 @@ namespace Azure.AI.TextAnalytics.Tests
             foreach (HealthcareEntity entity in entities)
             {
                 Assert.That(entity.Text, Is.Not.Null.And.Not.Empty);
-                Assert.IsTrue(minimumExpectedOutput.Contains(entity.Text, StringComparer.OrdinalIgnoreCase));
                 Assert.IsNotNull(entity.Category);
                 Assert.GreaterOrEqual(entity.ConfidenceScore, 0.0);
                 Assert.GreaterOrEqual(entity.Offset, 0);


### PR DESCRIPTION
When the service updates the model version, they model predictions can return different entities as a result of an improvement on the model.
This just happened where the service improved the model and now our test are failing.
This PR stops checking the exact entity text, and instead compares the minimum number of entities returned.

Build broken example: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=734504&view=logs&j=9f6e9dd9-0daa-5061-5c37-5c529436a384&t=61e7f27f-a931-53e2-fc09-f29729967c4e