### PR TITLE
[synapse] More correctly disable a few tests that require manual setup

### DIFF
--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SparkJobDefinitionClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SparkJobDefinitionClientLiveTests.cs
@@ -19,7 +19,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
     /// These tests have a dependency on live Azure services and may incur costs for the associated
     /// Azure subscription.
     /// </remarks>
-    [LiveOnly] // Requires uploaded application on associated storage (wordcount.zip sample)
+    [Ignore("Requires upload of zip from https://github.com/Azure-Samples/Synapse/tree/main/Spark/DotNET as samples/net/wordcount/wordcount.zip to associated storage.")]
     public class SparkJobDefinitionClientLiveTests : RecordedTestBase<SynapseTestEnvironment>
     {
         internal class DisposableSparkJobDefinition : IAsyncDisposable

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
@@ -19,7 +19,7 @@ namespace Azure.Analytics.Synapse.Monitoring.Samples
     /// </summary>
     public partial class Sample1_PipelineMonitoring : SamplesBase<SynapseTestEnvironment>
     {
-        [LiveOnly] // https://github.com/Azure/azure-sdk-for-net/issues/18832 - Fails on nightly lane due to unreproducable NRE
+        [Ignore] // https://github.com/Azure/azure-sdk-for-net/issues/18832 - Fails on nightly lane due to unreproducable NRE
         [Test]
         public void MonitorPipelineRuns()
         {

--- a/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Monitoring/tests/samples/Sample1_PipelineMonitoring.cs
@@ -19,7 +19,7 @@ namespace Azure.Analytics.Synapse.Monitoring.Samples
     /// </summary>
     public partial class Sample1_PipelineMonitoring : SamplesBase<SynapseTestEnvironment>
     {
-        [Ignore] // https://github.com/Azure/azure-sdk-for-net/issues/18832 - Fails on nightly lane due to unreproducable NRE
+        [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/18832 - Fails on nightly lane due to unreproducable NRE")]
         [Test]
         public void MonitorPipelineRuns()
         {


### PR DESCRIPTION
- Correct test disabling done in https://github.com/Azure/azure-sdk-for-net/pull/18833

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running generate.ps1. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version,

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
