### PR TITLE
[FR] Enable other clouds

### DIFF
--- a/sdk/formrecognizer/test-resources.json
+++ b/sdk/formrecognizer/test-resources.json
@@ -11,7 +11,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "canadacentral",
+            "defaultValue": "[resourceGroup().location]",
             "metadata": {
                 "description": "The location of the resource. By default, this is the same as the resource group."
             }
@@ -20,7 +20,7 @@
             "defaultValue": "formrecognizer",
             "type": "string"
         },
-        "endpointSuffix": {
+        "cognitiveServicesEndpointSuffix": {
             "defaultValue": ".cognitiveservices.azure.com",
             "type": "string"
         },
@@ -48,7 +48,7 @@
         },
         "trainingDataResourceId": {
             "type": "string",
-            "defaultValue": "[resourceId('2cd617ea-1866-46b1-90e3-fffb087ebf9b', 'TrainingData', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
+            "defaultValue": "[resourceId('TrainingData', 'Microsoft.Storage/storageAccounts', parameters('trainingDataAccount'))]"
         },
         "trainingDataSasProperties": {
             "type": "object",
@@ -81,7 +81,7 @@
     "variables": {
         "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908')]",
         "uniqueSubDomainName": "[format('{0}-{1}', parameters('baseName'), parameters('endpointPrefix'))]",
-        "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('endpointSuffix'))]"
+        "endpointValue": "[format('https://{0}-{1}{2}', parameters('baseName'), parameters('endpointPrefix'), parameters('cognitiveServicesEndpointSuffix'))]"
     },
     "resources": [
         {

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -9,9 +9,6 @@ extends:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'canadacentral'
-      Preview:
-        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
-        Location: 'canadacentral'
       Canary:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: 'centraluseuap'

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -4,4 +4,5 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: formrecognizer
+    SupportedClouds: 'Public,Canary,UsGov,China'
     TimeoutInMinutes: 90

--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -4,5 +4,21 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
   parameters:
     ServiceDirectory: formrecognizer
-    SupportedClouds: 'Public,Canary,UsGov,China'
     TimeoutInMinutes: 90
+    CloudConfig:
+      Public:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        Location: 'canadacentral'
+      Preview:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
+        Location: 'canadacentral'
+      Canary:
+        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        Location: 'centraluseuap'
+      UsGov:
+        SubscriptionConfiguration: $(sub-config-gov-test-resources-test)
+        Location: 'usgovvirginia'
+      China:
+        SubscriptionConfiguration: $(sub-config-cn-test-resources)
+        Location: 'chinaeast2'
+    SupportedClouds: 'Public,Canary,UsGov,China'


### PR DESCRIPTION
Notes:
- AAD tests will fail because of issue https://github.com/Azure/azure-sdk-for-net/issues/17192 . Still worth to enable the API Key test.
- Service team asked us to test in `canadacentral` so doing "custom" CloudConfig