### PR TITLE
[Event Hubs Client] Fix for AMQP Race Condition

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducerPool.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportProducerPool.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Core.Pipeline;
 
 namespace Azure.Messaging.EventHubs.Core
 {
@@ -161,9 +162,10 @@ namespace Azure.Messaging.EventHubs.Core
             {
             }
 
-            var pendingCloses = new List<Task>();
-
-            pendingCloses.Add(EventHubProducer.CloseAsync(cancellationToken));
+            var pendingCloses = new List<Task>
+            {
+                EventHubProducer.CloseAsync(cancellationToken)
+            };
 
             foreach (var poolItem in Pool.Values)
             {
@@ -171,7 +173,6 @@ namespace Azure.Messaging.EventHubs.Core
             }
 
             Pool.Clear();
-
             await Task.WhenAll(pendingCloses).ConfigureAwait(false);
         }
 
@@ -201,9 +202,9 @@ namespace Azure.Messaging.EventHubs.Core
                                 // if there was a context switch between the if conditions
                                 // and the pool item clean up kicked in.
 
-#pragma warning disable AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
-                                poolItem.PartitionProducer.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
-#pragma warning restore AZC0102 // Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.
+#pragma warning disable AZC0106 // Non-public asynchronous method needs 'async' parameter.
+                                poolItem.PartitionProducer.CloseAsync(CancellationToken.None).EnsureCompleted();
+#pragma warning restore AZC0106 // Non-public asynchronous method needs 'async' parameter.
                             }
                         }
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubProducerClient.cs
@@ -800,7 +800,6 @@ namespace Azure.Messaging.EventHubs.Producer
             }
 
             using DiagnosticScope scope = CreateDiagnosticScope(diagnosticIdentifiers);
-
             var pooledProducer = PartitionProducerPool.GetPooledProducer(options.PartitionId, PartitionProducerLifespan);
 
             while (!cancellationToken.IsCancellationRequested)
@@ -813,7 +812,8 @@ namespace Azure.Messaging.EventHubs.Producer
                     return;
                 }
                 catch (EventHubsException eventHubException)
-                    when (eventHubException.Reason == EventHubsException.FailureReason.ClientClosed && ShouldRecreateProducer(pooledProducer.TransportProducer, options.PartitionId))
+                    when (eventHubException.Reason == EventHubsException.FailureReason.ClientClosed
+                        && ShouldRecreateProducer(pooledProducer.TransportProducer, options.PartitionId))
                 {
                     if (++attempts >= MaximumCreateProducerAttempts)
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpErrorTests.cs
@@ -444,6 +444,32 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public void CreateExceptionForErrorWithIllegalStateCondition()
+        {
+            var description = $"'someclient' is closed";
+            var resourceName = "TestHub";
+
+            var error = new Error
+            {
+                Condition = AmqpErrorCode.IllegalState,
+                Description = description
+            };
+
+            Exception exception = AmqpError.CreateExceptionForError(error, resourceName);
+
+            Assert.That(exception, Is.Not.Null, "An exception should have been created");
+            Assert.That(exception, Is.TypeOf<EventHubsException>(), "The exception should match");
+            Assert.That(((EventHubsException)exception).IsTransient, Is.True, "The exception should be transient.");
+            Assert.That(((EventHubsException)exception).Reason, Is.EqualTo(EventHubsException.FailureReason.ClientClosed), "The exception reason should match.");
+            Assert.That(exception.Message, Is.SupersetOf(description), "The exception message should contain the description");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="AmqpError.CreateExceptionForError" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
         public void CreateExceptionForErrorWithUnknownCondition()
         {
             var description = "NOT_KNOWN";


### PR DESCRIPTION
# Summary

The focus of these changes is to address a race condition where the Event Hubs service closes an AMQP connection or link after its state was validated and an operation is being prepared.  When the AMQP library attempts to initiate the operation, it fails returning an `IllegalState` condition.

In this scenario, the Event Hubs client library should consider the failure to be transient and allow retries.  Our retry logic will ensure that the client itself was not closed/disposed before allowing the retry attempt.

Because this exception path is also monitored as a benign race condition when managing pooled transport producers, that code path has also been validated to ensure no behavioral changes.  There were some minor formatting tweaks in this area to better align with surrounding code.

# Last Upstream Rebase

Wednesday, February 17, 2021, 2:30pm (EST)