### PR TITLE
[Perf Framework] Options for Size+Count

### DIFF
--- a/common/Perf/Azure.Test.Perf/SizeCountOptions.cs
+++ b/common/Perf/Azure.Test.Perf/SizeCountOptions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using CommandLine;
+
+namespace Azure.Test.Perf
+{
+    public class SizeCountOptions : PerfOptions
+    {
+        [Option('s', "size", Default = 1024, HelpText = "Size of payload (in bytes)")]
+        public long Size { get; set; }
+
+        [Option('c', "count", Default = 10, HelpText = "Number of items")]
+        public int Count { get; set; }
+    }
+}


### PR DESCRIPTION
# Summary

The focus of these changes is to add an options type allowing both the size of a payload and a count of items.  This is useful in common scenarios for Event Hubs and Service Bus.

# Last Upstream Rebase

Friday, February 19, 12:00pm (EST)