### PR TITLE
Initialize scopes in base policy when loading from cache

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Shared/BearerTokenChallengeAuthenticationPolicy.cs
@@ -19,7 +19,7 @@ namespace Azure.Core.Pipeline
     internal class BearerTokenChallengeAuthenticationPolicy : HttpPipelinePolicy
     {
         private readonly AccessTokenCache _accessTokenCache;
-        protected string[] Scopes { get; private set; }
+        protected string[] Scopes { get; set; }
 
         /// <summary>
         /// Creates a new instance of <see cref="BearerTokenChallengeAuthenticationPolicy"/> using provided token credential and scope to authenticate for.

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -20,8 +20,12 @@ namespace Azure.Security.KeyVault.Tests
         }
 
         [Test]
+        [NonParallelizable]
         public async Task ScopesAreInitializedFromCache()
         {
+            // Clear the cache to ensure the test starts with an empty cache.
+            ChallengeBasedAuthenticationPolicy.ClearCache();
+
             var keyvaultChallengeResponse = new MockResponse(401);
             keyvaultChallengeResponse.AddHeader(new HttpHeader("WWW-Authenticate", KeyVaultChallenge));
             MockTransport transport = CreateMockTransport(keyvaultChallengeResponse, new MockResponse(200));

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/tests/ChallengeBasedAuthenticationPolicyTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Security.KeyVault.Tests
+{
+    public class ChallengeBasedAuthenticationPolicyTests : SyncAsyncPolicyTestBase
+    {
+        internal ChallengeBasedAuthenticationPolicy _policy;
+        private const string KeyVaultChallenge = "Bearer authorization=\"https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47\", resource=\"https://vault.azure.net\"";
+        public ChallengeBasedAuthenticationPolicyTests(bool isAsync) : base(isAsync)
+        {
+            _policy = new ChallengeBasedAuthenticationPolicy(new MockCredentialThrowsWithNoScopes());
+        }
+
+        [Test]
+        public async Task ScopesAreInitializedFromCache()
+        {
+            var keyvaultChallengeResponse = new MockResponse(401);
+            keyvaultChallengeResponse.AddHeader(new HttpHeader("WWW-Authenticate", KeyVaultChallenge));
+            MockTransport transport = CreateMockTransport(keyvaultChallengeResponse, new MockResponse(200));
+
+            var response = await SendGetRequest(transport, _policy, uri: new Uri("https://example.com"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+
+            // Construct a new policy so that we can get the Scopes from cache.
+            _policy = new ChallengeBasedAuthenticationPolicy(new MockCredentialThrowsWithNoScopes());
+
+            transport = CreateMockTransport(keyvaultChallengeResponse, new MockResponse(200));
+            response = await SendGetRequest(transport, _policy, uri: new Uri("https://example.com"));
+
+            Assert.That(response.Status, Is.EqualTo(200));
+        }
+
+        public class MockCredentialThrowsWithNoScopes : TokenCredential
+        {
+            public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                return new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+            }
+
+            public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            {
+                if (requestContext.Scopes.Length != 1)
+                {
+                    Assert.Fail("TokenRequestContext contained no scopes.");
+                }
+                return new AccessToken("TEST TOKEN " + string.Join(" ", requestContext.Scopes), DateTimeOffset.MaxValue);
+            }
+        }
+    }
+}

--- a/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Shared/src/ChallengeBasedAuthenticationPolicy.cs
@@ -67,6 +67,11 @@ namespace Azure.Security.KeyVault
                 // set the content to the original content.
                 message.Request.Content = originalContent;
             }
+            else
+            {
+                // We fetched the scope from the cache, but we have not initialized the Scopes in the base yet.
+                Scopes = _scope.Scopes;
+            }
         }
 
         protected override bool TryGetTokenRequestContextFromChallenge(HttpMessage message, out TokenRequestContext context)


### PR DESCRIPTION
This fixes an issue where the `ChallengeBasedAuthenticationPolicy` doesn't initialize the base BearerTokenChallengeAuthenticationPolicy Scopes array on requests where the `ChallengeBasedAuthenticationPolicy` is fetching its initial scope from cache.