### PR TITLE
[Core] Set default polling time to zero when running on Playback mode

### DIFF
--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -135,16 +135,19 @@ namespace Azure.Core.TestFramework
         }
 
         [OneTimeSetUp]
-        public void OverrideDefaultPollingTime()
+        public void UpdateDefaultPollingTime()
         {
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            if (Mode == RecordedTestMode.Playback)
             {
-                var operationHelpers = assembly.GetType("Azure.Core.OperationHelpers");
-
-                if (operationHelpers != null)
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
                 {
-                    operationHelpers.GetProperty("DefaultPollingInterval").SetValue(null, TimeSpan.FromSeconds(0));
-                    break;
+                    var operationHelpers = assembly.GetType("Azure.Core.OperationHelpers");
+
+                    if (operationHelpers != null)
+                    {
+                        operationHelpers.GetProperty("DefaultPollingInterval").SetValue(null, TimeSpan.FromSeconds(0));
+                        break;
+                    }
                 }
             }
         }

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -134,6 +134,21 @@ namespace Azure.Core.TestFramework
             Logger = null;
         }
 
+        [OneTimeSetUp]
+        public void OverrideDefaultPollingTime()
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var operationHelpers = assembly.GetType("Azure.Core.OperationHelpers");
+
+                if (operationHelpers != null)
+                {
+                    operationHelpers.GetProperty("DefaultPollingInterval").SetValue(null, TimeSpan.FromSeconds(0));
+                    break;
+                }
+            }
+        }
+
         [SetUp]
         public virtual void StartTestRecording()
         {

--- a/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs
@@ -145,7 +145,11 @@ namespace Azure.Core.TestFramework
 
                     if (operationHelpers != null)
                     {
-                        operationHelpers.GetProperty("DefaultPollingInterval").SetValue(null, TimeSpan.FromSeconds(0));
+                        operationHelpers
+                            .GetProperty("DefaultPollingInterval")?
+                            .GetSetMethod()?
+                            .Invoke(null, new object[] { TimeSpan.FromSeconds(0) });
+
                         break;
                     }
                 }

--- a/sdk/core/Azure.Core/src/Shared/OperationHelpers.cs
+++ b/sdk/core/Azure.Core/src/Shared/OperationHelpers.cs
@@ -11,7 +11,7 @@ namespace Azure.Core
 {
     internal static class OperationHelpers
     {
-        public static TimeSpan DefaultPollingInterval { get; } = TimeSpan.FromSeconds(1);
+        public static TimeSpan DefaultPollingInterval { get; set; } = TimeSpan.FromSeconds(1);
 
         public static T GetValue<T>(ref T? value) where T: class
         {

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormRecognizerClient/FormRecognizerClientLiveTests.cs
@@ -58,7 +58,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             // Sanity check to make sure we got an actual response back from the service.
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
+            FormPageCollection formPages = await operation.WaitForCompletionAsync();
             var formPage = formPages.Single();
 
             Assert.Greater(formPage.Lines.Count, 0);
@@ -91,7 +91,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
 
             var formPage = operation.Value.Single();
@@ -198,7 +198,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
 
             var formPage = operation.Value.Single();
@@ -311,7 +311,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentFromUriAsync(uri);
             }
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
+            FormPageCollection formPages = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(2, formPages.Count);
 
@@ -343,7 +343,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentAsync(stream, options);
             }
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
+            FormPageCollection formPages = await operation.WaitForCompletionAsync();
             var blankPage = formPages.Single();
 
             ValidateFormPage(blankPage, includeFieldElements: true, expectedPageNumber: 1);
@@ -365,7 +365,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentAsync(stream);
             }
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
+            FormPageCollection formPages = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(3, formPages.Count);
 
@@ -442,7 +442,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
 
             var formPage = operation.Value.Single();
@@ -464,7 +464,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentAsync(stream, new RecognizeContentOptions() { Pages =  { pages } });
             }
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
+            FormPageCollection formPages = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(expected, formPages.Count);
         }
@@ -483,7 +483,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeContentAsync(stream, new RecognizeContentOptions() { Pages = { page1, page2 } });
             }
 
