### PR TITLE
Log more content for Key Vault live tests

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -58,7 +58,9 @@ namespace Azure.Security.KeyVault.Keys.Tests
                                 LoggedHeaderNames =
                                 {
                                     "x-ms-request-id",
-                                }
+                                },
+                                // TODO: Remove once https://github.com/Azure/azure-sdk-for-net/issues/18800 is resolved.
+                                IsLoggingContentEnabled = Mode != RecordedTestMode.Playback,
                             },
                         })),
                 interceptors);


### PR DESCRIPTION
To help diagnose #18800

We need more information to see why this fails nightly, but not 100% consistently across all test runs. It appears as if a leading zero is trimmed *sometimes* but I can't reproduce locally. Perhaps if I ran it enough times, but more efficient to let the nightly live runs do it since they have been hitting it every night for a week or so.
