### PR TITLE
Fix image name typo in ci job

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -149,7 +149,7 @@ jobs:
       matrix:
         Linux:
           Pool: azsdk-pool-mms-ubuntu-1804-general
-          OSVmImage: MMSUbunut18.04
+          OSVmImage: MMSUbuntu18.04
           TestTargetFramework: netcoreapp2.1
         Windows_NetCoreApp:
           Pool: azsdk-pool-mms-win-2019-general # Comment out to swap back to public hosted pool.


### PR DESCRIPTION
The OSVmImage name is misspelled as MMSUbun**ut**18.04.