-            FormPageCollection formPages = await operation.WaitForCompletionAsync(PollingInterval);
+            FormPageCollection formPages = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(expected, formPages.Count);
         }
@@ -497,7 +497,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var uri = FormRecognizerTestEnvironment.CreateUri(TestFile.Form1);
             operation = await client.StartRecognizeContentFromUriAsync(uri, new RecognizeContentOptions() { Language = FormRecognizerLanguage.En } );
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
 
             var formPage = operation.Value.Single();
@@ -533,7 +533,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             // Sanity check to make sure we got an actual response back from the service.
 
-            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync();
 
             RecognizedForm form = formPage.Single();
             Assert.NotNull(form);
@@ -571,7 +571,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsFromUriAsync(uri, default);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -682,7 +682,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsFromUriAsync(uri, default);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -797,7 +797,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsFromUriAsync(uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(2, recognizedForms.Count);
 
@@ -843,7 +843,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var blankForm = recognizedForms.Single();
 
@@ -874,7 +874,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(3, recognizedForms.Count);
 
@@ -959,7 +959,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeReceiptsAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var receipt = recognizedForms.Single();
 
@@ -1011,7 +1011,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             // Sanity check to make sure we got an actual response back from the service.
 
-            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync();
 
             RecognizedForm form = formPage.Single();
             Assert.NotNull(form);
@@ -1045,7 +1045,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeBusinessCardsFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -1152,7 +1152,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeBusinessCardsFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -1250,7 +1250,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeBusinessCardsAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var businessCardsForm = recognizedForms.Single();
 
@@ -1274,7 +1274,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeBusinessCardsAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var blankForm = recognizedForms.Single();
 
@@ -1345,7 +1345,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeBusinessCardsFromUriAsync(uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(2, recognizedForms.Count);
 
@@ -1401,7 +1401,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeBusinessCardsAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var businessCard = recognizedForms.Single();
 
@@ -1453,7 +1453,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             // Sanity check to make sure we got an actual response back from the service.
 
-            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync();
 
             RecognizedForm form = formPage.Single();
             Assert.NotNull(form);
@@ -1487,7 +1487,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeInvoicesFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -1555,7 +1555,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeInvoicesFromUriAsync(uri);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -1620,7 +1620,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeInvoicesAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var invoicesform = recognizedForms.Single();
 
@@ -1643,7 +1643,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeInvoicesAsync(stream);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var blankForm = recognizedForms.Single();
 
@@ -1685,7 +1685,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeInvoicesFromUriAsync(uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var form = recognizedForms.Single();
 
@@ -1769,7 +1769,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeInvoicesAsync(stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var invoice = recognizedForms.Single();
 
@@ -1824,7 +1824,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             // Sanity check to make sure we got an actual response back from the service.
 
-            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection formPage = await operation.WaitForCompletionAsync();
 
             RecognizedForm form = formPage.Single();
             Assert.NotNull(form);
@@ -1881,7 +1881,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
             Assert.GreaterOrEqual(operation.Value.Count, 1);
@@ -1930,7 +1930,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream, options);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
             Assert.GreaterOrEqual(operation.Value.Count, 1);
@@ -1974,7 +1974,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var recognizedForm = recognizedForms.Single();
 
@@ -2023,7 +2023,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var recognizedForm = recognizedForms.Single();
 
@@ -2066,7 +2066,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var recognizedForm = recognizedForms.Single();
 
@@ -2115,7 +2115,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream);
             }
 
-            RecognizedFormCollection forms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection forms = await operation.WaitForCompletionAsync();
             var fields = forms.Single().Fields;
 
             // Verify that we got back at least one null field to make sure we hit the code path we want to test.
@@ -2154,7 +2154,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
             Assert.GreaterOrEqual(operation.Value.Count, 1);
@@ -2214,7 +2214,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(2, recognizedForms.Count);
 
@@ -2256,7 +2256,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             var blankForm = recognizedForms.Single();
 
@@ -2300,7 +2300,7 @@ namespace Azure.AI.FormRecognizer.Tests
                 operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, uri, options);
             }
 
-            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync(PollingInterval);
+            RecognizedFormCollection recognizedForms = await operation.WaitForCompletionAsync();
 
             Assert.AreEqual(3, recognizedForms.Count);
 
