### PR TITLE
Azure Monitor Exporter: Live Tests

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -153,6 +153,7 @@
     <PackageReference Update="CommandLineParser" Version="2.8.0" />
     <PackageReference Update="FluentAssertions" Version="5.10.3" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
+    <PackageReference Update="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Update="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Update="Microsoft.AspNetCore.Server.WebListener" Version="1.0.2" />
     <PackageReference Update="Microsoft.Azure.Core.Spatial" Version="1.0.0" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
@@ -17,8 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.Benchmarks", "tests\Azure.Monitor.OpenTelemetry.Exporter.Benchmarks\Azure.Monitor.OpenTelemetry.Exporter.Benchmarks.csproj", "{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".DependentProjects", ".DependentProjects", "{517B9D01-3911-4287-8F96-FBCB68748974}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,9 +54,6 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{8052009B-2126-44A3-88CD-4F3B17894C64} = {517B9D01-3911-4287-8F96-FBCB68748974}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A97F4B90-2591-4689-B1F8-5F21FE6D6CAE}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
@@ -19,8 +19,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".DependentProjects", ".DependentProjects", "{517B9D01-3911-4287-8F96-FBCB68748974}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ApplicationInsights.Query", "..\..\applicationinsights\Microsoft.Azure.ApplicationInsights.Query\src\Microsoft.Azure.ApplicationInsights.Query.csproj", "{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,17 +53,12 @@ Global
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{8052009B-2126-44A3-88CD-4F3B17894C64} = {517B9D01-3911-4287-8F96-FBCB68748974}
-		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E} = {517B9D01-3911-4287-8F96-FBCB68748974}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A97F4B90-2591-4689-B1F8-5F21FE6D6CAE}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/Azure.Monitor.OpenTelemetry.Exporter.sln
@@ -17,6 +17,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Monitor.OpenTelemetry.Exporter.Benchmarks", "tests\Azure.Monitor.OpenTelemetry.Exporter.Benchmarks\Azure.Monitor.OpenTelemetry.Exporter.Benchmarks.csproj", "{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".DependentProjects", ".DependentProjects", "{517B9D01-3911-4287-8F96-FBCB68748974}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ApplicationInsights.Query", "..\..\applicationinsights\Microsoft.Azure.ApplicationInsights.Query\src\Microsoft.Azure.ApplicationInsights.Query.csproj", "{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,9 +55,17 @@ Global
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D57D79BA-6D39-4E9E-970C-A5F73A4425BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{8052009B-2126-44A3-88CD-4F3B17894C64} = {517B9D01-3911-4287-8F96-FBCB68748974}
+		{A4A788B6-6F1C-4208-8206-5C6B099E1D9E} = {517B9D01-3911-4287-8F96-FBCB68748974}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A97F4B90-2591-4689-B1F8-5F21FE6D6CAE}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -6,6 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="2.1.1" />
+    <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" VersionOverride="1.0.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" VersionOverride="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -6,7 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="2.1.1" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" VersionOverride="2.4.1" />
+    <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
@@ -32,7 +33,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\applicationinsights\Microsoft.Azure.ApplicationInsights.Query\src\Microsoft.Azure.ApplicationInsights.Query.csproj" />
     <ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
     <ProjectReference Include="..\Integration.Tests.AspNetCoreWebApp\Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebApp.csproj" />
@@ -43,3 +43,4 @@
   </ItemGroup>
 
 </Project>
+ 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\applicationinsights\Microsoft.Azure.ApplicationInsights.Query\src\Microsoft.Azure.ApplicationInsights.Query.csproj" />
-    <ProjectReference Include="..\..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
+    <ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
     <ProjectReference Include="..\Integration.Tests.AspNetCoreWebApp\Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebApp.csproj" />
   </ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="2.1.1" />
-    <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" VersionOverride="1.0.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" VersionOverride="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
@@ -33,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\applicationinsights\Microsoft.Azure.ApplicationInsights.Query\src\Microsoft.Azure.ApplicationInsights.Query.csproj" />
     <ProjectReference Include="..\..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
     <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
     <ProjectReference Include="..\Integration.Tests.AspNetCoreWebApp\Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebApp.csproj" />

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -43,4 +43,3 @@
   </ItemGroup>
 
 </Project>
- 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.csproj
@@ -38,4 +38,8 @@
     <ProjectReference Include="..\Integration.Tests.AspNetCoreWebApp\Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.AspNetCoreWebApp.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(AzureCoreSharedSources)\HttpPipelineMessageHandler.cs" LinkBase="Shared" />
+  </ItemGroup>
+
 </Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
