### PR TITLE
[Event Hubs Client] Performance Tests

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -10,6 +10,7 @@ omitted_paths:
   - common/Perf/*
   - common/SmokeTests/*
   - common/Stress/*
+  - sdk/*/*/perf/*
   - sdk/*/samples/*
   - sdk/*/*/samples/*
   - sdk/*/swagger/*

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Processor/Directory.Build.props
@@ -9,8 +9,9 @@
   -->
   <PropertyGroup Condition="$(MSBuildProjectName.Contains('.Samples'))">
     <IsSamplesProject>true</IsSamplesProject>
+    <IsTestSupportProject>true</IsTestSupportProject>
   </PropertyGroup>
 
   <!-- Import the common SDK build properties. -->
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\.., Directory.Build.props))\Directory.Build.props" />
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.Perf.projitems
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Azure.Messaging.EventHubs.Shared.Perf.projitems
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>113f551c-1f39-4f7c-afd6-9b330b4b1137</SharedGUID>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Import_RootNamespace>Azure.Messaging.EventHubs.Tests</Import_RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisfileDirectory)Testing\EventGenerator.cs" Link="SharedSource\Perf\%(Filename)%(Extension)" />
+    <Compile Include="$(MSBuildThisfileDirectory)Testing\EventHubScope.cs" Link="SharedSource\Perf\%(Filename)%(Extension)" />
+    <Compile Include="$(MSBuildThisfileDirectory)Testing\EventHubsTestEnvironment.cs" Link="SharedSource\Perf\%(Filename)%(Extension)" />
+    <Compile Include="$(MSBuildThisfileDirectory)Testing\LiveResourceManager.cs" Link="SharedSource\Perf\%(Filename)%(Extension)" />
+  </ItemGroup>
+</Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventGenerator.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs.Shared/src/Testing/EventGenerator.cs
@@ -26,6 +26,23 @@ namespace Azure.Messaging.EventHubs.Tests
         private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
 
         /// <summary>
+        ///   Creates a buffer of read-only memory with random values to serve
+        ///   as the body of an event.
+        /// </summary>
+        ///
+        /// <param name="bodySizeBytes">The size of the body, in bytes.</param>
+        ///
+        /// <returns>A memory buffer of the requested size range containing randomized data.</returns>
+        ///
+        public static ReadOnlyMemory<byte> CreateRandomBody(long bodySizeBytes)
+        {
+            var buffer = new byte[bodySizeBytes];
+            RandomNumberGenerator.Value.NextBytes(buffer);
+
+            return buffer;
+        }
+
+        /// <summary>
         ///   Creates a set of events with random data and random body size.
         /// </summary>
         ///
@@ -84,6 +101,25 @@ namespace Azure.Messaging.EventHubs.Tests
             currentEvent.Properties.Add(IdPropertyName, Guid.NewGuid().ToString());
 
             return currentEvent;
+        }
+
+        /// <summary>
+        ///   Creates and configures an <see cref="EventData" /> instance using the
+        ///   provided <paramref name="eventBody" /> as the embedded data.
+        /// </summary>
+        ///
+        /// <param name="numberOfEvents">The number of events to create.</param>
+        /// <param name="eventBody">The set of bytes to use as the data body of the event.</param>
+        ///
+        /// <returns>The requested set of events.</returns>
+        ///
+        public static IEnumerable<EventData> CreateEventsFromBody(int numberOfEvents,
+                                                                  ReadOnlyMemory<byte> eventBody)
+        {
+            for (var index = 0; index < numberOfEvents; ++index)
+            {
+                yield return CreateEventFromBody(eventBody);
+            }
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Directory.Build.props
@@ -9,8 +9,9 @@
   -->
   <PropertyGroup Condition="$(MSBuildProjectName.Contains('.Samples'))">
     <IsSamplesProject>true</IsSamplesProject>
+    <IsTestSupportProject>true</IsTestSupportProject>
   </PropertyGroup>
 
   <!-- Import the common SDK build properties. -->
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\.., Directory.Build.props))\Directory.Build.props" />
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Azure.Messaging.EventHubs.Perf.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Azure.Messaging.EventHubs.Perf.csproj
@@ -1,0 +1,30 @@
+﻿
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.0.0</Version>
+    <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
+    <IsTestSupportProject>true</IsTestSupportProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="SharedSource\" />
+  </ItemGroup>
+
+   <ItemGroup>
+    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
+    <PackageReference Include="Polly" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\src\Azure.Messaging.EventHubs.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
+    <ProjectReference Include="$(AzureCoreTestFramework)" />
+  </ItemGroup>
+
+  <!-- Import Event Hubs shared source -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\Azure.Messaging.EventHubs.Shared\src\Azure.Messaging.EventHubs.Shared.Perf.projitems" Label="Perf" />
+</Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Azure.Messaging.EventHubs.Perf.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Azure.Messaging.EventHubs.Perf.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs.Perf", "Azure.Messaging.EventHubs.Perf.csproj", "{91411BDA-79AE-45EA-AE76-A630680CE72F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91411BDA-79AE-45EA-AE76-A630680CE72F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0EF42B14-3D19-4BE9-AE4E-B23186F2E985}
+	EndGlobalSection
+EndGlobal

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/BatchPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/BatchPublishPerfTest.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Messaging.EventHubs.Tests;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing batches of events.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public abstract class BatchPublishPerfTest : EventHubsPerfTest
+    {
+        /// <summary>The Event Hub to publish events to; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubScope s_scope;
+
+        /// <summary>The producer instance for publishing events; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubProducerClient s_producer;
+
+        /// <summary>The body to use when creating events.</summary>
+        private static ReadOnlyMemory<byte> s_eventBody;
+
+        /// <summary>The set of options to use when creating batches.</summary>
+        private static CreateBatchOptions s_batchOptions;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="BatchPublishPerfTest"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public BatchPublishPerfTest(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalSetupAsync().ConfigureAwait(false);
+
+            s_scope = await EventHubScope.CreateAsync(4).ConfigureAwait(false);
+            s_producer = new EventHubProducerClient(TestEnvironment.EventHubsConnectionString, s_scope.EventHubName);
+            s_batchOptions = await CreateBatchOptions(s_producer).ConfigureAwait(false);
+            s_eventBody = EventGenerator.CreateRandomBody(Options.Size);
+
+            // Publish an empty event to force the connection and link to be established.
+
+            using var batch = await s_producer.CreateBatchAsync(s_batchOptions).ConfigureAwait(false);
+
+            if (!batch.TryAdd(new EventData(Array.Empty<byte>())))
+            {
+                throw new InvalidOperationException("The empty event could not be added to the batch during global setup.");
+            }
+
+            await s_producer.SendAsync(batch).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await s_producer.CloseAsync().ConfigureAwait(false);
+            await s_scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            using var batch = await s_producer.CreateBatchAsync(s_batchOptions, cancellationToken).ConfigureAwait(false);
+
+            // Fill the batch with events using the same body.  This will result in a batch of events of equal size.
+            // The events will only differ by the id property that is assigned to them.
+
+            foreach (var eventData in EventGenerator.CreateEventsFromBody(Options.Count, s_eventBody))
+            {
+                if (!batch.TryAdd(eventData))
+                {
+                    throw new InvalidOperationException("It was not possible to fit the requested number of events in a single batch.");
+                }
+            }
+
+            await s_producer.SendAsync(batch, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Determines the set of <see cref="Azure.Messaging.EventHubs.Producer.CreateBatchOptions"/>
+        ///   needed for this test scenario.
+        /// </summary>
+        ///
+        /// <param name="producer">The active producer for the test scenario.</param>
+        ///
+        /// <returns>The set of options to use when creating batches to be published.</returns>
+        ///
+        protected abstract Task<CreateBatchOptions> CreateBatchOptions(EventHubProducerClient producer);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/EventHubsPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/EventHubsPerfTest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure.Messaging.EventHubs.Tests;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf
+{
+    /// <summary>
+    ///   A base class for Event Hubs performance test scenarios, facilitating.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Test.Perf.PerfTest{SizeCountOptions}" />
+    ///
+    public abstract class EventHubsPerfTest : PerfTest<SizeCountOptions>
+    {
+        /// <summary>
+        ///   The active <see cref="EventHubsTestEnvironment" /> instance for the
+        ///   performance test scenarios.
+        /// </summary>
+        ///
+        protected EventHubsTestEnvironment TestEnvironment => EventHubsTestEnvironment.Instance;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsPerfTest"/> class.
+        /// </summary>
+        ///
+        /// /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        protected EventHubsPerfTest(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario synchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public override void Run(CancellationToken cancellationToken) => throw new InvalidOperationException("Only asynchronous execution is supported.");
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/EventPublishPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/EventPublishPerfTest.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Messaging.EventHubs.Tests;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing sets of events
+    ///   without a batch.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public abstract class EventPublishPerfTest : EventHubsPerfTest
+    {
+        /// <summary>The Event Hub to publish events to; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubScope s_scope;
+
+        /// <summary>The producer instance for publishing events; shared across all concurrent instances of the scenario.</summary>
+        private static EventHubProducerClient s_producer;
+
+        /// <summary>The body to use when creating events.</summary>
+        private static ReadOnlyMemory<byte> s_eventBody;
+
+        /// <summary>The set of options to use when publishing events.</summary>
+        private static SendEventOptions s_sendOptions;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventPublishPerfTest"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public EventPublishPerfTest(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalSetupAsync().ConfigureAwait(false);
+
+            s_scope = await EventHubScope.CreateAsync(4).ConfigureAwait(false);
+            s_producer = new EventHubProducerClient(TestEnvironment.EventHubsConnectionString, s_scope.EventHubName);
+            s_sendOptions = await CreateSendOptions(s_producer).ConfigureAwait(false);
+            s_eventBody = EventGenerator.CreateRandomBody(Options.Size);
+
+            // Publish an empty event to force the connection and link to be established.
+
+            await s_producer.SendAsync(new[] { new EventData(Array.Empty<byte>()) }, s_sendOptions).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await s_producer.CloseAsync().ConfigureAwait(false);
+            await s_scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            // Generate a set of events using the same body.  This will result in publishing a set of events
+            // of equal size. The events will only differ by the id property that is assigned to them.
+
+            await s_producer.SendAsync(
+                EventGenerator.CreateEventsFromBody(Options.Count, s_eventBody),
+                s_sendOptions,
+                cancellationToken
+            ).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Determines the set of <see cref="Azure.Messaging.EventHubs.Producer.SendEventOptions"/>
+        ///   needed for this test scenario.
+        /// </summary>
+        ///
+        /// <param name="producer">The active producer for the test scenario.</param>
+        ///
+        /// <returns>The set of options to use when publishing events.</returns>
+        ///
+        protected abstract Task<SendEventOptions> CreateSendOptions(EventHubProducerClient producer);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/ReadPerfTest.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Infrastructure/ReadPerfTest.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Messaging.EventHubs.Tests;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing sets of events
+    ///   without a batch.
+    /// </summary>
+    ///
+    /// <seealso cref="EventHubsPerfTest" />
+    ///
+    public abstract class ReadPerfTest : EventHubsPerfTest
+    {
+        /// <summary>
+        ///   The Event Hub to publish events to; shared across all concurrent instances of the scenario.
+        /// </summary>
+        ///
+        protected static EventHubScope Scope { get; private set; }
+
+        /// <summary>
+        ///   The set of consumer groups available for readers to reserve an instance of.
+        /// </summary>
+        ///
+        protected static ConcurrentQueue<string> ConsumerGroups { get; private set;}
+
+        /// <summary>
+        ///   The identifier of the Event Hub partition from which events should be read.
+        /// </summary>
+        ///
+        protected static string PartitionId { get; private set; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ReadPerfTest"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public ReadPerfTest(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the setup will take place once, prior to the
+        ///   execution of the first test instance.
+        /// </summary>
+        ///
+        public async override Task GlobalSetupAsync()
+        {
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+
+            // The limit for concurrent readers in a consumer group is 5; create
+            // enough consumer groups to support the requested parallelism.
+
+            var consumerGroups = Enumerable
+                .Range(0, (int)Math.Ceiling(Options.Parallel / 5.0d))
+                .Select(index => $"group{ index }");
+
+            // Create the Event Hub scope using the computed consumer groups; queue the
+            // groups with 5 instances each, so that readers can reserve one without
+            // exceeding the concurrent reader limit.
+
+            Scope = await EventHubScope.CreateAsync(4, consumerGroups).ConfigureAwait(false);
+            ConsumerGroups = new ConcurrentQueue<string>(consumerGroups.SelectMany(group => Repeat(group, 5)));
+
+            // Select the first available partition to use for operations.
+
+            await using var producer = new EventHubProducerClient(TestEnvironment.EventHubsConnectionString, Scope.EventHubName);
+            PartitionId = (await producer.GetPartitionIdsAsync().ConfigureAwait(false)).First();
+
+            // Seed the necessary number of events to the selected partition.  Note that this
+            // method makes heavy use of class state such as the TestEnvironment, Options, and
+            // PartitionId.
+
+            await SeedEventsToBeReadAsync(producer).ConfigureAwait(false);
+
+            // Force a pause to give the events time to be committed in the Event Hubs
+            // service and made available to read.
+
+            await Task.Delay(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for the test scenario.
+        ///   When multiple instances are run in parallel, the cleanup will take place once,
+        ///   after the execution of all test instances.
+        /// </summary>
+        ///
+        public async override Task GlobalCleanupAsync()
+        {
+            await Scope.DisposeAsync().ConfigureAwait(false);
+            await base.GlobalCleanupAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Seeds the Event Hub partition with enough events to satisfy the read operations the test scenario
+        ///   is expected to perform.
+        /// </summary>
+        ///
+        /// <param name="producer">The producer to use for publishing events; ownership is assumed to be retained by the caller.</param>
+        ///
+        /// <remarks>
+        ///   This method makes heavy use of class state, including the
+        ///   test environment and command line options.
+        /// </remarks>
+        ///
+        private async Task SeedEventsToBeReadAsync(EventHubProducerClient producer)
+        {
+            // Calculate the number of events needed to satisfy the number of events per iteration
+            // and then buffer it to allow for the warm-up.
+
+            var eventCount = Options.Count * Options.Iterations * 3;
+            var eventBody = EventGenerator.CreateRandomBody(Options.Size);
+            var batchOptions = new CreateBatchOptions { PartitionId = PartitionId };
+
+            foreach (var eventData in EventGenerator.CreateEventsFromBody(eventCount, eventBody))
+            {
+                using var batch = await producer.CreateBatchAsync(batchOptions).ConfigureAwait(false);
+
+                // Fill the batch with as many events that will fit.
+
+                while (batch.TryAdd(EventGenerator.CreateEventFromBody(eventBody)))
+                {
+                }
+
+                // If there were no events in the batch, then a single event was generated that is too large to
+                // ever send.  In this context, it will be detected on the first TryAdd call, since events are
+                // sharing a common body.
+
+                if (batch.Count == 0)
+                {
+                    throw new InvalidOperationException("There was an event too large to fit into a batch.");
+                }
+
+                await producer.SendAsync(batch).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        ///   Repeats the specified string the requested number of times, capturing the instances
+        ///   into a set.
+        /// </summary>
+        ///
+        /// <param name="item">The item to duplicate.</param>
+        /// <param name="count">The number of duplicate items that the resulting set should contain.</param>
+        ///
+        /// <returns>A set of <paramref name="item" /> duplicated <paramref name="count" /> times.</returns>
+        ///
+        private IEnumerable<string> Repeat(string item,
+                                           int count) =>
+            Enumerable
+                .Range(1, count)
+                .Select(index => item);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Program.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using Azure.Messaging.EventHubs.Tests;
+using Azure.Test.Perf;
+
+try
+{
+    // Ensure that there is an active Event Hubs namespace that can be used across all
+    // scenarios.  Requesting the connection string will trigger creation of an ephemeral
+    // namespace if an existing one wasn't explicitly provided.
+
+    _ = EventHubsTestEnvironment.Instance.EventHubsConnectionString;
+
+    // Allow the framework to execute the test scenarios.
+
+    await PerfProgram.Main(Assembly.GetEntryAssembly(), args);
+}
+finally
+{
+    if (EventHubsTestEnvironment.Instance.ShouldRemoveNamespaceAfterTestRunCompletion)
+    {
+        try
+        {
+            await EventHubScope.DeleteNamespaceAsync(EventHubsTestEnvironment.Instance.EventHubsNamespace).ConfigureAwait(false);
+        }
+        catch
+        {
+            // This should not be considered a critical failure that results in a test run failure.  Due
+            // to ARM being temperamental, some management operations may be rejected.  Throwing here
+            // does not help to ensure resource cleanup.
+            //
+            // Assume the standard orphan resource cleanup is being run and will take responsibility
+            // for cleaning up any orphans.
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishBatchesToGateway.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishBatchesToGateway.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing batches of events
+    ///   to the Event Hubs gateway endpoint.
+    /// </summary>
+    ///
+    /// <seealso cref="BatchPublishPerfTest" />
+    ///
+    public sealed class PublishBatchesToGateway : BatchPublishPerfTest
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishBatchesToGateway"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishBatchesToGateway(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Determines the set of <see cref="Azure.Messaging.EventHubs.Producer.CreateBatchOptions"/>
+        ///   needed for this test scenario.
+        /// </summary>
+        ///
+        /// <param name="producer">The active producer for the test scenario.</param>
+        ///
+        /// <returns>The set of options to use when creating batches to be published.</returns>
+        ///
+        protected override Task<CreateBatchOptions> CreateBatchOptions(EventHubProducerClient producer) =>
+            Task.FromResult(new CreateBatchOptions());
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishBatchesToPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishBatchesToPartition.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing a set of events.
+    /// </summary>
+    ///
+    /// <seealso cref="BatchPublishPerfTest" />
+    ///
+    public sealed class PublishBatchesToPartition : BatchPublishPerfTest
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishBatchesToPartition"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishBatchesToPartition(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Determines the set of <see cref="Azure.Messaging.EventHubs.Producer.CreateBatchOptions"/>
+        ///   needed for this test scenario.
+        /// </summary>
+        ///
+        /// <param name="producer">The active producer for the test scenario.</param>
+        ///
+        /// <returns>The set of options to use when creating batches to be published.</returns>
+        ///
+        protected async override Task<CreateBatchOptions> CreateBatchOptions(EventHubProducerClient producer)
+        {
+            // Query the available partitions and select the first for use in the batch options.
+
+            var partition = (await producer.GetPartitionIdsAsync().ConfigureAwait(false)).First();
+
+            return new CreateBatchOptions
+            {
+                PartitionId = partition
+            };
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishEventsToGateway.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishEventsToGateway.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing events
+    ///   to the Event Hubs gateway endpoint.
+    /// </summary>
+    ///
+    /// <seealso cref="EventPublishPerfTest" />
+    ///
+    public sealed class PublishEventsToGateway : EventPublishPerfTest
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishEventsToGateway"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishEventsToGateway(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Determines the set of <see cref="Azure.Messaging.EventHubs.Producer.SendEventOptions"/>
+        ///   needed for this test scenario.
+        /// </summary>
+        ///
+        /// <param name="producer">The active producer for the test scenario.</param>
+        ///
+        /// <returns>The set of options to use when publishing events.</returns>
+        ///
+        protected override Task<SendEventOptions> CreateSendOptions(EventHubProducerClient producer) => Task.FromResult(new SendEventOptions());
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishEventsToPartition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/PublishEventsToPartition.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing events
+    ///   to an Event Hubs partition.
+    /// </summary>
+    ///
+    /// <seealso cref="EventPublishPerfTest" />
+    ///
+    public sealed class PublishEventsToPartition : EventPublishPerfTest
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PublishEventsToPartition"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public PublishEventsToPartition(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Determines the set of <see cref="Azure.Messaging.EventHubs.Producer.SendEventOptions"/>
+        ///   needed for this test scenario.
+        /// </summary>
+        ///
+        /// <param name="producer">The active producer for the test scenario.</param>
+        ///
+        /// <returns>The set of options to use when publishing events.</returns>
+        ///
+        protected async override Task<SendEventOptions> CreateSendOptions(EventHubProducerClient producer)
+        {
+            // Query the available partitions and select the first for use in the batch options.
+
+            var partition = (await producer.GetPartitionIdsAsync().ConfigureAwait(false)).First();
+
+            return new SendEventOptions
+            {
+                PartitionId = partition
+            };
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/ReadFromPartitionWithConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/ReadFromPartitionWithConsumer.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing events
+    ///   to an Event Hubs partition.
+    /// </summary>
+    ///
+    /// <seealso cref="ReadPerfTest" />
+    ///
+    public sealed class ReadFromPartitionWithConsumer : ReadPerfTest
+    {
+        /// <summary>The consumer to use for reading from the partition.</summary>
+        private EventHubConsumerClient _consumer;
+
+        /// <summary>The asynchronous enumerator to use for reading; this ensures consistency across calls to RunAsync.</summary>
+        private ConfiguredCancelableAsyncEnumerable<PartitionEvent>.Enumerator _readEnumerator;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ReadFromPartitionWithConsumer"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public ReadFromPartitionWithConsumer(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for an instance
+        ///   of the test scenario.  When multiple instances are run in parallel, setup will be
+        ///   run once for each prior to its execution.
+        /// </summary>
+        ///
+        public async override Task SetupAsync()
+        {
+            await base.SetupAsync();
+
+            // Attempt to take a consumer group from the available set; to ensure that the
+            // test scenario can support the requested level of parallelism without violating
+            // the concurrent reader limits of a consumer group, the default consumer group
+            // should not be used.
+
+            if (!ConsumerGroups.TryDequeue(out var consumerGroup))
+            {
+                throw new InvalidOperationException("Unable to reserve a consumer group to read from.");
+            }
+
+            _consumer = new EventHubConsumerClient(consumerGroup, TestEnvironment.EventHubsConnectionString, Scope.EventHubName);
+
+            // In order to allow reading across multiple iterations, capture an enumerator.  Without using a consistent
+            // enumerator, a new AMQP link would be created and the position reset each time RunAsync was invoked.
+
+            _readEnumerator = _consumer
+                .ReadEventsFromPartitionAsync(PartitionId, EventPosition.Earliest)
+                .ConfigureAwait(false)
+                .GetAsyncEnumerator();
+
+            // Force the connection and link creation by reading a single event.
+
+            if (!(await _readEnumerator.MoveNextAsync()))
+            {
+                throw new InvalidOperationException("Unable to read from the partition.");
+            }
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for an instance
+        ///   of the test scenario.  When multiple instances are run in parallel, cleanup
+        ///   will be run once for each after execution has completed.
+        /// </summary>
+        ///
+        public async override Task CleanupAsync()
+        {
+            await _readEnumerator.DisposeAsync();
+            await _consumer.CloseAsync().ConfigureAwait(false);
+            await base.CleanupAsync();
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            // Read the requested number of events.
+
+            var readCount = 0;
+
+            while ((!cancellationToken.IsCancellationRequested) && (++readCount <= Options.Count))
+            {
+                if (!(await _readEnumerator.MoveNextAsync()))
+                {
+                    throw new InvalidOperationException("Unable to read from the partition.");
+                }
+            }
+
+            // If iteration stopped due to cancellation, ensure that the expected exception is thrown.
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/ReadFromPartitionWithReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/Azure.Messaging.EventHubs.Perf/Scenarios/ReadFromPartitionWithReceiver.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Consumer;
+using Azure.Messaging.EventHubs.Primitives;
+using Azure.Test.Perf;
+
+namespace Azure.Messaging.EventHubs.Perf.Scenarios
+{
+    /// <summary>
+    ///   The performance test scenario focused on publishing events
+    ///   to an Event Hubs partition.
+    /// </summary>
+    ///
+    /// <seealso cref="ReadPerfTest" />
+    ///
+    public sealed class ReadFromPartitionWithReceiver : ReadPerfTest
+    {
+        /// <summary>The receiver to use for reading from the partition.</summary>
+        private PartitionReceiver _receiver;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ReadFromPartitionWithReceiver"/> class.
+        /// </summary>
+        ///
+        /// <param name="options">The set of options to consider for configuring the scenario.</param>
+        ///
+        public ReadFromPartitionWithReceiver(SizeCountOptions options) : base(options)
+        {
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to initialize and set up the environment for an instance
+        ///   of the test scenario.  When multiple instances are run in parallel, setup will be
+        ///   run once for each prior to its execution.
+        /// </summary>
+        ///
+        public async override Task SetupAsync()
+        {
+            await base.SetupAsync();
+
+            // Attempt to take a consumer group from the available set; to ensure that the
+            // test scenario can support the requested level of parallelism without violating
+            // the concurrent reader limits of a consumer group, the default consumer group
+            // should not be used.
+
+            if (!ConsumerGroups.TryDequeue(out var consumerGroup))
+            {
+                throw new InvalidOperationException("Unable to reserve a consumer group to read from.");
+            }
+
+            _receiver = new PartitionReceiver(
+                consumerGroup,
+                PartitionId,
+                EventPosition.Earliest,
+                TestEnvironment.EventHubsConnectionString,
+                Scope.EventHubName);
+
+            // Force the connection and link creation by reading a single event.
+
+            await _receiver.ReceiveBatchAsync(1).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the environment for an instance
+        ///   of the test scenario.  When multiple instances are run in parallel, cleanup
+        ///   will be run once for each after execution has completed.
+        /// </summary>
+        ///
+        public async override Task CleanupAsync()
+        {
+            await _receiver.CloseAsync().ConfigureAwait(false);
+            await base.CleanupAsync();
+        }
+
+        /// <summary>
+        ///   Executes the performance test scenario asynchronously.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The token used to signal when cancellation is requested.</param>
+        ///
+        public async override Task RunAsync(CancellationToken cancellationToken)
+        {
+            // Read the requested number of events.
+
+            var remainingEvents = Options.Count;
+
+            while ((!cancellationToken.IsCancellationRequested) && (remainingEvents > 0))
+            {
+                remainingEvents -= (await _receiver.ReceiveBatchAsync(remainingEvents).ConfigureAwait(false)).Count();
+            }
+
+            // If iteration stopped due to cancellation, ensure that the expected exception is thrown.
+
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/perf/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/perf/README.md
@@ -1,0 +1,19 @@
+# Azure Event Hubs performance tests
+
+The assets in this area comprise a set of performance tests for the [Azure Event Hubs client library for .NET](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs) and its associated ecosystem.  The artifacts in this library are intended to be used primarily with the Azure SDK engineering system's testing infrastructure, but may also be run as stand-alone applications from the command line.
+
+## Running performance tests
+
+The Event Hubs client library performance tests by executing the command-line application using the `dotnet run` command or, in some environments, your operating system's executable support.  The performance tests rely on the same set of environment variables used by the Event Hubs client library's test suite.  Full details can be found in the [Running tests](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md#running-tests) section of the contributing guide.
+  
+## Contributing  
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+Please see our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
+  
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs.Perf%2FREADME.png)

--- a/sdk/storage/Azure.Storage.Blobs/perf/README.md
+++ b/sdk/storage/Azure.Storage.Blobs/perf/README.md
@@ -10,6 +10,6 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-Please see our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
+Please see our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md) for more information.
   
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Storage.Files.DataLake.Perf%2FREADME.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Fstorage%2FAzure.Storage.Blobs.Perf%2FREADME.png)

--- a/sdk/storage/Azure.Storage.Files.DataLake/perf/README.md
+++ b/sdk/storage/Azure.Storage.Files.DataLake/perf/README.md
@@ -10,6 +10,6 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-Please see our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
+Please see our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md) for more information.
   
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Storage.Files.DataLake.Perf%2FREADME.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Fstorage%2FAzure.Storage.Files.DataLake.Perf%2FREADME.png)


### PR DESCRIPTION
# Summary

The focus of these changes is to introduce a set of performance tests for the Event Hubs client library, covering key scenarios for publishing and reading events.  Notable omissions to the perforance scenarios are coverage for the `EventProcessorClient` and `EventProcessor<TPartition>`.  To effectively test, these require patterns not currently supported in the performance testing framework and will be addressed at a later time.

# Last Upstream Rebase

Wednesday, February 24, 9:45pm (EST)

# References and Related

- [Event Hubs: Performance Test Starter Kit (#18541)](https://github.com/Azure/azure-sdk-for-net/issues/18541)