@@ -2354,7 +2354,7 @@ namespace Azure.AI.FormRecognizer.Tests
             await using var trainedModel = await CreateDisposableTrainedModelAsync(useTrainingLabels);
             var operation = await client.StartRecognizeCustomFormsAsync(trainedModel.ModelId, stream);
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
 
             Assert.AreEqual("2005", ex.ErrorCode);
 
@@ -2378,7 +2378,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             var operation = await client.StartRecognizeCustomFormsFromUriAsync(trainedModel.ModelId, invalidUri);
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
 
             Assert.AreEqual("2003", ex.ErrorCode);
             Assert.True(operation.HasCompleted);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/FormTrainingClient/FormTrainingClientLiveTests.cs
@@ -45,7 +45,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false);
 
-            CustomFormModel model = await operation.WaitForCompletionAsync(PollingInterval);
+            CustomFormModel model = await operation.WaitForCompletionAsync();
 
             // Sanity check to make sure we got an actual response back from the service.
             Assert.IsNotNull(model.ModelId);
@@ -65,7 +65,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var trainingFilesUri = new Uri(singlePage ? TestEnvironment.BlobContainerSasUrl : TestEnvironment.MultipageBlobContainerSasUrl);
 
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, labeled);
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -116,7 +116,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var trainingFilesUri = new Uri(TestEnvironment.BlobContainerSasUrl);
 
             TrainingOperation trainingOperation = await client.StartTrainingAsync(trainingFilesUri, labeled);
-            await trainingOperation.WaitForCompletionAsync(PollingInterval);
+            await trainingOperation.WaitForCompletionAsync();
             Assert.IsTrue(trainingOperation.HasValue);
 
             CustomFormModel model = trainingOperation.Value;
@@ -124,7 +124,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             var uri = FormRecognizerTestEnvironment.CreateUri(TestFile.Form1);
             RecognizeCustomFormsOperation recognizeOperation = await formClient.StartRecognizeCustomFormsFromUriAsync(model.ModelId, uri);
-            await recognizeOperation.WaitForCompletionAsync(PollingInterval);
+            await recognizeOperation.WaitForCompletionAsync();
             Assert.IsTrue(recognizeOperation.HasValue);
 
             RecognizedForm form = recognizeOperation.Value.Single();
@@ -145,7 +145,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var modelIds = new List<string> { trainedModelA.ModelId, trainedModelB.ModelId };
 
             CreateComposedModelOperation operation = await client.StartCreateComposedModelAsync(modelIds, "My composed model");
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -225,7 +225,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var filter = new TrainingFileFilter { IncludeSubfolders = true, Prefix = "subfolder" };
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, new TrainingOptions() { TrainingFileFilter = filter});
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
             Assert.AreEqual(CustomFormModelStatus.Ready, operation.Value.Status);
@@ -240,7 +240,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var filter = new TrainingFileFilter { IncludeSubfolders = true, Prefix = "invalidPrefix" };
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, new TrainingOptions() { TrainingFileFilter = filter });
 
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
             Assert.AreEqual("2014", ex.ErrorCode);
         }
 
@@ -253,7 +253,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: true, modelName);
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
             Assert.AreEqual(modelName, operation.Value.ModelName);
@@ -269,7 +269,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false, modelName);
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
             Assert.AreEqual(modelName, operation.Value.ModelName);
@@ -283,7 +283,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var containerUrl = new Uri("https://someUrl");
 
             TrainingOperation operation = await client.StartTrainingAsync(containerUrl, useTrainingLabels: false);
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
             Assert.AreEqual("2001", ex.ErrorCode);
 
             Assert.False(operation.HasValue);
@@ -302,7 +302,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             TrainingOperation operation = await client.StartTrainingAsync(trainingFilesUri, labeled);
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
 
@@ -390,7 +390,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             CopyModelOperation operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
 
             CustomFormModelInfo modelCopied = operation.Value;
@@ -417,7 +417,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             CopyModelOperation operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
 
             CustomFormModelInfo modelCopied = operation.Value;