+{
+    using System.Threading.Tasks;
+
+    using global::Azure.Core.TestFramework;
+
+    using global::OpenTelemetry;
+    using global::OpenTelemetry.Logs;
+
+    using Microsoft.Azure.ApplicationInsights.Query;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Collection of tests to evaluate the <see cref="AzureMonitorLogExporter"/>.
+    /// </summary>
+    public class AzureMonitorLogExporterLiveTests : AzureMonitorTestBase
+    {
+        public AzureMonitorLogExporterLiveTests(bool isAsync) : base(isAsync, RecordedTestMode.Record)
+        {
+        }
+
+        [RecordedTest]
+        public async Task VerifyLogExporter()
+        {
+            // SETUP
+            var exporter = this.GetAzureMonitorLogExporter();
+            var processor = new BatchLogRecordExportProcessor(exporter);
+
+            var serviceCollection = new ServiceCollection().AddLogging(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Trace)
+                    .AddOpenTelemetry(options => options
+                        .AddProcessor(processor));
+            });
+
+            using var serviceProvider = serviceCollection.BuildServiceProvider();
+            var logger = serviceProvider.GetRequiredService<ILogger<AzureMonitorLogExporterLiveTests>>();
+
+            // ACT
+            var testMessage = "Hello World";
+
+            // TODO: For proper test isolation, we should include a CustomProperty on telemetry items.
+            // CustomProperty should be unique per test method.
+            // This would allow us to run tests in parallel.
+            logger.Log(logLevel: LogLevel.Information, message: testMessage);
+
+            var flushResult = processor.ForceFlush(this.FlushTimeoutMilliseconds);
+            Assert.IsTrue(flushResult, "Processor failed to flush");
+
+            // TODO: MAYBE WE COULD HAVE A SHORT WAIT, AND IF NO TELEMETRY IS FOUND, WAIT FOR A LONGER PERIOD.
+            // THIS MIGHT MAKE TEST RUN FASTER, BUT PROVIDE A TRY-AGAIN MECHANIC FOR DAYS THAT INGESTION IS HAVING A BAD DAY.
+            await this.WaitForIgnestionAsync();
+
+            // VERIFY
+            // TODO: NEED TO WORK WITH PAVEL TO MAKE THIS STUBBABLE SO IT CAN BE USED IN RECORDED TESTS
+            var client = await this.GetApplicationInsightsDataClientAsync();
+
+            var telemetry = await client.Events.GetTraceEventsAsync(appId: TestEnvironment.ApplicationId, timespan: QueryDuration.TenMinutes);
+            Assert.AreEqual(testMessage, telemetry.Value[0].Trace.Message);
+            Assert.AreEqual(TestEnvironment.InstrumentationKey, telemetry.Value[0].Ai.IKey);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
@@ -3,15 +3,12 @@
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
 {
-    using System;
-    using System.Linq;
     using System.Threading.Tasks;
 
-    using global::Azure.Core.TestFramework;
+    using Azure.Core.TestFramework;
 
     using global::OpenTelemetry;
 
-    using Microsoft.Azure.ApplicationInsights.Query;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
 
@@ -42,76 +39,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
             var logger = serviceProvider.GetRequiredService<ILogger<AzureMonitorLogExporterLiveTests>>();
 
             // ACT
-            var testMessage = "Hello World";
-
             // TODO: For proper test isolation, we should include a CustomProperty on telemetry items.
             // CustomProperty should be unique per test method.
             // This would allow us to run tests in parallel.
+            var testMessage = "Hello World";
             logger.Log(logLevel: LogLevel.Information, message: testMessage);
 
             var flushResult = processor.ForceFlush(this.FlushTimeoutMilliseconds);
             Assert.IsTrue(flushResult, "Processor failed to flush");
 
-            // TODO: MAYBE WE COULD HAVE A SHORT WAIT, AND IF NO TELEMETRY IS FOUND, WAIT FOR A LONGER PERIOD.
-            // THIS MIGHT MAKE TEST RUN FASTER, BUT PROVIDE A TRY-AGAIN MECHANIC FOR DAYS THAT INGESTION IS HAVING A BAD DAY.
-            // DON'T KNOW IF THIS WOULD BE COMPATIBLE WITH THE RECORDED TESTS
-            //await this.WaitForIgnestionAsync();
-
-            //// VERIFY
-            //var client = await this.GetApplicationInsightsDataClientAsync();
-
-            //var telemetry = await client.Events.GetTraceEventsAsync(appId: TestEnvironment.ApplicationId, timespan: QueryDuration.TenMinutes);
-            //Assert.AreEqual(testMessage, telemetry.Value[0].Trace.Message);
-            //Assert.AreEqual(TestEnvironment.InstrumentationKey, telemetry.Value[0].Ai.IKey);
-
-            var telemetry = await GetTelemetry();
+            // VERIFY
+            // TODO: Need to verify additional fields. The LogExporter is still in development.
+            var telemetry = await FetchTelemetryAsync();
             Assert.AreEqual(testMessage, telemetry[0].Trace.Message);
             Assert.AreEqual(TestEnvironment.InstrumentationKey, telemetry[0].Ai.IKey);
-        }
-
-        private async Task<System.Collections.Generic.IList<Microsoft.Azure.ApplicationInsights.Query.Models.EventsTraceResult>> GetTelemetry()
-        {
-            var timeoutDuration = TimeSpan.FromMinutes(5); // timeout after 5 minutes.
-            //var period = TimeSpan.FromSeconds(30); // query once every 30 seconds.
-            var period = GetWaitPeriod(); // query once every 30 seconds.
-
-            System.Collections.Generic.IList<Microsoft.Azure.ApplicationInsights.Query.Models.EventsTraceResult> telemetry = null;
-
-            for (double actualDuration = 0; actualDuration < timeoutDuration.TotalMilliseconds; actualDuration += period.TotalMilliseconds)
-            {
-                await Task.Delay(period);
-
-                var client = await this.GetApplicationInsightsDataClientAsync();
-
-                var queryResult = await client.Events.GetTraceEventsAsync(appId: TestEnvironment.ApplicationId, timespan: QueryDuration.TenMinutes);
-
-                if (queryResult.Value.Any())
-                {
-                    telemetry = queryResult.Value;
-                    break;
-                }
-            }
-
-            if (telemetry == null)
-            {
-                Assert.Inconclusive("Failed to query telemetry from Kusto. This is not necessarily a test failure, this could be a result of an ingestion delay.");
-            }
-
-            return telemetry;
-        }
-
-        private TimeSpan GetWaitPeriod()
-        {
-            switch (this.Mode)
-            {
-                case RecordedTestMode.Live:
-                case RecordedTestMode.Record:
-                    return TimeSpan.FromSeconds(30);
-                case RecordedTestMode.Playback:
-                    return TimeSpan.FromSeconds(0);
-                default:
-                    throw new Exception($"Unknown RecordedTestMode '{this.Mode}'");
-            }
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
@@ -52,7 +52,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
             // TODO: Need to verify additional fields. The LogExporter is still in development.
             var telemetry = await FetchTelemetryAsync();
             Assert.AreEqual(testMessage, telemetry[0].Trace.Message);
-            Assert.AreEqual(TestEnvironment.InstrumentationKey, telemetry[0].Ai.IKey);
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
@@ -8,7 +8,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
     using global::Azure.Core.TestFramework;
 
     using global::OpenTelemetry;
-    using global::OpenTelemetry.Logs;
 
     using Microsoft.Azure.ApplicationInsights.Query;
     using Microsoft.Extensions.DependencyInjection;
@@ -21,16 +20,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
     /// </summary>
     public class AzureMonitorLogExporterLiveTests : AzureMonitorTestBase
     {
-        public AzureMonitorLogExporterLiveTests(bool isAsync) : base(isAsync, RecordedTestMode.Record)
-        {
-        }
+        public AzureMonitorLogExporterLiveTests(bool isAsync) : base(isAsync) { }
 
-        /// <summary>
-        /// TODO: This test is using <see cref="ApplicationInsightsDataClient"/> that currently can't be mocked for the RecordedTests.
-        /// See: (https://github.com/Azure/azure-sdk-for-net/issues/18853).
-        /// Will change this to [RecordedTest] at a later date.
-        /// </summary>
-        [LiveOnly]
+        [RecordedTest]
         public async Task VerifyLogExporter()
         {
             // SETUP
@@ -64,7 +56,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
             await this.WaitForIgnestionAsync();
 
             // VERIFY
-            // TODO: NEED TO WORK WITH PAVEL TO MAKE THIS STUBBABLE SO IT CAN BE USED IN RECORDED TESTS
             var client = await this.GetApplicationInsightsDataClientAsync();
 
             var telemetry = await client.Events.GetTraceEventsAsync(appId: TestEnvironment.ApplicationId, timespan: QueryDuration.TenMinutes);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
@@ -3,6 +3,8 @@
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
 {
+    using System;
+    using System.Linq;
     using System.Threading.Tasks;
 
     using global::Azure.Core.TestFramework;
@@ -53,14 +55,63 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
             // TODO: MAYBE WE COULD HAVE A SHORT WAIT, AND IF NO TELEMETRY IS FOUND, WAIT FOR A LONGER PERIOD.
             // THIS MIGHT MAKE TEST RUN FASTER, BUT PROVIDE A TRY-AGAIN MECHANIC FOR DAYS THAT INGESTION IS HAVING A BAD DAY.
             // DON'T KNOW IF THIS WOULD BE COMPATIBLE WITH THE RECORDED TESTS
-            await this.WaitForIgnestionAsync();
+            //await this.WaitForIgnestionAsync();
 
-            // VERIFY
-            var client = await this.GetApplicationInsightsDataClientAsync();
+            //// VERIFY
+            //var client = await this.GetApplicationInsightsDataClientAsync();
 
-            var telemetry = await client.Events.GetTraceEventsAsync(appId: TestEnvironment.ApplicationId, timespan: QueryDuration.TenMinutes);
-            Assert.AreEqual(testMessage, telemetry.Value[0].Trace.Message);
-            Assert.AreEqual(TestEnvironment.InstrumentationKey, telemetry.Value[0].Ai.IKey);
+            //var telemetry = await client.Events.GetTraceEventsAsync(appId: TestEnvironment.ApplicationId, timespan: QueryDuration.TenMinutes);
+            //Assert.AreEqual(testMessage, telemetry.Value[0].Trace.Message);
+            //Assert.AreEqual(TestEnvironment.InstrumentationKey, telemetry.Value[0].Ai.IKey);
+
+            var telemetry = await GetTelemetry();
+            Assert.AreEqual(testMessage, telemetry[0].Trace.Message);
+            Assert.AreEqual(TestEnvironment.InstrumentationKey, telemetry[0].Ai.IKey);
+        }
+
+        private async Task<System.Collections.Generic.IList<Microsoft.Azure.ApplicationInsights.Query.Models.EventsTraceResult>> GetTelemetry()
+        {
+            var timeoutDuration = TimeSpan.FromMinutes(5); // timeout after 5 minutes.
+            //var period = TimeSpan.FromSeconds(30); // query once every 30 seconds.
+            var period = GetWaitPeriod(); // query once every 30 seconds.
+
+            System.Collections.Generic.IList<Microsoft.Azure.ApplicationInsights.Query.Models.EventsTraceResult> telemetry = null;
+
+            for (double actualDuration = 0; actualDuration < timeoutDuration.TotalMilliseconds; actualDuration += period.TotalMilliseconds)
+            {
+                await Task.Delay(period);
+
+                var client = await this.GetApplicationInsightsDataClientAsync();
+
+                var queryResult = await client.Events.GetTraceEventsAsync(appId: TestEnvironment.ApplicationId, timespan: QueryDuration.TenMinutes);
+
+                if (queryResult.Value.Any())
+                {
+                    telemetry = queryResult.Value;
+                    break;
+                }
+            }
+
+            if (telemetry == null)
+            {
+                Assert.Inconclusive("Failed to query telemetry from Kusto. This is not necessarily a test failure, this could be a result of an ingestion delay.");
+            }
+
+            return telemetry;
+        }
+
+        private TimeSpan GetWaitPeriod()
+        {
+            switch (this.Mode)
+            {
+                case RecordedTestMode.Live:
+                case RecordedTestMode.Record:
+                    return TimeSpan.FromSeconds(30);
+                case RecordedTestMode.Playback:
+                    return TimeSpan.FromSeconds(0);
+                default:
+                    throw new Exception($"Unknown RecordedTestMode '{this.Mode}'");
+            }
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorLogExporterLiveTests.cs
@@ -25,7 +25,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         {
         }
 
-        [RecordedTest]
+        /// <summary>
+        /// TODO: This test is using <see cref="ApplicationInsightsDataClient"/> that currently can't be mocked for the RecordedTests.
+        /// See: (https://github.com/Azure/azure-sdk-for-net/issues/18853).
+        /// Will change this to [RecordedTest] at a later date.
+        /// </summary>
+        [LiveOnly]
         public async Task VerifyLogExporter()
         {
             // SETUP
@@ -55,6 +60,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
 
             // TODO: MAYBE WE COULD HAVE A SHORT WAIT, AND IF NO TELEMETRY IS FOUND, WAIT FOR A LONGER PERIOD.
             // THIS MIGHT MAKE TEST RUN FASTER, BUT PROVIDE A TRY-AGAIN MECHANIC FOR DAYS THAT INGESTION IS HAVING A BAD DAY.
+            // DON'T KNOW IF THIS WOULD BE COMPATIBLE WITH THE RECORDED TESTS
             await this.WaitForIgnestionAsync();
 
             // VERIFY

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using global::Azure.Core.TestFramework;
+
+    using Microsoft.Azure.ApplicationInsights.Query;
+    using Microsoft.Rest.Azure.Authentication;
+
+    using NUnit.Framework;
+
+    public abstract class AzureMonitorTestBase : RecordedTestBase<AzureMonitorTestEnvironment>
+    {
+        public int FlushTimeoutMilliseconds = 1000;
+
+        public AzureMonitorTestBase(bool isAsync) : base(isAsync) { }
+
+        public AzureMonitorTestBase(bool isAsync, RecordedTestMode mode) : base(isAsync, mode) { }
+
+        /// <summary>
+        /// We need to have one TEST in this class for NUnit to discover this class.
+        /// </summary>
+        [Test]
+        public void Dummy() { }
+
+        /// <remarks>
+        /// TODO: The <see cref="AzureMonitorLogExporter" /> is currently INTERNAL while under development.
+        /// When this Exporter is finished, this method can be changed to PUBLIC.
+        /// </remarks>
+        internal AzureMonitorLogExporter GetAzureMonitorLogExporter()
+        {
+            var exporterOptions = new AzureMonitorExporterOptions
+            {
+                ConnectionString = TestEnvironment.ConnectionString,
+            };
+
+            var clientOptions = this.InstrumentClientOptions(exporterOptions);
+
+            return new AzureMonitorLogExporter(clientOptions);
+        }
+
+        /// <summary>
+        /// Uses the TestEnvironment to log into Application Insights using a Service Principal.
+        /// These values are created when running the New-TestResources.ps1 script.
+        /// The code here comes from the sample provided in the Application Insights REST API doc.
+        /// (https://dev.applicationinsights.io/documentation/Tools/CSharp-Sdk).
+        /// </summary>
+        /// <remarks>
+        /// Alternatively for manual testing, can supply an Application Insights API Key.
+        /// (https://dev.applicationinsights.io/documentation/Authorization/API-key-and-App-ID).
+        /// <code>var creds = new ApiKeyClientCredentials("00000000-0000-0000-0000-000000000000");</code>
+        /// </remarks>
+        protected async Task<ApplicationInsightsDataClient> GetApplicationInsightsDataClientAsync()
+        {
+            var clientId = TestEnvironment.ClientId;
+            var clientSecret = TestEnvironment.ClientSecret;
+            var domain = TestEnvironment.TenantId;
+            var authEndpoint = "https://login.microsoftonline.com";
+            var tokenAudience = "https://api.applicationinsights.io/";
+            var adSettings = new ActiveDirectoryServiceSettings
+            {
+                AuthenticationEndpoint = new Uri(authEndpoint),
+                TokenAudience = new Uri(tokenAudience),
+                ValidateAuthority = true
+            };
+
+            var creds = await ApplicationTokenProvider.LoginSilentAsync(domain, clientId, clientSecret, adSettings);
+
+            var client = new ApplicationInsightsDataClient(creds);
+            return client;
+        }
+
+        /// <summary>
+        /// Application Insights ingestion is not immediate.
+        /// On a good day, this can take a few minutes.
+        /// Unit tests need to consider the <see cref="RecordedTestMode"/> and wait accordingly.
+        /// </summary>
+        protected async Task WaitForIgnestionAsync()
+        {
+            TimeSpan timeSpan;
+
+            switch (this.Mode)
+            {
+                case RecordedTestMode.Live:
+                case RecordedTestMode.Record:
+                    timeSpan = TimeSpan.FromMinutes(5);
+                    break;
+                case RecordedTestMode.Playback:
+                    timeSpan = TimeSpan.FromSeconds(0);
+                    break;
+                default:
+                    throw new Exception($"Unknown RecordedTestMode '{this.Mode}'");
+            }
+
+            await Task.Delay(timeSpan);
+        }
+
+        /// <summary>
+        /// <see cref="ApplicationInsightsDataClient"/> uses ISO 8601 Format for Durations.
+        /// (https://en.wikipedia.org/wiki/ISO_8601?oldformat=true#Durations).
+        /// </summary>
+        protected static class QueryDuration
+        {
+            public static string TenMinutes = "PT10M";
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -33,6 +33,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         /// </remarks>
         internal AzureMonitorLogExporter GetAzureMonitorLogExporter()
         {
+            // TODO: I WOULD LIKE TO TAKE ADVANTAGE OF THIS: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837
+            // In these tests we have to manually build the Exporter and processor so we can call ForceFlush in the tests.
+            // But we would expect customers to use the Extension method 
+
             var exporterOptions = new AzureMonitorExporterOptions
             {
                 ConnectionString = TestEnvironment.ConnectionString,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -35,12 +35,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
             this.ValidateClientInstrumentation = false;
         }
 
-        /// <summary>
-        /// We need to have one TEST for NUnit to discover this class.
-        /// </summary>
-        //[Test]
-        //public void Dummy() { }
-
         /// <remarks>
         /// TODO: The <see cref="AzureMonitorLogExporter" /> is currently INTERNAL while under development.
         /// When this Exporter is finished, this method can be changed to PUBLIC.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -161,7 +161,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         /// </summary>
         protected static class QueryDuration
         {
-            public static string TenMinutes = "PT10M";
+            public const string TenMinutes = "PT10M";
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -89,7 +89,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         protected async Task<IList<EventsTraceResult>> FetchTelemetryAsync()
         {
             var timeoutDuration = TimeSpan.FromMinutes(5); // timeout after 5 minutes.
-            var period = GetWaitPeriod(); // query once every 30 seconds.
+            var period = TestEnvironment.IsTestModeLive ? TimeSpan.FromSeconds(10) : TimeSpan.FromSeconds(0); // query once every 10 seconds.
 
             var client = await this.GetApplicationInsightsDataClientAsync();
             IList<EventsTraceResult> telemetry = null;
@@ -107,27 +107,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
                 }
             }
 
-            Assert.IsNotNull(telemetry, "Failed to query telemetry. This is not necessarily a test failure, this could be a result of an ingestion delay.");
+            Assert.IsNotNull(telemetry, "Failed to query telemetry. This is not necessarily a test failure and could be a result of an ingestion delay.");
 
             return telemetry;
-        }
-
-        /// <summary>
-        /// Application Insights ingestion is not immediate.
-        /// Unit tests need to consider the <see cref="RecordedTestMode"/> and wait accordingly.
-        /// </summary>
-        private TimeSpan GetWaitPeriod()
-        {
-            switch (this.Mode)
-            {
-                case RecordedTestMode.Live:
-                case RecordedTestMode.Record:
-                    return TimeSpan.FromSeconds(5);
-                case RecordedTestMode.Playback:
-                    return TimeSpan.FromSeconds(0);
-                default:
-                    throw new Exception($"Unknown RecordedTestMode '{this.Mode}'");
-            }
         }
 
         /// <summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -21,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
 
     public abstract class AzureMonitorTestBase : RecordedTestBase<AzureMonitorTestEnvironment>
     {
-        public int FlushTimeoutMilliseconds = 1000;
+        public int FlushTimeoutMilliseconds = 15000;
 
         public AzureMonitorTestBase(bool isAsync) : base(isAsync) { }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -38,8 +38,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         /// <summary>
         /// We need to have one TEST for NUnit to discover this class.
         /// </summary>
-        [Test]
-        public void Dummy() { }
+        //[Test]
+        //public void Dummy() { }
 
         /// <remarks>
         /// TODO: The <see cref="AzureMonitorLogExporter" /> is currently INTERNAL while under development.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -35,7 +35,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         {
             // TODO: I WOULD LIKE TO TAKE ADVANTAGE OF THIS: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837
             // In these tests we have to manually build the Exporter and processor so we can call ForceFlush in the tests.
-            // But we would expect customers to use the Extension method 
+            // But we would expect customers to use the Extension method.
 
             var exporterOptions = new AzureMonitorExporterOptions
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestBase.cs
@@ -123,10 +123,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
                 }
             }
 
-            if (telemetry == null)
-            {
-                Assert.Inconclusive("Failed to query telemetry from Kusto. This is not necessarily a test failure, this could be a result of an ingestion delay.");
-            }
+            Assert.IsNotNull(telemetry, "Failed to query telemetry. This is not necessarily a test failure, this could be a result of an ingestion delay.");
 
             return telemetry;
         }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
+{
+    using global::Azure.Core.TestFramework;
+
+    public class AzureMonitorTestEnvironment : TestEnvironment
+    {
+        public AzureMonitorTestEnvironment() : base()
+        {
+        }
+
+        /// <summary>
+        /// Connection String is used to connect to an Application Insights resource.
+        /// This value comes from the ARM Template.
+        /// </summary>
+        public string ConnectionString => GetRecordedVariable(EnvironmentVariableNames.ConnectionString);
+
+        /// <summary>
+        /// Instrumentation Key are unique per Application Insights resource.
+        /// IKey's are added to telemetry items and is checked in validation.
+        /// This value comes from the ARM Template.
+        /// </summary>
+        public string InstrumentationKey => GetRecordedVariable(EnvironmentVariableNames.InstrumentationKey);
+
+        /// <summary>
+        /// Application ID is used to identify an Application Insights resource when querying telemetry from the REST API.
+        /// This value comes from the ARM Template.
+        /// </summary>
+        public string ApplicationId => GetRecordedVariable(EnvironmentVariableNames.ApplicationId);
+
+        internal static class EnvironmentVariableNames
+        {
+            public const string ConnectionString = "CONNECTION_STRING";
+            public const string InstrumentationKey = "INSTRUMENTATION_KEY";
+            public const string ApplicationId = "APPLICATION_ID";
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
@@ -3,6 +3,8 @@
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
 {
+    using System;
+
     using Azure.Core.TestFramework;
 
     public class AzureMonitorTestEnvironment : TestEnvironment
@@ -10,6 +12,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         public AzureMonitorTestEnvironment() : base()
         {
         }
+
+        /// <summary>
+        /// We depend on the ClientSecret for AAD.
+        /// This value is not included in the recorded so we must fake it during Playback.
+        /// This value comes from the New-TestResources.ps1 script.
+        /// </summary>
+        //public new string ClientSecret => this.Mode == RecordedTestMode.Playback ? Guid.Empty.ToString() : base.ClientSecret;
 
         /// <summary>
         /// Connection String is used to connect to an Application Insights resource.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
@@ -3,7 +3,7 @@
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
 {
-    using global::Azure.Core.TestFramework;
+    using Azure.Core.TestFramework;
 
     public class AzureMonitorTestEnvironment : TestEnvironment
     {
@@ -18,13 +18,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         public string ConnectionString => GetRecordedVariable(EnvironmentVariableNames.ConnectionString);
 
         /// <summary>
-        /// Instrumentation Key are unique per Application Insights resource.
-        /// IKey's are added to telemetry items and is checked in validation.
-        /// This value comes from the ARM Template.
-        /// </summary>
-        public string InstrumentationKey => GetRecordedVariable(EnvironmentVariableNames.InstrumentationKey);
-
-        /// <summary>
         /// Application ID is used to identify an Application Insights resource when querying telemetry from the REST API.
         /// This value comes from the ARM Template.
         /// </summary>
@@ -33,7 +26,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         internal static class EnvironmentVariableNames
         {
             public const string ConnectionString = "CONNECTION_STRING";
-            public const string InstrumentationKey = "INSTRUMENTATION_KEY";
             public const string ApplicationId = "APPLICATION_ID";
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
@@ -13,9 +13,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
 
     public class AzureMonitorTestEnvironment : TestEnvironment
     {
-        public AzureMonitorTestEnvironment() : base()
-        {
-        }
+        public AzureMonitorTestEnvironment() : base() { }
 
         /// <summary>
         /// Connection String is used to connect to an Application Insights resource.
@@ -29,6 +27,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         /// </summary>
         public string ApplicationId => GetRecordedVariable(EnvironmentVariableNames.ApplicationId);
 
+        public bool IsTestModeLive => this.Mode != RecordedTestMode.Playback;
+
         /// <summary>
         /// Get a <see cref="ServiceClientCredentials"/> needed by <see cref="ApplicationInsightsDataClient"/> to query Kusto.
         /// - IN LIVE OR RECORD TEST MODE
@@ -39,7 +39,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         /// </summary>
         public async Task<ServiceClientCredentials> GetServiceClientCredentialsAsync()
         {
-            if (this.Mode == RecordedTestMode.Live || this.Mode == RecordedTestMode.Record)
+            if (this.IsTestModeLive)
             {
                 var authEndpoint = "https://login.microsoftonline.com";
                 var tokenAudience = "https://api.applicationinsights.io/";
@@ -56,13 +56,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
                     secret: this.ClientSecret,
                     settings: adSettings);
             }
-            else if (this.Mode == RecordedTestMode.Playback)
-            {
-                return new TokenCredentials("testValue");
-            }
             else
             {
-                throw new Exception($"Unknown RecordedTestMode '{this.Mode}'");
+                return new TokenCredentials("testValue");
             }
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/FunctionalTests/AzureMonitorTestEnvironment.cs
@@ -14,13 +14,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.FunctionalTests
         }
 
         /// <summary>
-        /// We depend on the ClientSecret for AAD.
-        /// This value is not included in the recorded so we must fake it during Playback.
-        /// This value comes from the New-TestResources.ps1 script.
-        /// </summary>
-        //public new string ClientSecret => this.Mode == RecordedTestMode.Playback ? Guid.Empty.ToString() : base.ClientSecret;
-
-        /// <summary>
         /// Connection String is used to connect to an Application Insights resource.
         /// This value comes from the ARM Template.
         /// </summary>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
@@ -7,12 +7,12 @@
         "Accept": "application/json",
         "Content-Length": "268",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210219.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "317da2a4e77cdfc2869d3662b03f2d2b",
+        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210222.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "5b038d11498400a8985c8a1feb236df1",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": [
-        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 00:57:57\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/23/2021 01:01:38\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
       ],
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -21,10 +21,10 @@
         "Access-Control-Max-Age": "3600",
         "Content-Length": "49",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 20 Feb 2021 00:57:57 GMT",
+        "Date": "Tue, 23 Feb 2021 01:01:38 GMT",
         "Strict-Transport-Security": "max-age=31536000",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-session-id": "48CE495B-F943-472B-9FE0-7258677D3213"
+        "x-ms-session-id": "8CDE98CB-FC1D-4F2A-81B5-ECE70248C2D4"
       },
       "ResponseBody": {
         "itemsReceived": 1,
@@ -52,14 +52,209 @@
         "Connection": "keep-alive",
         "Content-Length": "227",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 00:58:29 GMT",
+        "Date": "Tue, 23 Feb 2021 01:01:44 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": [
           "Accept",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-5dd9df5569-4fbw2",
+        "Via": "1.1 draft-oms-5dd9df5569-thmq2",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "5",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:01:49 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-nfn8v",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "10",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:01:54 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-z5w7k",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "15",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:01:59 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-2c896",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "20",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:04 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-zcz5n",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "25",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:09 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-zfjlj",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -94,11 +289,11 @@
         "Connection": "keep-alive",
         "Content-Length": "227",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 00:58:59 GMT",
+        "Date": "Tue, 23 Feb 2021 01:02:14 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-5dd9df5569-bf28m",
+        "Via": "1.1 draft-oms-5dd9df5569-8jfnh",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -129,15 +324,15 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "60",
+        "Age": "35",
         "Connection": "keep-alive",
         "Content-Length": "227",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 00:59:29 GMT",
+        "Date": "Tue, 23 Feb 2021 01:02:20 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-5dd9df5569-75qtl",
+        "Via": "1.1 draft-oms-5dd9df5569-msbmk",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -168,15 +363,561 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "90",
+        "Age": "40",
         "Connection": "keep-alive",
         "Content-Length": "227",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 00:59:59 GMT",
+        "Date": "Tue, 23 Feb 2021 01:02:25 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-5dd9df5569-vk4wk",
+        "Via": "1.1 draft-oms-5dd9df5569-fg7lp",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "47",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:32 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-fhnlt",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "52",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:37 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-qg2nz",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "57",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:42 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-fjhrg",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "62",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:47 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-zlxh8",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "67",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:52 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-fxgwn",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "72",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:02:57 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-fxgwn",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "77",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:02 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-6bvgk",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "82",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:07 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-qvhnx",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "87",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:12 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-v5dlf",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "92",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:17 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-bm52c",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "97",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:22 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-9vljs",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "103",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:27 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-lkbt2",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "108",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:32 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-d8fgc",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "115",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Tue, 23 Feb 2021 01:03:39 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-z5w7k",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -210,7 +951,7 @@
         "Connection": "keep-alive",
         "Content-Length": "987",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 01:00:29 GMT",
+        "Date": "Tue, 23 Feb 2021 01:03:44 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": [
@@ -218,7 +959,7 @@
           "Accept",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-5dd9df5569-4kvs9",
+        "Via": "1.1 draft-oms-5dd9df5569-k4g82",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -231,10 +972,10 @@
         ],
         "value": [
           {
-            "id": "abcc4da0-7316-11eb-a2e2-05d8e6f9e647",
+            "id": "aec0e210-7572-11eb-a86a-cfd3d5c8ad02",
             "count": 1,
             "type": "trace",
-            "timestamp": "2021-02-20T00:57:57.000Z",
+            "timestamp": "2021-02-23T01:01:38.000Z",
             "trace": {
               "message": "Hello World",
               "severityLevel": 1
@@ -287,7 +1028,7 @@
     "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
     "CLIENT_ID": "1b695356-0046-4617-ab97-cf253ebfe36b",
     "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
-    "RandomSeed": "965220595",
+    "RandomSeed": "293975811",
     "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
@@ -7,12 +7,12 @@
         "Accept": "application/json",
         "Content-Length": "268",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210218.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "3551b3e390bf93714a4909a0ea926abb",
+        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210219.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "317da2a4e77cdfc2869d3662b03f2d2b",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": [
-        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 00:38:27\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 00:57:57\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
       ],
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -21,10 +21,10 @@
         "Access-Control-Max-Age": "3600",
         "Content-Length": "49",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 20 Feb 2021 00:38:26 GMT",
+        "Date": "Sat, 20 Feb 2021 00:57:57 GMT",
         "Strict-Transport-Security": "max-age=31536000",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-session-id": "6C6E1A34-154B-4586-B64B-20CFA57352C5"
+        "x-ms-session-id": "48CE495B-F943-472B-9FE0-7258677D3213"
       },
       "ResponseBody": {
         "itemsReceived": 1,
@@ -50,9 +50,167 @@
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
         "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Sat, 20 Feb 2021 00:58:29 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": [
+          "Accept",
+          "Accept-Encoding"
+        ],
+        "Via": "1.1 draft-oms-5dd9df5569-4fbw2",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "30",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Sat, 20 Feb 2021 00:58:59 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-bf28m",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "60",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Sat, 20 Feb 2021 00:59:29 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-75qtl",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "90",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Sat, 20 Feb 2021 00:59:59 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-vk4wk",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Connection": "keep-alive",
         "Content-Length": "987",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 00:38:59 GMT",
+        "Date": "Sat, 20 Feb 2021 01:00:29 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": [
@@ -60,7 +218,7 @@
           "Accept",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-965856f6f-p4jbx",
+        "Via": "1.1 draft-oms-5dd9df5569-4kvs9",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -73,10 +231,10 @@
         ],
         "value": [
           {
-            "id": "f253c080-7313-11eb-abe7-7f07a3f5233f",
+            "id": "abcc4da0-7316-11eb-a2e2-05d8e6f9e647",
             "count": 1,
             "type": "trace",
-            "timestamp": "2021-02-20T00:38:27.000Z",
+            "timestamp": "2021-02-20T00:57:57.000Z",
             "trace": {
               "message": "Hello World",
               "severityLevel": 1
@@ -129,7 +287,7 @@
     "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
     "CLIENT_ID": "1b695356-0046-4617-ab97-cf253ebfe36b",
     "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
-    "RandomSeed": "1135375261",
+    "RandomSeed": "965220595",
     "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
@@ -1,0 +1,187 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2-0.in.applicationinsights.azure.com/v2/track",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "268",
+        "Content-Type": "application/json",
+        "User-Agent": [
+          "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210218.1",
+          "(.NET 5.0.3; Microsoft Windows 10.0.19042)"
+        ],
+        "x-ms-client-request-id": "e87212d239a685e80a559f43bfc58cf3",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": [
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/19/2021 22:31:48\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet5.0:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+      ],
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Name, Content-Type, Accept, Sdk-Context",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Max-Age": "3600",
+        "Content-Length": "49",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 19 Feb 2021 22:31:48 GMT",
+        "Strict-Transport-Security": "max-age=31536000",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-session-id": "54F4538F-8403-4566-A348-538D07126B28"
+      },
+      "ResponseBody": {
+        "itemsReceived": 1,
+        "itemsAccepted": 1,
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/5.0.321.7212",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.19042",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "35",
+        "Connection": "keep-alive",
+        "Content-Length": "1748",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Fri, 19 Feb 2021 22:32:19 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": [
+          "Accept-Encoding",
+          "Accept-Encoding"
+        ],
+        "Via": "1.1 draft-oms-5dd9df5569-22bcc",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": [
+          {
+            "id": "e47c6050-7301-11eb-b8c9-2fc76a5012f0",
+            "count": 1,
+            "type": "trace",
+            "timestamp": "2021-02-19T22:29:13.000Z",
+            "trace": {
+              "message": "Hello World",
+              "severityLevel": 1
+            },
+            "customDimensions": null,
+            "customMeasurements": null,
+            "operation": {
+              "name": "",
+              "id": "",
+              "parentId": "",
+              "syntheticSource": ""
+            },
+            "session": {
+              "id": ""
+            },
+            "user": {
+              "id": "",
+              "authenticatedId": "",
+              "accountId": ""
+            },
+            "application": {
+              "version": ""
+            },
+            "client": {
+              "type": "PC",
+              "model": "Other",
+              "os": "Windows",
+              "ip": "0.0.0.0",
+              "city": "Redmond",
+              "stateOrProvince": "Washington",
+              "countryOrRegion": "United States",
+              "browser": "Other"
+            },
+            "cloud": {
+              "roleName": "",
+              "roleInstance": ""
+            },
+            "ai": {
+              "appId": "cab179c4-5745-42ef-9b49-1eb443e7b760",
+              "appName": "tileemonitor",
+              "iKey": "a0151fae-78ce-447c-88fc-9020efb2091c",
+              "sdkVersion": "dotnet4.8:otel1.0.1:ext1.0.0"
+            }
+          },
+          {
+            "id": "d2284c70-7301-11eb-959a-c9595b93b2fb",
+            "count": 1,
+            "type": "trace",
+            "timestamp": "2021-02-19T22:28:41.000Z",
+            "trace": {
+              "message": "Hello World",
+              "severityLevel": 1
+            },
+            "customDimensions": null,
+            "customMeasurements": null,
+            "operation": {
+              "name": "",
+              "id": "",
+              "parentId": "",
+              "syntheticSource": ""
+            },
+            "session": {
+              "id": ""
+            },
+            "user": {
+              "id": "",
+              "authenticatedId": "",
+              "accountId": ""
+            },
+            "application": {
+              "version": ""
+            },
+            "client": {
+              "type": "PC",
+              "model": "Other",
+              "os": "Windows",
+              "ip": "0.0.0.0",
+              "city": "Redmond",
+              "stateOrProvince": "Washington",
+              "countryOrRegion": "United States",
+              "browser": "Other"
+            },
+            "cloud": {
+              "roleName": "",
+              "roleInstance": ""
+            },
+            "ai": {
+              "appId": "cab179c4-5745-42ef-9b49-1eb443e7b760",
+              "appName": "tileemonitor",
+              "iKey": "a0151fae-78ce-447c-88fc-9020efb2091c",
+              "sdkVersion": "dotnet4.8:otel1.0.1:ext1.0.0"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
+    "CLIENT_ID": "72edb0cc-3a4f-4950-b8a1-79ccb14abbff",
+    "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
+    "RandomSeed": "1672450036",
+    "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
+  }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporter.json
@@ -7,15 +7,12 @@
         "Accept": "application/json",
         "Content-Length": "268",
         "Content-Type": "application/json",
-        "User-Agent": [
-          "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210218.1",
-          "(.NET 5.0.3; Microsoft Windows 10.0.19042)"
-        ],
-        "x-ms-client-request-id": "e87212d239a685e80a559f43bfc58cf3",
+        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210218.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "3551b3e390bf93714a4909a0ea926abb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": [
-        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/19/2021 22:31:48\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet5.0:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 00:38:27\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
       ],
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -24,10 +21,10 @@
         "Access-Control-Max-Age": "3600",
         "Content-Length": "49",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Feb 2021 22:31:48 GMT",
+        "Date": "Sat, 20 Feb 2021 00:38:26 GMT",
         "Strict-Transport-Security": "max-age=31536000",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-session-id": "54F4538F-8403-4566-A348-538D07126B28"
+        "x-ms-session-id": "6C6E1A34-154B-4586-B64B-20CFA57352C5"
       },
       "ResponseBody": {
         "itemsReceived": 1,
@@ -41,10 +38,10 @@
       "RequestHeaders": {
         "Authorization": "Sanitized",
         "User-Agent": [
-          "FxVersion/5.0.321.7212",
+          "FxVersion/4.8.4300.0",
           "OSName/Windows",
-          "OSVersion/Microsoft.Windows.10.0.19042",
-          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
         ]
       },
       "RequestBody": null,
@@ -52,18 +49,18 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "35",
         "Connection": "keep-alive",
-        "Content-Length": "1748",
+        "Content-Length": "987",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Fri, 19 Feb 2021 22:32:19 GMT",
+        "Date": "Sat, 20 Feb 2021 00:38:59 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": [
           "Accept-Encoding",
+          "Accept",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-5dd9df5569-22bcc",
+        "Via": "1.1 draft-oms-965856f6f-p4jbx",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -76,59 +73,10 @@
         ],
         "value": [
           {
-            "id": "e47c6050-7301-11eb-b8c9-2fc76a5012f0",
+            "id": "f253c080-7313-11eb-abe7-7f07a3f5233f",
             "count": 1,
             "type": "trace",
-            "timestamp": "2021-02-19T22:29:13.000Z",
-            "trace": {
-              "message": "Hello World",
-              "severityLevel": 1
-            },
-            "customDimensions": null,
-            "customMeasurements": null,
-            "operation": {
-              "name": "",
-              "id": "",
-              "parentId": "",
-              "syntheticSource": ""
-            },
-            "session": {
-              "id": ""
-            },
-            "user": {
-              "id": "",
-              "authenticatedId": "",
-              "accountId": ""
-            },
-            "application": {
-              "version": ""
-            },
-            "client": {
-              "type": "PC",
-              "model": "Other",
-              "os": "Windows",
-              "ip": "0.0.0.0",
-              "city": "Redmond",
-              "stateOrProvince": "Washington",
-              "countryOrRegion": "United States",
-              "browser": "Other"
-            },
-            "cloud": {
-              "roleName": "",
-              "roleInstance": ""
-            },
-            "ai": {
-              "appId": "cab179c4-5745-42ef-9b49-1eb443e7b760",
-              "appName": "tileemonitor",
-              "iKey": "a0151fae-78ce-447c-88fc-9020efb2091c",
-              "sdkVersion": "dotnet4.8:otel1.0.1:ext1.0.0"
-            }
-          },
-          {
-            "id": "d2284c70-7301-11eb-959a-c9595b93b2fb",
-            "count": 1,
-            "type": "trace",
-            "timestamp": "2021-02-19T22:28:41.000Z",
+            "timestamp": "2021-02-20T00:38:27.000Z",
             "trace": {
               "message": "Hello World",
               "severityLevel": 1
@@ -179,9 +127,9 @@
   ],
   "Variables": {
     "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
-    "CLIENT_ID": "72edb0cc-3a4f-4950-b8a1-79ccb14abbff",
+    "CLIENT_ID": "1b695356-0046-4617-ab97-cf253ebfe36b",
     "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
-    "RandomSeed": "1672450036",
+    "RandomSeed": "1135375261",
     "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
@@ -8,11 +8,11 @@
         "Content-Length": "268",
         "Content-Type": "application/json",
         "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210218.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "086909f367a505b00e788e6e381d71d4",
+        "x-ms-client-request-id": "ab22ecf322b952181dee84b166700ca4",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": [
-        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/19/2021 22:29:13\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 00:39:01\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
       ],
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -21,10 +21,10 @@
         "Access-Control-Max-Age": "3600",
         "Content-Length": "49",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Fri, 19 Feb 2021 22:29:12 GMT",
+        "Date": "Sat, 20 Feb 2021 00:38:59 GMT",
         "Strict-Transport-Security": "max-age=31536000",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-session-id": "2CE49750-E973-4CF1-827F-74FBDED68BEC"
+        "x-ms-session-id": "DD5D6795-365E-4905-8C1A-4B37855A94FE"
       },
       "ResponseBody": {
         "itemsReceived": 1,
@@ -41,48 +41,7 @@
           "FxVersion/4.8.4300.0",
           "OSName/Windows",
           "OSVersion/10.0.19042.0",
-          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
-        ]
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Connection": "keep-alive",
-        "Content-Length": "227",
-        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Fri, 19 Feb 2021 22:29:44 GMT",
-        "OData-Version": "4.0;",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Vary": [
-          "Accept",
-          "Accept-Encoding"
-        ],
-        "Via": "1.1 draft-oms-5dd9df5569-2l848",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
-        "@ai.messages": [
-          {
-            "code": "AddedLimitToQuery",
-            "message": "The query was limited to 500 rows"
-          }
-        ],
-        "value": []
-      }
-    },
-    {
-      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "FxVersion/4.8.4300.0",
-          "OSName/Windows",
-          "OSVersion/10.0.19042.0",
-          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.0.20.51503"
         ]
       },
       "RequestBody": null,
@@ -92,133 +51,16 @@
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
         "Age": "30",
         "Connection": "keep-alive",
-        "Content-Length": "227",
+        "Content-Length": "987",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Fri, 19 Feb 2021 22:30:14 GMT",
-        "OData-Version": "4.0;",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-5dd9df5569-db66m",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
-        "@ai.messages": [
-          {
-            "code": "AddedLimitToQuery",
-            "message": "The query was limited to 500 rows"
-          }
-        ],
-        "value": []
-      }
-    },
-    {
-      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "FxVersion/4.8.4300.0",
-          "OSName/Windows",
-          "OSVersion/10.0.19042.0",
-          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
-        ]
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "60",
-        "Connection": "keep-alive",
-        "Content-Length": "227",
-        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Fri, 19 Feb 2021 22:30:44 GMT",
-        "OData-Version": "4.0;",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-5dd9df5569-txwzw",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
-        "@ai.messages": [
-          {
-            "code": "AddedLimitToQuery",
-            "message": "The query was limited to 500 rows"
-          }
-        ],
-        "value": []
-      }
-    },
-    {
-      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "FxVersion/4.8.4300.0",
-          "OSName/Windows",
-          "OSVersion/10.0.19042.0",
-          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
-        ]
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "90",
-        "Connection": "keep-alive",
-        "Content-Length": "227",
-        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Fri, 19 Feb 2021 22:31:14 GMT",
-        "OData-Version": "4.0;",
-        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
-        "Vary": "Accept-Encoding",
-        "Via": "1.1 draft-oms-5dd9df5569-bf28m",
-        "X-Content-Type-Options": "nosniff"
-      },
-      "ResponseBody": {
-        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
-        "@ai.messages": [
-          {
-            "code": "AddedLimitToQuery",
-            "message": "The query was limited to 500 rows"
-          }
-        ],
-        "value": []
-      }
-    },
-    {
-      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
-      "RequestMethod": "GET",
-      "RequestHeaders": {
-        "Authorization": "Sanitized",
-        "User-Agent": [
-          "FxVersion/4.8.4300.0",
-          "OSName/Windows",
-          "OSVersion/10.0.19042.0",
-          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
-        ]
-      },
-      "RequestBody": null,
-      "StatusCode": 200,
-      "ResponseHeaders": {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Connection": "keep-alive",
-        "Content-Length": "1748",
-        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Fri, 19 Feb 2021 22:31:44 GMT",
+        "Date": "Sat, 20 Feb 2021 00:39:30 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": [
           "Accept-Encoding",
-          "Accept",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-5dd9df5569-hpl8m",
+        "Via": "1.1 draft-oms-965856f6f-z8tlk",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -231,59 +73,10 @@
         ],
         "value": [
           {
-            "id": "e47c6050-7301-11eb-b8c9-2fc76a5012f0",
+            "id": "f253c080-7313-11eb-abe7-7f07a3f5233f",
             "count": 1,
             "type": "trace",
-            "timestamp": "2021-02-19T22:29:13.000Z",
-            "trace": {
-              "message": "Hello World",
-              "severityLevel": 1
-            },
-            "customDimensions": null,
-            "customMeasurements": null,
-            "operation": {
-              "name": "",
-              "id": "",
-              "parentId": "",
-              "syntheticSource": ""
-            },
-            "session": {
-              "id": ""
-            },
-            "user": {
-              "id": "",
-              "authenticatedId": "",
-              "accountId": ""
-            },
-            "application": {
-              "version": ""
-            },
-            "client": {
-              "type": "PC",
-              "model": "Other",
-              "os": "Windows",
-              "ip": "0.0.0.0",
-              "city": "Redmond",
-              "stateOrProvince": "Washington",
-              "countryOrRegion": "United States",
-              "browser": "Other"
-            },
-            "cloud": {
-              "roleName": "",
-              "roleInstance": ""
-            },
-            "ai": {
-              "appId": "cab179c4-5745-42ef-9b49-1eb443e7b760",
-              "appName": "tileemonitor",
-              "iKey": "a0151fae-78ce-447c-88fc-9020efb2091c",
-              "sdkVersion": "dotnet4.8:otel1.0.1:ext1.0.0"
-            }
-          },
-          {
-            "id": "d2284c70-7301-11eb-959a-c9595b93b2fb",
-            "count": 1,
-            "type": "trace",
-            "timestamp": "2021-02-19T22:28:41.000Z",
+            "timestamp": "2021-02-20T00:38:27.000Z",
             "trace": {
               "message": "Hello World",
               "severityLevel": 1
@@ -334,9 +127,9 @@
   ],
   "Variables": {
     "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
-    "CLIENT_ID": "72edb0cc-3a4f-4950-b8a1-79ccb14abbff",
+    "CLIENT_ID": "1b695356-0046-4617-ab97-cf253ebfe36b",
     "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
-    "RandomSeed": "1836388136",
+    "RandomSeed": "777990078",
     "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
@@ -7,12 +7,12 @@
         "Accept": "application/json",
         "Content-Length": "268",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210219.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "b8af79b3f3a95cafdcabcfb610e27bcb",
+        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210222.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "886126972ee9a96278ef59f1373e1546",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": [
-        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 01:00:31\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/23/2021 01:03:45\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
       ],
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -21,10 +21,10 @@
         "Access-Control-Max-Age": "3600",
         "Content-Length": "49",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 20 Feb 2021 01:00:31 GMT",
+        "Date": "Tue, 23 Feb 2021 01:03:44 GMT",
         "Strict-Transport-Security": "max-age=31536000",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-session-id": "F0F52E01-EF0B-4873-9C71-4FE42B6387C1"
+        "x-ms-session-id": "7A651808-574D-4F39-8A29-7FF546C3956D"
       },
       "ResponseBody": {
         "itemsReceived": 1,
@@ -49,18 +49,18 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "31",
+        "Age": "5",
         "Connection": "keep-alive",
         "Content-Length": "987",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 01:01:01 GMT",
+        "Date": "Tue, 23 Feb 2021 01:03:50 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": [
           "Accept-Encoding",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-5dd9df5569-kp8f2",
+        "Via": "1.1 draft-oms-5dd9df5569-cwdkm",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -73,10 +73,10 @@
         ],
         "value": [
           {
-            "id": "abcc4da0-7316-11eb-a2e2-05d8e6f9e647",
+            "id": "aec0e210-7572-11eb-a86a-cfd3d5c8ad02",
             "count": 1,
             "type": "trace",
-            "timestamp": "2021-02-20T00:57:57.000Z",
+            "timestamp": "2021-02-23T01:01:38.000Z",
             "trace": {
               "message": "Hello World",
               "severityLevel": 1
@@ -129,7 +129,7 @@
     "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
     "CLIENT_ID": "1b695356-0046-4617-ab97-cf253ebfe36b",
     "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
-    "RandomSeed": "1578816871",
+    "RandomSeed": "1021630504",
     "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
@@ -7,12 +7,12 @@
         "Accept": "application/json",
         "Content-Length": "268",
         "Content-Type": "application/json",
-        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210218.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
-        "x-ms-client-request-id": "ab22ecf322b952181dee84b166700ca4",
+        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210219.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "b8af79b3f3a95cafdcabcfb610e27bcb",
         "x-ms-return-client-request-id": "true"
       },
       "RequestBody": [
-        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 00:39:01\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/20/2021 01:00:31\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
       ],
       "StatusCode": 200,
       "ResponseHeaders": {
@@ -21,10 +21,10 @@
         "Access-Control-Max-Age": "3600",
         "Content-Length": "49",
         "Content-Type": "application/json; charset=utf-8",
-        "Date": "Sat, 20 Feb 2021 00:38:59 GMT",
+        "Date": "Sat, 20 Feb 2021 01:00:31 GMT",
         "Strict-Transport-Security": "max-age=31536000",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-session-id": "DD5D6795-365E-4905-8C1A-4B37855A94FE"
+        "x-ms-session-id": "F0F52E01-EF0B-4873-9C71-4FE42B6387C1"
       },
       "ResponseBody": {
         "itemsReceived": 1,
@@ -49,18 +49,18 @@
       "ResponseHeaders": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
-        "Age": "30",
+        "Age": "31",
         "Connection": "keep-alive",
         "Content-Length": "987",
         "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
-        "Date": "Sat, 20 Feb 2021 00:39:30 GMT",
+        "Date": "Sat, 20 Feb 2021 01:01:01 GMT",
         "OData-Version": "4.0;",
         "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
         "Vary": [
           "Accept-Encoding",
           "Accept-Encoding"
         ],
-        "Via": "1.1 draft-oms-965856f6f-z8tlk",
+        "Via": "1.1 draft-oms-5dd9df5569-kp8f2",
         "X-Content-Type-Options": "nosniff"
       },
       "ResponseBody": {
@@ -73,10 +73,10 @@
         ],
         "value": [
           {
-            "id": "f253c080-7313-11eb-abe7-7f07a3f5233f",
+            "id": "abcc4da0-7316-11eb-a2e2-05d8e6f9e647",
             "count": 1,
             "type": "trace",
-            "timestamp": "2021-02-20T00:38:27.000Z",
+            "timestamp": "2021-02-20T00:57:57.000Z",
             "trace": {
               "message": "Hello World",
               "severityLevel": 1
@@ -129,7 +129,7 @@
     "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
     "CLIENT_ID": "1b695356-0046-4617-ab97-cf253ebfe36b",
     "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
-    "RandomSeed": "777990078",
+    "RandomSeed": "1578816871",
     "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
   }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/SessionRecords/AzureMonitorLogExporterLiveTests/VerifyLogExporterAsync.json
@@ -1,0 +1,342 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://westus2-0.in.applicationinsights.azure.com/v2/track",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Content-Length": "268",
+        "Content-Type": "application/json",
+        "User-Agent": "azsdk-net-Monitor.OpenTelemetry.Exporter/1.0.0-alpha.20210218.1 (.NET Framework 4.8.4300.0; Microsoft Windows 10.0.19042 )",
+        "x-ms-client-request-id": "086909f367a505b00e788e6e381d71d4",
+        "x-ms-return-client-request-id": "true"
+      },
+      "RequestBody": [
+        "{\u0022name\u0022:\u0022Message\u0022,\u0022time\u0022:\u002202/19/2021 22:29:13\u0022,\u0022iKey\u0022:\u0022a0151fae-78ce-447c-88fc-9020efb2091c\u0022,\u0022tags\u0022:{\u0022ai.internal.sdkVersion\u0022:\u0022dotnet4.8:otel1.0.1:ext1.0.0\u0022},\u0022data\u0022:{\u0022baseType\u0022:\u0022MessageData\u0022,\u0022baseData\u0022:{\u0022message\u0022:\u0022Hello World\u0022,\u0022severityLevel\u0022:\u0022Information\u0022,\u0022ver\u0022:2}}}\n"
+      ],
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Name, Content-Type, Accept, Sdk-Context",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Max-Age": "3600",
+        "Content-Length": "49",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Fri, 19 Feb 2021 22:29:12 GMT",
+        "Strict-Transport-Security": "max-age=31536000",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-session-id": "2CE49750-E973-4CF1-827F-74FBDED68BEC"
+      },
+      "ResponseBody": {
+        "itemsReceived": 1,
+        "itemsAccepted": 1,
+        "errors": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Fri, 19 Feb 2021 22:29:44 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": [
+          "Accept",
+          "Accept-Encoding"
+        ],
+        "Via": "1.1 draft-oms-5dd9df5569-2l848",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "30",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Fri, 19 Feb 2021 22:30:14 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-db66m",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "60",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Fri, 19 Feb 2021 22:30:44 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-txwzw",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Age": "90",
+        "Connection": "keep-alive",
+        "Content-Length": "227",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Fri, 19 Feb 2021 22:31:14 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": "Accept-Encoding",
+        "Via": "1.1 draft-oms-5dd9df5569-bf28m",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": []
+      }
+    },
+    {
+      "RequestUri": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/traces?timespan=PT10M",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Authorization": "Sanitized",
+        "User-Agent": [
+          "FxVersion/4.8.4300.0",
+          "OSName/Windows",
+          "OSVersion/10.0.19042.0",
+          "Microsoft.Azure.ApplicationInsights.Query.ApplicationInsightsDataClient/1.1.0.0"
+        ]
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Expose-Headers": "Retry-After,Age,WWW-Authenticate,x-resource-identities,x-ms-status-location",
+        "Connection": "keep-alive",
+        "Content-Length": "1748",
+        "Content-Type": "application/json; charset=utf-8; ieee754compatible=false; odata.metadata=none; odata.streaming=false",
+        "Date": "Fri, 19 Feb 2021 22:31:44 GMT",
+        "OData-Version": "4.0;",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains",
+        "Vary": [
+          "Accept-Encoding",
+          "Accept",
+          "Accept-Encoding"
+        ],
+        "Via": "1.1 draft-oms-5dd9df5569-hpl8m",
+        "X-Content-Type-Options": "nosniff"
+      },
+      "ResponseBody": {
+        "@odata.context": "https://api.applicationinsights.io/v1/apps/cab179c4-5745-42ef-9b49-1eb443e7b760/events/$metadata#traces",
+        "@ai.messages": [
+          {
+            "code": "AddedLimitToQuery",
+            "message": "The query was limited to 500 rows"
+          }
+        ],
+        "value": [
+          {
+            "id": "e47c6050-7301-11eb-b8c9-2fc76a5012f0",
+            "count": 1,
+            "type": "trace",
+            "timestamp": "2021-02-19T22:29:13.000Z",
+            "trace": {
+              "message": "Hello World",
+              "severityLevel": 1
+            },
+            "customDimensions": null,
+            "customMeasurements": null,
+            "operation": {
+              "name": "",
+              "id": "",
+              "parentId": "",
+              "syntheticSource": ""
+            },
+            "session": {
+              "id": ""
+            },
+            "user": {
+              "id": "",
+              "authenticatedId": "",
+              "accountId": ""
+            },
+            "application": {
+              "version": ""
+            },
+            "client": {
+              "type": "PC",
+              "model": "Other",
+              "os": "Windows",
+              "ip": "0.0.0.0",
+              "city": "Redmond",
+              "stateOrProvince": "Washington",
+              "countryOrRegion": "United States",
+              "browser": "Other"
+            },
+            "cloud": {
+              "roleName": "",
+              "roleInstance": ""
+            },
+            "ai": {
+              "appId": "cab179c4-5745-42ef-9b49-1eb443e7b760",
+              "appName": "tileemonitor",
+              "iKey": "a0151fae-78ce-447c-88fc-9020efb2091c",
+              "sdkVersion": "dotnet4.8:otel1.0.1:ext1.0.0"
+            }
+          },
+          {
+            "id": "d2284c70-7301-11eb-959a-c9595b93b2fb",
+            "count": 1,
+            "type": "trace",
+            "timestamp": "2021-02-19T22:28:41.000Z",
+            "trace": {
+              "message": "Hello World",
+              "severityLevel": 1
+            },
+            "customDimensions": null,
+            "customMeasurements": null,
+            "operation": {
+              "name": "",
+              "id": "",
+              "parentId": "",
+              "syntheticSource": ""
+            },
+            "session": {
+              "id": ""
+            },
+            "user": {
+              "id": "",
+              "authenticatedId": "",
+              "accountId": ""
+            },
+            "application": {
+              "version": ""
+            },
+            "client": {
+              "type": "PC",
+              "model": "Other",
+              "os": "Windows",
+              "ip": "0.0.0.0",
+              "city": "Redmond",
+              "stateOrProvince": "Washington",
+              "countryOrRegion": "United States",
+              "browser": "Other"
+            },
+            "cloud": {
+              "roleName": "",
+              "roleInstance": ""
+            },
+            "ai": {
+              "appId": "cab179c4-5745-42ef-9b49-1eb443e7b760",
+              "appName": "tileemonitor",
+              "iKey": "a0151fae-78ce-447c-88fc-9020efb2091c",
+              "sdkVersion": "dotnet4.8:otel1.0.1:ext1.0.0"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "Variables": {
+    "APPLICATION_ID": "cab179c4-5745-42ef-9b49-1eb443e7b760",
+    "CLIENT_ID": "72edb0cc-3a4f-4950-b8a1-79ccb14abbff",
+    "CONNECTION_STRING": "InstrumentationKey=a0151fae-78ce-447c-88fc-9020efb2091c;IngestionEndpoint=https://westus2-0.in.applicationinsights.azure.com/",
+    "RandomSeed": "1836388136",
+    "TENANT_ID": "118397e9-9159-4ad5-bd6f-1d9190d9406a"
+  }
+}

--- a/sdk/monitor/init-test-environment.ps1
+++ b/sdk/monitor/init-test-environment.ps1
@@ -16,4 +16,4 @@ Connect-AzAccount -Subscription $Subscription
 $RootDirectory = (get-item $PSScriptRoot).parent.parent
 $TestResourcesDirectory = Join-Path -Path $RootDirectory -ChildPath eng\common\TestResources
 
-& $TestResourcesDirectory\New-TestResources.ps1 -ServiceDirectory monitor -Subscription $Subscriptiony
+& $TestResourcesDirectory\New-TestResources.ps1 -ServiceDirectory monitor -Subscription $Subscription

--- a/sdk/monitor/init-test-environment.ps1
+++ b/sdk/monitor/init-test-environment.ps1
@@ -1,0 +1,19 @@
+param(
+    [Parameter(Mandatory=$True,HelpMessage="Please enter the Subscription Id (GUID) to setup your test environment.")]
+    [System.String]
+    $Subscription
+)
+
+# README
+# Use this script to initialize a local test environment for running the Integration tests.
+
+# This script requires the AZ Powershell module from the PowerShellGallery
+# https://docs.microsoft.com/en-us/powershell/azure/install-az-ps
+# https://www.powershellgallery.com/packages/Az
+
+Connect-AzAccount -Subscription $Subscription
+
+$RootDirectory = (get-item $PSScriptRoot).parent.parent
+$TestResourcesDirectory = Join-Path -Path $RootDirectory -ChildPath eng\common\TestResources
+
+& $TestResourcesDirectory\New-TestResources.ps1 -ServiceDirectory monitor -Subscription $Subscriptiony

--- a/sdk/monitor/test-resources.json
+++ b/sdk/monitor/test-resources.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "baseName": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "The base resource name."
+            }
+        },
+        "tenantId": {
+            "type": "string",
+            "defaultValue": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+            "metadata": {
+                "description": "The tenant ID to which the application and resources belong."
+            }
+        },
+        "testApplicationOid": {
+            "type": "string",
+            "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
+            "metadata": {
+                "description": "The client OID to grant access to test resources."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "The location of the resource. By default, this is the same as the resource group."
+            }
+        }
+    },
+    "variables": {
+        "azureKeyVaultUrl": "[format('https://{0}.vault.azure.net', parameters('baseName'))]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('baseName')]",
+            "type": "Microsoft.Insights/components",
+            "location": "[parameters('location')]",
+            "apiVersion": "2015-05-01",
+            "properties": {
+                "Application_Type": "other"
+            }
+        }
+    ],
+    "outputs": {
+        "INSTRUMENTATION_KEY": {
+            "value": "[reference(resourceId('Microsoft.Insights/components', parameters('baseName')), '2015-05-01').InstrumentationKey]",
+            "type": "string"
+        },
+        "CONNECTION_STRING": {
+            "value": "[reference(resourceId('Microsoft.Insights/components', parameters('baseName')), '2015-05-01').ConnectionString]",
+            "type": "string"
+        },
+        "APPLICATION_ID": {
+            "value": "[reference(resourceId('Microsoft.Insights/components', parameters('baseName')), '2015-05-01').AppId]",
+            "type": "string"
+        }
+    }
+}

--- a/sdk/monitor/test-resources.json
+++ b/sdk/monitor/test-resources.json
@@ -9,20 +9,6 @@
                 "description": "The base resource name."
             }
         },
-        "tenantId": {
-            "type": "string",
-            "defaultValue": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-            "metadata": {
-                "description": "The tenant ID to which the application and resources belong."
-            }
-        },
-        "testApplicationOid": {
-            "type": "string",
-            "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
-            "metadata": {
-                "description": "The client OID to grant access to test resources."
-            }
-        },
         "location": {
             "type": "string",
             "defaultValue": "[resourceGroup().location]",
@@ -32,7 +18,6 @@
         }
     },
     "variables": {
-        "azureKeyVaultUrl": "[format('https://{0}.vault.azure.net', parameters('baseName'))]"
     },
     "resources": [
         {

--- a/sdk/monitor/test-resources.json
+++ b/sdk/monitor/test-resources.json
@@ -31,10 +31,6 @@
         }
     ],
     "outputs": {
-        "INSTRUMENTATION_KEY": {
-            "value": "[reference(resourceId('Microsoft.Insights/components', parameters('baseName')), '2015-05-01').InstrumentationKey]",
-            "type": "string"
-        },
         "CONNECTION_STRING": {
             "value": "[reference(resourceId('Microsoft.Insights/components', parameters('baseName')), '2015-05-01').ConnectionString]",
             "type": "string"


### PR DESCRIPTION
This PR replaces #18374 

This test is a proof of concept and uses the `AzureMonitorLogExporter` which is still in development.
This test is necessary to set up all the automation and supporting classes for live testing.


This test will:
- provision an Application Insights resource.
- use ILogger to manually log telemetry.
- telemetry will be sent to Azure Monitor ingestion.
- wait for ingestion.
- query Azure Monitor to get the ingestion telemetry.
- validate that actual telemetry matches expected.


This test uses the Azure.Core.TestFramework.
- Includes an ARM template for provisioning a new Application Insights resource.
- This test can run in either Record or Playback mode, and must account for Application Insights' ingestion delay.
     - In record mode, this test will query for telemetry every 30 seconds, timing out after 5 minutes.
     - In playback mode, this test will repeat the retry sequence, but the wait time has been reduced to 0 seconds.