### PR TITLE
Move HttpPipelineMessageHandler to Azure.Core Shared

### DIFF
--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="..\src\Shared\BearerTokenChallengeAuthenticationPolicy.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ConnectionString.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ForwardsClientCallsAttribute.cs" LinkBase="Shared" />
+    <Compile Include="..\src\Shared\HttpPipelineMessageHandler.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\NoBodyResponseOfT.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\ObjectNotDisposedException.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\OperationHelpers.cs" LinkBase="Shared" />
@@ -34,7 +35,7 @@
     <Compile Include="..\src\Shared\RetriableStream.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\RequestRequestContent.cs" LinkBase="Shared" />
     <Compile Include="..\src\Shared\SyncAsyncEventHandlerExtensions.cs" LinkBase="Shared" />
-    <Compile Include="..\src\Shared\ValueStopwatch.cs" LinkBase="Shared" />
+    <Compile Include="..\src\Shared\ValueStopwatch.cs" LinkBase="Shared" />    
   </ItemGroup>
 
 </Project>

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -18,16 +18,17 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)Argument.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" />
-    <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" />
-    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" />
-    <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" />
-    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" />
-    <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" />
-    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" />
-    <Compile Include="$(AzureCoreSharedSources)Base64Url.cs" />
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ClientDiagnostics.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)HttpMessageSanitizer.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)HttpPipelineMessageHandler.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScope.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ContentTypeUtilities.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)DiagnosticScopeFactory.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)TaskExtensions.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)Base64Url.cs" LinkBase="Shared" />
   </ItemGroup>
   <!-- Import the Azure.Base project -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />

--- a/sdk/identity/Azure.Identity/src/HttpPipelineClientFactory.cs
+++ b/sdk/identity/Azure.Identity/src/HttpPipelineClientFactory.cs
@@ -28,29 +28,7 @@ namespace Azure.Identity
 
         public HttpClient GetHttpClient()
         {
-            return new HttpClient(new PipelineHttpMessageHandler(_pipeline));
-        }
-
-        /// <summary>
-        /// An HttpMessageHandler which delegates SendAsync to a specified HttpPipeline.
-        /// </summary>
-        private class PipelineHttpMessageHandler : HttpMessageHandler
-        {
-            private readonly HttpPipeline _pipeline;
-
-            public PipelineHttpMessageHandler(HttpPipeline pipeline)
-            {
-                _pipeline = pipeline;
-            }
-
-            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                Request pipelineRequest = await request.ToPipelineRequestAsync(_pipeline).ConfigureAwait(false);
-
-                Response pipelineResponse = await _pipeline.SendRequestAsync(pipelineRequest, cancellationToken).ConfigureAwait(false);
-
-                return pipelineResponse.ToHttpResponseMessage();
-            }
+            return new HttpClient(new HttpPipelineMessageHandler(_pipeline));
         }
     }
 }


### PR DESCRIPTION
Partner teams would like to be able to record HttpClient-based types. Having this type in shared code would allow it.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/18853