@@ -446,14 +446,14 @@ namespace Azure.AI.FormRecognizer.Tests
 
             string modelName = "My composed model";
             CreateComposedModelOperation operation = await sourceClient.StartCreateComposedModelAsync(modelIds, modelName);
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
             CustomFormModel composedModel = operation.Value;
 
             CopyAuthorization targetAuth = await targetClient.GetCopyAuthorizationAsync(resourceId, region);
 
             CopyModelOperation copyOperation = await sourceClient.StartCopyModelAsync(composedModel.ModelId, targetAuth);
-            await copyOperation.WaitForCompletionAsync(PollingInterval);
+            await copyOperation.WaitForCompletionAsync();
             Assert.IsTrue(copyOperation.HasValue);
             CustomFormModelInfo modelCopied = copyOperation.Value;
 
@@ -485,7 +485,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             CopyModelOperation operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
-            await operation.WaitForCompletionAsync(PollingInterval);
+            await operation.WaitForCompletionAsync();
             Assert.IsTrue(operation.HasValue);
 
             CustomFormModelInfo modelCopied = operation.Value;
@@ -526,7 +526,7 @@ namespace Azure.AI.FormRecognizer.Tests
 
             var operation = await sourceClient.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync(PollingInterval));
+            Assert.ThrowsAsync<RequestFailedException>(async () => await operation.WaitForCompletionAsync());
         }
 
         [Test]

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DisposableTrainedModel.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/DisposableTrainedModel.cs
@@ -48,13 +48,12 @@ namespace Azure.AI.FormRecognizer.Tests
         /// <param name="trainingClient">The client to use for training and for deleting the model upon disposal.</param>
         /// <param name="trainingFilesUri">An externally accessible Azure storage blob container Uri.</param>
         /// <param name="useTrainingLabels">If <c>true</c>, use a label file created in the &lt;link-to-label-tool-doc&gt; to provide training-time labels for training a model. If <c>false</c>, the model will be trained from forms only.</param>
-        /// <param name="pollingInterval">Polling interval value to use.</param>
         /// <param name="modelName">Optional model name.</param>
         /// <returns>A <see cref="DisposableTrainedModel"/> instance from which the trained model ID can be obtained.</returns>
