### PR TITLE
Add pipeline YAML trigger for net - mgmt - ci pipeline.

### DIFF
--- a/eng/pipelines/mgmt.yml
+++ b/eng/pipelines/mgmt.yml
@@ -6,6 +6,7 @@ pr:
     - '*-preview'
   paths:
     include:
+    - eng/pipelines/mgmt.yml
     - sdk/advisor/Microsoft.Azure.Management.Advisor
     - sdk/alertsmanagement/Microsoft.Azure.Management.AlertsManagement
     - sdk/analysisservices/Microsoft.Azure.Management.AnalysisServices


### PR DESCRIPTION
Adds a trigger on the management pipeline YAML file. This will help detect when errors are introduced as part of edits to the client pipelines which wouldn't normally trigger management pipeline changes.