-        public static async Task<DisposableTrainedModel> TrainModelAsync(FormTrainingClient trainingClient, Uri trainingFilesUri, bool useTrainingLabels, TimeSpan pollingInterval, string modelName = default)
+        public static async Task<DisposableTrainedModel> TrainModelAsync(FormTrainingClient trainingClient, Uri trainingFilesUri, bool useTrainingLabels, string modelName = default)
         {
             TrainingOperation operation = await trainingClient.StartTrainingAsync(trainingFilesUri, useTrainingLabels, modelName);
-            await operation.WaitForCompletionAsync(pollingInterval);
+            await operation.WaitForCompletionAsync();
 
             Assert.IsTrue(operation.HasValue);
             Assert.AreEqual(CustomFormModelStatus.Ready, operation.Value.Status);

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Infrastructure/FormRecognizerLiveTestBase.cs
@@ -11,8 +11,6 @@ namespace Azure.AI.FormRecognizer.Tests
 {
     public class FormRecognizerLiveTestBase : RecordedTestBase<FormRecognizerTestEnvironment>
     {
-        protected TimeSpan PollingInterval => TimeSpan.FromSeconds(Mode == RecordedTestMode.Playback ? 0 : 1);
-
         public FormRecognizerLiveTestBase(bool isAsync)
             : base(isAsync)
         {
@@ -115,7 +113,7 @@ namespace Azure.AI.FormRecognizer.Tests
             };
             var trainingFilesUri = new Uri(trainingFiles);
 
-            return await DisposableTrainedModel.TrainModelAsync(trainingClient, trainingFilesUri, useTrainingLabels, PollingInterval, modelName);
+            return await DisposableTrainedModel.TrainModelAsync(trainingClient, trainingFilesUri, useTrainingLabels, modelName);
         }
 
         protected enum ContainerType

--- a/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
+++ b/sdk/formrecognizer/Azure.AI.FormRecognizer/tests/Models/OperationsLiveTests.cs
@@ -37,7 +37,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartRecognizeContentFromUriAsync(uri);
 
             var sameOperation = new RecognizeContentOperation(operation.Id, nonInstrumentedClient);
-            await sameOperation.WaitForCompletionAsync(PollingInterval);
+            await sameOperation.WaitForCompletionAsync();
 
             Assert.IsTrue(sameOperation.HasValue);
             Assert.AreEqual(1, sameOperation.Value.Count);
@@ -52,7 +52,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartRecognizeReceiptsFromUriAsync(uri);
 
             var sameOperation = new RecognizeReceiptsOperation(operation.Id, nonInstrumentedClient);
-            await sameOperation.WaitForCompletionAsync(PollingInterval);
+            await sameOperation.WaitForCompletionAsync();
 
             Assert.IsTrue(sameOperation.HasValue);
             Assert.AreEqual(1, sameOperation.Value.Count);
@@ -67,7 +67,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartRecognizeInvoicesFromUriAsync(uri);
 
             var sameOperation = new RecognizeInvoicesOperation(operation.Id, nonInstrumentedClient);
-            await sameOperation.WaitForCompletionAsync(PollingInterval);
+            await sameOperation.WaitForCompletionAsync();
 
             Assert.IsTrue(sameOperation.HasValue);
             Assert.AreEqual(1, sameOperation.Value.Count);
@@ -88,7 +88,7 @@ namespace Azure.AI.FormRecognizer.Tests
             }
 
             var sameOperation = new RecognizeCustomFormsOperation(operation.Id, nonInstrumentedClient);
-            await sameOperation.WaitForCompletionAsync(PollingInterval);
+            await sameOperation.WaitForCompletionAsync();
 
             Assert.IsTrue(sameOperation.HasValue);
             Assert.AreEqual(1, sameOperation.Value.Count);
@@ -103,7 +103,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartTrainingAsync(trainingFilesUri, useTrainingLabels: false);
 
             var sameOperation = new TrainingOperation(operation.Id, nonInstrumentedClient);
-            await sameOperation.WaitForCompletionAsync(PollingInterval);
+            await sameOperation.WaitForCompletionAsync();
 
             Assert.IsTrue(sameOperation.HasValue);
             Assert.AreEqual(CustomFormModelStatus.Ready, sameOperation.Value.Status);
@@ -120,7 +120,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartCreateComposedModelAsync(new List<string> { trainedModelA.ModelId, trainedModelB.ModelId });
 
             var sameOperation = new CreateComposedModelOperation(operation.Id, nonInstrumentedClient);
-            await sameOperation.WaitForCompletionAsync(PollingInterval);
+            await sameOperation.WaitForCompletionAsync();
 
             Assert.IsTrue(sameOperation.HasValue);
             Assert.AreEqual(CustomFormModelStatus.Ready, sameOperation.Value.Status);
@@ -139,7 +139,7 @@ namespace Azure.AI.FormRecognizer.Tests
             var operation = await client.StartCopyModelAsync(trainedModel.ModelId, targetAuth);
 
             var sameOperation = new CopyModelOperation(operation.Id, targetAuth.ModelId, nonInstrumentedClient);
-            await sameOperation.WaitForCompletionAsync(PollingInterval);
+            await sameOperation.WaitForCompletionAsync();
 
             Assert.IsTrue(sameOperation.HasValue);
             Assert.AreEqual(targetAuth.ModelId, sameOperation.Value.ModelId);


### PR DESCRIPTION
Libraries that clearly improved Playback running time when setting default polling time to zero:
- FormRecognizer (25.1m => 31.9s): polling time was already being manually set to zero in every test. Manual setup has been removed.
- KeyVault.Certificates (30.2s => 950ms)

The following libraries didn't show major improvements, possibly because their APIs don't rely that much on LROs. Their running times are considerably short anyway (<10s, except for Storage):
- Communication.PhoneNumbers
- KeyVault.Administration
- KeyVault.Keys
- KeyVault.Secrets
- Storage.Blobs
- Synapse.Spark
- TextAnalytics

Some libraries set their own default polling time interval, so our current approach won't work against them (follow-up: https://github.com/Azure/azure-sdk-for-net/issues/18958).

All runs performed locally (single-thread).

Fixes https://github.com/azure/azure-sdk-for-net/issues/12815.